### PR TITLE
ci: run the Go tests under the race detector

### DIFF
--- a/.github/workflows/db-matrix.yml
+++ b/.github/workflows/db-matrix.yml
@@ -149,7 +149,7 @@ jobs:
       # needed here to make a Docker-less run fail.
       - name: Test
         working-directory: goproxy
-        run: go test ./...
+        run: go test -race ./...
 
   auditmon:
     name: auditmon ${{ matrix.pg }}
@@ -167,7 +167,7 @@ jobs:
       - uses: jdx/mise-action@v4
       - name: Test
         working-directory: auditmon
-        run: go test ./...
+        run: go test -race ./...
 
   # A single required check that is green only when every leg is. Without it, a branch protection rule
   # would have to name each matrix leg, and adding a version to db-support.json would silently create

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,9 @@ package paths and never need a `cd` — `go test ./goproxy/...` from the repo
 root. Bare `go test ./...` does not work there: the root is a workspace, not a
 module. `mise run verify` enumerates the modules for you.
 
+Every task that runs the Go tests passes `-race`, so a hand-run `go test`
+without it is a weaker check than the gate: a data race reads as a pass.
+
 ## Tests are DB-backed
 
 Enforcement is exercised against real databases, not mocks. Write MySQL and

--- a/mise.toml
+++ b/mise.toml
@@ -200,7 +200,12 @@ mise run lint
 ./gradlew --no-daemon :analyzer:jvm:test :engine:test :control-plane:test
 # Explicit module patterns: the repo root is a Go workspace, not a module, so `./...` does not resolve
 # there. go.work is what makes these root-relative paths work with no cd.
-go test ./analyzer/... ./auditmon/... ./goproxy/... ./mysqlwire/... ./pmon/...
+#
+# -race: the concurrency this proxy is built on — the events loop, the per-connection goroutines — is
+# where a race is both most likely and least visible, and a data race is a correctness bug the plain
+# run reports as a pass. These tests wait on containers and sockets far more than they compute, so the
+# detector costs a few seconds of wall clock rather than the usual multiple.
+go test -race ./analyzer/... ./auditmon/... ./goproxy/... ./mysqlwire/... ./pmon/...
 pnpm -C web test:unit
 pnpm -C web build
 '''
@@ -230,18 +235,6 @@ description = "Go tests against one database version (defaults to the newest sup
 shell = "bash -c"
 # Each Go module is entered explicitly rather than using a root `./...`: the repo root is not a Go
 # module, so a root-relative pattern only resolves once a go.work exists.
-run = '''
-set -euo pipefail
-for m in analyzer auditmon goproxy mysqlwire pmon; do
-  echo "=== $m ==="
-  (cd "$m" && go test ./...)
-done
-'''
-
-[tasks.test-go-race]
-description = "Go race-detector tests against one database version (defaults to the newest supported)"
-shell = "bash -c"
-# Keep the same module loop as `test-go`; only enable the race detector.
 run = '''
 set -euo pipefail
 for m in analyzer auditmon goproxy mysqlwire pmon; do
@@ -281,11 +274,11 @@ for pg in $pgs; do
         ./gradlew --no-daemon :control-plane:test; then
       failed="$failed jvm($pg,$my)"
     fi
-    if ! (cd goproxy && PM_TEST_POSTGRES_IMAGE="$pg" PM_TEST_MYSQL_IMAGE="$my" go test ./...); then
+    if ! (cd goproxy && PM_TEST_POSTGRES_IMAGE="$pg" PM_TEST_MYSQL_IMAGE="$my" go test -race ./...); then
       failed="$failed goproxy($pg,$my)"
     fi
   done
-  if ! (cd auditmon && PM_TEST_POSTGRES_IMAGE="$pg" go test ./...); then
+  if ! (cd auditmon && PM_TEST_POSTGRES_IMAGE="$pg" go test -race ./...); then
     failed="$failed auditmon($pg)"
   fi
 done
@@ -365,7 +358,7 @@ while read -r pg my; do
       --project-cache-dir "$logs/gradle-$tag" :control-plane:test \
       > "$logs/jvm-$tag.log" 2>&1 || echo "jvm($pg,$my)" >> "$logs/failed"
     (cd goproxy && PM_TEST_POSTGRES_IMAGE="$pg" PM_TEST_MYSQL_IMAGE="$my" \
-      PM_TEST_CONTAINER_SUFFIX="$tag" go test ./...) \
+      PM_TEST_CONTAINER_SUFFIX="$tag" go test -race ./...) \
       > "$logs/goproxy-$tag.log" 2>&1 || echo "goproxy($pg,$my)" >> "$logs/failed"
   ) &
 done <<< "$legs"
@@ -374,7 +367,7 @@ for pg in $pgs; do
   throttle
   echo "--> auditmon leg: $pg"
   (
-    (cd auditmon && PM_TEST_POSTGRES_IMAGE="$pg" PM_TEST_CONTAINER_SUFFIX="am-${pg//[:\/]/-}" go test ./...) \
+    (cd auditmon && PM_TEST_POSTGRES_IMAGE="$pg" PM_TEST_CONTAINER_SUFFIX="am-${pg//[:\/]/-}" go test -race ./...) \
       > "$logs/auditmon-${pg//[:\/]/-}.log" 2>&1 || echo "auditmon($pg)" >> "$logs/failed"
   ) &
 done


### PR DESCRIPTION
A data race is a correctness bug the plain test run reports as a pass, and the concurrency this proxy is built on — the events loop, the per-connection goroutines — is where one is both most likely and least visible. #53 fixed a real race in `goproxy/cp`; leaving the detector opt-in means nothing stops the next one from landing green.

Every path that runs the Go tests now passes `-race`: `verify`, `test-go`, both local matrix tasks, and the goproxy + auditmon CI legs. The separate opt-in `test-go-race` task is folded back into `test-go` rather than keeping two module loops that differ by one flag.

The cost that would normally argue against this is not there. Measured across the full five-module sweep, uncached, on this machine: **33.5s without `-race` vs 36.9s with** — these tests wait on containers and sockets far more than they compute. Peak RSS moves ~374MB → ~512MB for goproxy, which is noise beside the MySQL and Postgres containers in the same job.

Where it could bite: the timing-sensitive tests in `goproxy/cp` poll on 5s deadlines against 120–300ms intervals. Verified stable at `-count=10` with `-cpu=1`, and at `-count=3` under full CPU saturation — the margin is 10–20x, and race overhead instruments memory access rather than stretching sleep- and I/O-bound waits.

Verified: `go test -race -count=1` across all five modules — 0 cached, 29 packages run, 0 races. `mise run verify` passes (its web build needs network for Google Fonts, which this sandbox lacks; CI has it).