### PR TITLE
ci: build on GitHub's standard runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,0 @@
-# The org's GitHub-hosted larger runners. actionlint only knows the standard labels, so without
-# these it reports every `runs-on` here as an unknown label.
-self-hosted-runner:
-  labels:
-    - ubuntu-24-x64
-    - ubuntu-24-arm

--- a/.github/workflows/server-images.yml
+++ b/.github/workflows/server-images.yml
@@ -4,8 +4,7 @@ name: server images
 # needs neither a Docker Hub account nor its rate limits.
 #
 # Each architecture builds on a runner of that architecture, and a merge job joins the two into one
-# manifest. Emulating arm64 on an amd64 runner took 39 minutes for control-plane's Gradle build
-# against 50 seconds for auditmon's Go build — a JVM compile under QEMU runs interpreted.
+# manifest. Emulating arm64 costs a JVM compile most of its speed — the JIT itself runs interpreted.
 #
 # pmon is not here: it is a client binary, shipped as a release archive and a Homebrew formula
 # (pmon-release-binaries.yml).
@@ -26,7 +25,7 @@ permissions:
 
 jobs:
   version:
-    runs-on: ubuntu-24-x64
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -60,7 +59,8 @@ jobs:
 
   build:
     needs: version
-    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24-arm' || 'ubuntu-24-x64' }}
+    runs-on:
+      ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     timeout-minutes: 60
 
     strategy:
@@ -137,7 +137,7 @@ jobs:
     # image's own digests decide: an image missing an architecture fails its own merge, and the
     # rest still publish.
     if: ${{ !cancelled() && needs.version.result == 'success' }}
-    runs-on: ubuntu-24-x64
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
 
     # Only this job assumes the ECR role. At workflow level every build cell could mint a token the


### PR DESCRIPTION
`server-v0.1.3` published on the org's runners and confirmed the split works. Those runners are 4 vCPU / 16 GB — exactly what `ubuntu-24.04` and `ubuntu-24.04-arm` give a **public** repository, so they bought this repo nothing. Reaching them required `allows_public_repositories` on their runner group, an org-wide setting every public repo in `ridi-oss` inherits.

They stay the right choice for private repos, where the standard runners are half that.

`.github/actionlint.yaml` goes too — it existed only to declare the org's custom labels.

## Measured on 0.1.3

Cold cache on both sides:

| image | QEMU (0.1.2) | native (0.1.3) |
|---|---|---|
| auditmon | 0m50s | 1m05s |
| goproxy | 7m19s | 1m12s |
| web | 12m02s | 3m11s |
| control-plane | **39m04s** | **4m36s** |

Total run wall-clock 39m08s → 20m43s. The run does not drop 8× because it now has three sequential phases and four merge jobs; the slowest *build* is what got 8× faster. The two control-plane arches finished within a second of each other, so emulation was the whole penalty, not the architecture.

## Traps

**Merge this before the org runners are deleted.** `main` references `ubuntu-24-x64` / `ubuntu-24-arm` today; if those disappear first, a release cut in between queues forever rather than failing.

**Runner labels inside the `runs-on` ternary are not checked by actionlint**, with or without the config — only the two literal `runs-on:` values are. A typo in the expression surfaces as a job that never starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)