### PR TITLE
fix(cp): compare only the host on the /mcp authority gate

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -176,13 +176,14 @@ must be listed in `PM_TRUSTED_PROXIES`, by the socket-peer address the CP sees �
 a literal address, or a CIDR block when the edge autoscales and its address is
 not knowable in advance. That list is what lets the CP read `X-Forwarded-For`
 (requester IP), `X-Forwarded-Proto` (the SCIM TLS gate), and `X-Forwarded-Host`
-(the authority the client addressed, which the `/mcp` check compares against
-`PM_MCP_RESOURCE`). Unlisted, those headers are ignored and the CP uses the
-socket's own facts — so a chained proxy that is not listed makes `/mcp` return
-`403 mcp.invalid_host` and SCIM return `403`, while the console's own `/api` and
-`/auth` traffic keeps working. Set `PM_MCP_RESOURCE` to the public origin
-whatever the topology: the OAuth issuer is derived from it and is deliberately
-never inferred from request headers.
+(the host the client addressed, which the `/mcp` check compares against
+`PM_MCP_RESOURCE`'s host — only the host, never the port, which a client omits
+when it is the scheme default). Unlisted, those headers are ignored and the CP
+uses the socket's own facts — so a chained proxy that is not listed makes `/mcp`
+return `403 mcp.invalid_host` and SCIM return `403`, while the console's own
+`/api` and `/auth` traffic keeps working. Set `PM_MCP_RESOURCE` to the public
+origin whatever the topology: the OAuth issuer is derived from it and is
+deliberately never inferred from request headers.
 
 ## Ports and protocols
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,15 +67,14 @@ configured per proxy under `PM_TARGET_*`.
 - `PM_TRUSTED_PROXIES` — _optional, set behind an LB_. Comma-separated
   socket-peer addresses or CIDR blocks of the edges trusted to assert forwarded
   headers about a request: `X-Forwarded-For` for client-IP attestation,
-  `X-Forwarded-Proto` for the SCIM TLS gate, and `X-Forwarded-Host` for the
-  authority the `/mcp` check compares. Empty (default) ignores all three and
-  uses the socket's own facts, so SCIM then requires direct HTTPS and `/mcp`
-  sees the proxy's authority. Example: `10.20.1.15,10.20.2.15`, or
-  `10.20.0.0/16` for an autoscaled edge whose address is not knowable in
-  advance. A block must cover only hops you operate — anything inside it can
-  assert its own client IP, so prefer the narrowest prefix that covers the edge.
-  Entries that are neither an address nor a valid block are ignored and logged
-  at startup.
+  `X-Forwarded-Proto` for the SCIM TLS gate, and `X-Forwarded-Host` for the host
+  the `/mcp` check compares. Empty (default) ignores all three and uses the
+  socket's own facts, so SCIM then requires direct HTTPS and `/mcp` sees the
+  proxy's authority. Example: `10.20.1.15,10.20.2.15`, or `10.20.0.0/16` for an
+  autoscaled edge whose address is not knowable in advance. A block must cover
+  only hops you operate — anything inside it can assert its own client IP, so
+  prefer the narrowest prefix that covers the edge. Entries that are neither an
+  address nor a valid block are ignored and logged at startup.
 
   An edge you list here must **overwrite** the forwarded headers it asserts,
   from its own view of the connection — never relay a client-supplied value. An
@@ -463,16 +462,20 @@ server. Set `PM_MCP_RESOURCE="https://<host>/mcp"` to that public origin. With
 `PM_AUTH_DEBUG=false` it must be HTTPS, and you additionally need a non-default
 32+ character `PM_SESSION_SECRET`, all `PM_OIDC_*` values, and an OIDC redirect
 URI exactly equal to `https://<host>/auth/oidc/callback`. If a reverse proxy
