### PR TITLE
fix(proxy): bound the events stream so a dead one cannot persist

### DIFF
--- a/goproxy/cp/client.go
+++ b/goproxy/cp/client.go
@@ -14,11 +14,13 @@ package cp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
@@ -40,12 +42,39 @@ const (
 	// secretTokenHeader is the shared transport secret header the control plane expects.
 	secretTokenHeader = "x-pm-secret-token"
 	// eventsReconnect is the backoff between Events stream reconnect attempts.
-	eventsReconnect = 5 * time.Second
+	eventsReconnectDefault = 5 * time.Second
+	// eventsStreamMaxAge bounds how long one Events stream is used before it is replaced. HTTP/2 keepalive
+	// proves the CONNECTION is alive, not that the stream on it still reaches a live control plane: a
+	// load balancer that keeps a connection open toward a replaced backend leaves the proxy holding a
+	// stream nothing will ever answer, and because the proxy's other calls are unary they open their own
+	// connections and keep succeeding — so the catalog stays fresh while the control plane reports this
+	// datasource as having no proxy attached, and every query against it is refused. Ending the stream on
+	// a timer makes that state self-healing and bounds it to one period, without needing the control
+	// plane to notice anything.
+	eventsStreamMaxAgeDefault = 4 * time.Minute
 	// keepaliveTime / keepaliveTimeout configure HTTP/2 keepalive so a half-open connection is detected
 	// instead of silently wedging the long-lived Events stream.
 	keepaliveTime    = 30 * time.Second
 	keepaliveTimeout = 10 * time.Second
 )
