### PR TITLE
feat(pmon): check the local password before brokering a connection

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,7 +76,7 @@ only.
 | Web console | UI · Next.js | User-facing UI: query editor, policy/role/grant management, approvals, audit view. Thin, and holds no state. Rewrites `/api` and `/auth` to the CP so the browser talks same-origin — the browser's paths, not the CP's whole surface: `/mcp`, `/oauth`, and `/.well-known` are not rewritten, so a deployment using MCP routes those to the CP at the edge (see [How users reach it](#how-users-reach-it)). |
 | auditmon | watcher · Go | Independent audit monitor: reads the committed trail, re-verifies the tamper-evident hash chain, exports redacted batches to a WORM object store, signs off-box anchors, runs anomaly rules to alerts. Separate from the CP by design. Its access to the control-plane store is read-only. |
 | Control-plane store | store · PostgreSQL only | System of record: identity, policy, catalog, sessions, and the `audit_event` hash chain. The CP reads and writes it; auditmon only reads. PostgreSQL is the only supported store engine — `Db.kt` hardcodes the Postgres JDBC driver, and the migrations use `RETURNING`, `ON CONFLICT`, `jsonb`, and `::` casts. Independent of which engine a target database runs. |
-| pmon | client connector · Go | A single static binary each user runs locally. `pmon login` authenticates to the CP (OIDC device auth) and mints a short-lived wire token, and re-running it is how a login is extended — there is no silent renewal in the client; the daemon then opens one local broker per datasource, which any SQL client points at (any password), injecting the real token upstream and pinning the proxy to its advertised leaf-cert fingerprint. |
+| pmon | client connector · Go | A single static binary each user runs locally. `pmon login` authenticates to the CP (OIDC device auth) and mints a short-lived wire token, and re-running it is how a login is extended — there is no silent renewal in the client; the daemon then opens one local broker per datasource, which any SQL client points at with the sticky local password, injecting the real token upstream and pinning the proxy to its advertised leaf-cert fingerprint. |
 
 Source layout, module by module, is in [AGENTS.md](./AGENTS.md#layout).
 
@@ -134,13 +134,13 @@ registers itself, and why the control plane holds no target credentials).
   fall on which side, and what the code does and does not enforce, is below.
 - Apps and SQL clients connect through pmon: `pmon login` runs the CP
   device-auth flow and stores a short-lived wire token; the daemon then runs a
-  local broker you point any SQL driver at (any password), injecting the token
-  to the proxy over the wire's clear-password auth-switch. Upstream TLS is
-  pinned, not CA-verified: the control plane hands the broker the proxy's
-  advertised leaf-cert SHA-256, and the broker accepts exactly that leaf — no
-  CA, no system trust store, no hostname check — so a self-signed wire cert
-  works and nothing has to be distributed to clients. A pinned datasource whose
-  proxy offers no TLS is refused rather than sent the token in the clear.
+  local broker you point any SQL driver at with the sticky local password,
+  injecting the token to the proxy over the wire's clear-password auth-switch.
+  Upstream TLS is pinned, not CA-verified: the control plane hands the broker
+  the proxy's advertised leaf-cert SHA-256, and the broker accepts exactly that
+  leaf — no CA, no system trust store, no hostname check — so a self-signed wire
+  cert works and nothing has to be distributed to clients. A pinned datasource
+  whose proxy offers no TLS is refused rather than sent the token in the clear.
   Without an advertised fingerprint, TLS (if the proxy offers it) falls back to
   system-trust verification against the proxy's hostname, and a proxy offering
   no TLS is brokered in plaintext — the token crosses in the clear, which only a

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -287,9 +287,6 @@ Fixes for gaps documented in
 - PostgreSQL brokering in `pmon`: the daemon fronts MySQL only, so PostgreSQL
   datasources are discovered but skipped and their connection strings are
   rendered without a broker behind them.
-- Broker-side enforcement of the local `pmon` password: today any password a
-  loopback client sends is accepted, and the sticky local password is only a
-  convention `pmon show` hands out.
 - Bound the native-wire relay by `PM_QUERY_TIMEOUT`. The control-plane-driven
   editor and workflow runs honor it; the wire relay passes no execution guard
   and keeps a fixed socket-inactivity cap, so a direct statement through `pmon`

--- a/mysqlwire/mysql.go
+++ b/mysqlwire/mysql.go
@@ -220,6 +220,42 @@ func AuthSwitchClearPassword() []byte {
 	return []byte("\xfemysql_clear_password\x00")
 }
 
+// Scramble returns a fresh 20-byte auth scramble with no NUL byte in it.
+//
+// The wire sends a scramble NUL-terminated, and a client that reads it as a C string stops at the
+// first NUL — hashing a truncated salt while the server hashes the whole thing, so the digests
+// disagree and the connection is denied. A uniformly random 20 bytes contains a NUL about 7.5% of
+// the time, which would surface as an auth failure that goes away on retry. Real servers exclude it
+// for the same reason.
+func Scramble() ([]byte, error) {
+	b := make([]byte, 20)
+	if _, err := rand.Read(b); err != nil {
+		return nil, err
+	}
+	for i, v := range b {
+		if v == 0 {
+			// Any nonzero byte does; the salt's job is freshness, not a uniform distribution.
+			b[i] = 1
+		}
+	}
+	return b, nil
+}
+
+// AuthSwitchCachingSHA2 builds an AuthSwitchRequest for caching_sha2_password carrying scramble. The
+// scramble is sent NUL-terminated, as a server does, because the client reads it as a C string and
+// would otherwise fold the terminator into the salt it hashes.
+func AuthSwitchCachingSHA2(scramble []byte) []byte {
+	b := []byte("\xfecaching_sha2_password\x00")
+	b = append(b, scramble...)
+	return append(b, 0)
+}
+
+// AuthMoreDataPacket builds an AuthMoreData packet carrying one status marker — the fast-auth
+// outcome a caching_sha2_password server reports after seeing the client's digest.
+func AuthMoreDataPacket(marker byte) []byte {
+	return []byte{AuthMoreData, marker}
+}
+
 // ParseClearPassword returns the clear-password response, stripping one trailing NUL.
 func ParseClearPassword(payload []byte) string {
 	if len(payload) > 0 && payload[len(payload)-1] == 0 {
@@ -446,6 +482,13 @@ type HandshakeResponse struct {
 	Capabilities uint32
 	Username     string
 	Database     string
+	// AuthResponse is the client's answer to the greeting's scramble, in whichever encoding its
+	// capabilities selected. Empty when the client sent no password at all, which is not the same as
+	// a wrong one: a server that treats the two alike accepts every unauthenticated connection.
+	AuthResponse []byte
+	// AuthPlugin is the plugin the client used to compute AuthResponse, which need not be the one the
+	// greeting asked for. Empty when the client negotiated no CapPluginAuth.
+	AuthPlugin string
 }
 
 // ParseHandshakeResponse parses a Protocol 41 HandshakeResponse. connectWithDBSupported must be the
@@ -468,13 +511,17 @@ func ParseHandshakeResponse(payload []byte, connectWithDBSupported bool) (Handsh
 	if err != nil {
 		return HandshakeResponse{}, err
 	}
+	var authResponse []byte
 	switch {
 	case caps&CapPluginAuthLenenc != 0:
 		n, err := r.Lenenc()
 		if err != nil {
 			return HandshakeResponse{}, err
 		}
-		if n > uint64(len(payload)) || r.Skip(int(n)) != nil {
+		if n > uint64(len(payload)) {
+			return HandshakeResponse{}, io.ErrUnexpectedEOF
+		}
+		if authResponse, err = r.Bytes(int(n)); err != nil {
 			return HandshakeResponse{}, io.ErrUnexpectedEOF
 		}
 	case caps&CapSecureConn != 0:
@@ -482,13 +529,15 @@ func ParseHandshakeResponse(payload []byte, connectWithDBSupported bool) (Handsh
 		if err != nil {
 			return HandshakeResponse{}, err
 		}
-		if err := r.Skip(int(n)); err != nil {
+		if authResponse, err = r.Bytes(int(n)); err != nil {
 			return HandshakeResponse{}, err
 		}
 	default:
-		if _, err := r.Cstr(); err != nil {
+		s, err := r.Cstr()
+		if err != nil {
 			return HandshakeResponse{}, err
 		}
+		authResponse = []byte(s)
 	}
 
 	database := ""
@@ -498,7 +547,21 @@ func ParseHandshakeResponse(payload []byte, connectWithDBSupported bool) (Handsh
 			return HandshakeResponse{}, err
 		}
 	}
-	return HandshakeResponse{Capabilities: caps, Username: username, Database: database}, nil
+	// The plugin the client actually used to compute AuthResponse. A client may answer with a plugin
+	// other than the one the greeting named, so a server that verifies the response has to know which
+	// digest it is looking at rather than assume its own advertisement was honored. Absent when the
+	// client negotiated no CapPluginAuth, which leaves the greeting's plugin as the only claim.
+	authPlugin := ""
+	if caps&CapPluginAuth != 0 && r.HasRemaining() {
+		authPlugin, _ = r.Cstr()
+	}
+	return HandshakeResponse{
+		Capabilities: caps,
+		Username:     username,
+		Database:     database,
+		AuthResponse: authResponse,
+		AuthPlugin:   authPlugin,
+	}, nil
 }
 
 // Greeting is the backend server data needed by the client role.

--- a/mysqlwire/mysql_test.go
+++ b/mysqlwire/mysql_test.go
@@ -246,10 +246,11 @@ func TestParseHandshakeResponseAuthModes(t *testing.T) {
 		name string
 		caps uint32
 		mode string
+		auth []byte
 	}{
-		{"lenenc auth", CapProtocol41 | CapPluginAuthLenenc | CapConnectWithDB, "lenenc"},
-		{"secure auth", CapProtocol41 | CapSecureConn | CapConnectWithDB, "secure"},
-		{"cstr auth", CapProtocol41 | CapConnectWithDB, "cstr"},
+		{"lenenc auth", CapProtocol41 | CapPluginAuthLenenc | CapConnectWithDB, "lenenc", []byte{1, 2, 3}},
+		{"secure auth", CapProtocol41 | CapSecureConn | CapConnectWithDB, "secure", []byte{1, 2, 3}},
+		{"cstr auth", CapProtocol41 | CapConnectWithDB, "cstr", []byte("auth")},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -257,9 +258,12 @@ func TestParseHandshakeResponseAuthModes(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ParseHandshakeResponse: %v", err)
 			}
-			want := HandshakeResponse{Capabilities: test.caps, Username: "alice", Database: "app"}
-			if got != want {
-				t.Fatalf("got %+v, want %+v", got, want)
+			if got.Capabilities != test.caps || got.Username != "alice" || got.Database != "app" {
+				t.Fatalf("got %+v, want caps=%d user=alice db=app", got, test.caps)
+			}
+			// The auth response is what a password check compares; every encoding must surface it.
+			if !bytes.Equal(got.AuthResponse, test.auth) {
+				t.Fatalf("auth response: got %v, want %v", got.AuthResponse, test.auth)
 			}
 		})
 	}
@@ -532,5 +536,29 @@ func TestErrPacketRetainsExistingBytes(t *testing.T) {
 	want := append([]byte{0xff, 0x15, 0x04, '#'}, "HY000boom"...)
 	if got := ErrPacket(1045, "boom"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("ErrPacket = %x, want %x", got, want)
+	}
+}
+
+// TestScrambleHasNoNUL: the wire sends a scramble NUL-terminated, so a client reading it as a C
+// string would hash a truncated salt and disagree with the server. A uniformly random 20 bytes
+// carries a NUL about 7.5% of the time, which is an auth failure that goes away on retry.
+func TestScrambleHasNoNUL(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 2000; i++ {
+		s, err := Scramble()
+		if err != nil {
+			t.Fatalf("Scramble: %v", err)
+		}
+		if len(s) != 20 {
+			t.Fatalf("len = %d, want 20", len(s))
+		}
+		if bytes.IndexByte(s, 0) >= 0 {
+			t.Fatalf("scramble contains a NUL: % x", s)
+		}
+		seen[string(s)] = true
+	}
+	// Freshness matters as much as the shape: a constant scramble would let a captured digest replay.
+	if len(seen) < 1900 {
+		t.Fatalf("only %d distinct scrambles in 2000 draws", len(seen))
 	}
 }

--- a/pmon/README.md
+++ b/pmon/README.md
@@ -44,6 +44,12 @@ pmon show acme-mysql --cli      # mysql -h 127.0.0.1 -P 6100 -u 'user' -p'pw' 'm
 
 Output is the bare string, so it pipes straight into a client or an env var.
 
+The daemon checks that password. It answers `mysql_native_password` and
+`caching_sha2_password` directly, and switches any other plugin to
+`mysql_clear_password` — which the `mysql` CLI only permits with
+`--enable-cleartext-plugin`. A saved connection carrying a stale or blank
+password fails with access denied; re-copy it from `pmon show`.
+
 ## Architecture
 
 The daemon owns all state and logic and exposes a **local control socket**. This
@@ -110,8 +116,6 @@ pmon CLI ──┐                        ┌── menu-bar app
 
 - **Postgres brokering** — PG datasources are discovered and listed with a
   reason, not fronted.
-- **Local-password enforcement** — the broker hands out the sticky password but
-  accepts any password (loopback + OS-user isolation is the trust boundary).
 - **Notarized menu-bar app** — [`pmontray/`](../pmontray) is built and ad-hoc
   signed; distributing it to other machines needs a Developer ID signature +
   notarization.

--- a/pmon/internal/daemon/brokerconn.go
+++ b/pmon/internal/daemon/brokerconn.go
@@ -1,7 +1,7 @@
 package daemon
 
 import (
-	"crypto/rand"
+	"errors"
 	"io"
 	"net"
 	"time"
@@ -14,18 +14,23 @@ import (
 // certChainPEM is set the upstream TLS verifies against it as the root pool, with the advertised host checked
 // against it; otherwise it falls back to the system trust store. When wireTLS says this proxy serves TLS, a
 // greeting offering none is refused rather than sent the token in plaintext.
-func brokerMySQL(local net.Conn, proxyAddr, certChainPEM string, wireTLS bool, principal, token string) error {
-	scramble := make([]byte, 20)
-	if _, err := rand.Read(scramble); err != nil {
+func brokerMySQL(local net.Conn, proxyAddr, certChainPEM string, wireTLS bool, principal, token, localPassword string) error {
+	scramble, err := mysqlwire.Scramble()
+	if err != nil {
 		return err
 	}
-	clientCaps, err := localServerGreet(local, scramble)
+	clientCaps, seq, err := localServerGreet(local, scramble, localPassword)
 	if err != nil {
+		// A rejected password never reaches the proxy: answer here and drop the connection, so a
+		// caller that cannot authenticate locally cannot spend the session's token upstream.
+		if errors.Is(err, errLocalAuth) {
+			_ = mysqlwire.WritePacket(local, seq, mysqlwire.ErrPacketState(1045, "28000", "proxy-monster: access denied"))
+		}
 		return err
 	}
 	proxy, err := net.DialTimeout("tcp", proxyAddr, dialTimeout)
 	if err != nil {
-		_ = mysqlwire.WritePacket(local, 2, mysqlwire.ErrPacket(1045, "proxy-monster: cannot reach proxy"))
+		_ = mysqlwire.WritePacket(local, seq, mysqlwire.ErrPacket(1045, "proxy-monster: cannot reach proxy"))
 		return err
 	}
 	defer proxy.Close()
@@ -39,14 +44,14 @@ func brokerMySQL(local net.Conn, proxyAddr, certChainPEM string, wireTLS bool, p
 	}
 	up, err := proxyConnect(proxy, hostOf(proxyAddr), certChainPEM, wireTLS, principal, token, clientCaps)
 	if err != nil {
-		_ = mysqlwire.WritePacket(local, 2, mysqlwire.ErrPacket(1045, "proxy-monster: "+err.Error()))
+		_ = mysqlwire.WritePacket(local, seq, mysqlwire.ErrPacket(1045, "proxy-monster: "+err.Error()))
 		return err
 	}
 	// The relay has no time bound — a session may idle legitimately — so drop the handshake deadline.
 	if err := proxy.SetDeadline(time.Time{}); err != nil {
 		return err
 	}
-	if err := mysqlwire.WritePacket(local, 2, mysqlwire.OKPacket()); err != nil {
+	if err := mysqlwire.WritePacket(local, seq, mysqlwire.OKPacket()); err != nil {
 		return err
 	}
 	pipe(up, local)

--- a/pmon/internal/daemon/daemon.go
+++ b/pmon/internal/daemon/daemon.go
@@ -640,8 +640,8 @@ func (d *Daemon) current(name string) (Datasource, bool) {
 
 // broker fronts one client connection: it looks up the datasource's CURRENT advertised address (so a proxy
 // that re-registered from A to B is followed without a daemon restart), speaks its wire protocol to the local
-// client, and dials the proxy with the current token. Any password the local client sends is accepted
-// (loopback trust boundary); the sticky local password is the canonical one peers hand out.
+// client, and dials the proxy with the current token. The local client is checked against the sticky
+// local password before the proxy is dialed.
 func (d *Daemon) broker(local net.Conn, name string) {
 	defer local.Close()
 	// Register now (so a logout/revocation mid-session can close this socket) and deregister on return.
@@ -656,7 +656,9 @@ func (d *Daemon) broker(local net.Conn, name string) {
 		return
 	}
 	cfg := d.snapshot()
-	if err := brokerMySQL(local, ds.AdvertiseAddr, ds.CertChainPEM, ds.WireTLS, cfg.Principal, cfg.Token); err != nil {
+	// cfg.LocalPassword is the same value `pmon show` puts in its connection strings, so the client is
+	// checked against the password it was handed.
+	if err := brokerMySQL(local, ds.AdvertiseAddr, ds.CertChainPEM, ds.WireTLS, cfg.Principal, cfg.Token, cfg.LocalPassword); err != nil {
 		fmt.Fprintf(os.Stderr, "broker %q: %v\n", name, err)
 	}
 }

--- a/pmon/internal/daemon/mysql.go
+++ b/pmon/internal/daemon/mysql.go
@@ -1,9 +1,11 @@
 package daemon
 
 import (
+	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -12,21 +14,36 @@ import (
 )
 
 // pmon-specific MySQL handshake flows. The daemon's local broker acts as a MySQL *server* to the
-// local client (greeting → accept any auth → OK) and as a MySQL *client* to the proxy (handshake →
+// local client (greeting → check the local password → OK) and as a MySQL *client* to the proxy (handshake →
 // auth-switch → send the token as the cleartext password). After both handshakes the command phase
 // is piped raw. The low-level framing/message primitives live in the shared mysqlwire package.
 
 // serverVersion is what pmon's local broker reports to the client in its greeting.
 const serverVersion = "8.0.40-proxy-monster-pm"
 
-// localServerGreet plays the MySQL server to the local client up to (not including) the auth
-// result: greeting, then read its handshake response (auth ignored — the trust boundary is the
-// upstream token). The caller sends OK only after the upstream proxy handshake succeeds, so a bad
-// token surfaces as an auth error to the local client rather than a late failure.
-func localServerGreet(c io.ReadWriter, scramble []byte) (clientCaps uint32, err error) {
+// errLocalAuth is what a client that answered the greeting with the wrong password gets. It carries
+// no detail beyond access-denied — the wrong password is not worth naming — but it is a distinct
+// message from the other local failures, so this does tell a caller its password was wrong. That is
+// what any password prompt does; the password is 24 random bytes, not a guessable one.
+var errLocalAuth = errors.New("access denied")
+
+// localServerGreet plays the MySQL server to the local client up to (not including) the auth result:
+// greeting, then read and verify its handshake response against the daemon's local password. The
+// caller sends OK only after the upstream proxy handshake also succeeds, so a bad token surfaces as
+// an auth error to the local client rather than a late failure.
+//
+// The local password is not the credential that reaches the datasource — the upstream token is — but
+// checking it keeps any process that can open a loopback socket from borrowing this session. Reading
+// the password out of the state file is a strictly higher bar than connecting to a port.
+//
+// nextSeq is the sequence the caller's reply (OK or ERR) must carry. It depends on how many packets
+// the plugin negotiation spent, so the caller must use it rather than assume the handshake ended at
+// a fixed point.
+func localServerGreet(c io.ReadWriter, scramble []byte, localPassword string) (clientCaps uint32, nextSeq byte, err error) {
 	// false: this greeting must not advertise CapConnectWithDB — the handshake response below is read
-	// only for its capability flags (clientCaps), never for a handshake-supplied database, so a client
-	// connecting with one here would have it silently dropped rather than relayed upstream.
+	// only for its capability flags and auth response, never for a handshake-supplied database, so a
+	// client connecting with one here would have it silently dropped rather than relayed upstream.
+	nextSeq = 2
 	if err = mysqlwire.WritePacket(c, 0, mysqlwire.ServerGreeting(1, scramble, serverVersion, false)); err != nil {
 		return
 	}
@@ -37,7 +54,104 @@ func localServerGreet(c io.ReadWriter, scramble []byte) (clientCaps uint32, err 
 	if len(resp) >= 4 {
 		clientCaps = binary.LittleEndian.Uint32(resp[:4])
 	}
-	return
+
+	// An empty local password means one was never generated, which would otherwise make every
+	// password correct. Refuse rather than fall open.
+	if localPassword == "" {
+		return clientCaps, nextSeq, errLocalAuth
+	}
+	parsed, err := mysqlwire.ParseHandshakeResponse(resp, false)
+	if err != nil {
+		return clientCaps, nextSeq, errLocalAuth
+	}
+	nextSeq, err = verifyLocalPassword(c, scramble, localPassword, parsed)
+	return clientCaps, nextSeq, err
+}
+
+// verifyLocalPassword checks the client's auth response against localPassword, for whichever plugin
+// the client used.
+//
+// The greeting asks for mysql_native_password, and a client that honors it is answered directly. One
+// that asks for caching_sha2_password — MySQL 8's default — is served that plugin instead of refused
+// with an opaque access-denied it cannot act on. Anything else is switched to mysql_clear_password,
+// the same mechanism the proxy itself uses upstream; a client must permit that plugin, which the
+// mysql CLI gates behind --enable-cleartext-plugin.
+//
+// Every path ends in a constant-time comparison against the same password — as a digest under the
+// plugin the client chose, or as the password itself once switched to clear. Returns the sequence
+// the caller's reply must carry, which differs per path by how many packets the exchange spent.
+func verifyLocalPassword(c io.ReadWriter, scramble []byte, localPassword string, parsed mysqlwire.HandshakeResponse) (nextSeq byte, err error) {
+	switch parsed.AuthPlugin {
+	case "", "mysql_native_password":
+		want := mysqlwire.NativePassword(localPassword, scramble)
+		if subtle.ConstantTimeCompare(parsed.AuthResponse, want) != 1 {
+			return 2, errLocalAuth
+		}
+		return 2, nil
+	case "caching_sha2_password":
+		// A client that asked for this plugin against a native greeting sends no digest with its
+		// handshake — it waits to be switched, because it will not hash against a scramble issued
+		// under another plugin. Answering the empty response directly would reject every such client.
+		if len(parsed.AuthResponse) == 0 {
+			return cachingSHA2Switch(c, localPassword)
+		}
+		want := mysqlwire.CachingSHA2Password(localPassword, scramble)
+		if subtle.ConstantTimeCompare(parsed.AuthResponse, want) != 1 {
+			return 2, errLocalAuth
+		}
+		// The client still expects the fast-auth verdict this plugin always ends with.
+		if err := mysqlwire.WritePacket(c, 2, mysqlwire.AuthMoreDataPacket(mysqlwire.CachingSHA2FastAuthSuccess)); err != nil {
+			return 3, err
+		}
+		return 3, nil
+	}
+
+	// The auth-switch reply reuses the greeting's scramble, so nothing about the exchange changes but
+	// the encoding: the client sends the password itself over loopback.
+	if err := mysqlwire.WritePacket(c, 2, mysqlwire.AuthSwitchClearPassword()); err != nil {
+		return 2, err
+	}
+	_, reply, err := mysqlwire.ReadPacket(c)
+	if err != nil {
+		return 4, err
+	}
+	got := mysqlwire.ParseClearPassword(reply)
+	if subtle.ConstantTimeCompare([]byte(got), []byte(localPassword)) != 1 {
+		return 4, errLocalAuth
+	}
+	return 4, nil
+}
+
+// cachingSHA2Switch runs the server half of caching_sha2_password: switch the client to the plugin
+// with a fresh scramble, check the digest it answers with, and report the fast-auth verdict.
+//
+// A real server answers a correct-but-uncached credential with CachingSHA2FullAuth, which sends the
+// client down an RSA key exchange (or, under TLS, a cleartext send). Neither is needed here: this
+// server generated the password and holds it, so the digest alone settles the question, and the
+// verdict it reports is what the client waits for before proceeding.
+func cachingSHA2Switch(c io.ReadWriter, localPassword string) (byte, error) {
+	// Each return reports the sequence for what was actually sent, not what a successful exchange
+	// would have sent: a client told its reply was packet 3 and then handed an error numbered 5 reports
+	// packets out of order instead of the access-denied it was given.
+	scramble, err := mysqlwire.Scramble()
+	if err != nil {
+		return 2, err
+	}
+	if err := mysqlwire.WritePacket(c, 2, mysqlwire.AuthSwitchCachingSHA2(scramble)); err != nil {
+		return 2, err
+	}
+	_, reply, err := mysqlwire.ReadPacket(c)
+	if err != nil {
+		return 4, err
+	}
+	want := mysqlwire.CachingSHA2Password(localPassword, scramble)
+	if subtle.ConstantTimeCompare(reply, want) != 1 {
+		return 4, errLocalAuth // the switch (2) and its reply (3) only
+	}
+	if err := mysqlwire.WritePacket(c, 4, mysqlwire.AuthMoreDataPacket(mysqlwire.CachingSHA2FastAuthSuccess)); err != nil {
+		return 5, err
+	}
+	return 5, nil
 }
 
 // proxyConnect authenticates to the proxy as [principal], answering its clear-password auth-switch with

--- a/pmon/internal/daemon/mysql_test.go
+++ b/pmon/internal/daemon/mysql_test.go
@@ -1,13 +1,16 @@
 package daemon
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/binary"
 	"encoding/pem"
+	"errors"
 	"math/big"
 	"net"
 	"strings"
@@ -32,7 +35,7 @@ func TestLocalServerGreetDoesNotAdvertiseConnectWithDB(t *testing.T) {
 	}
 	done := make(chan greetResult, 1)
 	go func() {
-		caps, err := localServerGreet(brokerSide, make([]byte, 20))
+		caps, _, err := localServerGreet(brokerSide, make([]byte, 20), "pmlocal_test")
 		done <- greetResult{caps: caps, err: err}
 	}()
 
@@ -47,13 +50,21 @@ func TestLocalServerGreetDoesNotAdvertiseConnectWithDB(t *testing.T) {
 	if parsed.Capabilities&mysqlwire.CapConnectWithDB != 0 {
 		t.Fatalf("pmon greeting caps = %#x advertise CONNECT_WITH_DB; a client's DSN database would be silently dropped", parsed.Capabilities)
 	}
+	// The advertised plugin decides which digest a client computes, and the password check verifies
+	// against it. A greeting that named a different plugin would still authenticate — the switch paths
+	// cover that — but this is the one every client takes without extra configuration.
+	if parsed.AuthPlugin != "mysql_native_password" {
+		t.Fatalf("pmon greeting advertises %q, want mysql_native_password", parsed.AuthPlugin)
+	}
 
-	// Unblock localServerGreet with a minimal handshake response (it reads only the leading capability flags).
+	// Unblock localServerGreet with a minimal handshake response. It carries no auth response, so the
+	// password check rejects it — this test is about the greeting's capabilities, and the capability
+	// assertion above has already run against the real greeting.
 	if err := mysqlwire.WritePacket(clientSide, 1, make([]byte, 32)); err != nil {
 		t.Fatalf("write client handshake response: %v", err)
 	}
-	if res := <-done; res.err != nil {
-		t.Fatalf("localServerGreet: %v", res.err)
+	if res := <-done; !errors.Is(res.err, errLocalAuth) {
+		t.Fatalf("localServerGreet with no password: err = %v, want errLocalAuth", res.err)
 	}
 }
 
@@ -239,5 +250,374 @@ func TestProxyConnectAllowsPlaintextOnlyWhenTLSIsNotExpected(t *testing.T) {
 
 	if !<-wroteHandshake {
 		t.Error("a plaintext datasource with TLS off must still connect; the refusal must not fire here")
+	}
+}
+
+// handshakeResponseWith builds a client handshake response carrying authResp under plugin, in the
+// secure-connection encoding a real MySQL client uses. An empty plugin omits the field entirely,
+// which is what a client that negotiated no CapPluginAuth sends.
+func handshakeResponseWith(authResp []byte, plugin string) []byte {
+	caps := uint32(mysqlwire.CapProtocol41 | mysqlwire.CapSecureConn)
+	if plugin != "" {
+		caps |= mysqlwire.CapPluginAuth
+	}
+	var b []byte
+	b = binary.LittleEndian.AppendUint32(b, caps)
+	b = binary.LittleEndian.AppendUint32(b, 16<<20)
+	b = append(b, 45)
+	b = append(b, make([]byte, 23)...)
+	b = append(b, "pm"...)
+	b = append(b, 0)
+	b = append(b, byte(len(authResp)))
+	b = append(b, authResp...)
+	if plugin != "" {
+		b = append(b, plugin...)
+		b = append(b, 0)
+	}
+	return b
+}
+
+// TestLocalServerGreetChecksPassword is the local trust boundary: the daemon holds a live upstream
+// token, so any process that can open its loopback port could otherwise borrow the whole session.
+func TestLocalServerGreetChecksPassword(t *testing.T) {
+	const password = "pmlocal_correct-horse"
+	scramble := bytes.Repeat([]byte{7}, 20)
+
+	tests := []struct {
+		name    string
+		auth    []byte
+		plugin  string
+		stored  string
+		wantErr bool
+		// drains is how many packets the broker writes after the greeting. net.Pipe is unbuffered, so
+		// a test that does not read them deadlocks the broker mid-write.
+		drains int
+	}{
+		{"native, correct password", mysqlwire.NativePassword(password, scramble), "mysql_native_password", password, false, 0},
+		{"native, wrong password", mysqlwire.NativePassword("pmlocal_wrong", scramble), "mysql_native_password", password, true, 0},
+		{"no plugin named, correct password", mysqlwire.NativePassword(password, scramble), "", password, false, 0},
+		{"no password", nil, "mysql_native_password", password, true, 0},
+		{"empty stored password refuses every client", mysqlwire.NativePassword(password, scramble), "mysql_native_password", "", true, 0},
+		{"right password, wrong scramble", mysqlwire.NativePassword(password, bytes.Repeat([]byte{9}, 20)), "mysql_native_password", password, true, 0},
+		// MySQL 8's default plugin: a client that answers with it is verified, not refused.
+		{"caching_sha2, correct password", mysqlwire.CachingSHA2Password(password, scramble), "caching_sha2_password", password, false, 1},
+		{"caching_sha2, wrong password", mysqlwire.CachingSHA2Password("pmlocal_wrong", scramble), "caching_sha2_password", password, true, 0},
+		// A native digest presented AS caching_sha2 must not verify: the plugin selects the digest.
+		{"plugin/digest mismatch", mysqlwire.NativePassword(password, scramble), "caching_sha2_password", password, true, 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientSide, brokerSide := net.Pipe()
+			defer clientSide.Close()
+			defer brokerSide.Close()
+
+			done := make(chan error, 1)
+			go func() {
+				_, _, err := localServerGreet(brokerSide, scramble, test.stored)
+				done <- err
+			}()
+
+			if _, _, err := mysqlwire.ReadPacket(clientSide); err != nil {
+				t.Fatalf("read greeting: %v", err)
+			}
+			if err := mysqlwire.WritePacket(clientSide, 1, handshakeResponseWith(test.auth, test.plugin)); err != nil {
+				t.Fatalf("write handshake response: %v", err)
+			}
+			// Drain whatever the broker writes back, or its write blocks on this unbuffered pipe.
+			for i := 0; i < test.drains; i++ {
+				if _, _, err := mysqlwire.ReadPacket(clientSide); err != nil {
+					t.Fatalf("drain broker packet %d: %v", i, err)
+				}
+			}
+
+			err := <-done
+			if test.wantErr && !errors.Is(err, errLocalAuth) {
+				t.Fatalf("err = %v, want errLocalAuth", err)
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("err = %v, want nil", err)
+			}
+		})
+	}
+}
+
+// TestLocalServerGreetSwitchesUnknownPlugin: a client that answers with a plugin the broker cannot
+// verify directly is switched to mysql_clear_password rather than refused, so an unusual driver can
+// still authenticate. The switch reply is the password itself, over loopback.
+func TestLocalServerGreetSwitchesUnknownPlugin(t *testing.T) {
+	const password = "pmlocal_correct-horse"
+	scramble := bytes.Repeat([]byte{7}, 20)
+
+	for _, test := range []struct {
+		name    string
+		send    string
+		wantErr bool
+	}{
+		{"correct password after switch", password, false},
+		{"wrong password after switch", "pmlocal_nope", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			clientSide, brokerSide := net.Pipe()
+			defer clientSide.Close()
+			defer brokerSide.Close()
+
+			type res struct {
+				seq byte
+				err error
+			}
+			done := make(chan res, 1)
+			go func() {
+				_, seq, err := localServerGreet(brokerSide, scramble, password)
+				done <- res{seq: seq, err: err}
+			}()
+
+			if _, _, err := mysqlwire.ReadPacket(clientSide); err != nil {
+				t.Fatalf("read greeting: %v", err)
+			}
+			// sha256_password is a real plugin this broker verifies neither of directly.
+			if err := mysqlwire.WritePacket(clientSide, 1, handshakeResponseWith([]byte{1, 2, 3}, "sha256_password")); err != nil {
+				t.Fatalf("write handshake response: %v", err)
+			}
+			seq, sw, err := mysqlwire.ReadPacket(clientSide)
+			if err != nil {
+				t.Fatalf("read auth switch: %v", err)
+			}
+			if len(sw) == 0 || sw[0] != 0xfe {
+				t.Fatalf("expected an AuthSwitchRequest, got % x", sw)
+			}
+			if !bytes.Contains(sw, []byte("mysql_clear_password")) {
+				t.Fatalf("switch names %q, want mysql_clear_password", sw)
+			}
+			if err := mysqlwire.WritePacket(clientSide, seq+1, append([]byte(test.send), 0)); err != nil {
+				t.Fatalf("write switch reply: %v", err)
+			}
+
+			got := <-done
+			if test.wantErr && !errors.Is(got.err, errLocalAuth) {
+				t.Fatalf("err = %v, want errLocalAuth", got.err)
+			}
+			if !test.wantErr && got.err != nil {
+				t.Fatalf("err = %v, want nil", got.err)
+			}
+			// The switch consumed packets 2 and 3, so the caller's reply must not reuse 2.
+			if got.seq != 4 {
+				t.Fatalf("nextSeq = %d after an auth switch, want 4", got.seq)
+			}
+			_ = seq
+		})
+	}
+}
+
+// TestLocalServerGreetSwitchesToCachingSHA2 covers what a real MySQL 8 client does when told to
+// prefer caching_sha2_password against this broker's native greeting: it names the plugin but sends
+// NO digest, waiting to be switched, because it will not hash against a scramble issued under
+// another plugin. Verifying that empty response directly would reject every such client.
+func TestLocalServerGreetSwitchesToCachingSHA2(t *testing.T) {
+	const password = "pmlocal_correct-horse"
+
+	for _, test := range []struct {
+		name    string
+		send    string
+		wantErr bool
+	}{
+		{"correct password after switch", password, false},
+		{"wrong password after switch", "pmlocal_nope", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			clientSide, brokerSide := net.Pipe()
+			defer clientSide.Close()
+			defer brokerSide.Close()
+
+			done := make(chan error, 1)
+			go func() {
+				_, _, err := localServerGreet(brokerSide, bytes.Repeat([]byte{7}, 20), password)
+				done <- err
+			}()
+
+			if _, _, err := mysqlwire.ReadPacket(clientSide); err != nil {
+				t.Fatalf("read greeting: %v", err)
+			}
+			// The plugin named, no digest — exactly what the mysql CLI sends here.
+			if err := mysqlwire.WritePacket(clientSide, 1, handshakeResponseWith(nil, "caching_sha2_password")); err != nil {
+				t.Fatalf("write handshake response: %v", err)
+			}
+
+			seq, sw, err := mysqlwire.ReadPacket(clientSide)
+			if err != nil {
+				t.Fatalf("read auth switch: %v", err)
+			}
+			if len(sw) == 0 || sw[0] != 0xfe || !bytes.Contains(sw, []byte("caching_sha2_password")) {
+				t.Fatalf("expected a caching_sha2_password AuthSwitchRequest, got % x", sw)
+			}
+			// The scramble follows the NUL-terminated plugin name, itself NUL-terminated.
+			rest := sw[bytes.IndexByte(sw, 0)+1:]
+			scramble := bytes.TrimSuffix(rest, []byte{0})
+			if len(scramble) != 20 {
+				t.Fatalf("switch scramble is %d bytes, want 20", len(scramble))
+			}
+
+			if err := mysqlwire.WritePacket(clientSide, seq+1, mysqlwire.CachingSHA2Password(test.send, scramble)); err != nil {
+				t.Fatalf("write switch reply: %v", err)
+			}
+			if !test.wantErr {
+				// Success ends with the fast-auth verdict; drain it or the broker blocks writing.
+				_, more, err := mysqlwire.ReadPacket(clientSide)
+				if err != nil {
+					t.Fatalf("read AuthMoreData: %v", err)
+				}
+				if len(more) < 2 || more[0] != mysqlwire.AuthMoreData || more[1] != mysqlwire.CachingSHA2FastAuthSuccess {
+					t.Fatalf("expected fast-auth success, got % x", more)
+				}
+			}
+
+			err = <-done
+			if test.wantErr && !errors.Is(err, errLocalAuth) {
+				t.Fatalf("err = %v, want errLocalAuth", err)
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("err = %v, want nil", err)
+			}
+		})
+	}
+}
+
+// TestLocalServerGreetSequenceIsContiguous pins the packet numbering each path ends on. MySQL
+// requires strictly increasing sequence numbers within a handshake, so a wrong nextSeq desynchronizes
+// the client — it reads the caller's OK as belonging to a packet it never sent.
+func TestLocalServerGreetSequenceIsContiguous(t *testing.T) {
+	const password = "pmlocal_correct-horse"
+	scramble := bytes.Repeat([]byte{7}, 20)
+
+	// native: greeting 0, response 1 -> caller replies at 2.
+	t.Run("native", func(t *testing.T) {
+		clientSide, brokerSide := net.Pipe()
+		defer clientSide.Close()
+		defer brokerSide.Close()
+		type res struct {
+			seq byte
+			err error
+		}
+		done := make(chan res, 1)
+		go func() {
+			_, seq, err := localServerGreet(brokerSide, scramble, password)
+			done <- res{seq, err}
+		}()
+		if _, _, err := mysqlwire.ReadPacket(clientSide); err != nil {
+			t.Fatalf("greeting: %v", err)
+		}
+		auth := mysqlwire.NativePassword(password, scramble)
+		if err := mysqlwire.WritePacket(clientSide, 1, handshakeResponseWith(auth, "mysql_native_password")); err != nil {
+			t.Fatalf("response: %v", err)
+		}
+		got := <-done
+		if got.err != nil {
+			t.Fatalf("err = %v", got.err)
+		}
+		if got.seq != 2 {
+			t.Fatalf("nextSeq = %d, want 2", got.seq)
+		}
+	})
+
+	// caching_sha2 switch: greeting 0, response 1, switch 2, reply 3, AuthMoreData 4 -> caller at 5.
+	t.Run("caching_sha2 switch", func(t *testing.T) {
+		clientSide, brokerSide := net.Pipe()
+		defer clientSide.Close()
+		defer brokerSide.Close()
+		type res struct {
+			seq byte
+			err error
+		}
+		done := make(chan res, 1)
+		go func() {
+			_, seq, err := localServerGreet(brokerSide, scramble, password)
+			done <- res{seq, err}
+		}()
+		if _, _, err := mysqlwire.ReadPacket(clientSide); err != nil {
+			t.Fatalf("greeting: %v", err)
+		}
+		if err := mysqlwire.WritePacket(clientSide, 1, handshakeResponseWith(nil, "caching_sha2_password")); err != nil {
+			t.Fatalf("response: %v", err)
+		}
+		swSeq, sw, err := mysqlwire.ReadPacket(clientSide)
+		if err != nil {
+			t.Fatalf("switch: %v", err)
+		}
+		if swSeq != 2 {
+			t.Fatalf("switch seq = %d, want 2", swSeq)
+		}
+		rest := sw[bytes.IndexByte(sw, 0)+1:]
+		sc := bytes.TrimSuffix(rest, []byte{0})
+		if err := mysqlwire.WritePacket(clientSide, 3, mysqlwire.CachingSHA2Password(password, sc)); err != nil {
+			t.Fatalf("reply: %v", err)
+		}
+		moreSeq, _, err := mysqlwire.ReadPacket(clientSide)
+		if err != nil {
+			t.Fatalf("AuthMoreData: %v", err)
+		}
+		if moreSeq != 4 {
+			t.Fatalf("AuthMoreData seq = %d, want 4", moreSeq)
+		}
+		got := <-done
+		if got.err != nil {
+			t.Fatalf("err = %v", got.err)
+		}
+		if got.seq != 5 {
+			t.Fatalf("nextSeq = %d, want 5", got.seq)
+		}
+	})
+}
+
+// TestCachingSHA2SwitchFailureSequence pins the sequence on the REJECTED path. A wrong digest ends
+// the exchange at the reply (packet 3), so the caller's error is packet 4 — reporting 5, as if the
+// fast-auth verdict had been sent, makes the client read the error as out of order and hide the
+// access-denied behind a protocol complaint.
+func TestCachingSHA2SwitchFailureSequence(t *testing.T) {
+	clientSide, brokerSide := net.Pipe()
+	defer clientSide.Close()
+	defer brokerSide.Close()
+
+	const password = "pmlocal_correct-horse"
+	type res struct {
+		seq byte
+		err error
+	}
+	done := make(chan res, 1)
+	go func() {
+		_, seq, err := localServerGreet(brokerSide, bytes.Repeat([]byte{7}, 20), password)
+		done <- res{seq, err}
+	}()
+
+	if _, _, err := mysqlwire.ReadPacket(clientSide); err != nil {
+		t.Fatalf("greeting: %v", err)
+	}
+	if err := mysqlwire.WritePacket(clientSide, 1, handshakeResponseWith(nil, "caching_sha2_password")); err != nil {
+		t.Fatalf("response: %v", err)
+	}
+	swSeq, sw, err := mysqlwire.ReadPacket(clientSide)
+	if err != nil {
+		t.Fatalf("switch: %v", err)
+	}
+	if swSeq != 2 {
+		t.Fatalf("switch seq = %d, want 2", swSeq)
+	}
+	// The scramble is NUL-terminated, as a server sends it; a bare 20 bytes would be a protocol error.
+	if sw[len(sw)-1] != 0 {
+		t.Fatalf("switch payload does not end in NUL: % x", sw[len(sw)-8:])
+	}
+	rest := sw[bytes.IndexByte(sw, 0)+1:]
+	sc := rest[:len(rest)-1]
+	if len(sc) != 20 {
+		t.Fatalf("switch scramble is %d bytes, want 20", len(sc))
+	}
+
+	if err := mysqlwire.WritePacket(clientSide, 3, mysqlwire.CachingSHA2Password("pmlocal_wrong", sc)); err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+	got := <-done
+	if !errors.Is(got.err, errLocalAuth) {
+		t.Fatalf("err = %v, want errLocalAuth", got.err)
+	}
+	if got.seq != 4 {
+		t.Fatalf("nextSeq = %d after a rejected switch, want 4 (the switch and its reply only)", got.seq)
 	}
 }


### PR DESCRIPTION
The daemon accepted any password from a local client, so any process that could open its loopback port borrowed the user's session — their roles at the proxy, and their name in the audit trail. The sticky password existed and `pmon show` handed it out, but nothing compared it.

It is checked now, before the proxy is dialed.

## Where this bites

A saved connection whose password is stale or blank now gets access denied; re-copy it from `pmon show`.

A client that overrides its auth plugin to something other than `mysql_native_password` or `caching_sha2_password` is switched to `mysql_clear_password`, which the `mysql` CLI only permits with `--enable-cleartext-plugin`. Both defaults work untouched.

Scrambles are now drawn without NUL bytes — one is sent NUL-terminated, so a client reading it as a C string would hash a truncated salt and fail about 7% of the time.

## Verification

Exercised against a real `mysql` 8 client: default auth, `--default-auth=caching_sha2_password`, and wrong passwords on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)