### PR TITLE
ci: mint a GitHub App token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,10 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # A GitHub App installation token, not GITHUB_TOKEN: events from GITHUB_TOKEN cannot start another
+      # workflow, so a release PR's checks sit unrunnable — and main requires them to merge.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: token
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          # GITHUB_TOKEN cannot trigger other workflows, so the release PR does not start CI. CI already
-          # ran on every commit it collects.
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
Events from `GITHUB_TOKEN` cannot start another workflow, so a release PR's checks are created but never run — they sit in `action_required` awaiting manual approval. Once `main` requires those checks, a release PR could never merge.

An App installation token isn't subject to that restriction. It's also short-lived (1h), scoped to this repo and the App's declared permissions, and owned by the org rather than a person — so it survives credential rotation and carries no human's full access. `actions/create-github-app-token` is GitHub's own action, pinned to v3.2.0's SHA.

**Needs two settings before this works** (see below) — until then, the workflow fails at the token step.

The recursion `GITHUB_TOKEN`'s restriction guards against is self-limiting here: merging a release PR pushes `chore(main): release …`, which re-runs this workflow once; `chore` is hidden in `changelog-sections`, so that run finds nothing releasable and exits. One no-op run per release, so no path filter is needed.

## Setup required

1. **Create the App** — `ridi-oss` org settings → Developer settings → GitHub Apps → New. Name e.g. `ridi-oss-release`, homepage anything, uncheck Webhook. Repository permissions: **Contents: Read and write**, **Pull requests: Read and write**, **Issues: Read and write** (release-please labels its PRs `autorelease: pending`, and PR labels are Issues-scoped). Nothing else.
2. **Install it** on `ridi-oss/proxy-monster` only.
3. **Generate a private key**, then set on this repo:
   - variable `RELEASE_APP_ID` = the App's ID
   - secret `RELEASE_APP_PRIVATE_KEY` = the whole `.pem` contents

I can set the variable and secret via `gh` once you've created the App and shared the ID and key — the App itself can only be created in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

