### PR TITLE
fix(cp): end a task-event stream quietly when its client is gone

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -49,9 +49,9 @@ import io.ktor.server.sessions.get
 import io.ktor.server.sessions.cookie
 import io.ktor.server.sessions.set
 import io.ktor.server.sessions.sessions
-import io.ktor.server.sse.heartbeat
 import io.ktor.server.sse.sse
 import io.ktor.sse.ServerSentEvent
+import java.io.IOException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.onTimeout
@@ -110,10 +110,6 @@ internal fun Route.taskEventsRoute(
         val context = call.httpAuthzContext(config)
         val events = taskCompletionHub.subscribe(principal)
         try {
-            heartbeat {
-                period = 30.seconds
-                event = ServerSentEvent(comments = "keepalive")
-            }
             while (true) {
                 val keepOpen = select {
                     events.onReceiveCatching { result ->
@@ -129,11 +125,26 @@ internal fun Route.taskEventsRoute(
                     onTimeout(SSE_SESSION_RECHECK_MS) {
                         // A session revoked / expired / newest-wins-displaced mid-stream must stop receiving
                         // events; webSession() caches per-call, so re-resolve the store directly here.
+                        //
+                        // This tick also carries the keepalive, rather than Ktor's `heartbeat` helper. The
+                        // helper writes from its OWN coroutine, so when the client is gone its write throws
+                        // where no handler here can reach it — every ordinary disconnect surfaced as an
+                        // unhandled exception and a 500. Writing on this loop's own coroutine puts that
+                        // same throw inside the catch below, which is what turns a closed browser tab back
+                        // into the non-event it is.
+                        send(ServerSentEvent(comments = "keepalive"))
                         sessionStillLive(config, sessionId, deviceId, principalSessionStore)
                     }
                 }
                 if (!keepOpen) break
             }
+        } catch (_: IOException) {
+            // A browser closing the tab, navigating away, or reconnecting leaves this stream writing to a
+            // channel that is already gone, and the write throws. That is the NORMAL end of an SSE stream,
+            // not a server fault: unhandled, it logged a stack trace and a "500 Internal Server Error" for
+            // every disconnect, which buries real failures in a log nobody can then read. Nothing is left
+            // to send, so ending the coroutine quietly is the whole handling — the finally below still
+            // releases the subscription.
         } finally {
             taskCompletionHub.unsubscribe(principal, events)
         }


### PR DESCRIPTION
Closing a console tab, navigating away, or an EventSource reconnect leaves the per-principal SSE stream writing to a channel that is already gone. That write threw, and the throw was unhandled: every ordinary disconnect logged a stack trace and `500 Internal Server Error: GET /api/tasks/events in 60300ms`. A browsing session produced a steady stream of them, which is how a real failure in this log goes unnoticed.

Nothing was actually wrong. The write threw from Ktor's `heartbeat` helper, which runs on its **own** coroutine — so no handler in the route body could ever see it, and adding one there does nothing. The keepalive now rides on the loop's existing 30s session-recheck tick, on this coroutine, where the same throw lands in a catch. The stream ends, the subscription is released in the `finally` as before, and the client reconnects or does not.

The catch is `IOException`, not `Throwable`: a closed peer is the one failure that is not a fault here, and widening it would swallow the ones that are.

## Where it could bite

The keepalive is no longer independent of the loop. Under a steady stream of events the timeout branch never fires, so comment keepalives stop — but the event frames themselves refresh any intermediary's idle timer, so this only matters for a client that required comment-only heartbeats (EventSource does not). If the loop blocks inside a slow store call, no keepalive is written for the duration, where the separate heartbeat coroutine would have kept firing.

## Verification

Verified against a live control plane: four connect/disconnect cycles log `200 OK` with zero unhandled exceptions, where the same sequence previously logged a 500 and a stack trace each time.

**No automated test** — Grok asked for a disconnect/unsubscribe integration test and a DEBUG breadcrumb for non-closed-channel `IOException`s. Not yet written.

Reviewed by Grok (approve).