### PR TITLE
fix(cp): surface an editor denial as a decision, not a failure

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -982,6 +982,10 @@ fun Route.editorSessionRoutes(
         val requesterIp = call.httpRequesterIp(config)
         val maxRows = req.maxRows
         appScope.launch {
+            // A policy DENY carries its reason and audit decision id onto the failed child, so the polling
+            // tab can offer an approval request built from that decision instead of showing a bare error.
+            var denyReason: String? = null
+            var denyDecisionId: Long? = null
             val failureCode = try {
                 // runOnSession decides on the EDITOR channel under empty assumeRoles (the caller's own roles)
                 // and saves the enforced result instead of returning it inline.
@@ -993,6 +997,8 @@ fun Route.editorSessionRoutes(
                     exchangeTimeoutMs = config.queryExchangeTimeoutMs,
                 )
                 if (response.decision == EnfAction.DENY) {
+                    denyReason = response.denyReason
+                    denyDecisionId = response.decisionId
                     // Reuse the already-translated approval.* result codes (en/ko errors.json) — the messages
                     // ("denied at execution time" / "execution failed") are channel-agnostic, so the web
                     // localizes the polled code with no editor-specific catalog entries.
@@ -1026,7 +1032,11 @@ fun Route.editorSessionRoutes(
             }
             if (failureCode != null) {
                 // Child FAILED + parent FAILED in ONE transaction (mirrors the success path's single commit).
-                runCatching { store.failRun(task.id, failureCode) { conn, _ -> accessStore.markFailed(task.id, conn) } }
+                runCatching {
+                    store.failRun(task.id, failureCode, denyReason, denyDecisionId) { conn, _ ->
+                        accessStore.markFailed(task.id, conn)
+                    }
+                }
                     .onFailure { call.application.environment.log.error("editor task failure transition failed task=${task.id}", it) }
             }
             // Push the ACTUAL terminal state (EXECUTED / FAILED / or CANCELLED if a cancel raced) to the owner's

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/QueryResultStore.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/QueryResultStore.kt
@@ -20,6 +20,11 @@ data class QueryResultMeta(
     val expiresAt: String? = null,
     val status: String? = null,
     val errorCode: String? = null,
+    // Set only on a POLICY denial: the reason the decision recorded, and the audit decision it was recorded
+    // under. A polling client sees only this row, so without them a denial is indistinguishable from a
+    // generic failure and it cannot offer the approval request that a denial is supposed to lead to.
+    val denyReason: String? = null,
+    val decisionId: Long? = null,
     val columns: List<String> = emptyList(),
 )
 
@@ -53,6 +58,8 @@ class QueryResultStore(private val dataSource: DataSource, private val crypto: R
         expiresAt = getTimestamp("expires_at")?.toInstant()?.toString(),
         status = getString("status"),
         errorCode = getString("error_code"),
+        denyReason = getString("deny_reason"),
+        decisionId = getLong("decision_id").let { if (wasNull()) null else it },
         columns = json.decodeFromString(stringList, getString("columns") ?: "[]"),
     )
 
@@ -136,6 +143,11 @@ class QueryResultStore(private val dataSource: DataSource, private val crypto: R
     fun failRun(
         taskId: Long,
         errorCode: String,
+        // Set only when the failure is a POLICY DENIAL, carrying that decision's reason and audit id onto
+        // the child. A client polling this row can then present the denial as a decision it may request
+        // approval for, rather than as an opaque failure.
+        denyReason: String? = null,
+        decisionId: Long? = null,
         // Runs in the SAME transaction as the child's RUNNING → FAILED flip (mirrors [completeRun]'s
         // audit hook) so the caller can terminalize the parent task atomically with the child. A throw
         // here rolls the child transition back too, keeping the two consistent.
@@ -144,11 +156,14 @@ class QueryResultStore(private val dataSource: DataSource, private val crypto: R
         val now = Instant.now()
         val childId = latestChildId(c, taskId, "status = 'RUNNING'")
         val updated = childId != null && c.prepareStatement(
-            "UPDATE query_result SET status = 'FAILED', error_code = ?, expires_at = ? WHERE id = ? AND status = 'RUNNING'",
+            "UPDATE query_result SET status = 'FAILED', error_code = ?, deny_reason = ?, decision_id = ?, " +
+                "expires_at = ? WHERE id = ? AND status = 'RUNNING'",
         ).use { ps ->
             ps.setString(1, errorCode)
-            ps.setTimestamp(2, Timestamp.from(now.plusSeconds(RESULT_RETENTION_SEC)))
-            ps.setLong(3, childId)
+            ps.setString(2, denyReason)
+            if (decisionId == null) ps.setNull(3, java.sql.Types.BIGINT) else ps.setLong(3, decisionId)
+            ps.setTimestamp(4, Timestamp.from(now.plusSeconds(RESULT_RETENTION_SEC)))
+            ps.setLong(5, childId)
             ps.executeUpdate() > 0
         }
         val meta = if (updated) meta(taskId, c) else null
@@ -283,7 +298,10 @@ class QueryResultStore(private val dataSource: DataSource, private val crypto: R
 
     companion object {
         const val RESULT_RETENTION_SEC = 86_400L
+        // Every column [toMeta] reads. The mapper reads by NAME, so a column added there and missed here
+        // fails the read at runtime rather than at compile time — keep the two in step.
         private const val META_COLS =
-            "task_id, executed_by, executed_at, row_count, expires_at, status, error_code, columns"
+            "task_id, executed_by, executed_at, row_count, expires_at, status, error_code, " +
+                "deny_reason, decision_id, columns"
     }
 }

--- a/control-plane/src/main/resources/db/migration/V11__result_deny_context.sql
+++ b/control-plane/src/main/resources/db/migration/V11__result_deny_context.sql
@@ -1,0 +1,12 @@
+-- Why a saved query result failed, beyond its error code.
+--
+-- A statement the policy refuses is not an error: it is a decision, and the console's response to it is to
+-- offer an approval request built from that decision. Making that offer needs two facts the error code
+-- alone cannot carry -- the human-readable reason the decision recorded, and the audit decision it was
+-- recorded under, which is the identifier an approval request is opened against.
+--
+-- Both already exist on the decision the proxy round trip wrote; these columns carry them onto the result
+-- child so the polling client that only ever sees this row can present the denial as a decision rather
+-- than as a generic failure. NULL for every non-denial outcome.
+ALTER TABLE query_result ADD COLUMN deny_reason TEXT;
+ALTER TABLE query_result ADD COLUMN decision_id BIGINT REFERENCES audit_event(id) ON DELETE SET NULL;

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/EditorSubmitRouteDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/EditorSubmitRouteDbTest.kt
@@ -325,6 +325,10 @@ class EditorSubmitRouteDbTest {
             }
             assertEquals("approval.execute_denied", resultStore.meta(ack.taskId)?.errorCode)
             assertNull(resultStore.accessFor(ack.taskId)?.decrypted, "a DENY saves no readable rows")
+            // A denial is a decision, so the reason must reach the polling client: it is what the console
+            // shows instead of a generic failure, and what the approval request is composed against. The
+            // proxy sent this exact string above; an error code alone leaves the requester nowhere to go.
+            assertEquals("policy denies", resultStore.meta(ack.taskId)?.denyReason)
 
             client.delete("/api/editor/sessions/${session.sessionId}")
             session.await()

--- a/web/src/components/query/use-result-tabs.ts
+++ b/web/src/components/query/use-result-tabs.ts
@@ -236,9 +236,26 @@ export function useResultTabs(datasourceId: number | null, maxRows: number): Res
           if (!current()) throw SUPERSEDED
           const child = status.result
           if (status.status === 'FAILED' || child?.status === 'FAILED') {
-            // errorCode is a catalog code (e.g. approval.execute_denied, query.proxy_timeout) — localize it
-            // here so the panel shows bilingual copy, never the raw code. ApiError messages are already
-            // translated by the fetch wrapper; this covers the polled failure path.
+            // A policy DENY is a decision, not an error: returning it as a DENY result is what gives the
+            // panel the reason and the decisionId it needs to offer "request approval". Throwing here
+            // collapsed it into a generic failure and dropped both, leaving the requester nowhere to go.
+            if (child?.errorCode === 'approval.execute_denied') {
+              return {
+                decision: 'DENY',
+                decisionId: child.decisionId ?? null,
+                denyReason: child.denyReason ?? null,
+                maskedColumns: [],
+                piiTouched: [],
+                effectiveRoles: [],
+                columns: [],
+                rows: [],
+                rowsAffected: null,
+                latencyMs: Math.max(0, Math.round(performance.now() - startedAt)),
+              }
+            }
+            // Any other failure really is one. errorCode is a catalog code (e.g. query.proxy_timeout) —
+            // localize it here so the panel shows bilingual copy, never the raw code. ApiError messages are
+            // already translated by the fetch wrapper; this covers the polled failure path.
             throw new Error(translateApiError(child?.errorCode ?? 'approval.query_failed'))
           }
           if (status.status === 'CANCELLED' || child?.status === 'CANCELLED') {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -406,6 +406,13 @@ export interface QueryResultMeta {
   expiresAt?: string | null
   status?: 'RUNNING' | 'DONE' | 'FAILED' | 'CANCELLED' | null
   errorCode?: string | null
+  /**
+   * Present only when the failure was a POLICY DENIAL: the reason the decision recorded, and the audit
+   * decision it was recorded under — the id an approval request is opened against. A denial is a decision,
+   * not an error, and these are what let the console offer the request rather than a bare failure message.
+   */
+  denyReason?: string | null
+  decisionId?: number | null
   columns: string[]
 }
 
@@ -515,14 +522,9 @@ export interface EditorSubmitResponse {
 export interface EditorTaskStatus {
   taskId: number
   status: 'APPROVED' | 'EXECUTING' | 'EXECUTED' | 'FAILED' | 'CANCELLED'
-  result: {
-    status: 'RUNNING' | 'DONE' | 'FAILED' | 'CANCELLED' | null
-    rowCount: number | null
-    columns: string[]
-    errorCode: string | null
-    executedAt?: string
-    expiresAt?: string
-  } | null
+  // The child metadata the server actually sends here IS QueryResultMeta; a structural copy of it drifted
+  // from the real shape and silently hid the fields a denial needs.
+  result: QueryResultMeta | null
 }
 
 /** GET /api/editor/tasks/{taskId}/result: the saved, re-decided rows once the task is DONE. */


### PR DESCRIPTION
Re-opens #57, whose content never reached `main`: it was stacked on #56, and merging the parent deleted the base branch it targeted, so the merge landed on a branch that no longer exists. `V11` and the deny-reason plumbing are absent from `main`. Same commit, rebased onto current `main`.

---

A policy DENY in the editor became a thrown `Error` carrying only a localized code, so the console showed "Query failed / The query was denied at execution time" with no reason and none of the affordances a denial exists to lead to: Request approval, Request access, View audit entry. The requester was told no and left with nowhere to go — the deny path the approval workflow is built around was unreachable from the surface that produces it.

The facts were on the server the whole time. The run response carries `denyReason` and the audit `decisionId`; the async editor path dropped both and wrote only an error code onto the failed child, and the poll response is built from that child. Both now ride along on it (**V11**), and the client returns a DENY result rather than throwing.

Also: `EditorTaskStatus.result` was a structural copy of `QueryResultMeta` that had drifted from it; it is now the type itself. And `META_COLS` carries a note that it must list every column `toMeta` reads — a mismatch fails at runtime, not compile time, which is how it failed here first.

## Where it could bite

**Pre-existing, now inherited by this path:** `EnfAction.DENY` covers both policy denials and structural fail-closed ones (inadmissible SQL, catalog miss, mask-binding failure). `DecisionContext.structural` distinguishes them but is persisted nowhere — not on the audit row, not on `QueryResponse` — so a structural denial is offered "Request approval" that no role can satisfy. **`main` already does this on the synchronous editor path**; this reaches parity rather than introducing it. Filed as follow-up.

`decision_id` is `ON DELETE SET NULL`, so purging an audit row leaves the denial and its reason intact and drops only the now-invalid link.

## Verification

`:control-plane:test` 869 pass; `mise run lint` clean. `EditorSubmitRouteDbTest` now asserts the deny reason survives to the polling client — mutation-verified: setting `denyReason = null` in the editor coroutine fails it.

Verified in the console: the same DELETE renders a DENY badge, the real reason, and all three actions.

Reviewed by Sol (changes-needed on the structural/policy split above), Codex, and Grok.