### PR TITLE
fix(web): show the role's name, not its id, in the approval role picker

### DIFF
--- a/web/messages/en/workflows.json
+++ b/web/messages/en/workflows.json
@@ -125,6 +125,7 @@
     "discoverFailed": "Couldn't check roles — you can still submit without one.",
     "selectRole": "Select an elevation role",
     "noRolesFound": "No role would change the outcome for this query.",
+    "staleDiscovery": "The query changed since these roles were checked. Check available roles again.",
     "alreadyAllowed": "This query is already allowed without an elevated role.",
     "unmasksHint": "Unmasks: {columns}"
   },

--- a/web/messages/ko/workflows.json
+++ b/web/messages/ko/workflows.json
@@ -125,6 +125,7 @@
     "discoverFailed": "역할을 확인하지 못했습니다 — 역할 없이도 제출할 수 있습니다.",
     "selectRole": "권한 상승 역할 선택",
     "noRolesFound": "이 쿼리의 결과를 바꿀 수 있는 역할이 없습니다.",
+    "staleDiscovery": "역할을 확인한 뒤 쿼리가 변경되었습니다. 사용 가능한 역할을 다시 확인해 주세요.",
     "alreadyAllowed": "이 쿼리는 이미 역할 상승 없이 허용되어 있습니다.",
     "unmasksHint": "마스킹 해제: {columns}"
   },

--- a/web/src/components/workflows/query-request-composer.tsx
+++ b/web/src/components/workflows/query-request-composer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState, type FormEvent } from 'react'
+import { useRef, useState, type FormEvent } from 'react'
 import { useTranslations } from 'next-intl'
 import { mutate } from 'swr'
 import { toast } from 'sonner'
