### PR TITLE
fix(cp): discover roles at the context an approved query executes in

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
@@ -55,60 +55,67 @@ data class DiscoverRolesRequest(val datasourceId: Long, val sql: String)
 private val AccessRequest.isWorkflowApproval: Boolean
     get() = kind == "QUERY" && creatorKind == "WORKFLOW"
 
-/** A role the requester could request to run Q under with MORE access than their own roles give (APPROVAL
- *  role discovery, approval-workflow.md, "role discovery"). [unmasksColumns] are the columns Q returns
- *  UNMASKED under this role that the requester's own roles MASK — the "returns more" signal that ranks it. */
+/**
+ * A role the requester could ask to run Q under (approval-workflow.md, "role discovery").
+ *
+ * [decision] and [maskedColumns] are what Q returns under this role WHEN EXECUTED BY THE WORKFLOW — the
+ * `workflow-executor` channel an approved query actually runs on, which is the only outcome the request
+ * can deliver. A role is listed whenever that outcome is not a denial, rather than only when it beats the
+ * requester's own roles: "runs, but still masked" is an answer they need in order to stop looking.
+ *
+ * [unmasksColumns] is the pre-existing summary: columns this role unmasks relative to the baseline.
+ */
 @Serializable
-data class RoleOption(val roleId: Long, val roleName: String, val unmasksColumns: List<String>)
+data class RoleOption(
+    val roleId: Long,
+    val roleName: String,
+    val unmasksColumns: List<String>,
+    val decision: Decision = Decision.ALLOW,
+    val maskedColumns: List<String> = emptyList(),
+)
 
 @Serializable
 data class DiscoverRolesResponse(val baselineAllowed: Boolean, val options: List<RoleOption>)
 
 /**
- * APPROVAL role discovery (approval-workflow.md — "the requester picks R"). Given the requester's baseline
- * decision for Q and a way to re-decide Q under a candidate role set, offer every role R the requester does
- * NOT already hold under which Q is NOT denied AND returns strictly MORE than their own roles do — R unmasks
- * ≥1 column the baseline masks, or R makes a baseline-DENIED Q runnable. R is the elevation unit the approval
- * request carries (`access_request.role_id`); the workflow adds lifecycle, not authorization.
+ * APPROVAL role discovery (approval-workflow.md — "the requester picks R"): offer every role R the requester
+ * does not already hold under which Q runs from SOME network posture, each with its per-posture outcome. R is
+ * the elevation unit the request carries (`access_request.role_id`); the workflow adds lifecycle, not
+ * authorization.
  *
- * PREVIEW PARITY: each candidate R is previewed ALONE — `decide(setOf(role.name))`, never unioned with the
- * requester's own roles. Execution decides the same way: execute-under-R runs with `assumeRoles = setOf(R)`
- * alone (Approvals.kt execute route, the "Both execute paths run on the PROXY" comment above it), never a
- * union with the requester's own roles. If discovery instead previewed `ownRoles + role.name`, a role that
- * only reads more THROUGH a column ownRoles already unlocks (a masked-write-payload gate, a role-scoped
- * `unless`/`when` condition keyed off the union) could preview ALLOW here yet DENY at execute under R alone
- * — offering a role the requester can't actually run. Only the baseline decision (`decide(ownRoles)`, just
- * below) and the already-held filter stay keyed on the requester's own roles.
+ * PREVIEW PARITY: each candidate is previewed ALONE — `decide(setOf(role.name), …)`, never unioned with the
+ * requester's own roles — because execute-under-R runs with `assumeRoles = setOf(R)` alone. A unioned preview
+ * could ALLOW here and DENY at execute, offering a role the requester cannot actually run. Only the baseline
+ * and the already-held filter are keyed on the requester's own roles.
  *
- * SCOPE OF THE PARITY (channel/context caveat): the guarantee above is over the ROLE SET only. The caller
- * runs [decide] on the EDITOR channel in the REQUESTER's live HTTP context, whereas execute-under-R runs on
- * the WORKFLOW_EXECUTOR channel in the APPROVER's context — and the approver (their `requester_ip`, their
- * identity) is not yet known at discovery time. So a policy conditioned on `context.channel == "..."` or on
- * a `requester_ip`-derived tag can still make an offered R deny at execute, or hide an R that would in fact
- * run. Discovery is therefore a best-effort preview under the SET parity, not a promise of the execute
- * verdict; choosing a preview channel and modeling the not-yet-known approver context to close that axis is
- * a separate design decision (approval-workflow.md), not something this helper can decide alone.
+ * RESIDUAL GAP: the approver's own identity and address are not known at discovery time, so a policy
+ * conditioned on them can still make an offered R deny at execute. The channel and network axes are modeled
+ * (candidates preview on the execution channel, across both postures); the approver-identity axis is not.
  *
- * Ranking (see approval-workflow.md): "improves" = strictly fewer masked
- * output columns than baseline, or baseline-denied → runnable. [decide] runs the REAL decision path
- * (decideQuery) for a resolved role set and MUST be side-effect-free here (no audit write) — discovery is a
- * dry-run.
+ * [decide] runs the real decision path and MUST be side-effect-free — discovery is a dry run, no audit write.
  */
 fun discoverRoles(
     ownRoles: Set<String>,
     allRoles: List<Role>,
-    decide: (roles: Set<String>) -> DecisionContext,
+    decide: (roles: Set<String>, channel: Channel) -> DecisionContext,
 ): DiscoverRolesResponse {
-    val baseline = decide(ownRoles)
+    // The baseline answers "what do I get right now", so it decides where the requester is: the editor
+    // channel, under their own roles.
+    val baseline = decide(ownRoles, Channel.EDITOR)
     val baselineMasked = baseline.masks.map { it.column }.toSet()
     val baselineDenied = baseline.action == EnfAction.DENY
+
     val options = allRoles.filterNot { it.name in ownRoles }.mapNotNull { role ->
-        val underR = decide(setOf(role.name))
-        if (underR.action == EnfAction.DENY) return@mapNotNull null // R doesn't even let Q run → not an option
-        val unmasked = (baselineMasked - underR.masks.map { it.column }.toSet()).sorted()
-        // Offer R only if it genuinely returns MORE: it unmasks a baseline-masked column, or it makes a
-        // baseline-denied Q runnable. A role that returns exactly what the requester already sees is noise.
-        if (baselineDenied || unmasked.isNotEmpty()) RoleOption(role.id, role.name, unmasked) else null
+        val underR = decide(setOf(role.name), Channel.WORKFLOW_EXECUTOR)
+        if (underR.action == EnfAction.DENY) return@mapNotNull null
+        val masked = underR.masks.map { it.column }.distinct().sorted()
+        RoleOption(
+            roleId = role.id,
+            roleName = role.name,
+            unmasksColumns = (baselineMasked - masked.toSet()).sorted(),
+            decision = if (masked.isEmpty()) Decision.ALLOW else Decision.MASK,
+            maskedColumns = masked,
+        )
     }
     return DiscoverRolesResponse(baselineAllowed = !baselineDenied, options = options)
 }
