### PR TITLE
ci: attach prebuilt pmon binaries to each pmon-v* release

### DIFF
--- a/.github/workflows/pmon-release-binaries.yml
+++ b/.github/workflows/pmon-release-binaries.yml
@@ -1,0 +1,77 @@
+name: pmon release binaries
+
+# Attaches per-platform pmon archives to a pmon-v* release, so the Homebrew formula installs a binary
+# instead of compiling Go on every machine.
+on:
+  push:
+    tags: ["pmon-v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing pmon-v* tag to build and upload"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  binaries:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: pmon/go.mod
+
+      - name: Build and archive every platform
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -uo pipefail
+          version="${TAG#pmon-v}"
+          mkdir -p dist
+
+          # Every target is attempted even after one fails — a broken platform is a fact about that
+          # platform, and the others still need to report (the same reason db-matrix.yml sets
+          # fail-fast: false). Hence no `set -e`: failures accumulate and the step exits once at the end.
+          #
+          # CGO_ENABLED=0 keeps each binary static, so it runs on any host of that platform regardless
+          # of libc. GOWORK=off because the repo root is a workspace; a release build resolves pmon's
+          # own go.mod, the same as a fresh clone or a formula build.
+          failed=()
+          for target in darwin/arm64 darwin/amd64 linux/amd64 linux/arm64; do
+            os="${target%/*}"; arch="${target#*/}"
+            echo "::group::$os/$arch"
+            if (cd pmon && GOWORK=off CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" \
+                  go build -trimpath -ldflags '-s -w' -o "../dist/pmon" .) &&
+               tar -C dist -czf "dist/pmon_${version}_${os}_${arch}.tar.gz" pmon; then
+              echo "built $os/$arch"
+            else
+              echo "::error::pmon build failed for $os/$arch"
+              failed+=("$os/$arch")
+            fi
+            rm -f dist/pmon
+            echo "::endgroup::"
+          done
+
+          if [ ${#failed[@]} -ne 0 ]; then
+            echo "::error::${#failed[@]} of 4 targets failed: ${failed[*]}"
+            exit 1
+          fi
+
+          # One checksum file over the archives, so a formula bump can read the hash it needs and a
+          # user can verify a download independently.
+          (cd dist && shasum -a 256 *.tar.gz > checksums.txt)
+          cat dist/checksums.txt
+
+      - name: Attach them to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          gh release upload "$TAG" dist/*.tar.gz dist/checksums.txt --repo "$GITHUB_REPOSITORY" --clobber


### PR DESCRIPTION
The Homebrew formula installs a binary rather than compiling Go on every machine, so each `pmon-v*` tag needs per-platform archives on its release.

Builds darwin and linux on both arm64 and amd64 — static (`CGO_ENABLED=0`) so each runs on any host of that platform regardless of libc, and `-trimpath` so an archive is reproducible from the tag alone. `GOWORK=off` resolves `pmon`'s own `go.mod`, matching a fresh clone. A `checksums.txt` covers all four so a formula bump reads the hash it needs and users can verify independently.

`workflow_dispatch` takes a tag, so `pmon-v0.1.0` — already released — can be filled in without re-tagging.

## One job, not a matrix

Measured: all four targets cross-compile in ~15s total, less than the fixed setup a runner pays before compiling. Four matrix jobs would quadruple billed minutes to save a few seconds of wall clock.

The loop does adopt the matrix's `fail-fast: false` semantics, which the first version got wrong — `set -e` aborted on the first bad target. Now every target is attempted and the step exits once at the end naming the failures, for the reason `db-matrix.yml` states: a broken platform is a fact about that platform, and the others still need to report.

The tradeoff accepted: one check instead of four named ones, so a broken target is an `::error::` annotation rather than a red check per platform.

## Verification

Both paths exercised locally with the workflow's own commands. All four targets produce archives containing a bare `pmon` at the root, and the darwin/arm64 binary runs and reports `0.1.0`. With a bogus target injected, the other three still built and the step exited 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
