### PR TITLE
feat(cp): let a debug login simulate the source address it decides under

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -1,5 +1,6 @@
 package com.ridi.oss.proxymonster.controlplane
 
+import com.cedarpolicy.value.IpAddress
 import com.ridi.oss.proxymonster.controlplane.authz.Authz
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzContext
@@ -684,6 +685,14 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
             // principal with these roles" true. Replace rather than add: the claim is the whole intended
             // set, so a second debug login cannot silently accumulate roles from the first.
             val roles = login.roles.map { it.trim() }.filter { it.isNotBlank() }.distinct()
+            // Rejected outright when malformed rather than dropped to null: a silently-ignored address
+            // would present as "the tag rule does not work", sending the reader after a policy bug that
+            // isn't there.
+            val debugRequesterIp = login.requesterIp?.trim()?.takeIf { it.isNotEmpty() }
+            if (debugRequesterIp != null && !isStorableIpLiteral(debugRequesterIp, authz::evaluatesInCedar)) {
+                call.respond(HttpStatusCode.BadRequest, ApiError("auth.invalid_requester_ip"))
+                return@post
+            }
             val deviceId = call.ensureDeviceCookie(config.mcpIssuer.startsWith("https://"))
             // Roles and session in ONE transaction under ONE per-principal lock (mintWeb re-takes the same
             // advisory lock, which is re-entrant). Committing separately would let a failed mint leave the roles
@@ -700,6 +709,7 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
                         config.webSessionIdleSeconds,
                         deviceId,
                         c,
+                        debugRequesterIp,
                     )
                 }
             } catch (e: ManagementException) {
@@ -707,7 +717,7 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
                 return@post
             }
             call.sessions.set(WebSessionRef(sessionId))
-            call.respond(HttpStatusCode.OK, UserSession(login.principal, roles))
+            call.respond(HttpStatusCode.OK, UserSession(login.principal, roles, debugRequesterIp))
         }
 
         mePermissionsRoute(config, authz)
@@ -718,8 +728,11 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
                 // Resolved per request, never carried in the session: a role gained or lost after
                 // login (group change, expired JIT grant, deactivation) must be visible to the next
                 // read, and the console shows this set while explaining a decision.
