### PR TITLE
perf(cp): open a session from the catalog already held

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -464,6 +464,21 @@ path and `POST /api/datasources/{id}/query`, not the interactive editor.
   admission so passthrough only ever sees a pure session statement. Hard gate:
   per-statement re-decide (or an explicit session-mutation refusal) must remain
   the standing mitigation.
+- 🟡 Catalog adoption assumes one backend behind a datasource. On MySQL a new
+  connection may start from catalog content the control plane already holds
+  rather than measuring the backend itself, so its first statement decides
+  without a round-trip. That is sound because every backend session for a
+  datasource is opened by one proxy process against one target with one service
+  account, which is what makes a catalog scan the same for every connection —
+  MySQL temporary tables never appear in `information_schema` and reach a
+  decision through the per-request overlay instead. Two changes would break it
+  silently: running several proxies for one datasource against backends that can
+  disagree (a replica behind a load balancer, mid-failover), or varying backend
+  credentials per session, since `information_schema` is privilege-filtered and
+  two accounts legitimately see different columns. An adopting connection would
+  then decide against structure its own backend never had. PostgreSQL never
+  adopts: its `pg_temp_*` schemas are per-session and catalog-visible, so a
+  fragment there is only true for the connection that measured it.
 - 🟡 No concurrent-editor-session cap (auth'd DoS surface). Each open session
   pins ONE unpooled backend connection on the proxy for the life of its run
   stream, which `RUN_STREAM_TIMEOUT_MS` caps at 15 minutes. The proxy releases
@@ -480,10 +495,12 @@ path and `POST /api/datasources/{id}/query`, not the interactive editor.
   idle sweep, explicit close, or cleanup after a failed query. Neither TTL is a
   flat constant: both are floors that grow with `PM_QUERY_TIMEOUT` so a token
   never expires under the statement it authorizes. The editor session token
-  requests max(8h, `PM_QUERY_TIMEOUT` + 120s); the one-shot `run` token — the
+  requests max(8h, `PM_QUERY_TIMEOUT` + 180s); the one-shot `run` token — the
   approval-execute path and `POST /api/datasources/{id}/query` — requests
-  max(300s, `PM_QUERY_TIMEOUT` + 120s), so at the default 600s timeout it is
-  720s, not the 300s floor. `TokenStore.issue` then clamps every request into
+  max(900s, `PM_QUERY_TIMEOUT` + 180s), so at the default 600s timeout it is
+  900s, the floor. The floor covers a full-length dial plus a full-length
+  exchange, so a short `PM_QUERY_TIMEOUT` cannot leave a cold session's token
+  expiring mid-statement. `TokenStore.issue` then clamps every request into
   [60s, 24h], which is the real ceiling on both. A run-stream timeout or
   canceled HTTP query does not itself revoke it. It is barred from the
   wire-session handshake (`TokenStore.validate` rejects `kind='EDITOR'`), so a

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Config.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Config.kt
@@ -140,7 +140,13 @@ data class Config(
         // The control-plane's per-statement exchange budget sits this far above the configured query
         // timeout so the proxy's PM_QUERY_TIMEOUT watchdog — which starts later, at backend exec — fires
         // first and cancels the statement in-band, rather than the CP exchange pre-empting it.
-        const val QUERY_EXCHANGE_GRACE_MS = 30_000L
+        // Headroom the exchange budget adds over the proxy's own statement watchdog. It has to absorb
+        // everything the proxy does around the guarded execution — the watchdog wraps only the backend
+        // statement, while authorization and the catalog probes before it run outside that guard and have
+        // been measured in the tens of seconds against a large remote catalog. Too small and the control
+        // plane calls a timeout on a statement whose watchdog has not fired, blaming the query for time
+        // spent before it started.
+        const val QUERY_EXCHANGE_GRACE_MS = 150_000L
 
         fun fromEnv(env: (String) -> String? = System::getenv): Config {
             val oidc = run {

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ConnectionCatalog.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ConnectionCatalog.kt
@@ -12,7 +12,19 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
 private const val CONNECTION_ID_BYTES = 16
-private const val DEFAULT_STALENESS_NANOS = 5L * 60 * 1_000_000_000
+
+/**
+ * How long a connection may hold a schema fragment before re-measuring it. This is the backstop for drift the
+ * control plane never learned about — DDL run straight against the backend, which no push reports — so it
+ * bounds how long such a change can go unnoticed.
+ *
+ * Set above the proxy's ambient refresh interval, which re-reads the whole backend catalog and, through
+ * [ConnectionCatalogRegistry.recordAmbientMeasurement], re-measures the pooled fragments it still agrees
+ * with. That cycle is what detects out-of-band DDL; this bound is the ceiling for a connection whose
+ * schemas the refresh did not confirm, so it only has to sit far enough above the interval that an ordinary
+ * slow or skipped cycle does not put a full fetch in front of a user's query.
+ */
+private const val DEFAULT_STALENESS_NANOS = 15L * 60 * 1_000_000_000
 
 /** Immutable value key for catalog content. ByteString is required: raw ByteArray has reference equality. */
 data class ContentHash(val bytes: ByteString)
@@ -32,7 +44,18 @@ data class SchemaFragment(val key: PoolKey, val hash: ContentHash, val columns: 
 
 data class PooledFragment(val fragment: SchemaFragment, val refCount: Int)
 
-data class Authoritative(val hash: ContentHash, val pooledRef: PoolKey, val epoch: Long)
+/**
+ * [measuredNanos] is when THIS datasource's backend was last read and found to hold this content — the
+ * evidence a connection inherits when it adopts. It lives here rather than on [PooledFragment] because
+ * identical content is pooled once and shared across datasources, while a reading only ever speaks for the
+ * backend it came from.
+ */
+data class Authoritative(
+    val hash: ContentHash,
+    val pooledRef: PoolKey,
+    val epoch: Long,
+    val measuredNanos: Long,
+)
 
 data class Binding(val datasourceName: String, val principal: String, val tokenKind: String)
 
@@ -93,29 +116,65 @@ class ConnectionCatalogRegistry(
     // multi-map transitions atomic; every individual reference-count mutation still occurs under pool.compute.
     private val stateLock = Any()
 
-    fun open(binding: Binding, schemas: Collection<String>): OpenConnection {
+    /**
+     * [adoptHeldContent] lets a connection start from catalog content the control plane already holds instead
+     * of fetching it, for an engine whose scan cannot vary by connection
+     * ([Engine.catalogIsConnectionIndependent]). A schema with nothing held still gets its fetch, so this only
+     * removes redundant work — never the first measurement.
+     */
+    fun open(
+        binding: Binding,
+        schemas: Collection<String>,
+        adoptHeldContent: Boolean = false,
+    ): OpenConnection {
         while (true) {
             val bytes = ByteArray(CONNECTION_ID_BYTES).also(secureRandom::nextBytes)
             val id = ByteString.copyFrom(bytes)
             val connection = EnforcementConnection(id, binding, lastUsedNanos = clockNanos())
             if (connections.putIfAbsent(id, connection) == null) {
-                val commands = issueInitial(connection, schemas)
+                val commands = issueInitial(connection, schemas, adoptHeldContent)
                 return OpenConnection(id, commands)
             }
         }
     }
 
     /** Recreate a well-formed id after CP restart; an already-live id is never overwritten. */
-    fun recover(connectionId: ByteString, binding: Binding, schemas: Collection<String>): OpenConnection? {
+    fun recover(
+        connectionId: ByteString,
+        binding: Binding,
+        schemas: Collection<String>,
+        adoptHeldContent: Boolean = false,
+    ): OpenConnection? {
         val connection = EnforcementConnection(connectionId, binding, lastUsedNanos = clockNanos())
         if (connections.putIfAbsent(connectionId, connection) != null) return null
-        return OpenConnection(connectionId, issueInitial(connection, schemas))
+        return OpenConnection(connectionId, issueInitial(connection, schemas, adoptHeldContent))
     }
 
-    private fun issueInitial(connection: EnforcementConnection, schemas: Collection<String>): List<Refetch> =
+    private fun issueInitial(
+        connection: EnforcementConnection,
+        schemas: Collection<String>,
+        adoptHeldContent: Boolean,
+    ): List<Refetch> =
         synchronized(stateLock) {
-            schemas.asSequence().filter { it.isNotBlank() }.distinct().map { schema ->
+            schemas.asSequence().filter { it.isNotBlank() }.distinct().mapNotNull { schema ->
                 val auth = authoritative[connection.binding.datasourceName to schema]
+                val pooled = auth?.let { pool[it.pooledRef] }
+                // Where a scan cannot vary by connection, content another connection already measured is
+                // this connection's answer too, so it starts from that instead of putting a backend fetch in
+                // front of the first query. lastVerifiedNanos carries the original measurement time rather
+                // than now: the staleness gate must keep counting from when the backend was actually read, or
+                // a stream of new connections would refresh the clock forever and the bound would never fire.
+                if (adoptHeldContent && auth != null && pooled != null) {
+                    retain(pooled.fragment, 1)
+                    connection.held[schema] = HeldSchema(
+                        pooledRef = auth.pooledRef,
+                        hash = auth.hash,
+                        lastFetchNanos = auth.measuredNanos,
+                        lastVerifiedNanos = auth.measuredNanos,
+                        revalidatedAgainstAuthoritativeHash = null,
+                    )
+                    return@mapNotNull null
+                }
                 val pending = PendingRefetch(auth?.hash, auth?.hash)
                 connection.pending[schema] = pending
                 refetchOf(schema, pending.expectedHash)
@@ -243,7 +302,7 @@ class ConnectionCatalogRegistry(
             // against exactly what ITS OWN backend binds (freshnessGate re-verifies per connection). Under a
             // primary+replica pool a lagging push can regress this and cause bounded before_decide churn on
             // siblings (each self-heals in one round-trip); damping that is a deferred liveness optimization.
-            authoritative[authKey] = Authoritative(pushedHash, key, authoritativeEpoch.incrementAndGet())
+            authoritative[authKey] = Authoritative(pushedHash, key, authoritativeEpoch.incrementAndGet(), now)
             if (previousHeld != null && previousHeld.pooledRef != key) release(previousHeld.pooledRef)
             if (previousAuth != null && previousAuth.pooledRef != key) release(previousAuth.pooledRef)
             accept(connection, request.schema, request.backendGeneration)
@@ -353,6 +412,76 @@ class ConnectionCatalogRegistry(
 
     fun heldAndFreshSchemas(connection: EnforcementConnection): Set<String> =
         connection.held.keys.filterTo(LinkedHashSet()) { freshnessGate(connection, listOf(it)).isEmpty() }
+
+    /**
+     * Fold a whole-catalog measurement from the proxy's ambient refresh into this datasource's authoritative
+     * entries.
+     *
+     * The refresh reads every schema from the backend with the same six fields a fragment holds, so for a
+     * schema whose columns are byte-identical it is a genuine re-measurement of exactly that content — the
+     * same evidence a connection's own hash probe produces. Recording it advances the authoritative entry's
+     * measurement time, so the staleness gate counts from this reading rather than from the first time the
+     * content happened to be pooled.
+     *
+     * Recorded on the authoritative entry, NOT on the pooled fragment: identical system-schema content is
+     * pooled once per engine version and shared by every datasource on it ([poolKey]), so writing the time
+     * there would let one datasource's refresh vouch for another's schema that nobody read. Freshness is
+     * evidence about one backend; only the content itself is shareable.
+     *
+     * Deliberately narrow: a schema whose columns differ is left untouched, so this can only ever confirm
+     * content, never install it. Divergence stays the job of the connection's own probe, which alone knows
+     * what that connection's backend binds.
+     *
+     * Returns the schemas confirmed, for logging.
+     */
+    fun recordAmbientMeasurement(
+        datasourceName: String,
+        columnsBySchema: Map<String, List<FragmentColumn>>,
+    ): Set<String> = synchronized(stateLock) {
+        val confirmed = LinkedHashSet<String>()
+        val now = clockNanos()
+        for ((schema, columns) in columnsBySchema) {
+            val authKey = datasourceName to schema
+            val auth = authoritative[authKey] ?: continue
+            val pooled = pool[auth.pooledRef] ?: continue
+            // Compared as sets: the whole-catalog read and the per-schema fragment read are separate
+            // statements whose ORDER BY need not agree, and row order is not part of what a fragment
+            // asserts — the decide path sorts for itself. Comparing lists would silently stop confirming
+            // anything the moment the two orderings diverged, and nothing would report it.
+            if (pooled.fragment.columns.toSet() != columns.toSet()) continue
+            authoritative[authKey] = auth.copy(measuredNanos = now)
+            confirmed += schema
+        }
+        confirmed
+    }
+
+    /**
+     * Drop every authoritative entry for [datasourceName], for when the datasource is repointed at a
+     * different database.
+     *
+     * The persisted catalog is already cleared on a retarget, because keeping it would authorize the new
+     * target against the old schema. This state is the same hazard: a connection opening afterwards would
+     * otherwise adopt structure measured from the database that is no longer there, and decide against a
+     * catalog its backend never had. Dropping the entries makes the next connection measure for itself.
+     *
+     * Live connections are left alone — each already holds its own reference and re-verifies on its own
+     * clock, and tearing their content out mid-session would empty structuralRows under an in-flight
+     * statement. Returns the schemas invalidated, for logging.
+     */
+    /** When this datasource's [schema] was last read and found to hold the content held for it. */
+    internal fun measuredNanosFor(datasourceName: String, schema: String): Long? =
+        authoritative[datasourceName to schema]?.measuredNanos
+
+    fun invalidateDatasource(datasourceName: String): Set<String> = synchronized(stateLock) {
+        val dropped = LinkedHashSet<String>()
+        val keys = authoritative.keys.filter { it.first == datasourceName }
+        for (key in keys) {
+            val auth = authoritative.remove(key) ?: continue
+            release(auth.pooledRef)
+            dropped += key.second
+        }
+        dropped
+    }
 
     suspend fun close(connectionId: ByteString, datasourceName: String): CatalogMutationResult {
         val connection = connections[connectionId]

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Engines.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Engines.kt
@@ -126,6 +126,26 @@ fun Engine.isSystemSchema(schema: String): Boolean = when (this) {
 }
 
 /**
+ * Whether a schema's catalog content is the same for every connection to a datasource, so one connection's
+ * measurement answers for all of them.
+ *
+ * MySQL's temporary tables are absent from `information_schema.COLUMNS` entirely — a session's temp tables
+ * cannot appear in a catalog scan, so nothing a scan returns varies by connection. They reach a decision as
+ * the per-request temp overlay instead, never through the catalog. PostgreSQL's `pg_temp_*` schemas are real,
+ * per-session, and visible in the catalog, so there a fragment is only true for the connection that measured
+ * it.
+ *
+ * Where this is true, a connection may start from catalog content the control plane already holds rather than
+ * measuring the backend itself.
+ */
+val Engine.catalogIsConnectionIndependent: Boolean
+    get() = when (this) {
+        Engine.MYSQL -> true
+        Engine.POSTGRES -> false
+        else -> error("engine has no catalog scope: $this")
+    }
+
+/**
  * Parse a wire / registration engine string, fail-closed and case-insensitive: "mysql" → MYSQL,
  * "postgres" → POSTGRES, anything else throws. This is the one gate raw engine input passes through; it
  * accepts exactly the two canonical spellings the store persists and the proxy registers.

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Main.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Main.kt
@@ -9,6 +9,17 @@ import org.slf4j.LoggerFactory
 private val log = LoggerFactory.getLogger("com.ridi.oss.proxymonster.controlplane.Main")
 
 /**
+ * How long one proxy-dialed run stream may live.
+ *
+ * The stream is opened before the proxy reports ready, so its lifetime has to cover the dial as well as the
+ * exchange that follows. Leave the dial out and the cap falls short of the work it wraps once
+ * PM_QUERY_TIMEOUT is large: the stream then dies under a statement that is still legitimately running, and
+ * the caller sees a stream-closed error rather than the timeout it actually is.
+ */
+fun runStreamTimeoutMs(queryExchangeTimeoutMs: Long): Long =
+    maxOf(15 * 60_000L, DIAL_TIMEOUT_MS + queryExchangeTimeoutMs + 30_000)
+
+/**
  * Control-plane entry point: load config, bring up the Postgres store (with migrations),
  * then serve the HTTP API (DESIGN.md).
  */
@@ -43,7 +54,7 @@ fun main() {
     // proxy↔control-plane RPC. Fail-fast on purpose: a control-plane that can't bind its required
     // gRPC port is misconfigured — like a bad DB or a taken HTTP port — and must not come up serving
     // only HTTP while the data plane is silently dead.
-    val runStreamTimeoutMs = maxOf(15 * 60_000L, config.queryExchangeTimeoutMs + 30_000)
+    val runStreamTimeoutMs = runStreamTimeoutMs(config.queryExchangeTimeoutMs)
     val grpcServer = GrpcServer(
         config.grpcPort,
         ControlPlaneGrpcService(core, runStreamTimeoutMs),

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RunExec.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RunExec.kt
@@ -23,18 +23,27 @@ import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
 // Floor for a one-shot run token's TTL; the effective TTL grows to cover PM_QUERY_TIMEOUT (see
-// RunExecService.runTokenTtlSeconds). Comfortably covers dial + the exchange grace on short timeouts.
-private const val RUN_TOKEN_TTL_FLOOR_SECONDS = 300L
+// RunExecService.runTokenTtlSeconds). The floor alone must outlast a full-length dial plus a full-length
+// exchange, so a short PM_QUERY_TIMEOUT cannot leave a cold session's token expiring mid-statement.
+private const val RUN_TOKEN_TTL_FLOOR_SECONDS = 900L
 // A persistent editor SESSION token outlives many queries; give it a generous absolute TTL (sliding
 // refresh-on-activity is a follow-up) and bound the session with idle-sweep + explicit close. Per-session
 // and revoked on close, so a long TTL is not a standing credential.
 private const val EDITOR_SESSION_TTL_SECONDS = 8 * 3600L
 // Headroom added over PM_QUERY_TIMEOUT for a run token's TTL: covers the dial (DIAL_TIMEOUT_MS), the
 // CP exchange grace (Config.QUERY_EXCHANGE_GRACE_MS), and revalidation buffer, so the token never
-// expires while the statement it authorizes is still in flight.
-private const val TOKEN_TTL_GRACE_SECONDS = 120L
-internal const val DIAL_TIMEOUT_MS = 10_000L
-internal const val EXCHANGE_TIMEOUT_MS = 120_000L
+// expires while the statement it authorizes is still in flight. Must stay above DIAL_TIMEOUT_MS with
+// room to spare — a token that dies during a slow cold dial takes the session with it.
+private const val TOKEN_TTL_GRACE_SECONDS = 180L
+// The dial is not just a connect: the proxy also satisfies the connection's opening catalog commands
+// before it reports ready, and on a cold session against a large remote backend that is several schema
+// scans. Measured cold opens took ~26s, so a 10s bound failed them outright while the work was still
+// running.
+internal const val DIAL_TIMEOUT_MS = 120_000L
+// Fallback only: every production path passes Config.queryExchangeTimeoutMs, which tracks
+// PM_QUERY_TIMEOUT plus a grace so the proxy's own watchdog always fires first. This value exists for
+// callers that supply no config, and matches the default query timeout on the same principle.
+internal const val EXCHANGE_TIMEOUT_MS = 630_000L
 
 /** A CP-driven request waiting for the proxy to dial its dedicated [ControlRunMsg] stream. */
 data class PendingSession(
@@ -257,6 +266,7 @@ class RunExecService(
         taskId: Long? = null,
         preflight: (() -> Boolean)? = null,
         exchangeTimeoutMs: Long = EXCHANGE_TIMEOUT_MS,
+        dialTimeoutMs: Long = DIAL_TIMEOUT_MS,
     ): QueryResponse {
         val started = System.nanoTime()
         val issued = core.dataSource.mintForActivePrincipalLocked(principal, core.userGroupStore) { c ->
@@ -278,6 +288,7 @@ class RunExecService(
         val opened = core.connectionCatalog.open(
             Binding(ds.name, principal, kind),
             ds.defaultSchemas + ds.engine.systemSchemas,
+            adoptHeldContent = ds.engine.catalogIsConnectionIndependent,
         )
         val sessionId = UUID.randomUUID().toString()
         val pending = PendingSession(sessionId, principal, issued.id, CompletableDeferred())
@@ -295,7 +306,7 @@ class RunExecService(
             }
 
             attached = try {
-                withTimeout(DIAL_TIMEOUT_MS) { pending.ready.await() }
+                withTimeout(dialTimeoutMs) { pending.ready.await() }
             } catch (e: TimeoutCancellationException) {
                 throw ProxyRunTimeoutException(e)
             }
@@ -369,6 +380,7 @@ class RunExecService(
         val opened = core.connectionCatalog.open(
             Binding(ds.name, principal, TokenKind.EDITOR.name),
             ds.defaultSchemas + ds.engine.systemSchemas,
+            adoptHeldContent = ds.engine.catalogIsConnectionIndependent,
         )
         val sessionId = UUID.randomUUID().toString()
         val pending = PendingSession(sessionId, principal, issued.id, CompletableDeferred())

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/ControlPlaneGrpcService.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/ControlPlaneGrpcService.kt
@@ -4,11 +4,13 @@ import com.ridi.oss.proxymonster.controlplane.Attached
 import com.ridi.oss.proxymonster.controlplane.AttachedTableDetail
 import com.ridi.oss.proxymonster.controlplane.AuditEvent
 import com.ridi.oss.proxymonster.controlplane.CatalogColumn
+import com.ridi.oss.proxymonster.controlplane.FragmentColumn
 import com.ridi.oss.proxymonster.controlplane.Binding
 import com.ridi.oss.proxymonster.controlplane.CatalogMutationResult
 import com.ridi.oss.proxymonster.controlplane.Channel
 import com.ridi.oss.proxymonster.controlplane.ControlPlaneCore
 import com.ridi.oss.proxymonster.controlplane.DatasourceEngineConflictException
+import com.ridi.oss.proxymonster.controlplane.catalogIsConnectionIndependent
 import com.ridi.oss.proxymonster.controlplane.catalogName
 import com.ridi.oss.proxymonster.controlplane.EnforcementOutcome
 import com.ridi.oss.proxymonster.controlplane.DatasourceStore
@@ -129,6 +131,7 @@ class ControlPlaneGrpcService(
         val opened = core.connectionCatalog.open(
             Binding(ds.name, id.principal, id.kind),
             ds.defaultSchemas + ds.engine.systemSchemas,
+            adoptHeldContent = ds.engine.catalogIsConnectionIndependent,
         )
         return wireIdentity {
             principal = id.principal
@@ -200,6 +203,7 @@ class ControlPlaneGrpcService(
                 request.connectionId,
                 binding,
                 request.searchPathList + ds.defaultSchemas + ds.engine.systemSchemas,
+                adoptHeldContent = ds.engine.catalogIsConnectionIndependent,
             ) ?: throw StatusException(Status.ABORTED.withDescription("connection recovery raced with another request"))
             return beforeDecideDecision(recovered.onOpen)
         }
@@ -336,6 +340,7 @@ class ControlPlaneGrpcService(
                 )
             }
         }
+        val priorDbName = core.datasourceStore.getByName(request.name)?.dbName
         val ds = try {
             core.datasourceStore.register(
                 name = request.name,
@@ -352,6 +357,16 @@ class ControlPlaneGrpcService(
             // Engine is immutable at register — a mismatched re-register is a client precondition
             // failure (fix the caller's engine or delete-and-recreate), not a server error.
             throw StatusException(Status.FAILED_PRECONDITION.withDescription(e.message))
+        }
+        // A retarget makes the stored catalog describe a different database, which is why register drops the
+        // persisted columns. The enforcement state is the same hazard and outlives that delete: a connection
+        // opening next would otherwise start from structure measured on the database that is no longer there.
+        if (priorDbName != null && priorDbName != ds.dbName) {
+            val dropped = core.connectionCatalog.invalidateDatasource(ds.name)
+            log.info(
+                "datasource '{}' retargeted {} -> {}: dropped {} enforcement schema(s)",
+                ds.name, priorDbName, ds.dbName, dropped.size,
+            )
         }
         return registerResponse { name = ds.name }
     }
@@ -375,6 +390,19 @@ class ControlPlaneGrpcService(
             engineVersion = request.engineVersion,
             columns = pushedColumns,
         )
+        // This push is a fresh whole-catalog read of the backend, so where it agrees with content the
+        // enforcement pool already holds it re-measures that content — the ambient refresh keeps held
+        // fragments verified instead of only feeding the config catalog, and a connection is not made to
+        // re-probe a schema the proxy just confirmed.
+        val confirmed = core.connectionCatalog.recordAmbientMeasurement(
+            ds.name,
+            pushedColumns.groupBy({ it.schema }) {
+                FragmentColumn(it.schema, it.table, it.column, it.dataType, it.ordinal, it.nullable)
+            },
+        )
+        if (confirmed.isNotEmpty()) {
+            log.debug("datasource '{}': ambient refresh re-verified {} pooled schema(s)", ds.name, confirmed.size)
+        }
         // Which shipped system-classification manifest governs THIS datasource, resolved from the version the
         // proxy just pushed — so an operator sees at connect time whether its system schemas are classified,
         // on a fallback major, or uncertified (deny-by-default). Boot logs the available set; this logs the hit.

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/ControlPlaneGrpcService.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/ControlPlaneGrpcService.kt
@@ -358,9 +358,9 @@ class ControlPlaneGrpcService(
             // failure (fix the caller's engine or delete-and-recreate), not a server error.
             throw StatusException(Status.FAILED_PRECONDITION.withDescription(e.message))
         }
-        // A retarget makes the stored catalog describe a different database, which is why register drops the
-        // persisted columns. The enforcement state is the same hazard and outlives that delete: a connection
-        // opening next would otherwise start from structure measured on the database that is no longer there.
+        // The catalog push that follows registration cannot repair this: it only confirms content it agrees
+        // with, and a retarget is precisely the case where it disagrees. So the held structure would survive,
+        // describing a database that is no longer there, and the next connection would adopt it.
         if (priorDbName != null && priorDbName != ds.dbName) {
             val dropped = core.connectionCatalog.invalidateDatasource(ds.name)
             log.info(

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ConfigGuardTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ConfigGuardTest.kt
@@ -78,6 +78,35 @@ class ConfigGuardTest {
         }
     }
 
+    @Test fun `the run stream outlives the dial and exchange it wraps`() {
+        // The stream opens before the proxy reports ready, so its lifetime spans BOTH the dial and the
+        // statement exchange. If it expires first the control plane tears down a statement that is still
+        // legitimately running, and the caller sees a stream-closed error instead of a timeout. The margin
+        // is arithmetic across three files, so pin it here rather than leave it to inspection.
+        for (timeout in listOf(1L, 600L, 840L, 3600L, Config.MAX_QUERY_TIMEOUT_SECONDS)) {
+            val config = Config.fromEnv(envOf("PM_QUERY_TIMEOUT" to timeout.toString()))
+            val streamTimeout = runStreamTimeoutMs(config.queryExchangeTimeoutMs)
+            assertTrue(
+                streamTimeout > DIAL_TIMEOUT_MS + config.queryExchangeTimeoutMs,
+                "run stream ($streamTimeout ms) must outlive dial + exchange " +
+                    "(${DIAL_TIMEOUT_MS + config.queryExchangeTimeoutMs} ms) for timeout=$timeout",
+            )
+        }
+    }
+
+    @Test fun `the exchange budget outlives the proxy's own statement watchdog`() {
+        // The proxy aborts a statement at PM_QUERY_TIMEOUT. This bound sits outside that one, so it has to
+        // fire later — otherwise the control plane reports a timeout for a query the proxy goes on to
+        // finish, and the two ends disagree about whether it ran.
+        for (timeout in listOf(1L, 600L, 3600L, Config.MAX_QUERY_TIMEOUT_SECONDS)) {
+            val config = Config.fromEnv(envOf("PM_QUERY_TIMEOUT" to timeout.toString()))
+            assertTrue(
+                config.queryExchangeTimeoutMs > timeout * 1000,
+                "exchange budget must outlast the proxy watchdog for timeout=$timeout",
+            )
+        }
+    }
+
     @Test fun `PM_TRUSTED_PROXIES parses comma-separated entries, trimmed, with blanks dropped`() {
         assertEquals(
             setOf("10.0.0.1", "10.0.0.2"),

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PerConnectionCatalogStateTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PerConnectionCatalogStateTest.kt
@@ -131,6 +131,145 @@ class PerConnectionCatalogStateTest {
     }
 
     @Test
+    fun `adopting held content opens with no fetch and decides immediately`() = runBlocking {
+        var now = 0L
+        val registry = ConnectionCatalogRegistry(clockNanos = { now }, stalenessNanos = 100)
+        val first = registry.open(Binding(ds.name, "first", "USER"), listOf("app"))
+        assertEquals(listOf("app"), first.onOpen.map { it.schema }) // nothing held yet: it must fetch
+        registry.applyPush(push(first, "app", "h1"), ds)
+
+        now = 10
+        val second = registry.open(Binding(ds.name, "second", "USER"), listOf("app"), adoptHeldContent = true)
+        assertTrue(second.onOpen.isEmpty(), "an adopting connection must not be sent a refetch")
+        val connection = registry.find(second.connectionId)!!
+        assertEquals("h1", connection.held.getValue("app").hash.bytes.toStringUtf8())
+        assertTrue(connection.pending.isEmpty())
+        // The point of adopting: the first statement decides without waiting on the backend.
+        assertTrue(registry.freshnessGate(connection, listOf("app")).isEmpty())
+    }
+
+    @Test
+    fun `adoption inherits the original measurement time so staleness still fires`() = runBlocking {
+        // Adopting must not restart the staleness clock. If it did, a stream of new connections would keep
+        // content alive indefinitely without anyone re-reading the backend, and the bound could never fire.
+        var now = 0L
+        val registry = ConnectionCatalogRegistry(clockNanos = { now }, stalenessNanos = 10)
+        val first = registry.open(Binding(ds.name, "first", "USER"), listOf("app"))
+        registry.applyPush(push(first, "app", "h1"), ds) // measured at now = 0
+
+        now = 9
+        val second = registry.open(Binding(ds.name, "second", "USER"), listOf("app"), adoptHeldContent = true)
+        val connection = registry.find(second.connectionId)!!
+        assertTrue(registry.freshnessGate(connection, listOf("app")).isEmpty(), "still inside the window")
+
+        now = 11 // past staleness measured from the ORIGINAL read, not from adoption
+        assertEquals(
+            setOf("app"),
+            registry.freshnessGate(connection, listOf("app")),
+            "adopted content must go stale on the original measurement's clock",
+        )
+    }
+
+    @Test
+    fun `an ambient refresh re-measures pooled content so adopters stay fresh`() = runBlocking {
+        // The staleness ceiling sits above the ambient refresh interval on the premise that the refresh
+        // itself keeps pooled content verified. Without that, content pooled once would age out no matter
+        // how recently the backend was read, and every new session would refetch.
+        var now = 0L
+        val registry = ConnectionCatalogRegistry(clockNanos = { now }, stalenessNanos = 10)
+        val first = registry.open(Binding(ds.name, "first", "USER"), listOf("app"))
+        registry.applyPush(push(first, "app", "h1"), ds)
+
+        now = 8
+        val confirmed = registry.recordAmbientMeasurement(
+            ds.name,
+            mapOf("app" to listOf(FragmentColumn("app", "users", "id", "bigint", 1, false))),
+        )
+        assertEquals(setOf("app"), confirmed)
+
+        now = 15 // past the original measurement, inside the window from the ambient one
+        val second = registry.open(Binding(ds.name, "second", "USER"), listOf("app"), adoptHeldContent = true)
+        assertTrue(second.onOpen.isEmpty())
+        assertTrue(
+            registry.freshnessGate(registry.find(second.connectionId)!!, listOf("app")).isEmpty(),
+            "the ambient re-measurement must reset the staleness clock for later adopters",
+        )
+    }
+
+    @Test
+    fun `an ambient refresh whose columns differ never overwrites pooled content`() = runBlocking {
+        // Confirmation only. Divergence belongs to the connection's own probe, which alone knows what that
+        // connection's backend binds; installing a differing ambient read here would decide against a
+        // catalog no connection measured.
+        var now = 0L
+        val registry = ConnectionCatalogRegistry(clockNanos = { now }, stalenessNanos = 10)
+        val first = registry.open(Binding(ds.name, "first", "USER"), listOf("app"))
+        registry.applyPush(push(first, "app", "h1"), ds)
+
+        now = 8
+        val confirmed = registry.recordAmbientMeasurement(
+            ds.name,
+            mapOf("app" to listOf(FragmentColumn("app", "users", "DIFFERENT", "bigint", 1, false))),
+        )
+        assertTrue(confirmed.isEmpty(), "a differing ambient read must not count as a re-measurement")
+
+        now = 15
+        val second = registry.open(Binding(ds.name, "second", "USER"), listOf("app"), adoptHeldContent = true)
+        assertEquals(
+            setOf("app"),
+            registry.freshnessGate(registry.find(second.connectionId)!!, listOf("app")),
+            "unconfirmed content must still go stale on its original clock",
+        )
+        // And the pooled structure is untouched: still the originally measured column.
+        assertEquals(
+            listOf("id"),
+            registry.structuralRows(registry.find(second.connectionId)!!).map { it.column },
+        )
+    }
+
+    @Test
+    fun `adopting retains the pooled fragment so it survives the original holder closing`() = runBlocking {
+        // Adoption takes a reference of its own. Without it the fragment would be released out from under
+        // the adopter when the measuring connection closes, and structuralRows would silently go empty.
+        val registry = ConnectionCatalogRegistry()
+        val first = registry.open(Binding(ds.name, "first", "USER"), listOf("app"))
+        registry.applyPush(push(first, "app", "h1"), ds)
+        val key = registry.find(first.connectionId)!!.held.getValue("app").pooledRef
+
+        val second = registry.open(Binding(ds.name, "second", "USER"), listOf("app"), adoptHeldContent = true)
+        assertEquals(3, registry.pooledFor(key)!!.refCount) // authoritative + measurer + adopter
+
+        registry.close(first.connectionId, ds.name)
+        assertEquals(2, registry.pooledFor(key)!!.refCount)
+        assertEquals(
+            listOf("id"),
+            registry.structuralRows(registry.find(second.connectionId)!!).map { it.column },
+            "the adopter must still resolve its structure after the measurer closed",
+        )
+
+        registry.close(second.connectionId, ds.name)
+        assertEquals(1, registry.pooledFor(key)!!.refCount) // authoritative alone
+    }
+
+    @Test
+    fun `a schema with nothing held is still fetched when adopting`() = runBlocking {
+        // Adoption only skips work that is already done; it never skips the first measurement of a schema.
+        val registry = ConnectionCatalogRegistry()
+        val first = registry.open(Binding(ds.name, "first", "USER"), listOf("app"))
+        registry.applyPush(push(first, "app", "h1"), ds)
+
+        val second = registry.open(
+            Binding(ds.name, "second", "USER"),
+            listOf("app", "other"),
+            adoptHeldContent = true,
+        )
+        assertEquals(listOf("other"), second.onOpen.map { it.schema })
+        val connection = registry.find(second.connectionId)!!
+        assertTrue(connection.held.containsKey("app"))
+        assertTrue(connection.pending.containsKey("other"))
+    }
+
+    @Test
     fun `unchanged on-open cannot no-op an unconditional first fetch`() = runBlocking {
         // A fresh connection whose schema has no authoritative hash yet is issued an UNCONDITIONAL refetch
         // (pending.expectedHash == null). A proxy that replies unchanged=true has nothing to adopt — this
@@ -158,6 +297,72 @@ class PerConnectionCatalogStateTest {
         assertEquals(1, registry.poolSize())
         // dsA held + dsA authoritative + dsB held + dsB authoritative all reference the one pooled fragment.
         assertEquals(4, registry.pooledFor(key)!!.refCount)
+    }
+
+    @Test
+    fun `invalidating a datasource forces the next connection to measure for itself`() = runBlocking {
+        // Repointing a datasource at another database makes held structure describe a database that is no
+        // longer there. Adoption would otherwise hand that structure to the next connection, which would
+        // decide against a catalog its backend never had.
+        val registry = ConnectionCatalogRegistry()
+        val first = registry.open(Binding(ds.name, "first", "USER"), listOf("app"))
+        registry.applyPush(push(first, "app", "h1"), ds)
+        val key = registry.find(first.connectionId)!!.held.getValue("app").pooledRef
+
+        val adoptsBefore = registry.open(Binding(ds.name, "before", "USER"), listOf("app"), adoptHeldContent = true)
+        assertTrue(adoptsBefore.onOpen.isEmpty(), "same target: adoption is expected")
+
+        assertEquals(setOf("app"), registry.invalidateDatasource(ds.name))
+
+        val afterRetarget = registry.open(Binding(ds.name, "after", "USER"), listOf("app"), adoptHeldContent = true)
+        assertEquals(
+            listOf("app"),
+            afterRetarget.onOpen.map { it.schema },
+            "after a retarget the next connection must measure the new target itself",
+        )
+        // The fetch is unconditional: there is no hash left to claim the new database matches the old.
+        assertTrue(afterRetarget.onOpen.single().ifHashDiffers.isEmpty)
+        // Connections that already hold the content keep it — their own reference is still counted.
+        assertEquals(2, registry.pooledFor(key)!!.refCount)
+    }
+
+    @Test
+    fun `one datasource's ambient refresh cannot vouch for another's schema`() = runBlocking {
+        // System-schema content is pooled once per engine version and shared by every datasource on it, so a
+        // measurement recorded against the shared content would let a datasource nobody read look freshly
+        // verified. Freshness is evidence about one backend; only the content is shareable.
+        var now = 0L
+        val registry = ConnectionCatalogRegistry(clockNanos = { now }, stalenessNanos = 10)
+        val dsA = ds.copy(id = 1, name = "dsA")
+        val dsB = ds.copy(id = 2, name = "dsB")
+        registry.openPushSystem(dsA, "information_schema", "sys-h1")
+        registry.openPushSystem(dsB, "information_schema", "sys-h1")
+
+        now = 8
+        // Only dsA is re-read. Its columns match, so dsA is confirmed — dsB must not be.
+        val confirmed = registry.recordAmbientMeasurement(
+            dsA.name,
+            mapOf(
+                "information_schema" to
+                    listOf(FragmentColumn("information_schema", "t", "c", "bigint", 1, false)),
+            ),
+        )
+        assertEquals(setOf("information_schema"), confirmed)
+
+        now = 15
+        val onA = registry.open(
+            Binding(dsA.name, "p", "USER"), listOf("information_schema"), adoptHeldContent = true,
+        )
+        assertTrue(onA.onOpen.isEmpty(), "dsA was re-read, so its adopter is fresh")
+
+        val onB = registry.open(
+            Binding(dsB.name, "p", "USER"), listOf("information_schema"), adoptHeldContent = true,
+        )
+        assertEquals(
+            setOf("information_schema"),
+            registry.freshnessGate(registry.find(onB.connectionId)!!, listOf("information_schema")),
+            "dsB's backend was never re-read; dsA's refresh must not make it look fresh",
+        )
     }
 
     /** Open a connection on [ds] scoped to one system [schema] and push a single-column fragment for it. */

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/GrpcRegistrationHandlerDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/GrpcRegistrationHandlerDbTest.kt
@@ -1,5 +1,8 @@
 package com.ridi.oss.proxymonster.controlplane.grpc
 
+import com.google.protobuf.ByteString
+import com.ridi.oss.proxymonster.controlplane.Binding
+import com.ridi.oss.proxymonster.controlplane.CatalogMutationResult
 import com.ridi.oss.proxymonster.controlplane.ControlPlaneCore
 import com.ridi.oss.proxymonster.controlplane.Datasource
 import com.ridi.oss.proxymonster.controlplane.DatasourceEngineConflictException
@@ -11,6 +14,7 @@ import com.ridi.oss.proxymonster.grpc.Engine
 import com.ridi.oss.proxymonster.grpc.catalogRequest
 import com.ridi.oss.proxymonster.grpc.column
 import com.ridi.oss.proxymonster.grpc.registerRequest
+import com.ridi.oss.proxymonster.grpc.schemaFragmentPush
 import io.grpc.Status
 import io.grpc.StatusException
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
@@ -29,6 +33,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -476,6 +481,68 @@ class GrpcRegistrationHandlerDbTest {
         val rrn = cols.single { it.table == "users" && it.column == "rrn" }
         assertEquals("text", rrn.dataType)
         assertEquals("VARCHAR", rrn.sqlType, "the control-plane derives sql_type from the raw data_type")
+    }
+
+    @Test
+    fun `pushCatalog re-measures the enforcement catalog, not only the stored one`() = runBlocking {
+        // The staleness ceiling is set above the ambient refresh interval on the premise that the refresh
+        // keeps enforcement content verified. That premise is a single call in this handler: exercise it
+        // through the RPC, because a registry-level test would stay green if the wiring were removed and
+        // the refresh went back to feeding only the stored catalog.
+        stub.register(registerRequest { name = "reg-ambient"; engine = Engine.MYSQL; host = "h"; port = 1; dbName = "app" })
+        val ds = core.datasourceStore.getByName("reg-ambient")!!
+
+        // A connection measures `app` itself, so the control plane holds enforcement content for it.
+        val opened = core.connectionCatalog.open(Binding(ds.name, "p", "USER"), listOf("app"))
+        val applied = core.connectionCatalog.applyPush(
+            schemaFragmentPush {
+                connectionId = opened.connectionId
+                datasourceName = ds.name
+                schema = "app"
+                contentHash = ByteString.copyFromUtf8("h1")
+                backendGeneration = 1
+                columns.add(
+                    column { schema = "app"; table = "users"; this.column = "id"; dataType = "bigint"; ordinal = 1; nullable = false },
+                )
+            },
+            ds,
+        )
+        assertIs<CatalogMutationResult.Applied>(applied)
+        val measuredBefore = core.connectionCatalog.measuredNanosFor(ds.name, "app")!!
+
+        // The ambient refresh reports the same content for that schema.
+        stub.pushCatalog(
+            catalogRequest {
+                datasourceName = ds.name
+                defaultSchemas.add("app")
+                columns.add(
+                    column { schema = "app"; table = "users"; this.column = "id"; dataType = "bigint"; ordinal = 1; nullable = false },
+                )
+            },
+        )
+
+        // The recorded measurement time must have MOVED. Asserting that instead of "the adopter looks
+        // fresh" is deliberate: the adopter would look fresh anyway from the original measurement seconds
+        // earlier, so a freshness assertion holds even with this handler unwired and proves nothing.
+        val afterAmbient = core.connectionCatalog.measuredNanosFor(ds.name, "app")
+        assertNotNull(afterAmbient, "the enforcement entry must survive the push")
+        assertTrue(
+            afterAmbient > measuredBefore,
+            "pushCatalog must record its read against the enforcement catalog " +
+                "(before=$measuredBefore after=$afterAmbient)",
+        )
+
+        // The push confirms content; it never installs it.
+        val adopter = core.connectionCatalog.open(
+            Binding(ds.name, "later", "USER"), listOf("app"), adoptHeldContent = true,
+        )
+        assertTrue(adopter.onOpen.isEmpty(), "the ambient push must leave the adopter with nothing to fetch")
+        assertEquals(
+            listOf("id"),
+            core.connectionCatalog.structuralRows(
+                core.connectionCatalog.find(adopter.connectionId)!!,
+            ).map { it.column },
+        )
     }
 
     @Test

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/GrpcRunExecDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/GrpcRunExecDbTest.kt
@@ -325,7 +325,11 @@ class GrpcRunExecDbTest {
         supervisorScope {
             val event = async { stub.events(eventsRequest { datasourceName = datasource.name }).first() }
             awaitUntil("Events stream attached") { datasource.name in core.proxyEventsHub.attached() }
-            val result = async { runCatching { service.run("timeout-user", datasource, "select 1", 500) } }
+            // Inject a short dial bound: the production one is sized for a cold session against a remote
+            // backend, and waiting it out here would buy nothing but a two-minute test.
+            val result = async {
+                runCatching { service.run("timeout-user", datasource, "select 1", 500, dialTimeoutMs = 1_000) }
+            }
             val open = withTimeout(5_000) { event.await() }.openRunChannel
 
             assertEquals("timeout-user", core.tokenStore.resolve(open.ephemeralToken)?.principal)

--- a/goproxy/cp/client.go
+++ b/goproxy/cp/client.go
@@ -356,11 +356,15 @@ func (c *Client) PushCatalog(catalog *pb.CatalogRequest) error {
 	ctx, cancel := context.WithTimeout(context.Background(), rpcDeadline)
 	defer cancel()
 
+	started := time.Now()
 	ack, err := c.stub.PushCatalog(c.outCtx(ctx), catalog)
 	if err != nil {
 		return fmt.Errorf("cp: push catalog for %q: %w", c.datasourceName, err)
 	}
-	slog.Info("pushed catalog", "datasource", c.datasourceName, "columns", ack.GetColumns())
+	// Paired with introspect.Run's phase breakdown, this closes the refresh cycle: a slow refresh is
+	// either the backend scan or this push, and the two logs together say which.
+	slog.Info("pushed catalog", "datasource", c.datasourceName, "columns", ack.GetColumns(),
+		"push_ms", time.Since(started).Milliseconds())
 	return nil
 }
 

--- a/goproxy/introspect/introspect.go
+++ b/goproxy/introspect/introspect.go
@@ -26,8 +26,10 @@ import (
 	"github.com/ridi-oss/proxy-monster/goproxy/spi"
 )
 
-// queryTimeout bounds every introspection query.
-const queryTimeout = 30 * time.Second
+// queryTimeout bounds every introspection query. A full catalog scan of a large schema on a remote
+// backend has been measured at ~53s, so a bound near that turns an ordinary slow scan into a failed
+// refresh; this leaves room for one well clear of the observed cost.
+const queryTimeout = 120 * time.Second
 
 // connectTimeout bounds establishing the introspection connection to the target.
 const connectTimeout = 5 * time.Second
@@ -113,23 +115,31 @@ func Run(opener TargetOpener, target spi.BackendTarget) (*pb.CatalogRequest, err
 	// (a dial failure returns immediately, no reconnect), and every probe runs on it.
 	connectCtx, connectCancel := context.WithTimeout(context.Background(), connectTimeout+queryTimeout)
 	defer connectCancel()
+	started := time.Now()
 	conn, err := db.Conn(connectCtx)
 	if err != nil {
 		return nil, fmt.Errorf("introspect: connecting to target: %w", err)
 	}
 	defer conn.Close()
+	connectMs := time.Since(started).Milliseconds()
 
+	phase := time.Now()
 	engineVersion := probeVersion(conn)
+	versionMs := time.Since(phase).Milliseconds()
 
+	phase = time.Now()
 	defaultSchemas, mysqlLowerCaseTableNames, err := opener.ProbeNamespace(conn, target.Db)
 	if err != nil {
 		return nil, err
 	}
+	namespaceMs := time.Since(phase).Milliseconds()
 
+	phase = time.Now()
 	columns, err := introspectColumns(conn)
 	if err != nil {
 		return nil, err
 	}
+	columnsMs := time.Since(phase).Milliseconds()
 
 	// Normalize to the SAME canonical spelling the analyzer treats as authoritative (analyzer/probe,
 	// Go-to-Go — no FFM/marshaling) — an identity function for Postgres, MySQL's role-aware fold
@@ -144,19 +154,30 @@ func Run(opener TargetOpener, target spi.BackendTarget) (*pb.CatalogRequest, err
 	if mysqlLowerCaseTableNames != nil {
 		lctnMode = int(*mysqlLowerCaseTableNames)
 	}
+	phase = time.Now()
 	dbImpl := opener.NewDb()
 	columns = dbImpl.NormalizeColumns(lctnMode, columns)
 	defaultSchemas = normalizeSchemas(dbImpl, lctnMode, defaultSchemas)
+	normalizeMs := time.Since(phase).Milliseconds()
 
 	distinctTables := map[string]struct{}{}
 	for _, c := range columns {
 		distinctTables[c.GetSchema()+"."+c.GetTable()] = struct{}{}
 	}
+	// Per-phase timings, not just the total: introspection against a remote backend has been observed
+	// taking tens of seconds, and the total alone cannot say whether that is the dial, the catalog scan,
+	// or the fold over every column.
 	slog.Info("introspected catalog",
 		"columns", len(columns),
 		"tables", len(distinctTables),
 		"default_schemas", defaultSchemas,
 		"engine_version", engineVersion,
+		"total_ms", time.Since(started).Milliseconds(),
+		"connect_ms", connectMs,
+		"version_ms", versionMs,
+		"namespace_ms", namespaceMs,
+		"columns_ms", columnsMs,
+		"normalize_ms", normalizeMs,
 	)
 
 	return &pb.CatalogRequest{


### PR DESCRIPTION
Opening an editor session took ~26s against a large remote backend while the control plane abandoned the dial at 10s, so the first query reported that the proxy had not responded — for work that was still running and would have finished.

Two causes: the connection fetched the catalog it needed before its first statement could be decided (5 schemas, ~6800 columns, every session), and the bounds around that work were smaller than the work itself.

**Adoption.** A new connection now starts from catalog content the control plane already holds instead of measuring the backend again, for an engine whose scan cannot vary by connection. MySQL qualifies — its temp tables never appear in `information_schema` and reach a decision through the per-request overlay — and PostgreSQL does not, so it keeps fetching. A schema with nothing held is still fetched, so the first measurement is never skipped. Measured locally: session 1 issues 5 refetches, sessions 2+ issue 0.

**Timeouts** are sized to what they wrap: the dial covers a cold session's catalog work, the exchange grace covers the authorization and probes that run outside the proxy's statement watchdog, and the run stream outlasts both — it opens before the proxy reports ready and previously expired under statements still legitimately running. A guard test pins that ordering, which was arithmetic spread across three files.

### Where it could bite

- **Freshness is recorded per datasource, not on the pooled content.** Identical system-schema content is pooled once per engine version and shared, so recording it on the content would let one datasource's refresh vouch for another's schema that nobody read. Adopting inherits the measurement time rather than resetting it, so the staleness bound still fires.
- **Repointing a datasource at another database drops the held entries** — otherwise a connection would adopt structure describing a database that is no longer there.
- **The 15-minute staleness ceiling is earned by the refresh cycle**, which now re-measures the content it still agrees with. A schema whose columns differ is left untouched: the refresh can confirm content, never install it.
- **Adoption assumes one backend behind a datasource** (one proxy, one target, one service account). Several proxies against backends that can disagree, or per-session backend credentials, would break it silently — `information_schema` is privilege-filtered. Recorded in KNOWN_LIMITATIONS.

Verified: `mise run verify` green; 918 control-plane + engine tests, 0 failures. Every new test mutation-tested — including one that initially passed its mutation and was rewritten.