### PR TITLE
build: give Dependabot the conventional-commit prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,17 @@
 # Grouped per ecosystem rather than one PR per dependency: the JVM and Go trees each
 # pin transitively-coupled sets (grpc-java + protobuf, the AWS SDK modules), and
 # splitting those lands a PR that cannot build on its own.
+# Every PR title is a conventional-commit subject: `build(deps): …`. Dependabot writes
+# "Bump x from a to b" by default, which the PR-title check rejects, so the prefix is set
+# per ecosystem rather than renamed by hand on each PR.
 version: 2
 updates:
   - package-ecosystem: gradle
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: build(deps)
     open-pull-requests-limit: 5
     groups:
       jvm:
@@ -28,6 +33,8 @@ updates:
       - /pmontray
     schedule:
       interval: weekly
+    commit-message:
+      prefix: build(deps)
     open-pull-requests-limit: 5
     groups:
       go:
@@ -38,6 +45,8 @@ updates:
     directory: /web
     schedule:
       interval: weekly
+    commit-message:
+      prefix: build(deps)
     open-pull-requests-limit: 5
     groups:
       web:
@@ -48,3 +57,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: build(deps)


### PR DESCRIPTION
Dependabot titles its PRs `Bump x from a to b`, which is not a conventional-commit subject. All ten open dependency PRs had to be renamed by hand, and #14's PR-title check now rejects that shape outright — so without this, every future bump lands red.

`commit-message.prefix: build(deps)` on each ecosystem makes Dependabot write `build(deps): bump x from a to b` itself. `build` is in the type list #14 accepts.

All four ecosystems get it — gradle, gomod, npm, and github-actions. The last one had no other optional keys, so it is easy to miss and would have kept producing failing titles on its own.

Verified the YAML parses and every pre-existing key on all four entries survives (`groups`, `open-pull-requests-limit`, `directories`); the diff is additions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)