### PR TITLE
fix(web): label an editor result with the decision that released it

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
@@ -122,8 +122,21 @@ fun discoverRoles(
     val canCancel: Boolean = false,
 )
 
-/** The decrypted rows of an execute-under-R result, plus its metadata — returned only to an authorized viewer. */
-@Serializable data class QueryResultView(val meta: QueryResultMeta, val columns: List<String>, val rows: List<List<String?>>)
+/**
+ * The decrypted rows of an execute-under-R result, plus its metadata — returned only to an authorized viewer.
+ *
+ * [decision] and [maskedColumns] describe the LIVE view re-decision these rows were released under, not the
+ * execution that stored them: the viewer's own context can narrow an execution's ALLOW to a MASK. Without
+ * them the caller cannot tell a masked cell from a value that genuinely looks like one, and a console
+ * showing rows has nothing to label them with but a guess.
+ */
+@Serializable data class QueryResultView(
+    val meta: QueryResultMeta,
+    val columns: List<String>,
+    val rows: List<List<String?>>,
+    val decision: Decision = Decision.ALLOW,
+    val maskedColumns: List<String> = emptyList(),
+)
 
 /** Submit acknowledgement. Completion is observed by polling the task detail/result endpoints. */
 @Serializable data class ExecuteApprovalResponse(val decision: String)
@@ -150,7 +163,13 @@ fun validateApprovalSource(decision: AuditEvent?, requestingPrincipal: String): 
     }
 
 internal sealed class ResultViewDecision {
-    data class Allowed(val columns: List<String>, val rows: List<List<String?>>) : ResultViewDecision()
+    /** [maskedColumns] are the columns this VIEW masked — the viewer's context can narrow an execution's
+     *  ALLOW to a MASK, so the released rows are labelled by what happened to them, not by what was stored. */
+    data class Allowed(
+        val columns: List<String>,
+        val rows: List<List<String?>>,
+        val maskedColumns: List<String> = emptyList(),
+    ) : ResultViewDecision()
     data class Denied(val reason: String) : ResultViewDecision()
 }
 
@@ -229,7 +248,11 @@ internal fun decideResultView(
             if (kind == null) value else Masking.apply(value, kind)
         }
     }
-    return ResultViewDecision.Allowed(decrypted.columns, rows)
+    // Named from the BOUND indices, not from ctx.masks: binding is what actually rewrote a cell, so a mask
+    // the decision asked for but could not bind can never be reported as applied. (An unbound one denies
+    // above, so the two agree here — reading the binding keeps them agreeing if that ever changes.)
+    val maskedColumns = binding.byIndex.keys.sorted().map { decrypted.columns[it] }
+    return ResultViewDecision.Allowed(decrypted.columns, rows, maskedColumns)
 }
 
 /**
@@ -848,7 +871,16 @@ fun Route.approvalRoutes(
                 // Audit the view BEFORE returning rows — a failed audit insert propagates (500) so PII is never
                 // returned without a durable record.
                 auditStore.insert(e3Record(principal, req, viewEvent, Channel.WORKFLOW_VIEWER))
-                call.respond(QueryResultView(meta, viewDecision.columns, viewDecision.rows))
+                call.respond(
+                    QueryResultView(
+                        meta, viewDecision.columns, viewDecision.rows,
+                        // The stored bytes are R's execution output, but this VIEW re-decides under the
+                        // viewer's own context and may narrow further — so the label describes the release,
+                        // not the execution that produced it.
+                        decision = if (viewDecision.maskedColumns.isEmpty()) Decision.ALLOW else Decision.MASK,
+                        maskedColumns = viewDecision.maskedColumns,
+                    ),
+                )
             }
         }
     }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -1178,7 +1178,16 @@ fun Route.editorSessionRoutes(
                 call.respond(HttpStatusCode.Forbidden, ApiError("approval.result_view_denied"))
             }
             is ResultViewDecision.Allowed ->
-                call.respond(QueryResultView(meta, viewDecision.columns, viewDecision.rows))
+                call.respond(
+                    QueryResultView(
+                        meta, viewDecision.columns, viewDecision.rows,
+                        // MASK iff this view actually masked something. The editor labels its result from
+                        // this; deriving it client-side from "are there rows" is what let a masked result
+                        // display as a clean ALLOW.
+                        decision = if (viewDecision.maskedColumns.isEmpty()) Decision.ALLOW else Decision.MASK,
+                        maskedColumns = viewDecision.maskedColumns,
+                    ),
+                )
         }
     }
 

--- a/web/src/components/query/use-result-tabs.ts
+++ b/web/src/components/query/use-result-tabs.ts
@@ -272,10 +272,12 @@ export function useResultTabs(datasourceId: number | null, maxRows: number): Res
           if (child?.status === 'DONE') {
             const view = await getEditorResult(submit.taskId)
             return {
-              decision: 'ALLOW',
+              // From the server's re-decision, never assumed: these rows are released under the viewer's
+              // live context, which can mask columns the execution itself returned in the clear.
+              decision: view.decision,
               decisionId: null,
               denyReason: null,
-              maskedColumns: [],
+              maskedColumns: view.maskedColumns,
               piiTouched: [],
               effectiveRoles: [],
               columns: view.columns,

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -422,6 +422,13 @@ export interface QueryResultView {
   meta: QueryResultMeta
   columns: string[]
   rows: (string | null)[][]
+  /**
+   * The verdict of the LIVE view re-decision these rows were released under — the viewer's own context can
+   * narrow an execution's ALLOW to a MASK, so this describes the release, not the stored execution. Only
+   * these two values reach a caller holding rows: a denied view is a 403 with no body.
+   */
+  decision: 'ALLOW' | 'MASK'
+  maskedColumns: string[]
 }
 
 /** Submit acknowledgement; completion is observed through task polling. */
