### PR TITLE
build(deps): depend on the published mysqlwire, not the sibling directory

### DIFF
--- a/goproxy/go.mod
+++ b/goproxy/go.mod
@@ -8,15 +8,12 @@ require (
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/ridi-oss/proxy-monster/analyzer v0.0.0-00010101000000-000000000000
-	github.com/ridi-oss/proxy-monster/mysqlwire v0.0.0
+	github.com/ridi-oss/proxy-monster/mysqlwire v0.1.0
 	github.com/testcontainers/testcontainers-go v0.34.0
 	golang.org/x/crypto v0.27.0
 	google.golang.org/grpc v1.68.1
 	google.golang.org/protobuf v1.35.2
 )
-
-// In-repo modules: resolve locally (no go.work needed for CI / fresh clones).
-replace github.com/ridi-oss/proxy-monster/mysqlwire => ../mysqlwire
 
 // analyzer/probe (Go-to-Go, no cgo — cmd/libsqlglot is a separate package this never imports) is the
 // single source of truth for identifier normalization; introspect.go calls it directly instead of

--- a/goproxy/go.sum
+++ b/goproxy/go.sum
@@ -105,6 +105,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.0 h1:EqhwGXb2TZnu54s7Xk3BCZomUbTooHV66vZz5XEmmAk=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.0/go.mod h1:aLgJkOM6Sjm6AnQEzYk+1HameNl/O1jE7j8xFxjQR80=
 github.com/ridi-oss/sqlglot-go v0.20.0 h1:k+t+wD4YHPYjP8m3CEouCTXIGtMKIkpQ/5tMp9jhY+o=
 github.com/ridi-oss/sqlglot-go v0.20.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=

--- a/pmon/go.mod
+++ b/pmon/go.mod
@@ -2,9 +2,6 @@ module github.com/ridi-oss/proxy-monster/pmon
 
 go 1.23
 
-require github.com/ridi-oss/proxy-monster/mysqlwire v0.0.0
+require github.com/ridi-oss/proxy-monster/mysqlwire v0.1.0
 
 require github.com/alecthomas/kong v1.6.0
-
-// In-repo module: resolve locally (no go.work needed for CI / fresh clones).
-replace github.com/ridi-oss/proxy-monster/mysqlwire => ../mysqlwire

--- a/pmon/go.sum
+++ b/pmon/go.sum
@@ -6,3 +6,5 @@ github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.0 h1:EqhwGXb2TZnu54s7Xk3BCZomUbTooHV66vZz5XEmmAk=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.0/go.mod h1:aLgJkOM6Sjm6AnQEzYk+1HameNl/O1jE7j8xFxjQR80=

--- a/pmontray/go.mod
+++ b/pmontray/go.mod
@@ -14,7 +14,3 @@ require (
 
 // In-repo module: resolve locally (no go.work needed for CI / fresh clones).
 replace github.com/ridi-oss/proxy-monster/pmon => ../pmon
-
-// pmon depends on the in-repo mysqlwire; the replacement must be repeated here because a replace
-// directive in a dependency's go.mod is ignored outside its own main module.
-replace github.com/ridi-oss/proxy-monster/mysqlwire => ../mysqlwire


### PR DESCRIPTION
Every consumer required `mysqlwire v0.0.0` — a version that has never existed — and resolved it with a `replace` pointing at `../mysqlwire`. So nothing recorded which `mysqlwire` a build used, and a codec change altered `goproxy`'s and `pmon`'s behavior while their `go.mod` stayed byte-identical.

`mysqlwire` is now published as [`mysqlwire/v0.1.0`](https://github.com/ridi-oss/proxy-monster/releases/tag/mysqlwire/v0.1.0) and resolves through the module proxy.

- `goproxy`, `pmon` — require `v0.1.0`, drop the replace; `go.sum` now carries its checksum.
- `pmontray` — drops the `mysqlwire` replace entirely. It never imported the package; it repeated the directive only because a `replace` in a dependency's `go.mod` is ignored outside its own main module. Its `replace` for `pmon` stays.

**The dev loop is unchanged.** `go.work` still resolves `./mysqlwire` locally, ahead of the required version — verified by changing a constant and observing the new value through a workspace build. Only `GOWORK=off` builds (fresh-clone CI, a Homebrew formula) fetch the published version.

Also note the tag must be `mysqlwire/v0.1.0`, not `v0.1.0`: Go requires a module outside the repository root to be tagged with its subdirectory as the prefix.

## Verification

`mise run verify` green (29 Go packages, JVM, web). All four modules build both with `GOWORK=off` and through the workspace. `mysqlwire@v0.1.0` confirmed fetchable and compilable from an outside module.

`pmontray` was built and tested by hand — `mise run verify` does not enumerate it (`mise.toml:203`, pre-existing, worth a separate fix). `goproxy`'s `replace` for `analyzer` is left alone: same shape, but a larger surface with a cgo/FFM build step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
