### PR TITLE
docs: forbid narrating history in comments and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,9 +126,17 @@ See [docs/l10n.md](./docs/l10n.md).
 
 ## Conventions
 
-Full list in [CONTRIBUTING.md](./CONTRIBUTING.md#conventions). The two that most
-often get violated:
+Full list in [CONTRIBUTING.md](./CONTRIBUTING.md#conventions). The three that
+most often get violated:
 
+- Comments and docs are not a diary, and this is a **security** rule before it
+  is a style one: this repository is public. A comment explains what the code
+  cannot say — an outside constraint, a non-obvious failure mode, why not the
+  obvious alternative. It must not narrate how the code came to be: no review
+  findings, no what-was-tried, no "previously X", no debugging account. That
+  narration is what carries host names, paths, internal tooling, and topology
+  into a public repository. History goes in the commit message, which is also
+  public — the same rule about naming internal systems applies there.
 - l10n is non-negotiable. Every user-facing string is localized (English and
   Korean today). The server returns a stable dot-namespaced code via `ApiError`,
   never English prose; every message key must exist in every locale under

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,15 @@ handful of skips; zero skips is not the signal to look for.
 - Comments and docs describe the current state in present tense. No task, phase,
   or workstream codes in comments or docs — they go stale. Commit messages may
   keep such references.
+- A comment states what the code cannot: a constraint from outside the file, a
+  non-obvious failure mode, why this and not the obvious alternative. It never
+  narrates how the code came to be — no review findings, no what-was-tried, no
+  "previously X", no account of a debugging session. **This repository is
+  public.** A comment recounting how something was arrived at tends to carry
+  what was around at the time: host names, directory layouts, internal tooling,
+  network topology, who asked for what. Commit messages and pull requests are
+  where that history belongs; they are equally public, so the same rule about
+  naming internal systems applies there too.
 - Localization is non-negotiable. Every user-facing string is localized
   (currently English and Korean). The server returns a stable dot-namespaced
   code and params, never English prose; the web client resolves it through a


### PR DESCRIPTION
A comment that recounts how the code came to be carries whatever was around at the time — host names, directory layouts, internal tooling, network topology. This repository is public, so that is a disclosure, not a style problem.

The existing convention covered staleness (no task or phase codes). This covers the narration itself: no review findings, no what-was-tried, no "previously X", no debugging account.

Stated in `AGENTS.md` as well as `CONTRIBUTING.md` because that is the file an agent reads first, and an agent that has just finished a debugging session is the most likely author of such a comment.

History belongs in the commit message — which is equally public, so the same rule about naming internal systems applies there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)