### PR TITLE
fix(cp): return the principal's resolved roles from /auth/me

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -715,7 +715,11 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
         authenticate(WEB_SESSION_AUTH) {
             get("/auth/me") {
                 call.response.header(HttpHeaders.CacheControl, "no-store")
-                call.respond(UserSession(requireNotNull(call.principal<WebSessionRow>()).principal))
+                // Resolved per request, never carried in the session: a role gained or lost after
+                // login (group change, expired JIT grant, deactivation) must be visible to the next
+                // read, and the console shows this set while explaining a decision.
+                val principal = requireNotNull(call.principal<WebSessionRow>()).principal
+                call.respond(UserSession(principal, roleResolver.resolve(principal).sorted()))
             }
 
             get("/auth/session/status") {

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/WebSessionRoutesDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/WebSessionRoutesDbTest.kt
@@ -176,7 +176,10 @@ class WebSessionRoutesDbTest {
         assertContains(deviceCookie, "HttpOnly")
         assertContains(deviceCookie, "SameSite=Lax")
         assertEquals(UserSession("web@example.com", listOf("system:auditor")), login.body())
-        assertEquals(UserSession("web@example.com"), client.get("/auth/me").body())
+        // /auth/me re-resolves rather than echoing the session: the console reads this to show who it
+        // thinks you are, so reporting an empty set for a principal that holds roles misdescribes
+        // every later denial.
+        assertEquals(UserSession("web@example.com", listOf("system:auditor")), client.get("/auth/me").body())
 
         // The claim is not cosmetic: it became a direct assignment, so authorization (which reads the database,
         // never the session) actually sees it. Without this the route could echo any role back and still resolve


### PR DESCRIPTION
## What

`/auth/me` now returns the principal's resolved roles. It built `UserSession(principal)` and let the roles field take its empty-list default, so **every** session reported "no roles" regardless of what the principal held.

## Why it matters

The console renders that set in the identity menu. An admin with five group-derived roles was described as having none — misleading exactly when someone is reading it to work out why a query was denied. The sibling debug-login path a few lines above already passed roles; this route was the one that forgot.

Roles are resolved per request rather than carried in the session, so a role gained or lost after login (group change, expired JIT grant, deactivation) is visible to the next read instead of persisting until the session ends.

## Where it could bite

One `RoleResolver.resolve` per `/auth/me` call — three indexed lookups (direct assignments, group-derived, active grants). The route is polled by the console at session-status cadence, not per keystroke.

No authorization change: every gate already resolved roles server-side and never trusted the session's list. This only fixes what is *reported*.

## Verification

`mise run verify` green (853 tests). The route's own test asserted the empty set, so it passed on the defect — it now asserts the granted role, and is mutation-checked: removing the resolve makes it fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK83USBkxzao4uFfjxzy8n