### PR TITLE
build: keep the release trains below 1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": true,
   "include-v-in-tag": true,
+  "initial-version": "0.1.0",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
The first release-please run proposed **`server 1.0.0`** and **`pmon 1.0.0`** (#15, #16). From a `0.0.0` manifest it treats the initial release as 1.0.0, and above 1.0.0 it promotes a `feat:` to a minor and a breaking change to a major. proxy-monster is pre-1.0, so that overstates the guarantee on both counts.

- `initial-version: 0.1.0` — both trains start there.
- `bump-minor-pre-major` + `bump-patch-for-minor-pre-major` — while below 1.0.0, a breaking change bumps the minor and a feature bumps the patch. Reaching 1.0.0 becomes a deliberate act rather than a side effect of the first release.

`mysqlwire` is unaffected: its manifest entry is already `0.1.0`, the published version, so it proposed nothing.

#15 and #16 should be closed; release-please will reopen them with corrected versions once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