+
+// Overridable only so tests can shorten them; production always uses the defaults above.
+var (
+	eventsReconnect    = eventsReconnectDefault
+	eventsStreamMaxAge = eventsStreamMaxAgeDefault
+)
+
+func eventsStreamMaxAgeForTest(d time.Duration) func() {
+	prev := eventsStreamMaxAge
+	eventsStreamMaxAge = d
+	return func() { eventsStreamMaxAge = prev }
+}
+
+func eventsReconnectForTest(d time.Duration) func() {
+	prev := eventsReconnect
+	eventsReconnect = d
+	return func() { eventsReconnect = prev }
+}
 
 // Client is the proxy's gRPC client to the control plane. It satisfies engine.Decider.
 type Client struct {
@@ -365,14 +394,20 @@ func (c *Client) CloseConnection(connectionID []byte) error {
 
 // StreamEvents opens the proxy-initiated Events stream and dispatches refresh/run/table-detail
 // nudges until the stream ends or errors. Blocks the calling goroutine for the stream's lifetime.
-// Deliberately NOT deadlined: this is a long-lived liveness stream (the open stream IS the liveness
-// signal the control plane reads), not a unary RPC.
+//
+// Bounded by eventsStreamMaxAge rather than left open indefinitely. The open stream IS the liveness
+// signal the control plane reads, so a stream that survives its control plane costs this datasource
+// every query until something ends it — and nothing here would, because keepalive only proves the
+// connection is alive. Expiry is a normal end: RunEventsLoop resyncs and reopens, and the control
+// plane sees a detach immediately followed by an attach.
 func (c *Client) StreamEvents(
 	onRefresh func(),
 	onOpenRun func(spi.RunOpen),
 	onOpenTableDetail func(sessionID, schema, table string),
 ) error {
-	stream, err := c.stub.Events(c.outCtx(context.Background()), &pb.EventsRequest{DatasourceName: c.datasourceName})
+	ctx, cancel := context.WithTimeout(c.outCtx(context.Background()), eventsStreamMaxAge)
+	defer cancel()
+	stream, err := c.stub.Events(ctx, &pb.EventsRequest{DatasourceName: c.datasourceName})
 	if err != nil {
 		return fmt.Errorf("cp: opening events stream: %w", err)
 	}
@@ -406,7 +441,12 @@ func (c *Client) StreamEvents(
 
 // RunEventsLoop holds the Events stream open and never returns. On a drop it waits eventsReconnect,
 // resyncs (re-registers + re-pushes the catalog, so a control plane that restarted with lost state
-// re-learns this datasource) BEFORE reopening the stream, then reconnects.
+// re-learns this datasource) and reopens.
+//
+// The resync runs in the background rather than in line. It introspects the whole catalog, which on a
+// large database takes seconds and retries with its own backoff — done in line, a slow one delays the
+// reopen, and the control plane reports this datasource unattached for exactly that long. The stream is
+// what queries need; the catalog refresh is not, and it re-registers this datasource either way.
 func (c *Client) RunEventsLoop(
 	resync func(),
 	onRefresh func(),
@@ -415,9 +455,14 @@ func (c *Client) RunEventsLoop(
 ) {
 	for {
 		err := c.StreamEvents(onRefresh, onOpenRun, onOpenTableDetail)
-		slog.Info("events stream ended; reconnecting", "error", err, "reconnect_in", eventsReconnect)
+		// An expiry is the bounded rotation working, not a fault, so it should not read as one in the log.
+		if errors.Is(err, context.DeadlineExceeded) || status.Code(err) == codes.DeadlineExceeded {
+			slog.Info("events stream reached its max age; reopening", "max_age", eventsStreamMaxAge)
+		} else {
+			slog.Info("events stream ended; reconnecting", "error", err, "reconnect_in", eventsReconnect)
+		}
 		time.Sleep(eventsReconnect)
-		resync()
+		go resync()
 	}
 }
 

--- a/goproxy/cp/client_test.go
+++ b/goproxy/cp/client_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -557,5 +558,133 @@ func TestStreamEventsDispatchesMalformedRunOpen(t *testing.T) {
 	_ = c.StreamEvents(func() {}, func(open spi.RunOpen) { openedRun = open }, func(string, string, string) {})
 	if openedRun.SessionID != "bad" || openedRun.MapErr == nil {
 		t.Fatalf("malformed run open was not dispatched with MapErr: %+v", openedRun)
+	}
+}
+
+// holdOpenControlPlane never returns from Events, standing in for a control plane the proxy can reach but
+// which will never send anything — the shape a stream left pointing at a replaced backend takes.
+type holdOpenControlPlane struct {
+	pb.UnimplementedControlPlaneServer
+	mu    sync.Mutex
+	opens int
+	done  chan struct{}
+}
+
+func (f *holdOpenControlPlane) Events(_ *pb.EventsRequest, stream grpc.ServerStreamingServer[pb.ControlEvent]) error {
+	f.mu.Lock()
+	f.opens++
+	if f.opens == 1 && f.done != nil {
+		close(f.done)
+	}
+	f.mu.Unlock()
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+func (f *holdOpenControlPlane) openCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.opens
+}
+
+func startHoldOpenControlPlane(t *testing.T, fake *holdOpenControlPlane) *Client {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := grpc.NewServer()
+	pb.RegisterControlPlaneServer(server, fake)
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(server.Stop)
+
+	client, err := New(listener.Addr().String(), "secret-abc", "ds-1")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func TestStreamEventsEndsAtItsMaxAge(t *testing.T) {
+	// The stream must not outlive its deadline even when the peer sends nothing and the connection stays
+	// healthy. Without the bound this call blocks forever, which is exactly how a proxy ends up holding a
+	// stream to a control plane that is gone: keepalive proves the connection, not the stream.
+	fake := &holdOpenControlPlane{done: make(chan struct{})}
+	c := startHoldOpenControlPlane(t, fake)
+
+	restore := eventsStreamMaxAgeForTest(300 * time.Millisecond)
+	defer restore()
+
+	start := time.Now()
+	err := c.StreamEvents(func() {}, func(spi.RunOpen) {}, func(string, string, string) {})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected the stream to end at its max age")
+	}
+	if status.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("err = %v, want DeadlineExceeded", err)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("took %v — the deadline did not bound the stream", elapsed)
+	}
+}
+
+func TestEventsLoopReopensAfterMaxAge(t *testing.T) {
+	// Ending the stream is only useful if the loop opens another one: the reopen is what restores the
+	// control plane's view of this datasource as attached.
+	fake := &holdOpenControlPlane{done: make(chan struct{})}
+	c := startHoldOpenControlPlane(t, fake)
+
+	restore := eventsStreamMaxAgeForTest(150 * time.Millisecond)
+	defer restore()
+	restoreBackoff := eventsReconnectForTest(10 * time.Millisecond)
+	defer restoreBackoff()
+
+	go c.RunEventsLoop(func() {}, func() {}, func(spi.RunOpen) {}, func(string, string, string) {})
+
+	deadline := time.After(5 * time.Second)
+	for {
+		if fake.openCount() >= 3 {
+			return // rotated more than once, so it is a loop and not a single retry
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("only %d stream opens — the loop did not keep reopening", fake.openCount())
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}
+
+func TestEventsLoopReopensWithoutWaitingForResync(t *testing.T) {
+	// resync introspects the whole catalog and retries with its own backoff. Run in line it delays the
+	// reopen, and the datasource reads as unattached for that whole time — so a resync that never returns
+	// must not stop the stream coming back.
+	fake := &holdOpenControlPlane{done: make(chan struct{})}
+	c := startHoldOpenControlPlane(t, fake)
+
+	restore := eventsStreamMaxAgeForTest(150 * time.Millisecond)
+	defer restore()
+	restoreBackoff := eventsReconnectForTest(10 * time.Millisecond)
+	defer restoreBackoff()
+
+	blocked := make(chan struct{})
+	go c.RunEventsLoop(
+		func() { <-blocked }, // a resync that never finishes
+		func() {}, func(spi.RunOpen) {}, func(string, string, string) {},
+	)
+	defer close(blocked)
+
+	deadline := time.After(5 * time.Second)
+	for {
+		if fake.openCount() >= 3 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("only %d opens with a stuck resync — the reopen is behind it", fake.openCount())
+		case <-time.After(20 * time.Millisecond):
+		}
 	}
 }


### PR DESCRIPTION
The events stream had no deadline, on the reasoning that it is the liveness signal and should stay open. But HTTP/2 keepalive proves the **connection** is alive, not that the stream on it still reaches a live control plane — when a load balancer holds a connection open toward a replaced backend, the proxy keeps a stream nothing will ever answer, and nothing recovers from it.

The failure is quiet in the worst way. The proxy's other calls are unary, so they open their own connections and keep succeeding: the catalog refreshes every twelve minutes while the control plane reports the datasource as having no proxy attached, and every query is refused. The admin view reads `synced just now` and `not connected` simultaneously, both true.

The stream now ends after `eventsStreamMaxAge` and the loop opens another, making that state self-healing and bounded to one period instead of lasting until someone restarts the proxy. Four minutes is short enough that nobody sits through it and long enough that the rotation is not itself churn. An expiry logs as the rotation working rather than a fault.

The resync also moves off the reopen path. It introspects the whole catalog — seconds on a large database, with its own retry and backoff — and in line it delays the reopen by exactly that long, which is time the datasource reads as unattached. The stream is what queries need; the catalog refresh is not, and it re-registers the datasource either way.

Tests cover the deadline firing against a peer that sends nothing, the loop reopening more than once, and a resync that never returns not holding up the reopen. Mutation-tested: removing the deadline hangs the suite, putting resync back in line fails it. Eleven packages green, vet clean.