@@ -523,4 +530,11 @@ export interface EditorResultView {
   columns: string[]
   rows: (string | null)[][]
   meta?: unknown
+  /**
+   * The verdict of the re-decision that released these rows. The editor labels its result panel from this;
+   * inferring it from the presence of rows cannot distinguish a masked result from a clean one. Only these
+   * two values reach a caller holding rows: a denied view is a 403 with no body.
+   */
+  decision: 'ALLOW' | 'MASK'
+  maskedColumns: string[]
 }


### PR DESCRIPTION
The async editor path hardcoded `decision: 'ALLOW'` with an empty `maskedColumns` when a task completed, so every masked result rendered as a clean ALLOW with no per-column marking. A production viewer selecting `email, rrn, region` saw a green ALLOW over rows whose `email` and `rrn` had in fact been masked — the audit row recorded MASK, the console said otherwise, and nothing on screen distinguished a masked cell from a value that merely looks like one.

The client could not have known: `GET /api/editor/tasks/{id}/result` computed a full view re-decision and then discarded everything but columns and rows. The verdict now rides on the response. `maskedColumns` is named from the **bound** mask indices rather than the decision's requested masks, so a mask that could not be bound can never be reported as applied.

The same field is added to the approval result view, which returns the same type: a stored result is re-decided under the viewer's own context and can narrow an execution's ALLOW to a MASK, so the label describes the release rather than the execution that produced it.

## Where it could bite

Typed `'ALLOW' | 'MASK'` on the web — a denied view is a 403 with no body, so no caller ever holds rows under another verdict.

**Known gap, not introduced here:** the response describes the *view* re-decision only. A result masked at execution and later viewed under a permissive context reports ALLOW while returning the stored masked bytes. Execution-time mask provenance is not persisted, so this cannot be fixed without a schema change — filed as follow-up.

## Verification

`:control-plane:test` 869 pass; `mise run lint` clean. Behavior verified in the console: the same query renders a MASK badge, "masked email rrn", and a masked chip per affected column.

**No automated test covers the new fields** — reviewers asked for `EditorSubmitRouteDbTest` + `ApprovalResultViewContextDbTest` coverage. Not yet written.

Reviewed by Codex (changes-needed on the provenance gap above), Sol, and Grok.