### PR TITLE
build: hold dependency updates for a cooldown, and accept Dependabot's subject case

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,25 @@
 # Grouped per ecosystem rather than one PR per dependency: the JVM and Go trees each
 # pin transitively-coupled sets (grpc-java + protobuf, the AWS SDK modules), and
 # splitting those lands a PR that cannot build on its own.
+# `prefix` is what makes the PR title conventional — Dependabot's own "Bump x from a to b"
+# fails the title check.
+#
+# `cooldown` waits before proposing a bump, so a release compromised and then yanked is
+# usually gone before a PR exists. Longer for a major: more code, less scrutiny per line.
+# It must stay a sibling of commit-message; nested, Dependabot ignores it silently.
 version: 2
 updates:
   - package-ecosystem: gradle
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: build(deps)
+    cooldown:
+      default-days: 3
+      semver-patch-days: 3
+      semver-minor-days: 5
+      semver-major-days: 7
     open-pull-requests-limit: 5
     groups:
       jvm:
@@ -28,6 +41,13 @@ updates:
       - /pmontray
     schedule:
       interval: weekly
+    commit-message:
+      prefix: build(deps)
+    cooldown:
+      default-days: 3
+      semver-patch-days: 3
+      semver-minor-days: 5
+      semver-major-days: 7
     open-pull-requests-limit: 5
     groups:
       go:
@@ -38,6 +58,13 @@ updates:
     directory: /web
     schedule:
       interval: weekly
+    commit-message:
+      prefix: build(deps)
+    cooldown:
+      default-days: 3
+      semver-patch-days: 3
+      semver-minor-days: 5
+      semver-major-days: 7
     open-pull-requests-limit: 5
     groups:
       web:
@@ -48,3 +75,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: build(deps)
+    cooldown:
+      default-days: 3

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -13,5 +13,9 @@ module.exports = {
     ],
     // Subjects are truncated wherever they are displayed; the default 100 is the spec's own guidance.
     'header-max-length': [2, 'always', 100],
+    // config-conventional rejects any leading capital, which Dependabot always writes ("Bump x
+    // from a to b") and cannot be told not to. release-please parses it identically, so the only
+    // effect was renaming every dependency PR by hand. PascalCase and ALL CAPS stay rejected.
+    'subject-case': [2, 'never', ['pascal-case', 'upper-case']],
   },
 }


### PR DESCRIPTION
Replaces #20, which set the prefix but would still have failed the title check.

**Cooldown.** Updating on publication makes this repo an early adopter of whatever was just pushed — the window a compromised release occupies. Waits by blast radius: 3 days patch, 5 minor, 7 major. `github-actions` is not semver, so it gets `default-days` only.

**Subject case.** Dependabot writes `Bump …` and cannot be told otherwise; `config-conventional`'s `subject-case` rejects any leading capital, so every dependency PR fails #14's check. Now rejects only `pascal-case` and `upper-case`.

Trap worth knowing: `cooldown` must be a sibling of `commit-message`, not nested inside it — nested, Dependabot ignores it silently.

Verified with commitlint: `build(deps): Bump typescript …` passes; `BUMP TYPESCRIPT NOW` and `fix(web): WrapLongCedarLines` still fail.