### PR TITLE
fix(cp): tell a wedged proxy stream apart from an absent one

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ProxyEventsHub.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ProxyEventsHub.kt
@@ -59,6 +59,45 @@ class ProxyEventsHub {
     }
 
     /**
+     * The outcome of asking a proxy to open a stream. NOT_ATTACHED and WEDGED look identical to a caller
+     * that only gets a boolean, and they need different answers: the first means no proxy is there, the
+     * second means one is registered but its channel will not take an event — a stream already closed by
+     * a reset the server has not finished tearing down, or a consumer that stopped draining. Reporting
+     * both as "no proxy attached" sends whoever debugs it looking for a proxy that is in fact running.
+     */
+    enum class Dispatch { SENT, NOT_ATTACHED, WEDGED }
+
+    /**
+     * Hand [event] to exactly one attached replica. The first non-blocking send that succeeds wins;
+     * broadcasting would make every replica open a backend connection for the same request.
+     *
+     * A channel that refuses the event is deregistered here rather than left in place. It cannot serve a
+     * later request either, and leaving it registered means `attached()` keeps reporting a proxy that
+     * cannot be reached — the liveness view would lie until the stream's own close handler eventually ran.
+     */
+    private fun dispatch(name: String, what: String, event: ControlEvent): Dispatch {
+        val channels = streams[name] ?: return Dispatch.NOT_ATTACHED
+        val refused = mutableListOf<SendChannel<ControlEvent>>()
+        for (channel in channels) {
+            if (channel.trySend(event).isSuccess) {
+                refused.forEach { deregisterWedged(name, it, what) }
+                return Dispatch.SENT
+            }
+            refused += channel
+        }
+        refused.forEach { deregisterWedged(name, it, what) }
+        return if (refused.isEmpty()) Dispatch.NOT_ATTACHED else Dispatch.WEDGED
+    }
+
+    private fun deregisterWedged(name: String, channel: SendChannel<ControlEvent>, what: String) {
+        log.warn(
+            "proxy stream for datasource '{}' would not accept {} (closed or its buffer is full); dropping it",
+            name, what,
+        )
+        deregister(name, channel)
+    }
+
+    /**
      * Ask exactly one attached proxy replica to dial a run stream. The first successful non-blocking
      * send wins; broadcasting would make every replica open a backend connection for the same CP request.
      */
