### PR TITLE
ci: check that PR titles and commit subjects are conventional commits

### DIFF
--- a/.github/workflows/commit-convention.yml
+++ b/.github/workflows/commit-convention.yml
@@ -1,0 +1,47 @@
+name: commit convention
+
+# release-please derives every version and changelog entry from commit subjects, so a subject it cannot
+# parse drops the change from the release notes and a missed `feat:` or `!` bumps the wrong number.
+#
+# Checks the PR title, which squash-merge uses as the commit subject here
+# (squash_merge_commit_title = COMMIT_OR_PR_TITLE), and every commit the PR adds, since merge and rebase
+# are also enabled and land the individual subjects instead.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  subjects:
+    name: subjects are conventional commits
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      # Full history: the commit range is diffed against the merge base with the PR's base branch.
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Check the PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          printf '%s' "$PR_TITLE" | npx --yes @commitlint/cli@21 --config commitlint.config.js
+
+      - name: Check every added commit subject
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          npx --yes @commitlint/cli@21 --config commitlint.config.js --from "$BASE_SHA" --to "$HEAD_SHA"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,12 @@ handful of skips; zero skips is not the signal to look for.
   Coverage gaps are security gaps.
 - Kotlin uses standard conventions and Gradle (Kotlin DSL); Go uses the standard
   toolchain.
+- Commit subjects and pull request titles follow
+  [Conventional Commits](https://www.conventionalcommits.org):
+  `type(scope)!: subject`. The type is one of `feat`, `fix`, `perf`, `refactor`,
+  `build`, `docs`, `test`, `ci`, `chore`, `style`, `revert` — the component goes
+  in the scope, so `fix(web): wrap long Cedar lines`, not `web: ...`. A `!`
+  marks a breaking change. CI checks this on every pull request.
 
 Design docs follow the house style of
 [docs/authz-model.md](./docs/authz-model.md): lead with a short decision,

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,17 @@
+// Conventional Commits, checked in CI (.github/workflows/commit-convention.yml).
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    // The types release-please-config.json declares, plus style and revert. A type outside this set
+    // parses as conventional but matches no changelog section, so the change would be absent from the
+    // release notes and bump no version — which is why the component goes in the scope, `fix(web): …`
+    // rather than `web: …`.
+    'type-enum': [
+      2,
+      'always',
+      ['feat', 'fix', 'perf', 'refactor', 'build', 'docs', 'test', 'ci', 'chore', 'style', 'revert'],
+    ],
+    // Subjects are truncated wherever they are displayed; the default 100 is the spec's own guidance.
+    'header-max-length': [2, 'always', 100],
+  },
+}


### PR DESCRIPTION
release-please derives every version and changelog entry from commit subjects, so a subject it cannot parse drops the change from the release notes and a missed `feat:` or `!` bumps the wrong number. Nothing catches that today.

Uses **commitlint** — from `conventional-changelog`, the org that owns the Conventional Commits tooling — resolved from npm at a pinned major. Not a third-party action wrapping it: no bundled `dist/index.js` to trust, no token, read-only.

Checks the **PR title**, which squash-merge uses as the commit subject here (`squash_merge_commit_title = COMMIT_OR_PR_TITLE`), and **every commit the PR adds**, since merge and rebase are also enabled and land individual subjects. Only `BASE..HEAD` is read, so existing history isn't judged retroactively.

Types are the set `release-please-config.json` declares. A type outside it parses as conventional but matches no changelog section, so the change would be absent from the release notes and bump nothing — which is how `web:`, `goproxy:`, and `analyzer:` (25, 12, and 12 commits) would behave. The component goes in the scope: `fix(web): …`. `CONTRIBUTING.md` states the rule.

## Verification

Both modes exercised locally against the real cases: accepts `feat:`, `fix(db):`, `feat(api)!:`; rejects `web(policies):`, `initial commit`, `wip:`, `FEAT(x):`. Exit 1 on reject and 0 on pass in both stdin and `--from/--to` range mode, so CI fails rather than passing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
