### PR TITLE
docs(pmon): install from the Homebrew tap

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -690,7 +690,7 @@ for i in pm-goproxy pm-control-plane pm-web pm-auditmon; do docker push $REG/$i:
 ```
 
 pmon is not containerized — it's a client binary users install
-(`go build -o pmon ./pmon`).
+(`brew install ridi-oss/tap/pmon`, or `go build -o pmon ./pmon`).
 
 ### ECS task definitions
 

--- a/pmon/README.md
+++ b/pmon/README.md
@@ -6,7 +6,9 @@ background daemon holds a short-lived wire token, runs one loopback listener per
 datasource, and injects the token upstream.
 
 ```sh
-go build -o /usr/local/bin/pmon ./pmon
+# Homebrew 6 asks you to trust a third-party formula before it will load one.
+brew trust --formula ridi-oss/tap/pmon
+brew install ridi-oss/tap/pmon   # or: go build -o /usr/local/bin/pmon ./pmon
 
 pmon login                     # device-auth in your browser; starts the daemon + opens the brokers
 pmon status                    # principal, token expiry, every brokered datasource


### PR DESCRIPTION
`pmon-v0.1.0` ships prebuilt binaries and `ridi-oss/homebrew-tap` serves them, so `brew install ridi-oss/tap/pmon` needs no Go toolchain. The source build stays documented for contributors.

Verified end to end on this machine: tap, install (6s), `brew test` and `brew audit --strict --online` both exit 0, and `pmon --version` reports `0.1.0` from `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