@@ -68,7 +107,7 @@ class ProxyEventsHub {
         ephemeralToken: String,
         connectionId: com.google.protobuf.ByteString,
         onOpen: List<Refetch>,
-    ): Boolean {
+    ): Dispatch {
         val event = controlEvent {
             openRunChannel = openRunChannel {
                 this.sessionId = sessionId
@@ -77,13 +116,11 @@ class ProxyEventsHub {
                 this.onOpen.addAll(onOpen.map { proxyCommand { refetch = it } })
             }
         }
-        val channels = streams[name] ?: return false
-        for (channel in channels) if (channel.trySend(event).isSuccess) return true
-        return false
+        return dispatch(name, "an open-run request", event)
     }
 
     /** Ask exactly one attached proxy replica to dial an on-demand table-detail stream. */
-    fun requestOpenTableDetail(name: String, sessionId: String, schema: String, table: String): Boolean {
+    fun requestOpenTableDetail(name: String, sessionId: String, schema: String, table: String): Dispatch {
         val event = controlEvent {
             openTableDetailChannel = openTableDetailChannel {
                 this.sessionId = sessionId
@@ -91,9 +128,7 @@ class ProxyEventsHub {
                 this.table = table
             }
         }
-        val channels = streams[name] ?: return false
-        for (channel in channels) if (channel.trySend(event).isSuccess) return true
-        return false
+        return dispatch(name, "a table-detail request", event)
     }
 
     /** Datasource names with at least one open Events stream — the admin "which have a proxy attached". */

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -867,6 +867,8 @@ fun Route.queryRoutes(
             )
         } catch (_: NoProxyAttachedException) {
             call.respond(HttpStatusCode.ServiceUnavailable, ApiError("query.no_proxy_attached"))
+        } catch (_: ProxyStreamWedgedException) {
+            call.respond(HttpStatusCode.ServiceUnavailable, ApiError("query.proxy_stream_wedged"))
         } catch (_: ProxyRunTimeoutException) {
             call.respond(HttpStatusCode.GatewayTimeout, ApiError("query.proxy_timeout"))
         } catch (e: ProxyRunException) {
@@ -926,6 +928,8 @@ fun Route.editorSessionRoutes(
             call.respond(EditorSessionOpened(runExecService.openSession(principal, ds, call.httpRequesterIp(config))))
         } catch (_: NoProxyAttachedException) {
             call.respond(HttpStatusCode.ServiceUnavailable, ApiError("query.no_proxy_attached"))
+        } catch (_: ProxyStreamWedgedException) {
+            call.respond(HttpStatusCode.ServiceUnavailable, ApiError("query.proxy_stream_wedged"))
         } catch (_: ProxyRunTimeoutException) {
             call.respond(HttpStatusCode.GatewayTimeout, ApiError("query.proxy_timeout"))
         } catch (e: ProxyRunException) {
@@ -1010,6 +1014,8 @@ fun Route.editorSessionRoutes(
                 null
             } catch (_: NoProxyAttachedException) {
                 "query.no_proxy_attached"
+            } catch (_: ProxyStreamWedgedException) {
+                "query.proxy_stream_wedged"
             } catch (_: ProxyRunTimeoutException) {
                 "query.proxy_timeout"
             } catch (_: ProxyRunException) {

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RunExec.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RunExec.kt
@@ -142,6 +142,15 @@ sealed class RunExecException(message: String, cause: Throwable? = null) : Excep
 
 class NoProxyAttachedException : RunExecException("no proxy is attached to this datasource")
 
+/**
+ * A proxy IS attached, but its event stream would not accept the request — already closed by a reset the
+ * server has not finished tearing down, or its consumer stopped draining. Separate from
+ * [NoProxyAttachedException] because the operator answer differs: nothing is missing, a live stream is
+ * unusable, and the wedged one has been dropped so the proxy's own reconnect can replace it. Retrying
+ * after that reconnect is the fix; looking for an absent proxy is not.
+ */
+class ProxyStreamWedgedException : RunExecException("the proxy's event stream would not accept the request")
+
 class ProxyRunTimeoutException(cause: Throwable? = null) :
     RunExecException("the proxy run channel timed out", cause)
 
@@ -279,8 +288,10 @@ class RunExecService(
         try {
             core.runChannels.register(pending)
             registered = true
-            if (!core.proxyEventsHub.requestOpenRun(ds.name, sessionId, issued.token, opened.connectionId, opened.onOpen)) {
-                throw NoProxyAttachedException()
+            when (core.proxyEventsHub.requestOpenRun(ds.name, sessionId, issued.token, opened.connectionId, opened.onOpen)) {
+                ProxyEventsHub.Dispatch.SENT -> Unit
+                ProxyEventsHub.Dispatch.NOT_ATTACHED -> throw NoProxyAttachedException()
+                ProxyEventsHub.Dispatch.WEDGED -> throw ProxyStreamWedgedException()
             }
 
             attached = try {
@@ -364,8 +375,10 @@ class RunExecService(
         var attached: Attached? = null
         try {
             core.runChannels.register(pending)
-            if (!core.proxyEventsHub.requestOpenRun(ds.name, sessionId, issued.token, opened.connectionId, opened.onOpen)) {
-                throw NoProxyAttachedException()
+            when (core.proxyEventsHub.requestOpenRun(ds.name, sessionId, issued.token, opened.connectionId, opened.onOpen)) {
+                ProxyEventsHub.Dispatch.SENT -> Unit
+                ProxyEventsHub.Dispatch.NOT_ATTACHED -> throw NoProxyAttachedException()
+                ProxyEventsHub.Dispatch.WEDGED -> throw ProxyStreamWedgedException()
             }
             attached = try {
                 withTimeout(DIAL_TIMEOUT_MS) { pending.ready.await() }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/TableDetailExec.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/TableDetailExec.kt
@@ -80,8 +80,11 @@ class TableDetailService(private val core: ControlPlaneCore) {
         try {
             core.tableDetailChannels.register(pending)
             registered = true
-            if (!core.proxyEventsHub.requestOpenTableDetail(dsName, sessionId, schema, table)) {
+            when (core.proxyEventsHub.requestOpenTableDetail(dsName, sessionId, schema, table)) {
+                ProxyEventsHub.Dispatch.SENT -> Unit
+                ProxyEventsHub.Dispatch.NOT_ATTACHED, ProxyEventsHub.Dispatch.WEDGED -> {
                 throw NoTableDetailProxyAttachedException()
+                }
             }
 
             attached = try {

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ProxyEventsHubTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ProxyEventsHubTest.kt
@@ -1,0 +1,105 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.grpc.ControlEvent
+import com.google.protobuf.ByteString
+import kotlinx.coroutines.channels.Channel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A proxy whose stream is registered but unusable used to be reported as "no proxy is attached" — a different
+ * problem with a different answer. A load balancer that resets the events stream on a transient health-check
+ * blip leaves the control plane holding a channel the proxy has stopped reading, while its own log still says
+ * the proxy is attached, so every query fails claiming nothing is there.
+ */
+class ProxyEventsHubTest {
+    private fun openRun(hub: ProxyEventsHub, name: String) =
+        hub.requestOpenRun(name, "session", "token", ByteString.copyFrom(ByteArray(16)), emptyList())
+
+    @Test
+    fun `a datasource with no stream is not attached`() {
+        val hub = ProxyEventsHub()
+        assertEquals(ProxyEventsHub.Dispatch.NOT_ATTACHED, openRun(hub, "absent"))
+    }
+
+    @Test
+    fun `an open stream takes the event`() {
+        val hub = ProxyEventsHub()
+        val channel = Channel<ControlEvent>(Channel.BUFFERED)
+        hub.register("ds", channel)
+
+        assertEquals(ProxyEventsHub.Dispatch.SENT, openRun(hub, "ds"))
+        assertTrue(channel.tryReceive().isSuccess, "the event should be sitting in the channel")
+    }
+
+    @Test
+    fun `a closed stream is WEDGED, not NOT_ATTACHED`() {
+        // Registered, but the channel is dead. Distinguishing the two is the whole point: "no proxy attached"
+        // sends an operator looking for a proxy that is in fact running.
+        val hub = ProxyEventsHub()
+        val channel = Channel<ControlEvent>(Channel.BUFFERED)
+        hub.register("ds", channel)
+        channel.close()
+
+        assertEquals(ProxyEventsHub.Dispatch.WEDGED, openRun(hub, "ds"))
+    }
+
+    @Test
+    fun `a full buffer is WEDGED too`() {
+        // A consumer that stopped draining looks the same to a non-blocking send as a closed channel does.
+        val hub = ProxyEventsHub()
+        val channel = Channel<ControlEvent>(1)
+        hub.register("ds", channel)
+
+        assertEquals(ProxyEventsHub.Dispatch.SENT, openRun(hub, "ds"))
+        assertEquals(ProxyEventsHub.Dispatch.WEDGED, openRun(hub, "ds"), "the single slot is taken")
+    }
+
+    @Test
+    fun `a wedged stream is dropped so liveness stops claiming it`() {
+        // Left registered, the channel cannot serve a later request either, and attached() would keep
+        // reporting a reachable proxy until the stream's own close handler eventually ran.
+        val hub = ProxyEventsHub()
+        val channel = Channel<ControlEvent>(Channel.BUFFERED)
+        hub.register("ds", channel)
+        assertEquals(setOf("ds"), hub.attached())
+
+        channel.close()
+        assertEquals(ProxyEventsHub.Dispatch.WEDGED, openRun(hub, "ds"))
+
+        assertEquals(emptySet(), hub.attached(), "the dead stream should no longer count as attached")
+        assertEquals(
+            ProxyEventsHub.Dispatch.NOT_ATTACHED,
+            openRun(hub, "ds"),
+            "once dropped, the datasource genuinely has no proxy",
+        )
+    }
+
+    @Test
+    fun `a live replica serves the request even when another is wedged`() {
+        // Eviction must not cost availability: with one dead and one healthy stream the request still goes
+        // out, and only the dead one is dropped.
+        val hub = ProxyEventsHub()
+        val dead = Channel<ControlEvent>(Channel.BUFFERED)
+        val live = Channel<ControlEvent>(Channel.BUFFERED)
+        hub.register("ds", dead)
+        hub.register("ds", live)
+        dead.close()
+
+        assertEquals(ProxyEventsHub.Dispatch.SENT, openRun(hub, "ds"))
+        assertTrue(live.tryReceive().isSuccess, "the healthy replica should have received it")
+        assertEquals(setOf("ds"), hub.attached(), "the live stream keeps the datasource attached")
+        assertEquals(ProxyEventsHub.Dispatch.SENT, openRun(hub, "ds"), "the dead one is gone, not retried")
+    }
+
+    @Test
+    fun `a refresh push skips a wedged stream rather than counting it`() {
+        val hub = ProxyEventsHub()
+        val dead = Channel<ControlEvent>(Channel.BUFFERED)
+        hub.register("ds", dead)
+        dead.close()
+
+        assertEquals(0, hub.requestRefresh("ds"), "a dead stream notified nobody")
+    }
+}

--- a/web/messages/en/errors.json
+++ b/web/messages/en/errors.json
@@ -83,6 +83,7 @@
   "query": {
     "failed": "Query failed: {detail}",
     "no_proxy_attached": "No proxy is attached to this datasource.",
+    "proxy_stream_wedged": "The proxy for this datasource is reconnecting. Try again in a moment.",
     "proxy_timeout": "The proxy did not respond in time."
   }
 }

--- a/web/messages/ko/errors.json
+++ b/web/messages/ko/errors.json
@@ -83,6 +83,7 @@
   "query": {
     "failed": "쿼리 실행에 실패했습니다: {detail}",
     "no_proxy_attached": "이 데이터소스에 연결된 프록시가 없습니다.",
+    "proxy_stream_wedged": "이 데이터소스의 프록시가 재연결 중입니다. 잠시 후 다시 시도해 주세요.",
     "proxy_timeout": "프록시가 제한 시간 내에 응답하지 않았습니다."
   }
 }


### PR DESCRIPTION
`requestOpenRun` returned a bare boolean, so two different failures gave the same answer — no proxy attached, and a proxy attached whose event channel will not take the request. Both surfaced as `No proxy is attached to this datasource.`

The second happens when a load balancer terminates connections on an unhealthy target with no drain: the events stream is reset while the control plane still holds its channel, so every editor session fails in under 50ms claiming nothing is there, with the control plane's own log reporting `1 stream(s) open` a line above.

`Dispatch` names the three outcomes, and a channel that refuses an event is deregistered instead of left in place: it cannot serve a later request either, and leaving it registered means `attached()` keeps reporting an unreachable proxy until the stream's own close handler eventually runs. Eviction costs no availability — with one dead and one healthy replica the request still goes to the healthy one and only the dead channel is dropped.

`query.proxy_stream_wedged` is a separate code in both locales, saying the proxy is reconnecting and to retry.

Seven tests cover both failure modes, the eviction, the multi-replica case and the refresh path. Mutation-tested: collapsing WEDGED into NOT_ATTACHED fails 5 assertions; removing the eviction fails 3. 851 tests, 0 failures.

The infrastructure half — disabling unhealthy-target connection termination on the gRPC and wire target groups — belongs in the deployment configuration, not here.