### PR TITLE
fix(ci): run the published-digest check after a failed build too

### DIFF
--- a/.github/workflows/server-images.yml
+++ b/.github/workflows/server-images.yml
@@ -111,14 +111,32 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,scope=${{ matrix.name }},mode=max
 
-      # One build produces both registries' tags, but the pushes are sequential and not atomic:
-      # a failure between them leaves one registry on the new digest and the other on the old,
-      # which no step above would report. The role holds no delete, so the repair is another run.
+      # One build produces both registries' tags, but the pushes are sequential and not atomic: a
+      # failure part-way leaves one registry on the new digest and the other on the old, which no
+      # step above reports. The role holds no delete, so the repair is another run.
+      #
+      # This runs after a failed build too, which is when a partial push is possible at all — the
+      # default success() gating would skip it exactly then. With no digest to compare against it
+      # reports what each tag currently resolves to, so the log says which registry moved.
       - name: Check every published tag carries the built digest
+        if: ${{ !cancelled() }}
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
+          if [ -z "$TAGS" ]; then
+            echo "::error::no tags to check — expected the tag list to be set"
+            exit 1
+          fi
+
+          # A build that failed before pushing has no digest. The tags may still have moved, so
+          # report where each one points instead of comparing against nothing.
+          audit_only=false
+          if [ -z "$DIGEST" ]; then
+            echo "::warning::the build published no digest; reporting what each tag resolves to"
+            audit_only=true
+          fi
+
           rc=0
           checked=0
           while IFS= read -r tag; do
@@ -132,17 +150,21 @@ jobs:
               fi
               [ "$attempt" = 3 ] || sleep $((attempt * 5))
             done
-            if [ "$published" = "$DIGEST" ]; then
+            if [ "$audit_only" = true ]; then
+              echo "$tag -> $published"
+            elif [ "$published" = "$DIGEST" ]; then
               echo "ok   $tag -> $published"
             else
               echo "::error::$tag: expected $DIGEST, read '$published'"
               rc=1
             fi
           done <<< "$TAGS"
-          # An empty tag list would otherwise check nothing and report success.
-          if [ "$checked" -eq 0 ] || [ -z "$DIGEST" ]; then
-            echo "::error::verified $checked tags against digest '$DIGEST' — expected both to be set"
+
+          echo "checked $checked tags${DIGEST:+ against $DIGEST}"
+          if [ "$checked" -eq 0 ]; then
+            echo "::error::the tag list produced nothing to check"
             rc=1
           fi
-          echo "verified $checked tags against $DIGEST"
+          # The build's own failure already fails the job; this step only adds what it found.
+          [ "$audit_only" = true ] && exit 0
           exit "$rc"


### PR DESCRIPTION
The published-digest check added in #45 was gated on `success()` by default, so it was skipped whenever `build-push-action` failed — the only situation in which a partial push can occur. It confirmed successful pushes and nothing else, which is not what its comment claimed.

It now runs unless the job was canceled. A build that failed before pushing leaves no digest to compare against, so the step reports what each tag currently resolves to and leaves the verdict to the build step rather than adding a second failure for the same cause.

Confirmed in the live `server-v0.1.1` run: step 11 was `skipped`.

## Verification

`actionlint` clean. Mutation-tested across eight cases — mismatch, read failure, trailing newline, empty tag list, and both audit-mode paths. Mismatches and read failures fail; audit mode never adds a failure; an empty tag list fails rather than passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
