### PR TITLE
ci: publish the server images to Docker Hub on a server-v* tag

### DIFF
--- a/.github/workflows/server-images.yml
+++ b/.github/workflows/server-images.yml
@@ -1,0 +1,90 @@
+name: server images
+
+# Publishes the four server images for a server-v* release to Docker Hub.
+#
+# pmon is not here: it is a client binary, shipped as a release archive and a Homebrew formula
+# (pmon-release-binaries.yml).
+on:
+  push:
+    tags: ["server-v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing server-v* tag to build and push"
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  images:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    strategy:
+      # A failed image is a fact about that image; the others still need to publish.
+      fail-fast: false
+      matrix:
+        include:
+          # goproxy and control-plane build from the repo root: goproxy needs the sibling mysqlwire
+          # module, and control-plane's Gradle configuration phase needs every included module.
+          - name: goproxy
+            dockerfile: goproxy/Dockerfile
+            context: .
+          - name: control-plane
+            dockerfile: control-plane/Dockerfile
+            context: .
+          # auditmon and web are self-contained, so their own directory is the context.
+          - name: auditmon
+            dockerfile: auditmon/Dockerfile
+            context: auditmon
+          - name: web
+            dockerfile: web/Dockerfile
+            context: web
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Resolve the version from the tag
+        id: version
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: echo "version=${TAG#server-v}" >> "$GITHUB_OUTPUT"
+
+      # arm64 is emulated, so the matrix stays one job per image rather than one per platform:
+      # buildx produces the multi-arch manifest, and splitting would need a separate merge job.
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          # An organization access token, so the username is the org rather than a person's handle
+          # and the credential outlives any individual's account.
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ vars.DOCKERHUB_NAMESPACE }}/pm-${{ matrix.name }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Reuse layers across releases; scoped per image so one does not evict another.
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,scope=${{ matrix.name }},mode=max

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,22 +6,59 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "changelog-sections": [
-    { "type": "feat", "section": "Features" },
-    { "type": "fix", "section": "Bug Fixes" },
-    { "type": "perf", "section": "Performance" },
-    { "type": "refactor", "section": "Refactoring" },
-    { "type": "build", "section": "Build & Dependencies" },
-    { "type": "docs", "section": "Documentation" },
-    { "type": "test", "section": "Tests", "hidden": true },
-    { "type": "ci", "section": "CI", "hidden": true },
-    { "type": "chore", "section": "Chores", "hidden": true }
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance"
+    },
+    {
+      "type": "refactor",
+      "section": "Refactoring"
+    },
+    {
+      "type": "build",
+      "section": "Build & Dependencies"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation"
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "CI",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "Chores",
+      "hidden": true
+    }
   ],
   "packages": {
     ".": {
       "component": "server",
       "release-type": "simple",
       "changelog-path": "CHANGELOG.md",
-      "exclude-paths": ["pmon", "pmontray", "mysqlwire"]
+      "exclude-paths": ["pmon", "pmontray", "mysqlwire"],
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "web/package.json",
+          "jsonpath": "$.version"
+        }
+      ]
     },
     "pmon": {
       "component": "pmon",

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,6 +1,8 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
+import { version } from "./package.json";
+
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 // Proxy /api and /auth to the Kotlin control-plane (default :41390), so the
@@ -12,6 +14,10 @@ const nextConfig: NextConfig = {
   // minimal subset of node_modules the built server actually needs — instead of the full
   // node_modules tree. No effect on `next dev`/plain `next start` outside a container.
   output: "standalone",
+  // The console shows this on the login page. Read from package.json, which release-please bumps with
+  // the server release, so a plain `pnpm build` and a container image report the same version and
+  // neither needs a build argument. Inlined at build time, so only the string ships — not package.json.
+  env: { NEXT_PUBLIC_APP_VERSION: version },
   async rewrites() {
     return [
       { source: "/api/:path*", destination: `${target}/api/:path*` },

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -181,7 +181,7 @@ function LoginInner() {
         )}
       </div>
 
-      <p className="text-muted-foreground text-xs">v0.1.0</p>
+      <p className="text-muted-foreground text-xs">v{process.env.NEXT_PUBLIC_APP_VERSION}</p>
     </div>
   )
 }


### PR DESCRIPTION
Four images — `pm-goproxy`, `pm-control-plane`, `pm-web`, `pm-auditmon` — built for `linux/amd64` and `linux/arm64` on a `server-v*` tag, tagged with the release version plus `latest`. Replaces the hand-run `docker build`/`push` sequence in `INSTALL.md`.

Build contexts differ per component and are not interchangeable: `goproxy` and `control-plane` build from the repo root (goproxy needs the sibling `mysqlwire` module; control-plane's Gradle configuration phase needs every included module), while `auditmon` and `web` are self-contained in their own directories.

Authenticates with a Docker Hub **organization** access token, so the username is the org rather than a person's handle and the credential outlives any individual account.

**ECR Public is deliberately absent.** It needs an IAM role and registry alias that don't exist yet, and a workflow referencing missing variables would fail every release. Follow-up. Worth noting for that follow-up: ECR Public addresses a registry by alias (`public.ecr.aws/<alias>/<repo>`), so unlike private ECR it discloses no AWS account id.

## The console's version

`web/src/app/login/page.tsx` had a hardcoded `v0.1.0` — the only version string in the console, fed by nothing. It now reads `web/package.json` through `next.config.ts`, and release-please bumps that field with the server release (`extra-files`, `json`/`jsonpath`).

So a plain `pnpm build` and a container image report the same version, with no build argument to forget.

## Verification

All four images built locally from their real contexts: `pm-control-plane` 795MB, `pm-goproxy` 174MB, plus web and auditmon. `goproxy` building also confirms the `mysqlwire v0.1.0` unpinning works inside a container.

Confirmed `NEXT_PUBLIC_APP_VERSION = 0.1.0` is baked into the built **image** (read back out of `.next/required-server-files.json` inside it), not merely a local build. The `json`/`jsonpath` extra-files updater was checked against release-please's packaged source rather than its docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
