### PR TITLE
build: register the native-lib tasks the way Gradle 9 requires

### DIFF
--- a/analyzer/jvm/build.gradle.kts
+++ b/analyzer/jvm/build.gradle.kts
@@ -103,13 +103,13 @@ val nativeTasks = nativeTargets.associateWith { t ->
 val hostTarget = nativeTargets.firstOrNull { it.os == hostOs && it.arch == hostArch }
     ?: error("no native target defined for host $hostOs/$hostArch")
 
-val buildNativeLib by tasks.registering {
+val buildNativeLib = tasks.register("buildNativeLib") {
     group = "build"
     description = "Builds the c-shared lib for the host platform only (fast; used by the default build)."
-    dependsOn(nativeTasks[hostTarget])
+    dependsOn(nativeTasks.getValue(hostTarget))
 }
 
-val buildAllNativeLibs by tasks.registering {
+val buildAllNativeLibs = tasks.register("buildAllNativeLibs") {
     group = "build"
     description = "Builds c-shared libs for ALL targets (host native + Linux via Zig). Run on macOS/arm64."
     dependsOn(nativeTasks.values)


### PR DESCRIPTION
Unblocks #6 (wrapper bump to 9.6.1), which fails to compile the build script.

Gradle 9 removed the `by tasks.registering` delegate and tightened `dependsOn` to reject a nullable, so `analyzer/jvm/build.gradle.kts` no longer compiles: both registrations move to `tasks.register("name")`, and the host lookup uses `getValue` because the indexing operator returns `TaskProvider<Exec>?` even though `hostTarget` is guarded by `error()` above.

Compatible in both directions, so it can land before the bump: `:analyzer:jvm:tasks` compiles under 9.6.1, and `:analyzer:jvm:test` + `:control-plane:compileKotlin` still pass on 8.14.5.