-terminates TLS in front of control-plane (as any real deployment's will), its
-forwarded `Host` header must carry the exact public authority — hostname and
-port (`:443` for the implicit HTTPS default) — that `PM_MCP_RESOURCE` declares:
-control-plane's `/mcp` guard validates the request's host/port strictly against
-that configured value and has no `ForwardedHeaders`/`XForwardedHeaders` plugin,
-so it never derives this from `X-Forwarded-*` either — only the literal `Host`
-(or HTTP/2 `:authority`) the backend receives. A proxy that forwards the
-original client-facing Host unmodified usually satisfies this already; one that
-strips the port or substitutes its own backend address needs an explicit
-host-rewrite rule, or every `/mcp` call gets a fail-closed
+terminates TLS in front of control-plane (as any real deployment's will), the
+host the backend sees must equal the host `PM_MCP_RESOURCE` declares:
+control-plane's `/mcp` guard compares that host strictly, and only the host. The
+port is never compared — behind a TLS-terminating edge the backend is reached on
+its own cleartext port, and a client's `Host` omits the port whenever it is the
+scheme default, so requiring one would reject every such request. It reads the
+literal `Host` (or HTTP/2 `:authority`) the backend receives, plus
+`X-Forwarded-Host` when the socket peer is listed in `PM_TRUSTED_PROXIES`; there
+is no `ForwardedHeaders`/`XForwardedHeaders` plugin, so nothing else is derived
+from `X-Forwarded-*`. A proxy that forwards the original client-facing hostname
+satisfies this already, whether or not it keeps the port. One that substitutes
+its own backend address in `Host` — an AWS ALB does this unless
+`preserve_host_header` is enabled — must either be fixed to preserve it or send
+`X-Forwarded-Host` from a trusted peer, or every `/mcp` call gets a fail-closed
 `403 mcp.invalid_host` instead of the expected `401` OAuth challenge. Configure
 the MCP client with the resource URL only — never a separate
 authorization-server URL, there isn't one — and it discovers OAuth through

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -262,6 +262,13 @@ tagging, table detail) and never feeds an enforcement decision.
 
 ## Authz / policy
 
+- 🟡 An IPv6-literal `PM_MCP_RESOURCE` is reachable only behind a trusted edge.
+  The `/mcp` host gate resolves the client-addressed host through Ktor's
+  `host()`, which splits a direct `Host: [::1]` at the literal's first colon and
+  yields `[` — so the comparison fails and every direct request gets
+  `403 mcp.invalid_host`. `X-Forwarded-Host` from a peer in `PM_TRUSTED_PROXIES`
+  is parsed by proxy-monster's own bracket-aware path and works. Use a hostname,
+  or front the control plane with a trusted edge.
 - 🔴 Role-approval `Request` EUID is not request-unique.
   `Request::"<requester>#<datasource>"` omits the request id and requested role,
   so one approval policy authorizes every later request that principal makes for

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Config.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Config.kt
@@ -68,8 +68,8 @@ data class Config(
     // to assert forwarded headers about a request — e.g. a load balancer or reverse proxy terminating TLS
     // in front of the HTTP API. THREE headers are trusted from such a peer: `X-Forwarded-For` for
     // requester_ip (resolveHttpRequesterIp), `X-Forwarded-Proto` for the SCIM TLS gate (resolveScimTls),
-    // and `X-Forwarded-Host`/`X-Forwarded-Port` for the authority the client addressed
-    // (resolveForwardedAuthority, which the /mcp host check compares against PM_MCP_RESOURCE).
+    // and `X-Forwarded-Host` for the host the client addressed (resolveForwardedAuthority, which the
+    // /mcp host check compares against PM_MCP_RESOURCE).
     // Empty (the default) means NO edge is trusted: every one of them is ignored, so requester_ip is the
     // raw socket peer, a plaintext request can never pass the SCIM TLS gate, and the /mcp check sees the
     // socket authority — the fail-closed posture, since an untrusted client can set any of them to anything.

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RequesterIp.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RequesterIp.kt
@@ -124,8 +124,14 @@ internal fun resolveHttpRequesterIp(peerAddress: String?, xff: String?, trustedP
 }
 
 /**
- * The authority (`host` or `host:port`) the CLIENT addressed, for the checks that compare a request's
- * target against a configured public identity — today the `/mcp` host check (McpServer.kt).
+ * The HOST the CLIENT addressed, for the checks that compare a request's target against a configured
+ * public identity — today the `/mcp` host check (McpServer.kt).
+ *
+ * Host only, never a port. Behind a TLS-terminating edge the backend is reached on its own cleartext
+ * port, and a client's `Host` omits the port whenever it is the scheme default, so a port comparison
+ * rejects every request in the deployment shape the check exists to serve. It also buys nothing — an
+ * attacker who controls the host names any port they like. (The port of a browser-facing request is
+ * still enforced, by the `Origin` check's scheme+host+port comparison in McpServer.kt.)
  *
  * Direct `Host` is a fact of the request. `X-Forwarded-Host` is client-settable, so it is honored ONLY
  * when the socket peer is a configured trusted edge — [isTrustedEdge], the same
@@ -134,22 +140,19 @@ internal fun resolveHttpRequesterIp(peerAddress: String?, xff: String?, trustedP
  * would be bypassable by asserting a header, which is the DNS-rebinding defense it exists to provide.
  *
  * A multi-hop value takes the RIGHTMOST entry — the one THIS edge appended; everything left of it is
- * client-supplied. `X-Forwarded-Host` may itself carry a port; when it does not, [forwardedPort]
- * supplies one, so an edge that splits authority across the two headers still resolves correctly.
- * Falls back to the direct authority whenever the peer is untrusted or the header is absent/blank, so
- * a deployment with no edge behaves exactly as before.
+ * client-supplied. A port in `X-Forwarded-Host` is parsed off and discarded rather than left on the
+ * host, so `cp.example.com:8443` compares as `cp.example.com`. Falls back to the direct host whenever
+ * the peer is untrusted or the header is absent/blank, which is also the correct answer for an edge
+ * that preserves the client `Host` and sends no `X-Forwarded-Host` at all.
  */
 internal fun resolveForwardedAuthority(
     directHost: String,
-    directPort: Int,
     peerAddress: String?,
     forwardedHost: String?,
-    forwardedPort: String?,
     trustedProxies: Set<String>,
-): Pair<String, Int?> {
-    val direct = directHost to directPort
-    if (!isTrustedEdge(peerAddress, trustedProxies)) return direct
-    val asserted = forwardedHost?.split(',')?.lastOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: return direct
+): String {
+    if (!isTrustedEdge(peerAddress, trustedProxies)) return directHost
+    val asserted = forwardedHost?.split(',')?.lastOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: return directHost
     // An IPv6 literal authority is bracketed (`[::1]:443`), so only split a port off the LAST colon and
     // only when it follows the closing bracket — otherwise `[::1]` would be shredded at its first colon.
     val lastColon = asserted.lastIndexOf(':')
@@ -157,10 +160,7 @@ internal fun resolveForwardedAuthority(
         lastColon < asserted.length - 1 &&
         asserted.drop(lastColon + 1).all(Char::isDigit)
     val host = if (hasPort) asserted.take(lastColon) else asserted
-    val portFromHost = if (hasPort) asserted.drop(lastColon + 1).toIntOrNull() else null
-    val port = portFromHost
-        ?: forwardedPort?.split(',')?.lastOrNull()?.trim()?.toIntOrNull()
-    return host.removeSurrounding("[", "]") to port
+    return host.removeSurrounding("[", "]")
 }
 
 /**

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/mcp/McpServer.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/mcp/McpServer.kt
@@ -31,7 +31,6 @@ import io.ktor.server.application.ApplicationCallPipeline
 import io.ktor.server.application.call
 import io.ktor.server.request.host
 import io.ktor.server.request.path
-import io.ktor.server.request.port
 import io.ktor.server.response.header
 import io.ktor.server.response.respond
 import io.ktor.server.routing.get
@@ -95,27 +94,25 @@ fun Application.installMcp(
     val metadataUri = protectedResourceMetadataUri(config.mcpResource)
     val resourceUri = URI(config.mcpResource)
     val resourceOrigin = URI(resourceUri.scheme, null, resourceUri.host, resourceUri.port, null, null, null)
+    // Java exposes an IPv6 URI host bracketed (`[::1]`) while a request authority resolves to the bare
+    // address, so both sides are unbracketed before they are compared.
+    val resourceHost = resourceUri.host.removeSurrounding("[", "]")
 
     intercept(ApplicationCallPipeline.Plugins) {
         if (call.request.path() != "/mcp") return@intercept
-        // The client-addressed authority, not the socket's. Ktor normalizes HTTP/1.1 Host and HTTP/2
-        // :authority through host()/port(), so reading the literal Host header would reject every HTTP/2
-        // request; behind a reverse proxy that authority is the PROXY's, so a trusted edge's
-        // X-Forwarded-Host supersedes it (resolveForwardedAuthority — honored only from a peer in
-        // PM_TRUSTED_PROXIES, so a direct caller still cannot assert its way past this check).
-        val (host, port) = resolveForwardedAuthority(
+        // The client-addressed host, not the socket's. Ktor normalizes HTTP/1.1 Host and HTTP/2
+        // :authority through host(), so reading the literal Host header would reject every HTTP/2
+        // request; behind a reverse proxy that authority is the PROXY's unless the edge preserves the
+        // client Host, so a trusted edge's X-Forwarded-Host supersedes it (resolveForwardedAuthority —
+        // honored only from a peer in PM_TRUSTED_PROXIES, so a direct caller still cannot assert its
+        // way past this check).
+        val host = resolveForwardedAuthority(
             directHost = call.request.host(),
-            directPort = call.request.port(),
             peerAddress = call.request.local.remoteAddress,
             forwardedHost = call.request.headers["X-Forwarded-Host"],
-            forwardedPort = call.request.headers["X-Forwarded-Port"],
             trustedProxies = config.trustedProxies,
         )
-        // A forwarded authority carrying no port means the edge's default for its scheme, which
-        // effectivePort() already encodes for the configured resource — so an absent port matches.
-        if (!host.equals(resourceUri.host, ignoreCase = true) ||
-            (port != null && port != resourceUri.effectivePort())
-        ) {
+        if (!host.removeSurrounding("[", "]").equals(resourceHost, ignoreCase = true)) {
             call.respond(HttpStatusCode.Forbidden, ApiError("mcp.invalid_host"))
             finish()
             return@intercept
@@ -152,8 +149,8 @@ fun Application.installMcp(
     mcpStatelessStreamableHttp(
         path = "/mcp",
         // The SDK's built-in guard reads the HTTP/1.1 Host header literally and rejects HTTP/2
-        // :authority as missing. The interceptor above enforces the configured authority through
-        // Ktor's protocol-neutral host()/port() view and validates Origin before authentication.
+        // :authority as missing. The interceptor above enforces the configured host through Ktor's
+        // protocol-neutral host() view and validates Origin before authentication.
         enableDnsRebindingProtection = false,
     ) {
         val requestContext = call.attributes[MCP_CONTEXT]

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ForwardedAuthorityTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ForwardedAuthorityTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * [resolveForwardedAuthority] — which authority the client addressed, for the `/mcp` host check
+ * [resolveForwardedAuthority] — which host the client addressed, for the `/mcp` host check
  * (McpServer.kt). The invariant is the one [resolveHttpRequesterIp] enforces for `X-Forwarded-For` and
  * [resolveScimTls] for `X-Forwarded-Proto`: a client-settable header may speak for the request ONLY when
  * the socket peer is a configured trusted edge.
@@ -16,30 +16,29 @@ import kotlin.test.assertTrue
  * and the Host comparison is what makes that request fail. If `X-Forwarded-Host` were honored from any
  * peer, asserting one header would bypass it, so the header must buy nothing without the edge's socket
  * address behind it.
+ *
+ * Resolution is host-only. [aPortIsNeverPartOfTheResolvedHost] pins that: a TLS-terminating edge makes
+ * the addressed port unobservable, so carrying one through only reintroduces a comparison that rejects
+ * every request behind such an edge.
  */
 class ForwardedAuthorityTest {
     private val edge = setOf("10.0.0.1")
 
     @Test
-    fun `with no trusted edge the direct authority is used`() {
-        assertEquals(
-            "cp.example.com" to 443,
-            resolveForwardedAuthority("cp.example.com", 443, "203.0.113.9", null, null, emptySet()),
-        )
+    fun `with no trusted edge the direct host is used`() {
+        assertEquals("cp.example.com", resolveForwardedAuthority("cp.example.com", "203.0.113.9", null, emptySet()))
     }
 
     @Test
     fun `forwardedHostFromAnUntrustedPeerIsIgnored`() {
         // The security case: a direct caller asserting the expected public host must not pass a check it
-        // would otherwise fail. The direct authority wins, so the comparison still rejects it.
+        // would otherwise fail. The direct host wins, so the comparison still rejects it.
         assertEquals(
-            "127.0.0.1" to 8080,
+            "127.0.0.1",
             resolveForwardedAuthority(
                 directHost = "127.0.0.1",
-                directPort = 8080,
                 peerAddress = "203.0.113.9",
                 forwardedHost = "cp.example.com",
-                forwardedPort = "443",
                 trustedProxies = edge,
             ),
         )
@@ -49,30 +48,23 @@ class ForwardedAuthorityTest {
     fun `a trusted edge's forwarded host supersedes the proxy's own authority`() {
         // The deployment this exists for: an edge (or the Next console) forwards to the control plane, so
         // the socket authority is the proxy's and only the header carries what the client addressed.
-        assertEquals(
-            "cp.example.com" to 443,
-            resolveForwardedAuthority("127.0.0.1", 41390, "10.0.0.1", "cp.example.com", "443", edge),
-        )
+        assertEquals("cp.example.com", resolveForwardedAuthority("127.0.0.1", "10.0.0.1", "cp.example.com", edge))
     }
 
     @Test
-    fun `a port in the forwarded host wins over a separate forwarded port header`() {
-        // An edge may split the authority across the two headers or put it all in one; when both are
-        // present and disagree, the authority the client actually addressed is the one in Host.
-        assertEquals(
-            "cp.example.com" to 8443,
-            resolveForwardedAuthority("127.0.0.1", 41390, "10.0.0.1", "cp.example.com:8443", "443", edge),
-        )
+    fun `an edge that preserves the client host needs no forwarded header`() {
+        // An ALB with preserve_host_header forwards the client's Host untouched and sends no
+        // X-Forwarded-Host at all. The direct host is then already what the client addressed, so the
+        // absent header must fall back to it rather than resolve to the socket's own name.
+        assertEquals("cp.example.com", resolveForwardedAuthority("cp.example.com", "10.0.0.1", null, edge))
     }
 
     @Test
-    fun `a forwarded host with no port anywhere resolves the port as absent`() {
-        // Absent means "the edge's default for its scheme", which the caller compares as a match rather
-        // than guessing 80 vs 443 here — guessing would reject a correct request on the other scheme.
-        assertEquals(
-            "cp.example.com" to null,
-            resolveForwardedAuthority("127.0.0.1", 41390, "10.0.0.1", "cp.example.com", null, edge),
-        )
+    fun `aPortIsNeverPartOfTheResolvedHost`() {
+        // Whatever port the edge asserts, the result is the bare host: the caller compares hosts, and a
+        // port left dangling on the string would fail that compare (`cp.example.com:8443` != host).
+        assertEquals("cp.example.com", resolveForwardedAuthority("127.0.0.1", "10.0.0.1", "cp.example.com:8443", edge))
+        assertEquals("cp.example.com", resolveForwardedAuthority("127.0.0.1", "10.0.0.1", "cp.example.com:443", edge))
     }
 
     @Test
@@ -80,8 +72,8 @@ class ForwardedAuthorityTest {
         // Same convention as X-Forwarded-For: the rightmost entry is the one THIS edge appended;
         // everything left of it came from an upstream hop and is not attested.
         assertEquals(
-            "cp.example.com" to 443,
-            resolveForwardedAuthority("127.0.0.1", 41390, "10.0.0.1", "evil.example.net, cp.example.com", "443", edge),
+            "cp.example.com",
+            resolveForwardedAuthority("127.0.0.1", "10.0.0.1", "evil.example.net, cp.example.com", edge),
         )
     }
 
@@ -89,22 +81,22 @@ class ForwardedAuthorityTest {
     fun `a bracketed IPv6 authority is unwrapped without being split at its own colons`() {
         // A naive split on the first colon shreds `[::1]:8443` into host `[` — so the port is only taken
         // from a colon that follows the closing bracket.
-        assertEquals("::1" to 8443, resolveForwardedAuthority("127.0.0.1", 41390, "10.0.0.1", "[::1]:8443", null, edge))
-        assertEquals("::1" to null, resolveForwardedAuthority("127.0.0.1", 41390, "10.0.0.1", "[::1]", null, edge))
+        assertEquals("::1", resolveForwardedAuthority("127.0.0.1", "10.0.0.1", "[::1]:8443", edge))
+        assertEquals("::1", resolveForwardedAuthority("127.0.0.1", "10.0.0.1", "[::1]", edge))
     }
 
     @Test
     fun `a blank or non-numeric-port forwarded host falls back rather than resolving a partial authority`() {
         assertEquals(
-            "127.0.0.1" to 41390,
-            resolveForwardedAuthority("127.0.0.1", 41390, "10.0.0.1", "   ", null, edge),
+            "127.0.0.1",
+            resolveForwardedAuthority("127.0.0.1", "10.0.0.1", "   ", edge),
             "a blank header carries nothing to honor",
         )
-        // `cp.example.com:` and `cp.example.com:https` are not host:port — the trailing text is part of
-        // the host, so the comparison fails rather than silently accepting `cp.example.com`.
+        // `cp.example.com:https` is not host:port — the trailing text is part of the host, so the
+        // comparison fails rather than silently accepting `cp.example.com`.
         assertEquals(
-            "cp.example.com:https" to null,
-            resolveForwardedAuthority("127.0.0.1", 41390, "10.0.0.1", "cp.example.com:https", null, edge),
+            "cp.example.com:https",
+            resolveForwardedAuthority("127.0.0.1", "10.0.0.1", "cp.example.com:https", edge),
         )
     }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/McpServerDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/McpServerDbTest.kt
@@ -108,6 +108,85 @@ class McpServerDbTest {
     }
 
     @Test
+    fun `an https resource admits a cleartext-forwarded request whose Host carries no port`() = testApplication {
+        // The production shape behind a TLS-terminating edge: the resource is https (default port 443),
+        // the edge forwards cleartext to the container, and the client's Host omits the port because it
+        // is the scheme default. The gate must clear the host and move on to the bearer check — reaching
+        // `common.invalid_token` (not `mcp.invalid_host`) is what proves the authority matched.
+        application { installTestMcp("https://console.example.com/mcp") }
+        val client = createClient {
+            expectSuccess = false
+            install(ClientContentNegotiation) { json(TEST_JSON) }
+        }
+        val response = client.post("/mcp") {
+            acceptMcp()
+            header(HttpHeaders.Host, "console.example.com")
+            setBody(toolCall(1, "list_roles"))
+        }
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        assertEquals(
+            "common.invalid_token",
+            TEST_JSON.parseToJsonElement(response.bodyAsText()).jsonObject["code"]?.jsonPrimitive?.content,
+        )
+
+        // A port on the Host is ignored, not compared. `:443` alone would also pass an implementation
+        // that compared EFFECTIVE default ports, so the case that actually pins the property is a
+        // non-default port against an https resource: it must still reach the bearer check.
+        for (authority in listOf("console.example.com:443", "console.example.com:8443")) {
+            val withPort = client.post("/mcp") {
+                acceptMcp()
+                header(HttpHeaders.Host, authority)
+                setBody(toolCall(2, "list_roles"))
+            }
+            assertEquals(HttpStatusCode.Unauthorized, withPort.status, authority)
+        }
+
+        // The host is still enforced: a foreign name on the same listener is refused.
+        val foreign = client.post("/mcp") {
+            acceptMcp()
+            header(HttpHeaders.Host, "evil.example")
+            setBody(toolCall(3, "list_roles"))
+        }
+        assertEquals(HttpStatusCode.Forbidden, foreign.status)
+        assertEquals("mcp.invalid_host", TEST_JSON.parseToJsonElement(foreign.bodyAsText()).jsonObject["code"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `an IPv6 literal resource host matches a forwarded authority`() = testApplication {
+        // Java exposes an IPv6 URI host bracketed (`[::1]`) while a forwarded authority resolves to the
+        // bare address, so comparing them raw rejects every request to a valid IPv6 resource.
+        //
+        // Only the FORWARDED path is asserted. Ktor's own `host()` shreds a direct `Host: [::1]` at the
+        // literal's first colon and yields `[`, so an IPv6 resource reached without a trusted edge is
+        // unreachable for a reason that lives upstream of this gate (KNOWN_LIMITATIONS.md).
+        // testApplication's peer address is the literal string "localhost", which only isTrustedEdge's
+        // exact-match arm accepts (it never resolves a hostname — see TrustedEdgeCidrTest).
+        application { installTestMcp("http://[::1]/mcp", trustedProxies = setOf("localhost")) }
+        val client = createClient {
+            expectSuccess = false
+            install(ClientContentNegotiation) { json(TEST_JSON) }
+        }
+        val response = client.post("/mcp") {
+            acceptMcp()
+            header("X-Forwarded-Host", "[::1]")
+            setBody(toolCall(1, "list_roles"))
+        }
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        assertEquals(
+            "common.invalid_token",
+            TEST_JSON.parseToJsonElement(response.bodyAsText()).jsonObject["code"]?.jsonPrimitive?.content,
+        )
+
+        val foreign = client.post("/mcp") {
+            acceptMcp()
+            header("X-Forwarded-Host", "[::2]")
+            setBody(toolCall(2, "list_roles"))
+        }
+        assertEquals(HttpStatusCode.Forbidden, foreign.status)
+        assertEquals("mcp.invalid_host", TEST_JSON.parseToJsonElement(foreign.bodyAsText()).jsonObject["code"]?.jsonPrimitive?.content)
+    }
+
+    @Test
     fun `tool catalog is complete localized and scope cannot grant a write`() = testApplication {
         application { installTestMcp() }
         val principal = "mcp-catalog@example.com"
@@ -363,7 +442,10 @@ class McpServerDbTest {
         }
     }
 
-    private fun io.ktor.server.application.Application.installTestMcp() {
+    private fun io.ktor.server.application.Application.installTestMcp(
+        mcpResource: String = RESOURCE,
+        trustedProxies: Set<String> = emptySet(),
+    ) {
         install(ContentNegotiation) { json(TEST_JSON) }
         val datasourceService = DatasourceManagementService(core.datasourceStore, core.proxyEventsHub, TableDetailService(core))
         val policyService = PolicyManagementService(core.cedarPolicyStore, core.policyStore)
@@ -371,7 +453,7 @@ class McpServerDbTest {
             dataSource, core.userGroupStore, core.policyStore, core.tokenStore, core.accessStore,
             PrincipalSessionStore(dataSource, null),
         )
-        installMcp(config(), core, datasourceService, policyService, identityService)
+        installMcp(config(mcpResource, trustedProxies), core, datasourceService, policyService, identityService)
     }
 
     private fun io.ktor.client.request.HttpRequestBuilder.acceptMcp(token: String? = null) {
@@ -475,7 +557,7 @@ class McpServerDbTest {
         assertNotNull(result.structuredContent)
     }
 
-    private fun config() = Config(
+    private fun config(mcpResource: String = RESOURCE, trustedProxies: Set<String> = emptySet()) = Config(
         httpPort = 0,
         dbUrl = "",
         dbUser = "",
@@ -489,7 +571,8 @@ class McpServerDbTest {
         sessionWindowSeconds = 3_600,
         idpRecheckIntervalSeconds = 600,
         devMarker = false,
-        mcpResource = RESOURCE,
+        mcpResource = mcpResource,
+        trustedProxies = trustedProxies,
     )
 
     private companion object {


### PR DESCRIPTION
## What

The `/mcp` authority gate compared both **host and port** against `PM_MCP_RESOURCE`. It now compares only the host.

## Why

No request can satisfy the port comparison behind a TLS-terminating edge: the backend is reached on its own cleartext port, and a client's `Host` omits the port whenever it is the scheme default — so the resolved port could never equal the resource's 443. Every `/mcp` call returned `403 mcp.invalid_host`, which surfaced in an MCP client as a completed OAuth flow followed by a rejected reconnect.

The port bought nothing anyway. An attacker who controls the host names any port they like, and a browser-facing request still has its port enforced by the `Origin` check's scheme+host+port comparison. The host check stays — it is the DNS-rebinding defense the MCP spec calls for.

`resolveForwardedAuthority` now returns the host alone rather than a `(host, port)` pair, so a later caller cannot reintroduce the comparison.

## Also: IPv6 brackets

Java exposes a URI host bracketed (`[::1]`) while a forwarded authority resolves to the bare address, so an IPv6 `PM_MCP_RESOURCE` was rejected behind a trusted edge. Both sides are now unbracketed at the comparison.

The **direct-`Host`** path stays broken for an IPv6 literal — Ktor's own `host()` splits it at the literal's first colon and yields `[`. That is pre-existing and unchanged here; it is now recorded in `KNOWN_LIMITATIONS.md` rather than left undocumented.

## Where it could bite

A deployment relying on the port to distinguish two resources on the same hostname loses that distinction. Nothing in-tree does, and audience binding (`resolveAccess(token, mcpResource)`) still matches the full resource string including port, so a token minted for one resource is not valid at another.

## Verification

`mise run verify` green. Both regression tests are **mutation-checked** — each fails when the removed comparison is restored, so they cannot pass vacuously. The port case uses a **non-default** port (`:8443`): `:443` alone also passes an implementation that compares *effective default* ports, so it never pinned the property.

Confirmed live on a dev deployment: `/mcp` went from `403 mcp.invalid_host` to authenticating end to end. That needed a matching infra change — the ALB was also replacing `Host` (ridi/ridi#31176).

Reviewed by Codex, Sol, and Grok. No reviewer found a rebinding exploit from dropping the port; every valid finding they raised is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK83USBkxzao4uFfjxzy8n