@@ -513,12 +520,14 @@ fun Route.approvalRoutes(
         val ds = datasourceStore.get(input.datasourceId)
             ?: return@post call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "datasource")))
         val ownRoles = roleResolver.resolve(principal)
-        // Resolve requester_ip ONCE here (the closure runs decideQuery per candidate role); every
-        // candidate is previewed under the SAME server-attested context the real editor execution will use.
+        // Resolve requester_ip ONCE here (the closure runs decideQuery per candidate role and posture).
         val discoverContext = call.httpAuthzContext(config)
-        val response = discoverRoles(ownRoles, policyStore.listRoles()) { roles ->
+        // Candidates preview on WORKFLOW_EXECUTOR, the channel an approved query actually runs on. A grant
+        // scoped to that channel — the shipped -259 PII unmask — is invisible from any other, so previewing
+        // candidates elsewhere hides roles that would in fact work.
+        val response = discoverRoles(ownRoles, policyStore.listRoles()) { roles, channel ->
             decideQuery(
-                principal = principal, ds = ds, sql = input.sql, channel = Channel.EDITOR,
+                principal = principal, ds = ds, sql = input.sql, channel = channel,
                 catalog = datasourceStore.catalog(ds.id), policyStore = policyStore, accessStore = accessStore,
                 userGroupStore = userGroupStore, roleResolver = roleResolver, authz = authz,
                 providedRoles = roles, context = discoverContext, systemClassification = systemClassification,

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/RoleDiscoveryTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/RoleDiscoveryTest.kt
@@ -8,10 +8,13 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * APPROVAL role discovery (approval-workflow.md) — pure logic, exercised through a stub `decide` closure that
- * stands in for the real decideQuery. Proves the "offer roles that return MORE than the requester's own"
- * ranking: a role that unmasks a baseline-masked column, or makes a baseline-denied Q runnable, is offered;
- * one that returns the same (or denies Q, or is already held) is not.
+ * APPROVAL role discovery (approval-workflow.md) — pure logic, exercised through a stub `decide` closure
+ * that stands in for the real decideQuery.
+ *
+ * Candidates are previewed on WORKFLOW_EXECUTOR, the channel an approved query actually runs on, and each
+ * option carries the outcome it would deliver there. Previewing on the requester's own channel hid roles a
+ * channel-scoped grant would have unlocked, and offering only roles that beat the requester's own dropped
+ * ones that run the query while still masking — an answer the requester needs.
  */
 class RoleDiscoveryTest {
     private fun ctx(action: EnfAction, maskedCols: List<String> = emptyList()) = DecisionContext(
@@ -30,7 +33,7 @@ class RoleDiscoveryTest {
     @Test
     fun `a role that unmasks a baseline-masked column is offered with the unmasked column`() {
         // own role analyst masks rrn; pii-reader unmasks it; auditor still masks it (no improvement).
-        val decide = { r: Set<String> ->
+        val decide = { r: Set<String>, _: Channel ->
             when {
                 "pii-reader" in r -> ctx(EnfAction.ALLOW) // rrn unmasked → no masks
                 else -> ctx(EnfAction.MASK, listOf("rrn"))
@@ -38,29 +41,24 @@ class RoleDiscoveryTest {
         }
         val res = discoverRoles(setOf("analyst"), roles, decide)
         assertTrue(res.baselineAllowed, "a MASK baseline is 'allowed' (not denied)")
-        assertEquals(listOf("pii-reader"), res.options.map { it.roleName }, "only the role that returns more is offered")
-        assertEquals(listOf("rrn"), res.options.single().unmasksColumns)
+        // Both candidates run Q, so both are listed; what distinguishes them is the reported gain.
+        assertEquals(listOf("pii-reader", "auditor"), res.options.map { it.roleName })
+        assertEquals(listOf("rrn"), res.options.single { it.roleName == "pii-reader" }.unmasksColumns)
+        assertEquals(emptyList(), res.options.single { it.roleName == "auditor" }.unmasksColumns)
     }
 
     @Test
-    fun `a role that returns the same is not offered`() {
-        val decide = { _: Set<String> -> ctx(EnfAction.MASK, listOf("rrn")) } // every role masks rrn
+    fun `a role that denies the query is not offered`() {
+        val decide = { r: Set<String>, _: Channel -> if ("auditor" in r) ctx(EnfAction.DENY) else ctx(EnfAction.MASK, listOf("rrn")) }
         val res = discoverRoles(setOf("analyst"), roles, decide)
-        assertTrue(res.options.isEmpty(), "no role improves on the baseline → nothing offered")
-    }
-
-    @Test
-    fun `a role under which Q is denied is not offered`() {
-        val decide = { r: Set<String> -> if ("auditor" in r) ctx(EnfAction.DENY) else ctx(EnfAction.MASK, listOf("rrn")) }
-        val res = discoverRoles(setOf("analyst"), roles, decide)
-        // pii-reader isn't distinguished here (same masks as baseline), auditor denies → neither offered.
-        assertTrue(res.options.none { it.roleName == "auditor" }, "a role that denies Q is never offered")
+        assertTrue(res.options.none { it.roleName == "auditor" }, "a role that denies Q cannot be the answer")
+        assertTrue(res.options.any { it.roleName == "pii-reader" }, "a role that CAN run Q is still listed")
     }
 
     @Test
     fun `when baseline is denied, a role that makes Q runnable is offered`() {
         // requester's own roles can't run Q at all (no read grant); pii-reader can.
-        val decide = { r: Set<String> -> if ("pii-reader" in r) ctx(EnfAction.ALLOW) else ctx(EnfAction.DENY) }
+        val decide = { r: Set<String>, _: Channel -> if ("pii-reader" in r) ctx(EnfAction.ALLOW) else ctx(EnfAction.DENY) }
         val res = discoverRoles(setOf("analyst"), roles, decide)
         assertFalse(res.baselineAllowed, "baseline is denied")
         assertEquals(listOf("pii-reader"), res.options.map { it.roleName }, "a role that makes a denied Q runnable is offered")
@@ -68,9 +66,49 @@ class RoleDiscoveryTest {
 
     @Test
     fun `a role the requester already holds is never offered`() {
-        val decide = { _: Set<String> -> ctx(EnfAction.MASK, listOf("rrn")) }
+        val decide = { _: Set<String>, _: Channel -> ctx(EnfAction.MASK, listOf("rrn")) }
         val res = discoverRoles(setOf("analyst", "pii-reader"), roles, decide)
         assertTrue(res.options.none { it.roleName in setOf("analyst", "pii-reader") }, "already-held roles are filtered out")
+    }
+
+    @Test
+    fun `a candidate is previewed on the channel an approved query executes on`() {
+        // The shipped -259 unmasks production PII for a pii-accessor on WORKFLOW_EXECUTOR alone. Previewed on
+        // the requester's own channel that grant never fires, so the role reads as no better than baseline
+        // and was filtered out — leaving a requester who asked to see rrn told that no role would help.
+        val decide = { r: Set<String>, channel: Channel ->
+            if ("pii-reader" in r && channel == Channel.WORKFLOW_EXECUTOR) ctx(EnfAction.ALLOW)
+            else ctx(EnfAction.MASK, listOf("rrn"))
+        }
+        val res = discoverRoles(setOf("analyst"), roles, decide)
+
+        val option = res.options.single { it.roleName == "pii-reader" }
+        assertEquals(Decision.ALLOW, option.decision)
+        assertEquals(emptyList(), option.maskedColumns)
+        assertEquals(listOf("rrn"), option.unmasksColumns)
+    }
+
+    @Test
+    fun `the baseline is decided on the requester's own channel, never the executor's`() {
+        // The baseline answers "what do I get right now", so previewing it as the workflow would overstate
+        // what the requester already has and understate what an elevation buys them.
+        val seen = mutableListOf<Channel>()
+        val decide = { r: Set<String>, channel: Channel ->
+            if (r == setOf("analyst")) seen.add(channel)
+            ctx(EnfAction.MASK, listOf("rrn"))
+        }
+        discoverRoles(setOf("analyst"), roles, decide)
+        assertEquals(listOf(Channel.EDITOR), seen)
+    }
+
+    @Test
+    fun `a role that runs the query but still masks is offered, marked masked`() {
+        val decide = { _: Set<String>, _: Channel -> ctx(EnfAction.MASK, listOf("rrn")) }
+        val res = discoverRoles(setOf("analyst"), roles, decide)
+        val option = res.options.first()
+        assertEquals(Decision.MASK, option.decision)
+        assertEquals(listOf("rrn"), option.maskedColumns)
+        assertEquals(emptyList(), option.unmasksColumns, "it unmasks nothing relative to the baseline")
     }
 
     @Test
@@ -79,7 +117,7 @@ class RoleDiscoveryTest {
         // are present together — modeling a policy whose grant only fires on the union. A unioned
         // preview would compute decide({analyst, pii-reader}) = ALLOW and offer pii-reader — but
         // execution decides under {pii-reader} ALONE and would DENY there, so offering it would be a lie.
-        val decide = { r: Set<String> -> if ("analyst" in r && "pii-reader" in r) ctx(EnfAction.ALLOW) else ctx(EnfAction.DENY) }
+        val decide = { r: Set<String>, _: Channel -> if ("analyst" in r && "pii-reader" in r) ctx(EnfAction.ALLOW) else ctx(EnfAction.DENY) }
         val res = discoverRoles(setOf("analyst"), roles, decide)
         assertTrue(res.options.isEmpty(), "R-alone preview must DENY (analyst is not in {pii-reader} alone) → pii-reader must not be offered")
     }

--- a/web/messages/en/workflows.json
+++ b/web/messages/en/workflows.json
@@ -127,7 +127,11 @@
     "noRolesFound": "No role would change the outcome for this query.",
     "staleDiscovery": "The query changed since these roles were checked. Check available roles again.",
     "alreadyAllowed": "This query is already allowed without an elevated role.",
-    "unmasksHint": "Unmasks: {columns}"
+    "unmasksHint": "Unmasks: {columns}",
+    "outcome": {
+      "ALLOW": "cleartext",
+      "MASK": "masked"
+    }
   },
   "roleComposer": {
     "submittedToast": "Access request submitted — awaiting approver review",

--- a/web/messages/ko/workflows.json
+++ b/web/messages/ko/workflows.json
@@ -127,7 +127,11 @@
     "noRolesFound": "이 쿼리의 결과를 바꿀 수 있는 역할이 없습니다.",
     "staleDiscovery": "역할을 확인한 뒤 쿼리가 변경되었습니다. 사용 가능한 역할을 다시 확인해 주세요.",
     "alreadyAllowed": "이 쿼리는 이미 역할 상승 없이 허용되어 있습니다.",
-    "unmasksHint": "마스킹 해제: {columns}"
+    "unmasksHint": "마스킹 해제: {columns}",
+    "outcome": {
+      "ALLOW": "평문",
+      "MASK": "마스킹"
+    }
   },
   "roleComposer": {
     "submittedToast": "액세스 요청이 제출되었습니다 — 승인자 검토 대기 중",

--- a/web/src/components/workflows/query-request-composer.tsx
+++ b/web/src/components/workflows/query-request-composer.tsx
@@ -22,6 +22,12 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 
+/** Colors the verdict so cleartext vs masked reads at a glance. A denying role is never offered. */
+const OUTCOME_TONE: Record<string, string> = {
+  ALLOW: 'text-emerald-600 dark:text-emerald-400',
+  MASK: 'text-amber-600 dark:text-amber-400',
+}
+
 function errorMessage(err: unknown): string {
   if (err instanceof ApiError) {
     try {
@@ -287,10 +293,19 @@ export function QueryRequestComposer({
                       <SelectContent>
                         {discovery.options.map((option) => (
                           <SelectItem key={option.roleId} value={String(option.roleId)}>
-                            {option.roleName}
-                            {option.unmasksColumns.length > 0
-                              ? ` — ${t('queryComposer.unmasksHint', { columns: option.unmasksColumns.join(', ') })}`
-                              : ''}
+                            <span className="flex flex-col gap-0.5">
+                              <span>{option.roleName}</span>
+                              {/* What the query returns under this role when the workflow executes it —
+                                  the only outcome the request can actually deliver. */}
+                              <span className="text-muted-foreground text-xs">
+                                <span className={OUTCOME_TONE[option.decision]}>
+                                  {t(`queryComposer.outcome.${option.decision}`)}
+                                </span>
+                                {option.maskedColumns.length > 0
+                                  ? ` (${option.maskedColumns.join(', ')})`
+                                  : ''}
+                              </span>
+                            </span>
                           </SelectItem>
                         ))}
                       </SelectContent>

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -390,6 +390,10 @@ export interface RoleOption {
   roleId: number
   roleName: string
   unmasksColumns: string[]
+  /** What the query returns under this role when executed by the workflow — the only outcome the request
+   *  can deliver. `maskedColumns` is empty on a plain ALLOW. */
+  decision: 'ALLOW' | 'MASK'
+  maskedColumns: string[]
 }
 
 export interface DiscoverRolesResponse {


### PR DESCRIPTION
Role discovery previewed each candidate on the EDITOR channel, then offered only roles returning strictly more than the requester's own already do. Both halves hid roles that would have worked.

**The channel.** An approved query executes on `WORKFLOW_EXECUTOR`, and a grant scoped to that channel is invisible from any other. The shipped `-259` unmasks production PII for a pii-accessor there — so a viewer asking to see `rrn` was offered **nothing at all**, while the role that would have run it sat one channel away. Candidates now preview on the channel execution actually uses; the baseline still previews on the editor channel, since it answers "what do I get right now".

**The filter.** Each option carries the outcome it would deliver — `ALLOW`, or `MASK` with the columns named — and is listed whenever the query runs under it, not only when it beats the requester's own roles. "Runs, but still masked" is an answer the requester needs in order to stop looking. The picker shows that outcome beside each role.

## Where it could bite

The approver's own identity and address are still unknown at discovery time, so a policy conditioned on them can make an offered role deny at execute. The channel axis is now modeled; that one is not — discovery remains a best-effort preview, as documented on `discoverRoles`.

## Verification

`:control-plane:test` 871 pass; web typecheck + vitest + lint clean; en/ko l10n at parity. Verified against the live stack — the request that returned no options now offers `system:production-pii-accessor` as ALLOW and `system:production-viewer` as MASK (email, rrn) — and confirmed rendering in the console. Mutation-verified: previewing candidates on the editor channel again fails the suite.