@@ -59,16 +59,15 @@ export function QueryRequestComposer({
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [roleId, setRoleId] = useState<string | null>(null)
-  const [discovery, setDiscovery] = useState<DiscoverRolesResponse | null>(null)
+  // The discovery result, tagged with the inputs it was resolved FOR — that pairing is what makes a
+  // stale selection detectable without throwing the selection away on every derived-value flicker.
+  const [discovery, setDiscovery] = useState<
+    (DiscoverRolesResponse & { forSql: string; forDatasourceId: number }) | null
+  >(null)
   const [discovering, setDiscovering] = useState(false)
   const [discoverError, setDiscoverError] = useState<string | null>(null)
 
   const fromDenied = sourceDecisionId != null
-  // A query approval always runs under an elevation role R (execute-under-R), so a role must be picked from
-  // discovery before submitting — there is no requester-run / no-elevation mode.
-  const canSubmit = roleId != null && (fromDenied
-    ? reason.trim().length > 0 && record?.decision === 'DENY'
-    : datasourceId != null && sql.trim().length > 0 && title.trim().length > 0 && reason.trim().length > 0)
 
   // Effective (datasourceId, sql) used for role discovery, per composer branch.
   const effectiveSql = fromDenied ? (record?.statement ?? null) : sql.trim() || null
@@ -77,20 +76,26 @@ export function QueryRequestComposer({
     : datasourceId
   const canDiscover = effectiveDatasourceId != null && !!effectiveSql
 
-  // Every discovery (and every effective-input change) bumps this generation counter. A response is
-  // applied only if its generation is still current, so a role picked against stale SQL/datasource can
-  // neither be shown nor submitted — even if an in-flight request resolves AFTER the inputs changed.
+  // Every discovery bumps this generation counter, so a response is applied only if its generation is
+  // still current — an in-flight request that resolves after a newer one started cannot repopulate options.
   const discoverSeq = useRef(0)
 
-  // Staleness guard: reset the picker whenever the effective inputs change, and invalidate any
-  // in-flight discovery so its late response can't repopulate options for the old SQL/datasource.
-  useEffect(() => {
-    discoverSeq.current += 1
-    setDiscovery(null)
-    setRoleId(null)
-    setDiscoverError(null)
-    setDiscovering(false)
-  }, [effectiveSql, effectiveDatasourceId])
+  // Staleness guard: a role may be submitted ONLY if it was discovered for the query being submitted.
+  // Enforced by comparing the discovery's own inputs against the current ones, rather than by resetting
+  // the picker whenever those inputs change — `effectiveSql`/`effectiveDatasourceId` are derived from
+  // fetched data on the from-denied branch, so they legitimately transition through null while SWR
+  // resolves or revalidates, and a reset keyed on them wiped the user's selection for reasons that had
+  // nothing to do with the query changing. Comparing is also the stronger check: it holds even if a
+  // reset were missed, where the reset alone only held if it always fired.
+  const staleDiscovery =
+    discovery != null &&
+    (discovery.forSql !== effectiveSql || discovery.forDatasourceId !== effectiveDatasourceId)
+
+  // A query approval always runs under an elevation role R (execute-under-R), so a role must be picked from
+  // discovery before submitting — there is no requester-run / no-elevation mode.
+  const canSubmit = roleId != null && !staleDiscovery && (fromDenied
+    ? reason.trim().length > 0 && record?.decision === 'DENY'
+    : datasourceId != null && sql.trim().length > 0 && title.trim().length > 0 && reason.trim().length > 0)
 
   const handleDiscover = async () => {
     if (!canDiscover) return
@@ -100,13 +105,12 @@ export function QueryRequestComposer({
     setRoleId(null)
     setDiscovering(true)
     setDiscoverError(null)
+    const forDatasourceId = effectiveDatasourceId!
+    const forSql = effectiveSql!
     try {
-      const res = await discoverApprovalRoles({
-        datasourceId: effectiveDatasourceId!,
-        sql: effectiveSql!,
-      })
-      if (seq !== discoverSeq.current) return // inputs changed (or a newer discovery started) → stale
-      setDiscovery(res)
+      const res = await discoverApprovalRoles({ datasourceId: forDatasourceId, sql: forSql })
+      if (seq !== discoverSeq.current) return // a newer discovery started → this response is stale
+      setDiscovery({ ...res, forSql, forDatasourceId })
     } catch {
       if (seq !== discoverSeq.current) return
       // Discovery is a non-blocking helper — surface a friendly, actionable message
@@ -263,12 +267,22 @@ export function QueryRequestComposer({
                 {discovery && (
                   <div className="space-y-1.5">
                     <Label htmlFor="approval-role">{t('fields.role')}</Label>
-                    <Select
-                      value={roleId ?? undefined}
-                      onValueChange={(value: string | null) => setRoleId(value)}
-                    >
+                    {/* `value` must be the state itself, INCLUDING null. Passing `undefined` for the
+                        empty case makes the Select uncontrolled, and it then discards every selection —
+                        the picker snapped straight back to its placeholder and nothing could be
+                        submitted. `null` is "controlled, nothing selected"; `undefined` is "not
+                        controlled at all". */}
+                    <Select value={roleId} onValueChange={(value: string | null) => setRoleId(value)}>
                       <SelectTrigger id="approval-role" className="w-full">
-                        <SelectValue placeholder={t('queryComposer.selectRole')} />
+                        {/* The trigger renders the raw value unless given this mapping, which would show
+                            the role's numeric id — the one thing the approver must not misread, since the
+                            request is submitted to run under whichever role this names. */}
+                        <SelectValue placeholder={t('queryComposer.selectRole')}>
+                          {(value: string | null) =>
+                            discovery.options.find((option) => String(option.roleId) === value)?.roleName ??
+                            t('queryComposer.selectRole')
+                          }
+                        </SelectValue>
                       </SelectTrigger>
                       <SelectContent>
                         {discovery.options.map((option) => (
@@ -282,12 +296,17 @@ export function QueryRequestComposer({
                       </SelectContent>
                     </Select>
 
-                    {discovery.options.length === 0 && (
-                      <p className="text-muted-foreground text-sm">
-                        {discovery.baselineAllowed
-                          ? t('queryComposer.alreadyAllowed')
-                          : t('queryComposer.noRolesFound')}
-                      </p>
+                    {staleDiscovery ? (
+                      // Submitting is blocked here; say why, so a disabled button is not a dead end.
+                      <p className="text-sm text-amber-500">{t('queryComposer.staleDiscovery')}</p>
+                    ) : (
+                      discovery.options.length === 0 && (
+                        <p className="text-muted-foreground text-sm">
+                          {discovery.baselineAllowed
+                            ? t('queryComposer.alreadyAllowed')
+                            : t('queryComposer.noRolesFound')}
+                        </p>
+                      )
                     )}
                   </div>
                 )}


### PR DESCRIPTION
The elevation-role picker rendered the raw select value once a role was chosen, so the trigger read `10` instead of `system:production-deleter`. That is the one field on the form the requester and the approver must not misread: it names the role the approved query will execute under. Every other Select in the console already maps its value to a label; this one was the exception.

`value` is now the state itself including `null`, rather than `roleId ?? undefined` — passing `undefined` for the empty case makes the component uncontrolled, a latent break in the same place.

The staleness guard is now a comparison rather than a reset. It kept the same invariant — a role may only be submitted if it was discovered for the query being submitted — but enforced it by clearing the picker whenever the derived inputs changed, and on the from-denied branch those are read out of fetched data, so they pass through null while SWR resolves. Tagging the discovery with the inputs it ran against and comparing at submit time holds even if a reset were missed, where the reset alone only held if it always fired. A stale discovery now says so instead of silently disabling the button.

## Verification

`mise run lint` clean; new l10n key present in both `en` and `ko`. Verified in the console: discovery lists `system:production-deleter`, the trigger shows that name, and the request submits.

**No automated test** — reviewed as the higher test-debt of the batch, since the original bug was a timing/derived-state issue that manual happy-path clicking misses. Grok listed the race and SWR-flicker cases to cover; not yet written.

Reviewed by Grok (approve, with those tests requested before merge).