### PR TITLE
test(goproxy): make event-loop tests race-safe

### DIFF
--- a/goproxy/cp/client.go
+++ b/goproxy/cp/client.go
@@ -470,9 +470,6 @@ func (c *Client) runEventsLoop(
 	onOpenTableDetail func(sessionID, schema, table string),
 ) {
 	for {
-		if err := ctx.Err(); err != nil {
-			return
-		}
 		err := c.streamEvents(ctx, timings.streamMaxAge, onRefresh, onOpenRun, onOpenTableDetail)
 		// An expiry is the bounded rotation working, not a fault, so it should not read as one in the log.
 		if errors.Is(err, context.DeadlineExceeded) || status.Code(err) == codes.DeadlineExceeded {
@@ -480,18 +477,13 @@ func (c *Client) runEventsLoop(
 		} else {
 			slog.Info("events stream ended; reconnecting", "error", err, "reconnect_in", timings.reconnect)
 		}
-		timer := time.NewTimer(timings.reconnect)
+
 		select {
 		case <-ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
 			return
-		case <-timer.C:
+		case <-time.After(timings.reconnect):
 		}
-		if err := ctx.Err(); err != nil {
-			return
-		}
+
 		go resync()
 	}
 }

--- a/goproxy/cp/client.go
+++ b/goproxy/cp/client.go
@@ -41,7 +41,7 @@ const (
 	rpcDeadline = 30 * time.Second
 	// secretTokenHeader is the shared transport secret header the control plane expects.
 	secretTokenHeader = "x-pm-secret-token"
-	// eventsReconnect is the backoff between Events stream reconnect attempts.
+	// eventsReconnectDefault is the backoff between Events stream reconnect attempts.
 	eventsReconnectDefault = 5 * time.Second
 	// eventsStreamMaxAge bounds how long one Events stream is used before it is replaced. HTTP/2 keepalive
 	// proves the CONNECTION is alive, not that the stream on it still reaches a live control plane: a
@@ -58,22 +58,16 @@ const (
 	keepaliveTimeout = 10 * time.Second
 )
 
-// Overridable only so tests can shorten them; production always uses the defaults above.
-var (
-	eventsReconnect    = eventsReconnectDefault
-	eventsStreamMaxAge = eventsStreamMaxAgeDefault
-)
-
-func eventsStreamMaxAgeForTest(d time.Duration) func() {
-	prev := eventsStreamMaxAge
-	eventsStreamMaxAge = d
-	return func() { eventsStreamMaxAge = prev }
+type eventLoopTimings struct {
+	reconnect    time.Duration
+	streamMaxAge time.Duration
 }
 
-func eventsReconnectForTest(d time.Duration) func() {
-	prev := eventsReconnect
-	eventsReconnect = d
-	return func() { eventsReconnect = prev }
+func defaultEventLoopTimings() eventLoopTimings {
+	return eventLoopTimings{
+		reconnect:    eventsReconnectDefault,
+		streamMaxAge: eventsStreamMaxAgeDefault,
+	}
 }
 
 // Client is the proxy's gRPC client to the control plane. It satisfies engine.Decider.
@@ -395,7 +389,7 @@ func (c *Client) CloseConnection(connectionID []byte) error {
 // StreamEvents opens the proxy-initiated Events stream and dispatches refresh/run/table-detail
 // nudges until the stream ends or errors. Blocks the calling goroutine for the stream's lifetime.
 //
-// Bounded by eventsStreamMaxAge rather than left open indefinitely. The open stream IS the liveness
+// Bounded by eventsStreamMaxAgeDefault rather than left open indefinitely. The open stream IS the liveness
 // signal the control plane reads, so a stream that survives its control plane costs this datasource
 // every query until something ends it — and nothing here would, because keepalive only proves the
 // connection is alive. Expiry is a normal end: RunEventsLoop resyncs and reopens, and the control
@@ -405,7 +399,18 @@ func (c *Client) StreamEvents(
 	onOpenRun func(spi.RunOpen),
 	onOpenTableDetail func(sessionID, schema, table string),
 ) error {
-	ctx, cancel := context.WithTimeout(c.outCtx(context.Background()), eventsStreamMaxAge)
+	timings := defaultEventLoopTimings()
+	return c.streamEvents(context.Background(), timings.streamMaxAge, onRefresh, onOpenRun, onOpenTableDetail)
+}
+
+func (c *Client) streamEvents(
+	parent context.Context,
+	maxAge time.Duration,
+	onRefresh func(),
+	onOpenRun func(spi.RunOpen),
+	onOpenTableDetail func(sessionID, schema, table string),
+) error {
+	ctx, cancel := context.WithTimeout(c.outCtx(parent), maxAge)
 	defer cancel()
 	stream, err := c.stub.Events(ctx, &pb.EventsRequest{DatasourceName: c.datasourceName})
 	if err != nil {
@@ -439,7 +444,7 @@ func (c *Client) StreamEvents(
 	}
 }
 
-// RunEventsLoop holds the Events stream open and never returns. On a drop it waits eventsReconnect,
+// RunEventsLoop holds the Events stream open and never returns. On a drop it waits eventsReconnectDefault,
 // resyncs (re-registers + re-pushes the catalog, so a control plane that restarted with lost state
 // re-learns this datasource) and reopens.
 //
@@ -453,15 +458,40 @@ func (c *Client) RunEventsLoop(
 	onOpenRun func(spi.RunOpen),
 	onOpenTableDetail func(sessionID, schema, table string),
 ) {
+	c.runEventsLoop(context.Background(), defaultEventLoopTimings(), resync, onRefresh, onOpenRun, onOpenTableDetail)
+}
+
+func (c *Client) runEventsLoop(
+	ctx context.Context,
+	timings eventLoopTimings,
+	resync func(),
+	onRefresh func(),
+	onOpenRun func(spi.RunOpen),
+	onOpenTableDetail func(sessionID, schema, table string),
+) {
 	for {
-		err := c.StreamEvents(onRefresh, onOpenRun, onOpenTableDetail)
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		err := c.streamEvents(ctx, timings.streamMaxAge, onRefresh, onOpenRun, onOpenTableDetail)
 		// An expiry is the bounded rotation working, not a fault, so it should not read as one in the log.
 		if errors.Is(err, context.DeadlineExceeded) || status.Code(err) == codes.DeadlineExceeded {
-			slog.Info("events stream reached its max age; reopening", "max_age", eventsStreamMaxAge)
+			slog.Info("events stream reached its max age; reopening", "max_age", timings.streamMaxAge)
 		} else {
-			slog.Info("events stream ended; reconnecting", "error", err, "reconnect_in", eventsReconnect)
+			slog.Info("events stream ended; reconnecting", "error", err, "reconnect_in", timings.reconnect)
 		}
-		time.Sleep(eventsReconnect)
+		timer := time.NewTimer(timings.reconnect)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return
+		case <-timer.C:
+		}
+		if err := ctx.Err(); err != nil {
+			return
+		}
 		go resync()
 	}
 }

--- a/goproxy/cp/client_test.go
+++ b/goproxy/cp/client_test.go
@@ -613,11 +613,10 @@ func TestStreamEventsEndsAtItsMaxAge(t *testing.T) {
 	fake := &holdOpenControlPlane{done: make(chan struct{})}
 	c := startHoldOpenControlPlane(t, fake)
 
-	restore := eventsStreamMaxAgeForTest(300 * time.Millisecond)
-	defer restore()
-
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 	start := time.Now()
-	err := c.StreamEvents(func() {}, func(spi.RunOpen) {}, func(string, string, string) {})
+	err := c.streamEvents(ctx, 300*time.Millisecond, func() {}, func(spi.RunOpen) {}, func(string, string, string) {})
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -637,12 +636,19 @@ func TestEventsLoopReopensAfterMaxAge(t *testing.T) {
 	fake := &holdOpenControlPlane{done: make(chan struct{})}
 	c := startHoldOpenControlPlane(t, fake)
 
-	restore := eventsStreamMaxAgeForTest(150 * time.Millisecond)
-	defer restore()
-	restoreBackoff := eventsReconnectForTest(10 * time.Millisecond)
-	defer restoreBackoff()
-
-	go c.RunEventsLoop(func() {}, func() {}, func(spi.RunOpen) {}, func(string, string, string) {})
+	ctx, cancel := context.WithCancel(context.Background())
+	loopDone := make(chan struct{})
+	go func() {
+		defer close(loopDone)
+		c.runEventsLoop(ctx, eventLoopTimings{
+			streamMaxAge: 150 * time.Millisecond,
+			reconnect:    10 * time.Millisecond,
+		}, func() {}, func() {}, func(spi.RunOpen) {}, func(string, string, string) {})
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-loopDone
+	})
 
 	deadline := time.After(5 * time.Second)
 	for {
@@ -664,17 +670,24 @@ func TestEventsLoopReopensWithoutWaitingForResync(t *testing.T) {
 	fake := &holdOpenControlPlane{done: make(chan struct{})}
 	c := startHoldOpenControlPlane(t, fake)
 
-	restore := eventsStreamMaxAgeForTest(150 * time.Millisecond)
-	defer restore()
-	restoreBackoff := eventsReconnectForTest(10 * time.Millisecond)
-	defer restoreBackoff()
-
+	ctx, cancel := context.WithCancel(context.Background())
+	loopDone := make(chan struct{})
 	blocked := make(chan struct{})
-	go c.RunEventsLoop(
-		func() { <-blocked }, // a resync that never finishes
-		func() {}, func(spi.RunOpen) {}, func(string, string, string) {},
-	)
-	defer close(blocked)
+	resync := func() {
+		<-blocked // every background resync stays blocked until test cleanup releases it
+	}
+	go func() {
+		defer close(loopDone)
+		c.runEventsLoop(ctx, eventLoopTimings{
+			streamMaxAge: 150 * time.Millisecond,
+			reconnect:    10 * time.Millisecond,
+		}, resync, func() {}, func(spi.RunOpen) {}, func(string, string, string) {})
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-loopDone
+		close(blocked) // release the background resync goroutines after the loop exits
+	})
 
 	deadline := time.After(5 * time.Second)
 	for {

--- a/goproxy/cp/client_test.go
+++ b/goproxy/cp/client_test.go
@@ -701,3 +701,80 @@ func TestEventsLoopReopensWithoutWaitingForResync(t *testing.T) {
 		}
 	}
 }
+
+// refusingControlPlane fails every Events call immediately, standing in for a control plane that is
+// reachable but not serving — the shape a restart or a rollout takes from the proxy's side.
+type refusingControlPlane struct {
+	pb.UnimplementedControlPlaneServer
+	mu    sync.Mutex
+	opens []time.Time
+}
+
+func (f *refusingControlPlane) Events(_ *pb.EventsRequest, _ grpc.ServerStreamingServer[pb.ControlEvent]) error {
+	f.mu.Lock()
+	f.opens = append(f.opens, time.Now())
+	f.mu.Unlock()
+	return status.Error(codes.Unavailable, "not serving")
+}
+
+func (f *refusingControlPlane) openTimes() []time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]time.Time(nil), f.opens...)
+}
+
+func TestEventsLoopWaitsTheBackoffBetweenReopens(t *testing.T) {
+	// A stream that fails to open returns immediately, so the backoff is the only thing pacing the loop.
+	// Without it a control plane that is down turns into a hot reconnect loop that also launches a
+	// catalog-introspecting resync per iteration. Asserting that reopens happen is not enough to catch
+	// that: the reopens still happen, just unboundedly fast.
+	const backoff = 120 * time.Millisecond
+
+	fake := &refusingControlPlane{}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := grpc.NewServer()
+	pb.RegisterControlPlaneServer(server, fake)
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(server.Stop)
+
+	c, err := New(listener.Addr().String(), "secret-abc", "ds-1")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	loopDone := make(chan struct{})
+	go func() {
+		defer close(loopDone)
+		c.runEventsLoop(ctx, eventLoopTimings{
+			streamMaxAge: time.Minute, // long enough that only the backoff paces this test
+			reconnect:    backoff,
+		}, func() {}, func() {}, func(spi.RunOpen) {}, func(string, string, string) {})
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-loopDone
+	})
+
+	deadline := time.After(5 * time.Second)
+	for len(fake.openTimes()) < 3 {
+		select {
+		case <-deadline:
+			t.Fatalf("only %d opens against a refusing control plane — the loop is not reopening", len(fake.openTimes()))
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// Compare against the whole backoff rather than a fraction of it: the gap is the wait plus the failed
+	// RPC, so it can only run long. A loop that skipped the wait would show gaps near zero.
+	opens := fake.openTimes()
+	for i := 1; i < len(opens); i++ {
+		if gap := opens[i].Sub(opens[i-1]); gap < backoff {
+			t.Fatalf("reopen %d came %v after the previous one, faster than the %v backoff", i, gap, backoff)
+		}
+	}
+}

--- a/mise.toml
+++ b/mise.toml
@@ -222,6 +222,18 @@ for m in analyzer auditmon goproxy mysqlwire pmon; do
 done
 '''
 
+[tasks.test-go-race]
+description = "Go race-detector tests against one database version (defaults to the newest supported)"
+shell = "bash -c"
+# Keep the same module loop as `test-go`; only enable the race detector.
+run = '''
+set -euo pipefail
+for m in analyzer auditmon goproxy mysqlwire pmon; do
+  echo "=== $m ==="
+  (cd "$m" && go test -race ./...)
+done
+'''
+
 [tasks.test]
 description = "All tests against the newest supported database version — the local default"
 depends = ["test-jvm", "test-go"]


### PR DESCRIPTION
## Summary

- replace mutable package-level event-loop timing overrides with per-call timings
- make event-loop reconnect waits cancellation-aware for deterministic test cleanup
- preserve asynchronous resync behavior and verify that blocked resyncs do not delay stream reopening
- add an opt-in `mise run test-go-race` task without changing the existing test or CI gates

## Verification

- `git diff --check`
- `mise exec -- go test ./goproxy/cp -count=1`
- `mise exec -- go test -race ./goproxy/cp -count=1`
- `mise run test-go-race` passes through analyzer, auditmon, goproxy, and mysqlwire; pmon is blocked locally by VCS stamping and temporary-directory permission checks