-                val principal = requireNotNull(call.principal<WebSessionRow>()).principal
-                call.respond(UserSession(principal, roleResolver.resolve(principal).sorted()))
+                val row = requireNotNull(call.principal<WebSessionRow>())
+                // Reported only while the bypass that honors it is on, so the console never shows a
+                // simulated address the decision path is in fact ignoring.
+                val simulatedIp = row.debugRequesterIp.takeIf { config.authDebug }
+                call.respond(UserSession(row.principal, roleResolver.resolve(row.principal).sorted(), simulatedIp))
             }
 
             get("/auth/session/status") {

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Auth.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Auth.kt
@@ -19,9 +19,17 @@ private const val DEVICE_COOKIE_MAX_AGE_SECONDS = 7_776_000
 /**
  * The authenticated principal resolved from the server-side session row. Roles remain a
  * response-compatibility field; authorization resolves effective roles server-side.
+ *
+ * [requesterIp] is populated only for a session carrying a debug-login simulated address, so the console
+ * can show which network its decisions are being authorized against — a masked column and a cleartext one
+ * differ by nothing else on screen, and without this the reason is invisible.
  */
 @kotlinx.serialization.Serializable
-data class UserSession(val principal: String, val roles: List<String> = emptyList())
+data class UserSession(
+    val principal: String,
+    val roles: List<String> = emptyList(),
+    val requesterIp: String? = null,
+)
 
 @kotlinx.serialization.Serializable
 data class WebSessionRef(val sessionId: Long)
@@ -32,9 +40,19 @@ val FAILED_WEB_SESSION = AttributeKey<Long>("failed-web-session")
 private val RESOLVED_IDENTITY = AttributeKey<ResolvedIdentity>("resolved-session-identity")
 private data class ResolvedIdentity(val row: WebSessionRow?)
 
-/** Body for the dev-only debug login (PM_AUTH_DEBUG) — the dev bypass alongside the OIDC login (Oidc.kt). */
+/**
+ * Body for the dev-only debug login (PM_AUTH_DEBUG) — the dev bypass alongside the OIDC login (Oidc.kt).
+ *
+ * [requesterIp] simulates the source address the session's decisions are authorized under, so a Cedar tag
+ * rule keyed on a CIDR can be exercised from a development box where every request arrives from loopback.
+ * Blank/absent leaves the observed peer authoritative. Honored only while the bypass is enabled.
+ */
 @kotlinx.serialization.Serializable
-data class DebugLogin(val principal: String, val roles: List<String> = emptyList())
+data class DebugLogin(
+    val principal: String,
+    val roles: List<String> = emptyList(),
+    val requesterIp: String? = null,
+)
 
 /**
  * A [SessionSerializer] backed by kotlinx.serialization JSON. Ktor's bundled serializer

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/DaemonSession.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/DaemonSession.kt
@@ -79,6 +79,9 @@ data class WebSessionRow(
     val absoluteExpiresAt: Instant,
     val idleExpiresAt: Instant,
     val now: Instant,
+    // A simulated source address chosen at debug login, or null for every ordinary login. Read ONLY
+    // while the debug-authentication bypass is enabled; see [ApplicationCall.httpRequesterIp].
+    val debugRequesterIp: String? = null,
 )
 
 data class LivenessCandidate(
@@ -167,6 +170,9 @@ class PrincipalSessionStore(
         idleSeconds: Long,
         deviceId: String,
         c: Connection? = null,
+        // Set by the debug login, and carried over by the debug OAuth authorize when it remints the same
+        // principal's session. Read back only under the debug bypass.
+        debugRequesterIp: String? = null,
     ): Long {
         val encrypted = refreshToken?.let { crypto?.encrypt(it.toByteArray(Charsets.UTF_8)) }
         var displaced = 0
@@ -181,8 +187,8 @@ class PrincipalSessionStore(
             val id = connection.prepareStatement(
                 """WITH t AS (SELECT clock_timestamp() AS ts)
                    INSERT INTO principal_session
-                   (principal, refresh_token_enc, created_at, absolute_expires_at, idle_expires_at, liveness_status, device_id, kind)
-                   SELECT ?, ?, t.ts, t.ts + make_interval(secs => ?), t.ts + make_interval(secs => ?), ?, ?, 'WEB'
+                   (principal, refresh_token_enc, created_at, absolute_expires_at, idle_expires_at, liveness_status, device_id, kind, debug_requester_ip)
+                   SELECT ?, ?, t.ts, t.ts + make_interval(secs => ?), t.ts + make_interval(secs => ?), ?, ?, 'WEB', ?
                    FROM t
                    RETURNING id""",
             ).use { ps ->
@@ -192,6 +198,7 @@ class PrincipalSessionStore(
                 ps.setDouble(4, idleSeconds.toDouble())
                 ps.setString(5, LIVENESS_ACTIVE)
                 ps.setString(6, deviceId)
+                ps.setString(7, debugRequesterIp)
                 ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) }
             }
             displaced = connection.prepareStatement(
@@ -241,7 +248,7 @@ class PrincipalSessionStore(
     private fun resolveWeb(id: Long, deviceId: String?, c: Connection): WebSessionRow? {
         val resolved = c.prepareStatement(
             """SELECT id, principal, created_at, absolute_expires_at, idle_expires_at, device_id,
-                      clock_timestamp() AS db_now
+                      debug_requester_ip, clock_timestamp() AS db_now
                FROM principal_session
                WHERE id = ? AND kind = 'WEB' AND ended_at IS NULL
                  AND absolute_expires_at > clock_timestamp()
@@ -259,6 +266,7 @@ class PrincipalSessionStore(
                         absoluteExpiresAt = rs.getTimestamp("absolute_expires_at").toInstant(),
                         idleExpiresAt = rs.getTimestamp("idle_expires_at").toInstant(),
                         now = rs.getTimestamp("db_now").toInstant(),
+                        debugRequesterIp = rs.getString("debug_requester_ip"),
                     )
                 }
             }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RequesterIp.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RequesterIp.kt
@@ -198,12 +198,44 @@ private fun stripToBareIp(candidate: String?): String? {
 }
 
 /**
+ * Whether [candidate] can be stored AND evaluated by the Cedar engine.
+ *
+ * `IpAddress` is a Java-side regex, looser than the Rust engine that ultimately parses the value: it
+ * accepts a NUL-bearing string (which Postgres then rejects at INSERT) and non-canonical IPv4 like
+ * `100.100.001.010` (which the engine refuses — and an unevaluable context value fails the whole
+ * authorization closed, so the request denies everywhere with nothing naming the address). Hence
+ * [evaluatesInCedar], the authoritative gate; the character allowlist is only a cheap pre-filter.
+ */
+internal fun isStorableIpLiteral(candidate: String, evaluatesInCedar: (String) -> Boolean): Boolean {
+    if (candidate.isEmpty()) return false
+    if (!candidate.all { it.isDigit() || it == '.' || it == ':' || it in 'a'..'f' || it in 'A'..'F' }) return false
+    if (runCatching { IpAddress(candidate) }.isFailure) return false
+    return evaluatesInCedar(candidate)
+}
+
+/**
  * The HTTP entry point's resolved requester IP — trusted-edge-gated per
  * [resolveHttpRequesterIp]. `request.local.remoteAddress` is the raw socket peer Ktor's Netty engine reports;
  * no `ForwardedHeaders`/`XForwardedHeaders` plugin is installed (App.kt), so nothing upstream of this call
  * has already substituted a client-asserted value — the peer really is the TCP-level fact this resolver needs.
+ *
+ * Under [Config.authDebug] a session may instead carry a SIMULATED address chosen at debug login
+ * ([debugRequesterIp]) — every browser request on a development box arrives from loopback, so a tag rule
+ * keyed on a CIDR could otherwise never fire and the behavior it gates could not be exercised at all. This
+ * is the ONE resolver every HTTP-path decision reads, so the simulation reaches the editor, the approval
+ * routes, and the admin gates identically to a real address, rather than being special-cased per route.
+ *
+ * What this costs, stated precisely: `authDebug` already mints any role, so against a policy gated on role
+ * alone a simulated address adds nothing. But against one gated on role AND network — the shipped `-258`
+ * PII unmask needs `system:production-pii-accessor` AND the `trusted-network` tag — the peer was still a
+ * second, independent factor, and simulating it removes that. So this WIDENS the bypass rather than merely
+ * riding on it. It is acceptable only because `Config.fromEnv` refuses to start with `authDebug` on in a
+ * production-looking configuration, and because with the bypass off the stored value is never consulted.
  */
 internal fun ApplicationCall.httpRequesterIp(config: Config): String? {
+    if (config.authDebug) {
+        webSession()?.debugRequesterIp?.let { return it }
+    }
     val peer = request.local.remoteAddress
     val xff = request.headers.getAll("X-Forwarded-For")?.lastOrNull()
     return resolveHttpRequesterIp(peer, xff, config.trustedProxies)

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
@@ -298,6 +298,23 @@ class Authz(
     internal fun rolesOf(principal: String): Set<String> = roleSource.rolesOf(principal)
 
     /**
+     * Whether the ENGINE can evaluate [ip] as a `requester_ip` — which cedar-java's `IpAddress` regex
+     * does not answer (see [com.ridi.oss.proxymonster.controlplane.isStorableIpLiteral]).
+     *
+     * Runs one throwaway decision and asks only whether the engine produced a verdict at all: the
+     * verdict itself is irrelevant, only the absence of an engine ERROR is being tested.
+     */
+    fun evaluatesInCedar(ip: String): Boolean {
+        val principal = USER_TYPE.of("ip-probe")
+        val entities = Entities(setOf(Entity(principal, emptyMap(), emptySet())))
+        val context = AuthzContext(requesterIp = ip).toCedarMap()
+        val response = runCatching {
+            engine.isAuthorized(principal, ACTION_TYPE.of(AuthzAction.SQL_SELECT.cedarId), SYSTEM_TYPE.of("system"), entities, context)
+        }.getOrNull() ?: return false
+        return response.success.isPresent
+    }
+
+    /**
      * Single-resolution entry: resolve [principal]'s roles once, then authorize via [authorizeAs]. This is the
      * common case (System / AuditLog resources with no datasource-scoped tags — `requireAdmin`, computeMePermissions,
      * the audit routes). When a datasource-scoped `context.tags` derivation must AGREE with the final decision on

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/oauth/OAuthRoutes.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/oauth/OAuthRoutes.kt
@@ -13,6 +13,7 @@ import com.ridi.oss.proxymonster.controlplane.PrincipalSessionStore
 import com.ridi.oss.proxymonster.controlplane.WebSessionRef
 import com.ridi.oss.proxymonster.controlplane.ensureDeviceCookie
 import com.ridi.oss.proxymonster.controlplane.userSession
+import com.ridi.oss.proxymonster.controlplane.webSession
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -157,6 +158,16 @@ fun Route.mcpOAuthRoutes(
             call.sessions.set(MCP_OAUTH_PENDING_COOKIE, pending)
             // Debug OAuth and the web console intentionally share the same authenticated session,
             // matching the production co-hosted flow without a second identity boundary.
+            //
+            // Sharing the session means REPLACING it: mintWeb is newest-wins, so this ends the console's
+            // current session. Carry that session's simulated source address onto the new row, or an MCP
+            // authorization in the same browser would silently drop it and every later console decision
+            // would fall back to the observed peer — the console's authorization context changing as a
+            // side effect of an unrelated login. Only when the principal is unchanged: an explicit
+            // ?principal= switches identity, and one identity's simulated network must not follow another's.
+            val inheritedRequesterIp = call.webSession()
+                ?.takeIf { it.principal == principal }
+                ?.debugRequesterIp
             val deviceId = call.ensureDeviceCookie(config.mcpIssuer.startsWith("https://"))
             call.sessions.set(
                 WebSessionRef(
@@ -166,6 +177,7 @@ fun Route.mcpOAuthRoutes(
                         config.webSessionAbsoluteSeconds,
                         config.webSessionIdleSeconds,
                         deviceId,
+                        debugRequesterIp = inheritedRequesterIp,
                     ),
                 ),
             )

--- a/control-plane/src/main/resources/db/migration/V10__debug_requester_ip.sql
+++ b/control-plane/src/main/resources/db/migration/V10__debug_requester_ip.sql
@@ -1,0 +1,14 @@
+-- A development-only simulated source address for one console login.
+--
+-- Every authorization decision carries the requester's observed source address, and admin-authored
+-- rules derive named context tags from it -- a "trusted-network" tag earned by a CIDR match, for
+-- example -- which later rules condition on. On a development box every browser request arrives
+-- from loopback, so such a rule can never fire and the behavior it gates cannot be exercised
+-- without physically moving the client onto the matching network.
+--
+-- This column records an address chosen when a session is created through the debug-authentication
+-- bypass, and it is consulted ONLY while that bypass is enabled. With the bypass off the column is
+-- ignored outright and the observed socket peer stays authoritative, so a row left behind by an
+-- earlier development run can never weaken a real deployment. NULL means "use the observed
+-- address", which is what every non-debug login writes.
+ALTER TABLE principal_session ADD COLUMN debug_requester_ip TEXT;

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DebugRequesterIpDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DebugRequesterIpDbTest.kt
@@ -1,0 +1,318 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzDecision
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
+import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
+import com.ridi.oss.proxymonster.controlplane.authz.authorizeWithContext
+import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get as serverGet
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.Test
+import javax.sql.DataSource
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The development-only simulated source address chosen at debug login (Auth.kt `DebugLogin.requesterIp`).
+ *
+ * Every request on a development box arrives from loopback, so a Cedar tag rule keyed on a CIDR can never
+ * fire and the behavior it gates cannot be reached at all. The login may therefore name an address the
+ * session's decisions authorize under. That is only sound because it rides on a bypass that already lets
+ * anyone log in as any principal with any roles — so the load-bearing property, and what this test exists
+ * to pin, is that it is INERT the moment that bypass is off. A stored value surviving from an earlier
+ * development run must never weaken a real deployment.
+ *
+ * The assertions read the ONE resolver every HTTP-path decision goes through
+ * ([ApplicationCall.httpRequesterIp]) via a probe route, rather than an inner helper — the substitution is
+ * only worth anything if it reaches that resolver, and a helper-level test would stay green if the wiring
+ * into it were deleted.
+ */
+class DebugRequesterIpDbTest {
+    private val principal = "dev@example.com"
+
+    /** Written as an escape so the source file itself stays free of a literal NUL byte. */
+    private val NUL = "\u0000"
+
+    /** The datasource the tag rules below are evaluated against (pass 1 is datasource-scoped). */
+    private val TAG_DS = "tagged-ds"
+
+    /** Pass 1: the shipped producer's shape — an in-range requester_ip earns "trusted-network". */
+    private val trustedNetworkRule = """permit(
+        principal, action == Action::"context.tag::trusted-network", resource
+    ) when { context has requester_ip && context.requester_ip.isInRange(ip("100.100.0.0/16")) };"""
+
+    /** Pass 2: the consuming grant — fires only on the derived tag, never on the raw address. */
+    private val tagGatedPermit = """permit(
+        principal, action == Action::"task.approve", resource
+    ) when { context has tags && context.tags.contains("trusted-network") };"""
+
+    /**
+     * Echoes what the decision path would see as this request's requester IP ("-" when absent), plus a
+     * route that runs a REAL Cedar decision through the two-pass tag derivation — the difference between
+     * "the resolver returns the address" and "the address actually changes an authorization outcome".
+     */
+    private fun ApplicationTestBuilder.probe(config: Config, core: ControlPlaneCore): HttpClient {
+        application {
+            module(config, core)
+            routing {
+                serverGet("/test/requester-ip") { call.respond(call.httpRequesterIp(config) ?: "-") }
+                serverGet("/test/tag-gated") {
+                                val decision = core.authz.authorizeWithContext(
+                        call.parameters["principal"] ?: principal,
+                        AuthzAction.TASK_APPROVE,
+                        AuthzResource.ApprovalRequest(requester = "someone-else", datasourceName = TAG_DS),
+                        call.httpAuthzContext(config),
+                        TAG_DS,
+                    )
+                    call.respond(if (decision is AuthzDecision.Deny) "DENY" else "ALLOW")
+                }
+            }
+        }
+        return createClient {
+            expectSuccess = false
+            install(HttpCookies)
+            install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+    }
+
+    private suspend fun HttpClient.debugLogin(ip: String?) = post("/auth/debug") {
+        headers.append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+        setBody(DebugLogin(principal, emptyList(), ip))
+    }
+
+    private suspend fun HttpClient.observedIp(): String = get("/test/requester-ip").body()
+
+    /** WEB session rows in the store — lets a test assert that a refused login minted nothing. */
+    private fun webSessionCount(dataSource: DataSource): Int = dataSource.connection.use { c ->
+        c.prepareStatement("SELECT count(*) FROM principal_session WHERE kind = 'WEB'").use { ps ->
+            ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) }
+        }
+    }
+
+    private fun storedIp(dataSource: DataSource): String? = dataSource.connection.use { c ->
+        c.prepareStatement(
+            "SELECT debug_requester_ip FROM principal_session WHERE kind = 'WEB' ORDER BY id DESC LIMIT 1",
+        ).use { ps ->
+            ps.executeQuery().use { rs -> assertTrue(rs.next(), "no web session row was minted"); rs.getString(1) }
+        }
+    }
+
+    @Test
+    fun `a debug login's simulated address replaces the observed peer on the decision path`() = testApplication {
+        requireDockerOrSkip()
+        val dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_debug_requester_ip"))
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        val config = Config.fromEnv { null }.copy(dbUrl = "", dbUser = "", dbPassword = "")
+        val client = probe(config, ControlPlaneCore(dataSource))
+
+        // Baseline: with no simulated address the observed loopback peer is what a decision sees. Without
+        // this the substitution assertion below would also pass an implementation that returns the constant.
+        assertEquals(HttpStatusCode.OK, client.debugLogin(null).status)
+        val realPeer = client.observedIp()
+        assertTrue(realPeer != "100.100.1.10", "the socket peer must not already be the simulated address")
+        assertNull(storedIp(dataSource), "an ordinary login stores no simulated address")
+
+        assertEquals(HttpStatusCode.OK, client.debugLogin("100.100.1.10").status)
+        assertEquals("100.100.1.10", storedIp(dataSource))
+        assertEquals("100.100.1.10", client.observedIp(), "the decision path must see the simulated address")
+
+        // The console shows which network its decisions are made from, so a reload must keep reporting it —
+        // reading it back off the session row, not from a login response the reload never sees.
+        assertEquals(
+            UserSession(principal, emptyList(), "100.100.1.10"),
+            client.get("/auth/me").body<UserSession>(),
+        )
+
+        // A later login without one CLEARS it rather than inheriting the previous session's: an address the
+        // operator did not ask for is exactly the silently-wrong network this feature exists to make visible.
+        assertEquals(HttpStatusCode.OK, client.debugLogin(null).status)
+        assertNull(storedIp(dataSource))
+        assertEquals(realPeer, client.observedIp())
+    }
+
+    @Test
+    fun `a malformed address is refused rather than silently ignored`() = testApplication {
+        requireDockerOrSkip()
+        val dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_debug_requester_ip_bad"))
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        val config = Config.fromEnv { null }.copy(dbUrl = "", dbUser = "", dbPassword = "")
+        val client = probe(config, ControlPlaneCore(dataSource))
+
+        // Dropping it to null would present as "the tag rule does not work", sending the reader after a
+        // policy bug that isn't there. The login fails, naming the input as the problem.
+        val bad = listOf(
+            "not-an-ip", "999.1.1.1", "100.100.1.10:5432", "100.100.1.0/24",
+            // Both pass cedar-java's parse (its validator trims control characters) but are unstorable.
+            // Surrounding whitespace is deliberately absent: trim() removes it, leaving a valid address.
+            "100.100.1.10" + NUL, "100.100.1.10" + NUL + "12",
+            "100.100.1.10\u200b",
+            "fe80::1%lo0", "[::1]",
+            // Accepted by cedar-java's regex, refused by the engine — which denies the whole request.
+            "100.100.001.010", "010.1.1.1",
+        )
+        for (value in bad) {
+            val response = client.debugLogin(value)
+            assertEquals(HttpStatusCode.BadRequest, response.status, "'${value.escaped()}' must be refused")
+            assertEquals(ApiError("auth.invalid_requester_ip"), response.body<ApiError>())
+        }
+
+        // Rejection must leave NOTHING behind. Every assertion above would also hold for a handler that
+        // minted the session, rewrote the principal's roles, and only then returned 400 — leaving the
+        // caller logged in under a request the server said it refused.
+        assertEquals(0, webSessionCount(dataSource), "a refused login must mint no session")
+
+        // The positive controls: the loop above must be rejecting these specific values rather than
+        // rejecting everything. IPv6 and surrounding whitespace are here because they are exactly what a
+        // too-eager tightening would break — an IPv4-only allowlist, or dropping the server-side trim,
+        // would sail past every rejection assertion above.
+        for (good in listOf("100.100.1.10", "  100.100.1.10  ", "::1", "2001:db8::1", "fe80::1")) {
+            assertEquals(HttpStatusCode.OK, client.debugLogin(good).status, "'$good' must be accepted")
+            assertEquals(good.trim(), storedIp(dataSource), "'$good' must be stored as typed, trimmed")
+        }
+    }
+
+    /** Renders control characters visibly, so a failure message names the input instead of printing it raw. */
+    private fun String.escaped(): String = map { c ->
+        if (c.isLetterOrDigit() || c in ".:%[]/-") c.toString() else "\\u%04x".format(c.code)
+    }.joinToString("")
+
+    /**
+     * The point of the whole feature: a simulated address must change a REAL authorization outcome, through
+     * the two-pass tag derivation the shipped production preset uses.
+     *
+     * Everything else here asserts the resolver returns the address. That is necessary and not sufficient —
+     * an implementation that resolves it correctly but never threads it into the decision context would keep
+     * every other test green while the feature does nothing. This pins the property the feature exists for:
+     * same principal, same action, same resource, and the ONLY difference is the address the session claims.
+     */
+    @Test
+    fun `a simulated address changes a real Cedar decision through the derived tag`() = testApplication {
+        requireDockerOrSkip()
+        val dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_debug_requester_ip_cedar"))
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        val core = ControlPlaneCore(dataSource)
+        core.datasourceStore.create(
+            DatasourceInput(name = TAG_DS, engine = "postgres", host = "localhost", port = 5432, dbName = "app"),
+        )
+        core.cedarPolicyStore.create(CedarPolicyInput(name = "t-net-producer", cedarSrc = trustedNetworkRule), updatedBy = null)
+        core.cedarPolicyStore.create(CedarPolicyInput(name = "t-net-consumer", cedarSrc = tagGatedPermit), updatedBy = null)
+
+        // authDebug must stay ON — it is what honors the simulated address — but requireAuthz's own debug
+        // short-circuit never runs here, because this route calls authorizeWithContext directly. So the
+        // Cedar decision below is real.
+        val config = Config.fromEnv { null }.copy(dbUrl = "", dbUser = "", dbPassword = "")
+        val client = probe(config, core)
+
+        assertEquals(HttpStatusCode.OK, client.debugLogin("100.100.1.10").status)
+        assertEquals("ALLOW", client.get("/test/tag-gated").body<String>(), "in-range address must earn the tag")
+
+        // The negative control. Same principal, same policies, same resource — only the claimed address
+        // differs, so an ALLOW here would mean the decision never saw the address at all.
+        assertEquals(HttpStatusCode.OK, client.debugLogin("203.0.113.5").status)
+        assertEquals("DENY", client.get("/test/tag-gated").body<String>(), "out-of-range address must not")
+
+        // And with no simulated address the loopback peer is out of range too — so the ALLOW above came
+        // from the simulation rather than from the test host happening to sit in the range.
+        assertEquals(HttpStatusCode.OK, client.debugLogin(null).status)
+        assertEquals("DENY", client.get("/test/tag-gated").body<String>(), "the observed peer is not in range")
+    }
+
+    /**
+     * The risk this feature carries: a development session row keeps its simulated address, and something
+     * later turns the bypass off — an operator flipping `PM_AUTH_DEBUG`, or a database promoted out of
+     * development. The session is still live and its cookie still valid, so the row's address must simply
+     * stop being consulted.
+     *
+     * Both halves therefore run against ONE database with ONE session secret, and the SAME cookie minted
+     * under the bypass is replayed against a control plane running without it — the shape the risk actually
+     * takes. Building a cookie by hand cannot substitute: the cookie carries an opaque session key that only
+     * a real mint registers, so a forged one resolves to no session at all and the assertion passes for the
+     * wrong reason, no matter what the resolver does.
+     */
+    @Test
+    fun `the stored address is inert once the debug bypass is off`() = runBlocking {
+        requireDockerOrSkip()
+        val dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_debug_requester_ip_off"))
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        val secret = "debug-requester-ip-test-secret-0123456789"
+
+        fun config(authDebug: Boolean) = Config(
+            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = authDebug, secretToken = null,
+            sessionSecret = secret, oidc = null, resultKey = null, scimToken = null,
+            sessionWindowSeconds = 3600, idpRecheckIntervalSeconds = 600, devMarker = true,
+            // testApplication has no real socket, so its peer resolves to absent. Trusting it as an edge
+            // lets the bypass-off half assert a REAL resolved address (from XFF) rather than only "not the
+            // simulated one" — see the assertion below for why that distinction has teeth.
+            trustedProxies = setOf("localhost"),
+        )
+
+        // With the bypass ON: log in with a simulated address and keep the cookies a browser would hold.
+        var cookies = ""
+        testApplication {
+            val client = probe(config(authDebug = true), ControlPlaneCore(dataSource))
+            val login = client.debugLogin("100.100.1.10")
+            assertEquals(HttpStatusCode.OK, login.status)
+            assertEquals("100.100.1.10", storedIp(dataSource))
+            assertEquals("100.100.1.10", client.observedIp(), "the bypass-on control is this test's premise")
+            cookies = login.headers.getAll(HttpHeaders.SetCookie).orEmpty()
+                .joinToString("; ") { it.substringBefore(';') }
+        }
+
+        // The SAME live session, replayed against a control plane running without the bypass.
+        testApplication {
+            val client = probe(config(authDebug = false), ControlPlaneCore(dataSource))
+            // It must still AUTHENTICATE — otherwise the address goes absent because nothing resolved, not
+            // because the resolver refused to honor it, and the assertion below would prove nothing.
+            val me = client.get("/auth/me") { header(HttpHeaders.Cookie, cookies) }
+            assertEquals(HttpStatusCode.OK, me.status, "the session must still be live with the bypass off")
+            assertEquals(principal, me.body<UserSession>().principal)
+            assertNull(
+                me.body<UserSession>().requesterIp,
+                "the console must not display a simulated address the decision path is ignoring",
+            )
+            // Asserted as EQUALITY to the observed peer, not merely "not the simulated address". A
+            // resolver that returned null for every request — dropping requester_ip, and with it every
+            // network-derived tag, across the whole deployment — would satisfy an inequality while being
+            // catastrophically broken. The baseline peer comes from a cookie-less request to the same
+            // probe, so it is measured rather than assumed.
+            // The stored address must not reach the decision path. Asserted against a trusted-edge XFF
+            // rather than the socket peer, because testApplication has no real socket and its peer resolves
+            // to absent — so a plain "not the simulated address" would also hold for a resolver that
+            // returned null for EVERY production request, dropping requester_ip and every network-derived
+            // tag deployment-wide. Pinning an address production resolution must still produce closes that.
+            val forwarded = client.get("/test/requester-ip") {
+                header(HttpHeaders.Cookie, cookies)
+                header("X-Forwarded-For", "198.51.100.7")
+            }.body<String>()
+            assertEquals(
+                "198.51.100.7", forwarded,
+                "with the bypass off the request's own attested address stands, not the session's stored one",
+            )
+            // And the route that writes one is gone entirely, so no new session can acquire one.
+            assertEquals(HttpStatusCode.NotFound, client.debugLogin("100.100.1.10").status)
+        }
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/oauth/OAuthRoutesDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/oauth/OAuthRoutesDbTest.kt
@@ -54,6 +54,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -387,6 +388,74 @@ class OAuthRoutesDbTest {
         )
     }
 
+    /**
+     * The debug `/oauth/authorize` shares the console's authenticated session, and sharing means REPLACING
+     * it — `mintWeb` is newest-wins. So the simulated source address the console is deciding under has to
+     * survive that remint, or an MCP authorization in the same browser silently changes the console's
+     * authorization context: tag rules stop firing, and nothing on screen says why.
+     *
+     * Pinned here rather than in DebugRequesterIpDbTest because the bug lives in THIS route. Both branches
+     * are asserted — the carry-over, and the deliberate drop when `?principal=` names someone else, since
+     * one identity's simulated network must never follow another's.
+     */
+    @Test
+    fun `debug authorize carries the simulated source address across its session remint`() = testApplication {
+        application { oauthTestModule(config(), dataSource, resolver()) }
+        val client = createClient {
+            expectSuccess = false
+            followRedirects = false
+            install(HttpCookies)
+            install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+        suspend fun authorizeAs(principal: String): HttpStatusCode = client.get("/oauth/authorize") {
+            parameter("response_type", "code")
+            parameter("client_id", CLIENT_ID)
+            parameter("redirect_uri", REDIRECT_URI)
+            parameter("scope", "mcp:read")
+            parameter("state", "state-ip")
+            parameter("resource", RESOURCE)
+            parameter("code_challenge", CHALLENGE)
+            parameter("code_challenge_method", "S256")
+            parameter("principal", principal)
+        }.status
+
+        // The console session: signed in, deciding as if from the trusted network.
+        val owner = "ip-owner@example.com"
+        client.post("/test/login/$owner") { parameter("requesterIp", "100.100.1.10") }
+        assertEquals("100.100.1.10", liveDebugIp(owner))
+
+        // Same principal: the remint must carry the address over.
+        assertEquals(HttpStatusCode.Found, authorizeAs(owner))
+        assertEquals(
+            "100.100.1.10", liveDebugIp(owner),
+            "an MCP authorization must not silently drop the console's simulated address",
+        )
+
+        // A DIFFERENT principal: the new session must start with no simulated address at all.
+        val other = "ip-other@example.com"
+        assertEquals(HttpStatusCode.Found, authorizeAs(other))
+        assertNull(
+            liveDebugIp(other),
+            "one principal's simulated network must not follow another's identity",
+        )
+    }
+
+    /** The simulated address on [principal]'s single LIVE web session — the row a decision would resolve. */
+    private fun liveDebugIp(principal: String): String? = dataSource.connection.use { c ->
+        c.prepareStatement(
+            """SELECT debug_requester_ip FROM principal_session
+               WHERE principal = ? AND kind = 'WEB' AND ended_at IS NULL
+               ORDER BY id DESC LIMIT 1""",
+        ).use { ps ->
+            ps.setString(1, principal)
+            ps.executeQuery().use { rs ->
+                assertTrue(rs.next(), "no live web session for $principal")
+                rs.getString(1)
+            }
+        }
+    }
+
     private fun resolver(): CimdResolver = CimdResolver { clientId ->
         require(clientId == CLIENT_ID)
         metadata()
@@ -453,6 +522,9 @@ private fun Application.oauthTestModule(config: Config, dataSource: DataSource, 
                     config.webSessionAbsoluteSeconds,
                     config.webSessionIdleSeconds,
                     deviceId,
+                    // Optional so existing callers are unchanged; set by the inheritance test, which needs a
+                    // session that already carries a simulated address before OAuth remints it.
+                    debugRequesterIp = call.request.queryParameters["requesterIp"],
                 )))
             call.respond(HttpStatusCode.NoContent)
         }

--- a/docs/authz-context.md
+++ b/docs/authz-context.md
@@ -68,7 +68,8 @@ is consumed by [`mcp-access-control.md`](./mcp-access-control.md).
 ## `requester_ip` — attestation
 
 `requester_ip` is a Cedar `ipaddr`, server-observed, never client-supplied. Two
-disjoint resolution cases, never blended:
+disjoint resolution cases, never blended (plus a development-only exception,
+[below](#the-development-only-simulated-address)):
 
 - Wire path: the proxy's socket peer (`client_addr` on `DecisionRequest`) is the
   requester.
@@ -102,6 +103,32 @@ meaningfully attested, not a flat-LAN guess. A cryptographically-attested
 tailnet capability (resolved via `whois`) is the intended stronger successor to
 matching on the raw IP; consuming policies would be unchanged because they read
 the derived tag, not the raw signal.
+
+### The development-only simulated address
+
+`PM_AUTH_DEBUG` is the one exception to "never client-supplied", and it exists
+because a tag rule keyed on a CIDR can otherwise never fire on a development box
+— every browser request there arrives from loopback, so everything the rule
+gates is unreachable. Under that bypass, `POST /auth/debug` accepts a
+`requesterIp`, stores it on the session row
+(`principal_session.debug_requester_ip`), and `httpRequesterIp` substitutes it
+for the observed peer.
+
+Scope it honestly:
+
+- It is **inert whenever `PM_AUTH_DEBUG` is off** — the resolver consults the
+  column only under the bypass, so a row left by a development run cannot weaken
+  a real deployment. `/auth/me` likewise reports it only under the bypass, so
+  the console never shows an address the decision path is ignoring.
+- It **widens what the bypass already grants**, and is not merely equivalent to
+  it. `PM_AUTH_DEBUG` already mints any role, so for a policy gated on role
+  alone it adds nothing. But a policy conditioned on role **and** network — the
+  shipped `-258` PII unmask, which needs `system:production-pii-accessor` _and_
+  the `trusted-network` tag — previously still required a genuinely in-range
+  peer. Simulating the address removes that second, independent factor. That is
+  acceptable only because it is confined to a bypass a production-looking
+  configuration refuses to start with (`Config.fromEnv`), not because the two
+  are equivalent.
 
 `requester_ip` reaches every authorize site, query and non-query alike. The
 datasource-scoped non-query sites (`requireAdmin` — the single choke point the
@@ -194,7 +221,9 @@ Constraints that keep it safe and simple:
 - Server-attested, never client-asserted — `channel` from the entry point,
   `requester_ip` from the observed connection, `tags` computed by the
   control-plane. A wire / editor client cannot set its channel, spoof its
-  source, or assert a tag.
+  source, or assert a tag. The sole exception is the development-only simulated
+  address above, which is honored only under `PM_AUTH_DEBUG` and forfeits
+  network as an independent factor for as long as that bypass is on.
 - Fail-closed at every step (raw resolution, tag pass, real decision).
 - Tag rules see only raw context — no tag-on-tag, so the pre-pass is a pure
   one-level function of attested inputs.

--- a/web/messages/en/errors.json
+++ b/web/messages/en/errors.json
@@ -36,6 +36,7 @@
   },
   "auth": {
     "invalid_id_token": "Invalid ID token.",
+    "invalid_requester_ip": "That is not a valid IP address.",
     "missing_renewal_token": "Missing bearer renewal token.",
     "principal_deprovisioned": "This account has been deprovisioned.",
     "session_window_expired": "Your session has expired or your account was deprovisioned. Please sign in again."

--- a/web/messages/en/login.json
+++ b/web/messages/en/login.json
@@ -15,6 +15,8 @@
   "rolesLabel": "Roles",
   "rolesPlaceholder": "add a role…",
   "rolesHint": "Press Enter to add each role.",
+  "requesterIpLabel": "Source IP (optional)",
+  "requesterIpHint": "Authorize this session as if it came from this address, to exercise a network-conditioned policy. Leave blank to use the real one.",
   "signingIn": "Signing in…",
   "signInAsDebugUser": "Sign in as debug user",
   "debugLoginDisabled": "Debug login is disabled on this control-plane (PM_AUTH_DEBUG is off).",

--- a/web/messages/en/session.json
+++ b/web/messages/en/session.json
@@ -20,6 +20,7 @@
     "minutes": "{minutes}m"
   },
   "reauthNow": "Re-authenticate now",
+  "simulatedSourceIp": "Source IP",
   "reauthComplete": {
     "title": "Re-authentication complete",
     "body": "You can close this window and continue your work."

--- a/web/messages/ko/errors.json
+++ b/web/messages/ko/errors.json
@@ -36,6 +36,7 @@
   },
   "auth": {
     "invalid_id_token": "유효하지 않은 ID 토큰입니다.",
+    "invalid_requester_ip": "유효한 IP 주소가 아닙니다.",
     "missing_renewal_token": "갱신용 베어러 토큰이 없습니다.",
     "principal_deprovisioned": "이 계정은 비활성화(deprovision)되었습니다.",
     "session_window_expired": "세션이 만료되었거나 계정이 비활성화되었습니다. 다시 로그인해 주세요."

--- a/web/messages/ko/login.json
+++ b/web/messages/ko/login.json
@@ -15,6 +15,8 @@
   "rolesLabel": "역할(Roles)",
   "rolesPlaceholder": "역할 추가…",
   "rolesHint": "Enter를 눌러 역할을 추가하세요.",
+  "requesterIpLabel": "출발지 IP (선택)",
+  "requesterIpHint": "네트워크 조건이 걸린 정책을 확인할 수 있도록, 이 주소에서 온 요청처럼 세션을 인가합니다. 비워 두면 실제 주소를 사용합니다.",
   "signingIn": "로그인 중…",
   "signInAsDebugUser": "디버그 사용자로 로그인",
   "debugLoginDisabled": "이 컨트롤 플레인에서는 디버그 로그인이 비활성화되어 있습니다 (PM_AUTH_DEBUG 꺼짐).",

--- a/web/messages/ko/session.json
+++ b/web/messages/ko/session.json
@@ -20,6 +20,7 @@
     "minutes": "{minutes}분"
   },
   "reauthNow": "지금 재인증",
+  "simulatedSourceIp": "출발지 IP",
   "reauthComplete": {
     "title": "재인증이 완료되었습니다",
     "body": "이 창을 닫고 작업을 계속할 수 있습니다."

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -52,6 +52,9 @@ function LoginInner() {
     'system:development-pii-accessor',
     'system:development-updater',
   ])
+  // Simulates the source address this session's decisions authorize under. Every request from a dev box
+  // arrives from loopback, so a policy conditioned on a network cannot otherwise be reached at all.
+  const [requesterIp, setRequesterIp] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -67,7 +70,7 @@ function LoginInner() {
     }
     setSubmitting(true)
     try {
-      await loginDebug(principal.trim(), roles)
+      await loginDebug(principal.trim(), roles, requesterIp.trim())
       router.replace(
         callbackUrl === REAUTH_CALLBACK_PATH ? callbackUrl : (returnTo ?? next ?? '/query'),
       )
@@ -166,6 +169,16 @@ function LoginInner() {
                 <Label htmlFor="roles">{t('rolesLabel')}</Label>
                 <TagsInput id="roles" value={roles} onChange={setRoles} placeholder={t('rolesPlaceholder')} />
                 <p className="text-muted-foreground text-xs">{t('rolesHint')}</p>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="requesterIp">{t('requesterIpLabel')}</Label>
+                <Input
+                  id="requesterIp"
+                  value={requesterIp}
+                  onChange={(e) => setRequesterIp(e.target.value)}
+                  placeholder="100.100.1.10"
+                />
+                <p className="text-muted-foreground text-xs">{t('requesterIpHint')}</p>
               </div>
               {error && <p className="text-sm text-red-500">{error}</p>}
               <Button

--- a/web/src/components/identity-menu.tsx
+++ b/web/src/components/identity-menu.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
-import { Clock3, LogOut, RefreshCw, User } from 'lucide-react'
+import { Clock3, LogOut, Network, RefreshCw, User } from 'lucide-react'
 import { useAuth } from '@/lib/auth'
 import { openReauthPopup } from '@/lib/reauth'
 import { useSessionLifecycle } from '@/lib/session'
@@ -68,6 +68,15 @@ export function IdentityMenu() {
           </DropdownMenuLabel>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
+        {identity.requesterIp && (
+          // Two identical-looking results differ only by the network the decision was made from, so
+          // without this the reason a column is masked here and cleartext there is invisible.
+          <div className="text-muted-foreground flex items-center gap-1.5 px-1.5 py-1 text-xs">
+            <Network className="size-3.5" />
+            <span>{t('simulatedSourceIp')}</span>
+            <span className="ml-auto font-mono tabular-nums">{identity.requesterIp}</span>
+          </div>
+        )}
         {absoluteExpiresAt && (
           <div className="text-muted-foreground flex items-center gap-1.5 px-1.5 py-1 text-xs">
             <Clock3 className="size-3.5" />

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -148,11 +148,19 @@ export function getMePermissions(): Promise<MePermissions> {
   return request<MePermissions>('/api/me/permissions')
 }
 
-/** POST /auth/debug — dev-only login bypass; sets the session cookie. */
-export function debugLogin(principal: string, roles: string[]): Promise<Identity> {
+/**
+ * POST /auth/debug — dev-only login bypass; sets the session cookie. `requesterIp` simulates the source
+ * address the session's decisions authorize under, so a network-conditioned policy can be exercised from a
+ * dev box where every request arrives from loopback.
+ */
+export function debugLogin(
+  principal: string,
+  roles: string[],
+  requesterIp?: string,
+): Promise<Identity> {
   return request<Identity>('/auth/debug', {
     method: 'POST',
-    body: JSON.stringify({ principal, roles }),
+    body: JSON.stringify({ principal, roles, requesterIp: requesterIp || null }),
   })
 }
 

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -36,6 +36,11 @@ export interface AuditEvent {
 export interface Identity {
   principal: string
   roles: string[]
+  /**
+   * The simulated source address a debug-login session authorizes under, when one was chosen. Absent for
+   * every ordinary session, and absent whenever the control-plane is not honoring it.
+   */
+  requesterIp?: string | null
 }
 
 /** Coarse Cedar-backed capabilities for the authenticated principal. */

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -25,7 +25,7 @@ interface AuthState {
   unauthReason: SessionReason | null
   debugMode: boolean
   /** Debug-login path; on success the caller navigates into the app. */
-  loginDebug: (principal: string, roles: string[]) => Promise<void>
+  loginDebug: (principal: string, roles: string[], requesterIp?: string) => Promise<void>
   logout: () => Promise<void>
   hasRole: (role: string) => boolean
 }
@@ -70,8 +70,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
-  const loginDebug = useCallback(async (principal: string, roles: string[]) => {
-    const me = await debugLogin(principal, roles)
+  const loginDebug = useCallback(async (principal: string, roles: string[], requesterIp?: string) => {
+    const me = await debugLogin(principal, roles, requesterIp)
     sessionStorage.setItem(DEBUG_FLAG_KEY, '1')
     setDebugMode(true)
     setIdentity(me)


### PR DESCRIPTION
Lets `POST /auth/debug` name the source address its session's decisions authorize under, so a Cedar tag rule keyed on a CIDR can be exercised at all. On a dev box every browser request arrives from loopback, so the shipped `-300` trusted-network producer can never fire — and the `-258` production PII unmask it gates was untestable without physically moving the client onto that network.

Substituted at `ApplicationCall.httpRequesterIp`, the one resolver every HTTP-path decision reads, so it reaches the editor, the approval execute/view paths, and the admin gates identically to a real address.

## Where it could bite

**It widens the bypass rather than riding on it.** `PM_AUTH_DEBUG` already mints any role, so against a role-only policy this adds nothing. But `-258` needs the pii-accessor role **and** the `trusted-network` tag — the observed peer was a second, independent factor, and simulating it removes that. Acceptable only because `Config.fromEnv` refuses to start with the bypass on in a production-looking configuration, and because the value is inert whenever the bypass is off (`httpRequesterIp` and `/auth/me` each consult it only under the flag; the route that writes it 404s).

**Validation runs a real Cedar evaluation, not just the cedar-java constructor.** The two disagree in both directions, and the constructor alone admitted two values that fail later and worse:
- a NUL-bearing string — its validator trims control characters, then Postgres rejects the byte at INSERT (a 500);
- non-canonical IPv4 like `100.100.001.010` — the engine refuses it at evaluation, and an unevaluable context value fails the **whole** authorization closed, so the request denies with "no access to datasource" and nothing pointing at the address.

**Debug OAuth authorize shares the console session, and sharing means replacing it** (`mintWeb` is newest-wins), so it carries the simulated address across the remint — but only when the principal is unchanged.

## Verification

`:control-plane:test` 869 pass; web typecheck + vitest green. Tests pinned by mutation — deleting the `authDebug` guard, returning null from production resolution, dropping the Cedar-evaluability probe, dropping the OAuth inheritance, or removing its principal-equality guard each fail the suite. The bypass-off case replays a real cookie minted under the bypass against a control plane running without it; a hand-forged cookie resolves to no session and would pass regardless.

Two rounds of three-reviewer review (Codex / Sol / Grok) before this landed.