### PR TITLE
docs: point at the published server images, and verify a partial push

### DIFF
--- a/.github/workflows/server-images.yml
+++ b/.github/workflows/server-images.yml
@@ -111,14 +111,32 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,scope=${{ matrix.name }},mode=max
 
-      # One build produces both registries' tags, but the pushes are sequential and not atomic:
-      # a failure between them leaves one registry on the new digest and the other on the old,
-      # which no step above would report. The role holds no delete, so the repair is another run.
+      # One build produces both registries' tags, but the pushes are sequential and not atomic: a
+      # failure part-way leaves one registry on the new digest and the other on the old, which no
+      # step above reports. The role holds no delete, so the repair is another run.
+      #
+      # This runs after a failed build too, which is when a partial push is possible at all — the
+      # default success() gating would skip it exactly then. With no digest to compare against it
+      # reports what each tag currently resolves to, so the log says which registry moved.
       - name: Check every published tag carries the built digest
+        if: ${{ !cancelled() }}
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
+          if [ -z "$TAGS" ]; then
+            echo "::error::no tags to check — expected the tag list to be set"
+            exit 1
+          fi
+
+          # A build that failed before pushing has no digest. The tags may still have moved, so
+          # report where each one points instead of comparing against nothing.
+          audit_only=false
+          if [ -z "$DIGEST" ]; then
+            echo "::warning::the build published no digest; reporting what each tag resolves to"
+            audit_only=true
+          fi
+
           rc=0
           checked=0
           while IFS= read -r tag; do
@@ -132,17 +150,21 @@ jobs:
               fi
               [ "$attempt" = 3 ] || sleep $((attempt * 5))
             done
-            if [ "$published" = "$DIGEST" ]; then
+            if [ "$audit_only" = true ]; then
+              echo "$tag -> $published"
+            elif [ "$published" = "$DIGEST" ]; then
               echo "ok   $tag -> $published"
             else
               echo "::error::$tag: expected $DIGEST, read '$published'"
               rc=1
             fi
           done <<< "$TAGS"
-          # An empty tag list would otherwise check nothing and report success.
-          if [ "$checked" -eq 0 ] || [ -z "$DIGEST" ]; then
-            echo "::error::verified $checked tags against digest '$DIGEST' — expected both to be set"
+
+          echo "checked $checked tags${DIGEST:+ against $DIGEST}"
+          if [ "$checked" -eq 0 ]; then
+            echo "::error::the tag list produced nothing to check"
             rc=1
           fi
-          echo "verified $checked tags against $DIGEST"
+          # The build's own failure already fails the job; this step only adds what it found.
+          [ "$audit_only" = true ] && exit 0
           exit "$rc"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -675,19 +675,42 @@ directory. The control-plane and proxy images build for both `linux/amd64` and
 `linux/arm64` (Graviton/Fargate) via
 `docker buildx build --platform linux/amd64,linux/arm64`, with no extra flags.
 
+Published images are on Docker Hub, built for both platforms by
+`.github/workflows/server-images.yml` on every `server-v*` tag — pull these
+rather than building your own. `latest` tracks the newest release; a version tag
+pins one:
+
 ```bash
-ACCT=<acct>; REGION=ap-northeast-2; REG=$ACCT.dkr.ecr.$REGION.amazonaws.com
-aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $REG
-
-# proxy + control-plane — build context = repo root
-docker build -f goproxy/Dockerfile       -t $REG/pm-goproxy:0.1.0        .
-docker build -f control-plane/Dockerfile -t $REG/pm-control-plane:0.1.0  .
-# web + auditmon — build context = their own directory
-docker build -t $REG/pm-web:0.1.0        web/
-docker build -t $REG/pm-auditmon:0.1.0   auditmon/
-
-for i in pm-goproxy pm-control-plane pm-web pm-auditmon; do docker push $REG/$i:0.1.0; done
+docker pull ridi/pm-goproxy:0.1.0
+docker pull ridi/pm-control-plane:0.1.0
+docker pull ridi/pm-web:0.1.0
+docker pull ridi/pm-auditmon:0.1.0
 ```
+
+The same images are mirrored on ECR Public, which is worth preferring from AWS —
+pulls do not count against Docker Hub's rate limits and need no account:
+
+```bash
+docker pull public.ecr.aws/w1t1s2q1/pm-goproxy:0.1.0
+docker pull public.ecr.aws/w1t1s2q1/pm-control-plane:0.1.0
+docker pull public.ecr.aws/w1t1s2q1/pm-web:0.1.0
+docker pull public.ecr.aws/w1t1s2q1/pm-auditmon:0.1.0
+```
+
+To build them yourself — note the context differs per image, and is not
+interchangeable:
+
+```bash
+# proxy + control-plane — build context = repo root
+docker build -f goproxy/Dockerfile       -t pm-goproxy:dev        .
+docker build -f control-plane/Dockerfile -t pm-control-plane:dev  .
+# web + auditmon — build context = their own directory
+docker build -t pm-web:dev        web/
+docker build -t pm-auditmon:dev   auditmon/
+```
+
+To host them in your own registry, retag and push there; the ECS task
+definitions below reference `<acct>.dkr.ecr…` for exactly that case.
 
 pmon is not containerized — it's a client binary users install
 (`brew install ridi-oss/tap/pmon`, or `go build -o pmon ./pmon`).


### PR DESCRIPTION
`INSTALL.md` told users to build the four server images themselves and push them to a private ECR. They are published now, so it points at the published ones instead and keeps the build steps for people who want to build.

Also folds in a fix to the digest check added in #45: it was gated on `success()`, so it skipped whenever `build-push-action` failed — the only case where a partial push can happen. It now runs unless the job was canceled, and when there is no digest to compare against it reports what each tag resolves to instead of adding a second failure for the same cause.

## Traps

Documented pulls pin `0.1.0`, which is what is actually published. `server-v0.1.1` was tagged but its images never built — the run failed at assume-role, since the IAM trust policy predates GitHub's immutable OIDC subject format (fixed in ridi/compliance#455). Bump these once a release publishes from a tag.

ECR Public rate-limits anonymous manifest reads with `toomanyrequests`, which looks like a missing image rather than throttling.

## Verification

All eight documented pull commands resolve anonymously, logged out of both registries. `actionlint` clean; the digest check was mutation-tested across eight cases (mismatch, read failure, trailing newline, empty tag list, both audit-mode paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
