### PR TITLE
build: move the Go toolchain to 1.26

### DIFF
--- a/analyzer/go.mod
+++ b/analyzer/go.mod
@@ -6,7 +6,7 @@
 // analyzer/README.md for how the pin is bumped.
 module github.com/ridi-oss/proxy-monster/analyzer
 
-go 1.23
+go 1.26.0
 
 require github.com/ridi-oss/sqlglot-go v0.20.0
 

--- a/auditmon/Dockerfile
+++ b/auditmon/Dockerfile
@@ -10,11 +10,11 @@
 # AUDITMON_DB_DSN (the read-only Postgres DSN named by the config's db_dsn_env), AWS_REGION + a task IAM
 # role for S3 + KMS, and any webhook URL env the alert sinks reference (e.g. SECOPS_WEBHOOK_URL).
 
-FROM golang:1.23-bookworm AS build
+FROM golang:1.26-bookworm AS build
 WORKDIR /workspace
 COPY . .
 # All deps are pure Go (pgx, aws-sdk-go-v2), so CGO off → a fully static binary and the runtime image
-# needs no libc. GOTOOLCHAIN=local pins the module's go 1.23 (no network toolchain fetch).
+# needs no libc. GOTOOLCHAIN=local pins the module's go 1.26 (no network toolchain fetch).
 ENV GOTOOLCHAIN=local CGO_ENABLED=0
 RUN go build -trimpath -o /out/auditmon ./cmd/auditmon
 

--- a/auditmon/go.mod
+++ b/auditmon/go.mod
@@ -1,6 +1,6 @@
 module github.com/ridi-oss/proxy-monster/auditmon
 
-go 1.23.0
+go 1.26.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.2

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -13,9 +13,9 @@
 # is also set, but set PM_AUTH_DEBUG=false explicitly for any real deployment regardless.
 
 # Go toolchain for the analyzer's native lib (cmd/libsqlglot, cgo c-shared build). Pulled from the
-# official Go image rather than apt/curl so the version matches mise.toml's `go = "1.23"` exactly
+# official Go image rather than apt/curl so the version matches mise.toml's `go = "1.26"` exactly
 # and multi-arch (amd64/arm64) resolution is automatic.
-FROM golang:1.23-bookworm AS go
+FROM golang:1.26-bookworm AS go
 
 # eclipse-temurin's Debian ("noble") variant, not alpine: the analyzer's native lib is built for
 # glibc (analyzer/jvm/build.gradle.kts's zig targets are explicitly *-linux-gnu), and cedar-java's

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.23.12
+go 1.26.0
 
 use (
 	./analyzer

--- a/goproxy/Dockerfile
+++ b/goproxy/Dockerfile
@@ -9,14 +9,14 @@
 # committed, so no codegen runs at build time. Build from the repo root:
 #   docker build -f goproxy/Dockerfile -t proxy-monster-proxy .
 
-FROM golang:1.23-bookworm AS build
+FROM golang:1.26-bookworm AS build
 WORKDIR /workspace
 # goproxy's go.mod resolves ../mysqlwire and ../analyzer via `replace` directives; copy all three modules.
 COPY mysqlwire ./mysqlwire
 COPY analyzer ./analyzer
 COPY goproxy ./goproxy
 WORKDIR /workspace/goproxy
-# GOTOOLCHAIN=local pins the module's go 1.23 (no network toolchain fetch); CGO off → a static binary,
+# GOTOOLCHAIN=local pins the module's go 1.26 (no network toolchain fetch); CGO off → a static binary,
 # so the runtime image needs no libc beyond the base.
 ENV GOTOOLCHAIN=local CGO_ENABLED=0
 RUN go build -trimpath -o /out/goproxy ./cmd/goproxy

--- a/goproxy/go.mod
+++ b/goproxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/ridi-oss/proxy-monster/goproxy
 
-go 1.23
+go 1.26.0
 
 require (
 	github.com/alecthomas/kong v1.6.0

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,7 @@ java = "temurin-24.0.2"
 # Go builds the analyzer's c-shared native lib (analyzer/cmd/libsqlglot, via cgo) as part of the
 # Gradle build; matches analyzer/go.mod. (Zig — the Linux cross C compiler for the all-targets fat-jar
 # build, -Psqlglot.native.all=true — is only needed for that; add it when CI is wired.)
-go = "1.23"
+go = "1.26"
 # web/ (Next.js). Pinned rather than "whatever's on PATH" so `pnpm install`'s lockfile resolution
 # and `next build` behavior stay reproducible across machines. Match web/Dockerfile's base image +
 # corepack pin when bumping either.

--- a/mysqlwire/go.mod
+++ b/mysqlwire/go.mod
@@ -1,3 +1,3 @@
 module github.com/ridi-oss/proxy-monster/mysqlwire
 
-go 1.23
+go 1.26.0

--- a/pmon/go.mod
+++ b/pmon/go.mod
@@ -1,6 +1,6 @@
 module github.com/ridi-oss/proxy-monster/pmon
 
-go 1.23
+go 1.26.0
 
 require github.com/ridi-oss/proxy-monster/mysqlwire v0.1.0
 

--- a/pmontray/go.mod
+++ b/pmontray/go.mod
@@ -1,6 +1,6 @@
 module github.com/ridi-oss/proxy-monster/pmontray
 
-go 1.23
+go 1.26.0
 
 require (
 	fyne.io/systray v1.12.2


### PR DESCRIPTION
Unblocks #13 (the go dependency group), which currently fails to build at all.

Go 1.23 lost support on 2025-08-12 when 1.25 shipped — nearly a year with no security fixes. 1.25 and 1.26 are the supported releases.

It is also what #13 needs: the AWS SDK and testcontainers generations it proposes require `go >= 1.25`, and raising two modules while `go.work` stayed at 1.23.12 broke *every* module in the workspace, including ones the bump did not touch:

```
go: module ../auditmon listed in go.work file requires go >= 1.25.0,
    but go.work lists go 1.23.12
```

Every pin moves together — `mise.toml`, `go.work`, all six `go.mod` files, and the three Dockerfiles' `golang:` base images — since a partial bump is exactly what caused that. Two Dockerfile comments naming 1.23 next to `GOTOOLCHAIN=local` are corrected too.

1.26 rather than the 1.25 the deps demand: 1.25 is a year old and would need doing again soon.

Verified under 1.26.5 — all six modules build, `go vet` clean, 30 test packages pass, and `:analyzer:jvm:test` still produces the cgo c-shared lib (the one place the JVM build shells out to Go).