### PR TITLE
feat(control-plane): send a PKCE S256 challenge when the IdP advertises it

### DIFF
--- a/auth/src/main/kotlin/com/ridi/oss/proxymonster/auth/Oidc.kt
+++ b/auth/src/main/kotlin/com/ridi/oss/proxymonster/auth/Oidc.kt
@@ -30,6 +30,7 @@ data class OidcDiscoveryDocument(
     val userinfo_endpoint: String? = null,
     val jwks_uri: String,
     val device_authorization_endpoint: String? = null,
+    val code_challenge_methods_supported: List<String>? = null,
 )
 
 class OidcDiscovery(private val http: HttpClient, private val issuer: String) {

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -524,6 +524,21 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
                 ),
             )
         }
+        // Short-lived signed cookie holding the PKCE code_verifier across the redirect. Same
+        // lifetime as the nonce above: it only has to outlive one authorize round-trip.
+        cookie<OAuthVerifierSession>(OAUTH_VERIFIER_COOKIE) {
+            cookie.path = "/"
+            cookie.httpOnly = true
+            cookie.secure = config.mcpIssuer.startsWith("https://")
+            cookie.extensions["SameSite"] = "Lax"
+            cookie.maxAgeInSeconds = 300 // ~5 min — only needs to outlive the authorize round-trip
+            serializer = jsonSessionSerializer()
+            transform(
+                SessionTransportTransformerMessageAuthentication(
+                    config.sessionSecret.toByteArray(),
+                ),
+            )
+        }
         cookie<McpPendingAuthorization>(MCP_OAUTH_PENDING_COOKIE) {
             cookie.path = "/"
             cookie.httpOnly = true

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Oidc.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Oidc.kt
@@ -1,5 +1,6 @@
 package com.ridi.oss.proxymonster.controlplane
 
+import com.ridi.oss.proxymonster.auth.pkceS256
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.forms.submitForm
@@ -47,6 +48,26 @@ const val OAUTH_NONCE_COOKIE = "pm_oauth_nonce"
 @Serializable
 data class OAuthNonceSession(val nonce: String)
 
+/** Short-lived signed cookie carrying the PKCE `code_verifier` between /login and /callback. */
+const val OAUTH_VERIFIER_COOKIE = "pm_oauth_verifier"
+
+/**
+ * The PKCE `code_verifier` stashed in [OAUTH_VERIFIER_COOKIE] for the duration of the redirect
+ * dance. Only its S256 hash travels on the authorize request; the verifier itself is presented at
+ * the token endpoint, so an attacker who intercepts the redirect still cannot redeem the code.
+ *
+ * For a confidential client the `nonce` above is already what defeats authorization-code
+ * injection, so this is defense in depth rather than the primary control. It is sent only when
+ * discovery advertises S256, because an IdP that rejects unknown authorize parameters would
+ * otherwise break, and it is what satisfies providers configured to require PKCE (Okta's
+ * "Require PKCE as additional verification" returns `invalid_request` without it).
+ *
+ * Like [OAUTH_STATE_COOKIE] and [OAUTH_NONCE_COOKIE], this must be registered by whoever installs
+ * [oidcRoutes]; both handlers clear it unconditionally, so an unregistered name fails at login.
+ */
+@Serializable
+data class OAuthVerifierSession(val verifier: String)
+
 /** Token endpoint response — only the fields we consume; the rest are ignored. */
 @Serializable
 private data class TokenResponse(
@@ -58,6 +79,18 @@ private data class TokenResponse(
 /** A 32-byte random, URL-safe-ish opaque token — used for both the CSRF `state` and the `nonce`. */
 private fun randomOpaqueToken(): String {
     val bytes = ByteArray(24)
+    SecureRandom().nextBytes(bytes)
+    return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+}
+
+/**
+ * A PKCE `code_verifier`: 32 random bytes, base64url-encoded to 43 characters, which is the
+ * minimum RFC 7636 permits and what [isValidPkceVerifier] enforces on the server side of this
+ * same codebase. [randomOpaqueToken] is deliberately not reused — its 24 bytes encode to 32
+ * characters and would be rejected as too short.
+ */
+private fun randomCodeVerifier(): String {
+    val bytes = ByteArray(32)
     SecureRandom().nextBytes(bytes)
     return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
 }
@@ -99,6 +132,15 @@ fun Route.oidcRoutes(
         call.sessions.set(OAUTH_NONCE_COOKIE, OAuthNonceSession(nonce))
 
         val document = discovery.document()
+        // Negotiated, not assumed: only send a challenge to an IdP that advertises S256, so a
+        // provider that rejects unknown authorize parameters keeps working unchanged.
+        val verifier = if (document.supportsPkceS256()) randomCodeVerifier() else null
+        if (verifier != null) {
+            call.sessions.set(OAUTH_VERIFIER_COOKIE, OAuthVerifierSession(verifier))
+        } else {
+            call.sessions.clear(OAUTH_VERIFIER_COOKIE)
+        }
+
         val authorizeUrl = buildString {
             append(document.authorization_endpoint)
             append("?client_id=").append(oidc.clientId.encodeURLParameter())
@@ -107,6 +149,10 @@ fun Route.oidcRoutes(
             append("&redirect_uri=").append(oidc.redirectUri.encodeURLParameter())
             append("&state=").append(state.encodeURLParameter())
             append("&nonce=").append(nonce.encodeURLParameter())
+            if (verifier != null) {
+                append("&code_challenge=").append(pkceS256(verifier).encodeURLParameter())
+                append("&code_challenge_method=S256")
+            }
         }
         call.respondRedirect(authorizeUrl)
     }
@@ -126,9 +172,11 @@ fun Route.oidcRoutes(
         val stateSession = call.sessions.get<OAuthStateSession>()
         val expectedState = stateSession?.state
         val expectedNonce = call.sessions.get<OAuthNonceSession>()?.nonce
-        // One-time use: drop both cookies regardless of the outcome below.
+        val codeVerifier = call.sessions.get<OAuthVerifierSession>()?.verifier
+        // One-time use: drop all three cookies regardless of the outcome below.
         call.sessions.clear(OAUTH_STATE_COOKIE)
         call.sessions.clear(OAUTH_NONCE_COOKIE)
+        call.sessions.clear(OAUTH_VERIFIER_COOKIE)
 
         if (state == null || expectedState == null || state != expectedState) {
             log.warn("OIDC callback state validation failed")
@@ -166,6 +214,9 @@ fun Route.oidcRoutes(
                     append("redirect_uri", oidc.redirectUri)
                     append("client_id", oidc.clientId)
                     append("client_secret", oidc.clientSecret)
+                    // Present only when /login issued a challenge; sending it unconditionally
+                    // would fail against an IdP that never saw one.
+                    if (codeVerifier != null) append("code_verifier", codeVerifier)
                 },
             ).body()
 
@@ -211,6 +262,13 @@ fun Route.oidcRoutes(
         }
     }
 }
+
+/**
+ * Whether the IdP advertises S256 PKCE. Absent metadata means no: RFC 8414 makes the field
+ * optional, and a provider that omits it may reject the extra authorize parameters outright.
+ */
+internal fun OidcDiscoveryDocument.supportsPkceS256(): Boolean =
+    code_challenge_methods_supported?.any { it.equals("S256", ignoreCase = true) } == true
 
 internal fun oidcReturnTarget(raw: String?): String? =
     raw?.takeIf {

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/OidcCallbackTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/OidcCallbackTest.kt
@@ -1,17 +1,22 @@
 package com.ridi.oss.proxymonster.controlplane
 
+import com.ridi.oss.proxymonster.auth.isValidPkceChallenge
+import com.ridi.oss.proxymonster.auth.isValidPkceVerifier
+import com.ridi.oss.proxymonster.auth.pkceS256
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
 import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.get
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
 import io.ktor.http.parseQueryString
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.call
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.request.receiveParameters
 import io.ktor.server.response.respond
 import io.ktor.server.routing.get as serverGet
 import io.ktor.server.routing.post
@@ -25,9 +30,12 @@ import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicReference
 import javax.sql.DataSource
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 private const val TEST_SESSION_SECRET = "oidc-callback-test-secret-not-for-prod"
 
@@ -86,7 +94,11 @@ class OidcCallbackTest {
      * disabled, so the 3xx responses under test are inspectable directly instead of being silently
      * followed.
      */
-    private fun ApplicationTestBuilder.wireOidc(config: Config): HttpClient {
+    private fun ApplicationTestBuilder.wireOidc(
+        config: Config,
+        pkceMethods: List<String>? = null,
+        tokenForm: AtomicReference<Parameters>? = null,
+    ): HttpClient {
         // The client oidcRoutes/OidcDiscovery use for their OWN outbound calls (discovery fetch +
         // token exchange) — bound to this test app's in-process engine, so "/.well-known/..." and
         // "/token" below resolve without a real socket.
@@ -101,7 +113,11 @@ class OidcCallbackTest {
         // between `Application.install` and `TestApplicationBuilder.install` (both are implicit
         // receivers in scope) — pulling the app setup out to its own receiver scope, matching how
         // Application.module itself is structured, resolves it unambiguously.
-        application { installOidcTestApp(config, discovery, validator, internalHttp, userGroupStore, roleResolver, log) }
+        application {
+            installOidcTestApp(
+                config, discovery, validator, internalHttp, userGroupStore, roleResolver, log, pkceMethods, tokenForm,
+            )
+        }
 
         return createClient {
             expectSuccess = false
@@ -215,6 +231,89 @@ class OidcCallbackTest {
         val replayResp = client.get("/auth/oidc/callback?code=abc&state=$realState")
         assertEquals("/login?error=state", replayResp.headers[HttpHeaders.Location])
     }
+
+    @Test
+    fun `a challenge is sent when the IdP advertises S256`() = testApplication {
+        val client = wireOidc(testConfig(), pkceMethods = listOf("S256"))
+
+        val query = client.authorizeQuery()
+        assertEquals("S256", query["code_challenge_method"])
+        assertTrue(isValidPkceChallenge(query["code_challenge"]!!))
+    }
+
+    @Test
+    fun `no challenge is sent when the IdP advertises no PKCE methods`() = testApplication {
+        val client = wireOidc(testConfig())
+
+        val query = client.authorizeQuery()
+        assertNull(query["code_challenge"])
+        assertNull(query["code_challenge_method"])
+    }
+
+    @Test
+    fun `no challenge is sent when the IdP advertises only plain`() = testApplication {
+        val client = wireOidc(testConfig(), pkceMethods = listOf("plain"))
+
+        val query = client.authorizeQuery()
+        assertNull(query["code_challenge"])
+        assertNull(query["code_challenge_method"])
+    }
+
+    @Test
+    fun `S256 is matched case-insensitively`() = testApplication {
+        val client = wireOidc(testConfig(), pkceMethods = listOf("s256"))
+
+        assertEquals("S256", client.authorizeQuery()["code_challenge_method"])
+    }
+
+    @Test
+    fun `the challenge is the S256 hash of the verifier presented at the token endpoint`() = testApplication {
+        val tokenForm = AtomicReference<Parameters>()
+        val client = wireOidc(testConfig(), pkceMethods = listOf("S256"), tokenForm = tokenForm)
+
+        val query = client.authorizeQuery()
+        client.get("/auth/oidc/callback?code=abc&state=${query["state"]}")
+
+        // The RFC 7636 binding itself: what the IdP was shown must be the hash of what it is later
+        // told, or the whole exchange proves nothing.
+        val verifier = tokenForm.get()["code_verifier"]!!
+        assertTrue(isValidPkceVerifier(verifier))
+        assertEquals(query["code_challenge"], pkceS256(verifier))
+    }
+
+    @Test
+    fun `no verifier is sent to a token endpoint that never issued a challenge`() = testApplication {
+        val tokenForm = AtomicReference<Parameters>()
+        val client = wireOidc(testConfig(), tokenForm = tokenForm)
+
+        val query = client.authorizeQuery()
+        client.get("/auth/oidc/callback?code=abc&state=${query["state"]}")
+
+        // Absent, not blank: an empty code_verifier is itself a protocol error.
+        assertNull(tokenForm.get()["code_verifier"])
+    }
+
+    @Test
+    fun `the verifier cookie is one-time-use`() = testApplication {
+        val tokenForm = AtomicReference<Parameters>()
+        val client = wireOidc(testConfig(), pkceMethods = listOf("S256"), tokenForm = tokenForm)
+
+        val query = client.authorizeQuery()
+        client.get("/auth/oidc/callback?code=abc&state=${query["state"]}")
+        assertNotNull(tokenForm.get()["code_verifier"])
+
+        // A second login mints its own verifier rather than reusing the first one, which is what
+        // keeps an abandoned login from leaking a verifier into an unrelated exchange.
+        val second = client.authorizeQuery()
+        assertTrue(second["code_challenge"] != query["code_challenge"])
+    }
+
+    /** The authorize parameters `oidcRoutes` redirected to, lifted off the 302. */
+    private suspend fun HttpClient.authorizeQuery(path: String = "/auth/oidc/login"): Parameters {
+        val resp = get(path)
+        assertEquals(HttpStatusCode.Found, resp.status)
+        return parseQueryString(resp.headers[HttpHeaders.Location]!!.substringAfter('?'))
+    }
 }
 
 /**
@@ -230,6 +329,8 @@ private fun Application.installOidcTestApp(
     userGroupStore: UserGroupStore,
     roleResolver: RoleResolver,
     log: Logger,
+    pkceMethods: List<String>? = null,
+    tokenForm: AtomicReference<Parameters>? = null,
 ) {
     install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
     install(Sessions) {
@@ -251,6 +352,14 @@ private fun Application.installOidcTestApp(
             serializer = jsonSessionSerializer()
             transform(SessionTransportTransformerMessageAuthentication(TEST_SESSION_SECRET.toByteArray()))
         }
+        // oidcRoutes clears this on every login and every callback, so it must be registered even
+        // for an IdP that advertises no PKCE — an unregistered session name throws.
+        cookie<OAuthVerifierSession>(OAUTH_VERIFIER_COOKIE) {
+            cookie.path = "/"
+            cookie.httpOnly = true
+            serializer = jsonSessionSerializer()
+            transform(SessionTransportTransformerMessageAuthentication(TEST_SESSION_SECRET.toByteArray()))
+        }
     }
     routing {
         // Fake IdP double: a discovery document + token endpoint, just enough for oidcRoutes' own
@@ -262,10 +371,12 @@ private fun Application.installOidcTestApp(
                     authorization_endpoint = "/authorize",
                     token_endpoint = "/token",
                     jwks_uri = "http://jwks.invalid/keys",
+                    code_challenge_methods_supported = pkceMethods,
                 ),
             )
         }
         post("/token") {
+            tokenForm?.set(call.receiveParameters())
             call.respond(mapOf("id_token" to UNPARSEABLE_ID_TOKEN))
         }
         oidcRoutes(config, discovery, validator, http, userGroupStore, roleResolver, PrincipalSessionStore(UnusedDataSource, null), log)

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/OidcDiscoveryTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/OidcDiscoveryTest.kt
@@ -44,7 +44,8 @@ class OidcDiscoveryTest {
                         text = """
                             {"issuer":"$issuer","authorization_endpoint":"$issuer/authorize",
                              "token_endpoint":"$issuer/token","userinfo_endpoint":"$issuer/userinfo",
-                             "jwks_uri":"$issuer/jwks","device_authorization_endpoint":"$issuer/device/authorize"}
+                             "jwks_uri":"$issuer/jwks","device_authorization_endpoint":"$issuer/device/authorize",
+                             "code_challenge_methods_supported":["S256"]}
                         """.trimIndent(),
                     )
                 }
@@ -74,6 +75,7 @@ class OidcDiscoveryTest {
         assertEquals("$issuer/userinfo", doc.userinfo_endpoint)
         assertEquals("$issuer/jwks", doc.jwks_uri)
         assertEquals("$issuer/device/authorize", doc.device_authorization_endpoint)
+        assertEquals(listOf("S256"), doc.code_challenge_methods_supported)
     }
 
     @Test
@@ -82,6 +84,7 @@ class OidcDiscoveryTest {
         val doc = discovery.document()
         assertNull(doc.userinfo_endpoint)
         assertNull(doc.device_authorization_endpoint)
+        assertNull(doc.code_challenge_methods_supported)
     }
 
     @Test

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/OidcWebSessionDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/OidcWebSessionDbTest.kt
@@ -8,6 +8,7 @@ import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
+import com.ridi.oss.proxymonster.auth.pkceS256
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
 import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
@@ -30,6 +31,7 @@ import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.request.receiveParameters
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
@@ -59,6 +61,7 @@ class OidcWebSessionDbTest {
     private lateinit var key: RSAKey
     private lateinit var server: EmbeddedServer<*, *>
     private val nonce = AtomicReference<String>()
+    private val tokenCodeVerifier = AtomicReference<String>()
     private val callbackPrincipal = AtomicReference("oidc-web@example.com")
     private var port = 0
     private val issuer get() = "http://127.0.0.1:$port"
@@ -71,7 +74,7 @@ class OidcWebSessionDbTest {
             routing {
                 get("/.well-known/openid-configuration") {
                     call.respondText(
-                        """{"issuer":"$issuer","authorization_endpoint":"$issuer/authorize","token_endpoint":"$issuer/token","jwks_uri":"$issuer/jwks"}""",
+                        """{"issuer":"$issuer","authorization_endpoint":"$issuer/authorize","token_endpoint":"$issuer/token","jwks_uri":"$issuer/jwks","code_challenge_methods_supported":["S256"]}""",
                         ContentType.Application.Json,
                     )
                 }
@@ -79,6 +82,7 @@ class OidcWebSessionDbTest {
                     call.respondText(JWKSet(key.toPublicJWK()).toString(), ContentType.Application.Json)
                 }
                 post("/token") {
+                    tokenCodeVerifier.set(call.receiveParameters()["code_verifier"])
                     call.respondText(
                         Json.encodeToString(
                             kotlinx.serialization.json.JsonObject.serializer(),
@@ -164,6 +168,10 @@ class OidcWebSessionDbTest {
         val query = parseQueryString(assertNotNull(login.headers[HttpHeaders.Location]).substringAfter('?'))
         nonce.set(assertNotNull(query["nonce"]))
         val callback = client.get("/auth/oidc/callback?code=ok&state=${assertNotNull(query["state"])}")
+
+        // PKCE survives the full signed-id_token path, not just the redirect shape: this IdP double
+        // advertises S256, so the challenge on /authorize must be the hash of what /token received.
+        assertEquals(query["code_challenge"], pkceS256(assertNotNull(tokenCodeVerifier.get())))
         assertEquals(HttpStatusCode.Found, callback.status)
         assertEquals(returnTo, callback.headers[HttpHeaders.Location], "SSO returns to the device authorize URL")
         assertTrue(
@@ -331,6 +339,12 @@ class OidcWebSessionDbTest {
                 transform(SessionTransportTransformerMessageAuthentication(config.sessionSecret.toByteArray()))
             }
             cookie<DeviceVerifySession>(DEVICE_VERIFY_COOKIE) {
+                serializer = jsonSessionSerializer()
+                transform(SessionTransportTransformerMessageAuthentication(config.sessionSecret.toByteArray()))
+            }
+            // oidcRoutes clears this on every login and every callback, so it must be registered
+            // even when the IdP advertises no PKCE — an unregistered session name throws.
+            cookie<OAuthVerifierSession>(OAUTH_VERIFIER_COOKIE) {
                 serializer = jsonSessionSerializer()
                 transform(SessionTransportTransformerMessageAuthentication(config.sessionSecret.toByteArray()))
             }

--- a/docs/auth-model.md
+++ b/docs/auth-model.md
@@ -40,9 +40,12 @@ Endpoints (authorize / token / userinfo / jwks / device) are resolved from OIDC
 discovery (`OidcDiscovery.kt`), so the flow is provider-agnostic:
 
 ```
-/auth/oidc/login    → mint state + nonce (short-lived signed cookie) → 302 to the IdP /authorize
-                      (scope: openid profile email groups; response_type=code)
-/auth/oidc/callback → verify state → exchange code (+ client_secret) at the IdP /token
+/auth/oidc/login    → mint state + nonce (+ PKCE code_verifier) in short-lived signed cookies
+                      → 302 to the IdP /authorize
+                      (scope: openid profile email groups; response_type=code;
+                       code_challenge + code_challenge_method=S256 when discovery advertises S256)
+/auth/oidc/callback → verify state → exchange code (+ client_secret, + code_verifier if one was
+                      issued) at the IdP /token
                       → VALIDATE id_token (IdTokenValidator): JWKS signature, iss, aud, exp, AND nonce
                       → principal = email ?? sub
                       → JIT-provision the app_user (+ map groups claim → local groups)
@@ -50,8 +53,15 @@ discovery (`OidcDiscovery.kt`), so the flow is provider-agnostic:
 ```
 
 - The security floor is `id_token` validation with `nonce` plus `state` (CSRF)
-  on the confidential client. PKCE is optional OAuth-2.1 defense-in-depth
-  (guards a `client_secret` leak), not load-bearing here.
+  on the confidential client. PKCE is OAuth-2.1 defense-in-depth on top of that
+  (it guards a `client_secret` leak); `nonce`, not the challenge, is what
+  defeats authorization-code injection here.
+- PKCE is negotiated, not assumed: a challenge is sent only when the discovery
+  document advertises `S256` in `code_challenge_methods_supported`. Sending it
+  unconditionally would break an IdP that rejects unknown authorize parameters,
+  and omitting it entirely locks out providers configured to require PKCE —
+  Okta's "Require PKCE as additional verification" answers `invalid_request`
+  before it ever renders a login form. `plain` is never sent.
 - The `groups` claim feeds JIT provisioning (local group membership), _not_
   roles. Roles come from `RoleResolver` over the local directory, never from the
   token.
@@ -208,7 +218,7 @@ the directory on its own. Setting the token turns SCIM on.
   (`/auth/debug` sets any principal) and defaults on for dev. The server refuses
   to start with it on unless a dev marker is set, and warns loudly.
 - `id_token` fully validated (JWKS sig + `iss`/`aud`/`exp` + `nonce`); `state`
-  on every auth-code flow; `state`/`nonce` are one-time.
+  on every auth-code flow; `state`/`nonce`/`code_verifier` are one-time.
 - All wire credentials expire — no permanent tokens. The only standing secrets
   are `client_secret` and `PM_SCIM_TOKEN`, env-provided, never in the DB or
   logs; a server-held refresh token is encrypted at rest.


### PR DESCRIPTION
## Summary

The OIDC **relying-party** side never sent a `code_challenge`, so an IdP configured to require PKCE rejects the authorize request before it renders a login form. Against Okta with "Require PKCE as additional verification" enabled, `/auth/oidc/login` round-trips back to `/auth/oidc/callback` in ~500ms with:

```
error=invalid_request&error_description=PKCE+code+challenge+is+required+by+the+application.
```

This mints a `code_verifier` alongside the existing `state` and `nonce`, sends its S256 hash on `/authorize`, and presents the verifier at the token exchange.

## This is the RP side, not the AS side

Worth stating up front, because "proxy-monster already does PKCE" is an easy misreading. The control plane **as an authorization server** for MCP clients already implements and mandates PKCE (`oauth/OAuthRoutes.kt` advertises `code_challenge_methods_supported = ["S256"]` and rejects anything else; `auth/McpOAuth.kt` verifies the challenge at exchange). That direction is untouched here, as are `docs/mcp-access-control.md` and `docs/authz-model.md`.

What was missing is the opposite direction: proxy-monster **as a client of the IdP**. Both directions now share `pkceS256` from the `auth` module rather than growing a second implementation.

## Negotiated, not unconditional

The challenge is sent only when the discovery document advertises `S256` in `code_challenge_methods_supported`. Sending it unconditionally would break an IdP that rejects unknown authorize parameters, and RFC 8414 makes the field optional, so absent metadata is treated as "no". `plain` is never sent.

There is deliberately no config knob: discovery decides. The IANA registry defines only `plain` and `S256`, so a knob would offer a choice between the correct value and one OAuth 2.1 forbids. If a future method is registered, the change is a branch on the same advertised list.

## Not a vulnerability fix

Framing this precisely, since `SECURITY.md` asks for private disclosure of actual vulnerabilities. For a confidential client the `nonce` bound into the `id_token` is what defeats authorization-code injection, and that was already in place and validated. PKCE here is defense in depth that additionally guards a `client_secret` leak. The security floor is unchanged; what changes is compatibility with providers that require PKCE.

## One note for embedders

The new `pm_oauth_verifier` cookie must be registered by whoever installs `oidcRoutes`, exactly as `pm_oauth_state` and `pm_oauth_nonce` already must be. Both handlers clear it unconditionally, so an unregistered session name throws at login even for an IdP that advertises no PKCE. `App.kt` and both test harnesses are updated accordingly.

## Test plan

- [x] `./gradlew :control-plane:test --tests '*Oidc*'` — 31 tests, 0 skipped, 0 failures
- [x] `mise run format` after the docs edit, so `prettier --check` stays green
- [ ] End-to-end against a live IdP with PKCE required

New coverage, none of which existed before (every prior OIDC test omitted `code_challenge_methods_supported`, so the whole branch was untested):

| Test | Pins |
|---|---|
| `a challenge is sent when the IdP advertises S256` | the happy path |
| `no challenge is sent when the IdP advertises no PKCE methods` | absent metadata means no |
| `no challenge is sent when the IdP advertises only plain` | `plain` is never used |
| `S256 is matched case-insensitively` | metadata casing |
| `the challenge is the S256 hash of the verifier presented at the token endpoint` | the RFC 7636 binding itself |
| `no verifier is sent to a token endpoint that never issued a challenge` | absent, not blank |
| `the verifier cookie is one-time-use` | a second login mints a fresh verifier |
| `OidcWebSessionDbTest` (existing, extended) | the binding survives the full signed-`id_token` → session-minting path |

`OidcDiscoveryTest` covers the new field both present and omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)