### PR TITLE
test(pmon): build the spawned daemon with the race detector

### DIFF
--- a/pmon/cli_test.go
+++ b/pmon/cli_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -19,14 +20,40 @@ import (
 // it, reads status, renders connection strings, and stops it.
 
 // buildPmon compiles the binary once per test run and returns its path.
+//
+// Built with the race detector whenever the tests are, because the daemon these tests drive runs as a
+// separate process: instrumenting the test binary says nothing about the goroutines actually serving the
+// control socket and brokering tokens. A race there aborts the daemon with exit 2 and a report on its
+// stderr, which is the daemon log — see [assertNoDaemonRace].
 func buildPmon(t *testing.T) string {
 	t.Helper()
 	bin := filepath.Join(t.TempDir(), "pmon")
-	out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput()
+	args := []string{"build", "-o", bin}
+	if raceEnabled {
+		args = append(args, "-race")
+	}
+	out, err := exec.Command("go", append(args, ".")...).CombinedOutput()
 	if err != nil {
 		t.Fatalf("go build: %v\n%s", err, out)
 	}
 	return bin
+}
+
+// assertNoDaemonRace fails the test if the daemon logged a race report. The daemon is detached, so its
+// failure never surfaces as a non-zero exit here: a race aborts it mid-run and the CLI sees only a daemon
+// that stopped answering, which reads as a timeout in whatever the test was doing next.
+func assertNoDaemonRace(t *testing.T, stateDir string) {
+	t.Helper()
+	if !raceEnabled {
+		return
+	}
+	log, err := os.ReadFile(filepath.Join(stateDir, "daemon.log"))
+	if err != nil {
+		return // no log means the daemon never started, which the test's own assertions cover
+	}
+	if bytes.Contains(log, []byte("WARNING: DATA RACE")) {
+		t.Errorf("the daemon reported a data race:\n%s", log)
+	}
 }
 
 // env isolates a pmon invocation: its own state dir and its own broker port range, so it neither touches the
@@ -43,6 +70,8 @@ func newEnv(t *testing.T) *env {
 	t.Cleanup(func() {
 		// Always stop the daemon this env may have started, or it outlives the test (it is detached by design).
 		_, _ = e.run("stop", "--force")
+		// After the stop, so the log holds everything the daemon ever wrote.
+		assertNoDaemonRace(t, e.stateDir)
 	})
 	return e
 }

--- a/pmon/race_off_test.go
+++ b/pmon/race_off_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package main
+
+const raceEnabled = false

--- a/pmon/race_on_test.go
+++ b/pmon/race_on_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package main
+
+const raceEnabled = true


### PR DESCRIPTION
The pmon E2E tests drive a real daemon in a separate process, but `buildPmon` compiled it with a plain `go build`. So `go test -race ./pmon/...` instrumented the test binary while the goroutines that actually serve the control socket and broker tokens ran unchecked — the concurrent code those tests exist to cover.

Two parts, because the first alone would be decoration:

- Build the daemon with `-race` whenever the tests are, selected by a `//go:build race` constant.
- Read the daemon log for a race report at teardown. The daemon is **detached**, so a race there never surfaces as a failed command: it aborts the daemon mid-run and the CLI only sees one that stopped answering, which reads as a timeout in whatever the test did next.

Verified by injecting a real data race into `daemon.Run` — the suite fails with the report attached, where before it passed. The instrumentation itself was checked both directions with a throwaway probe (`go version -m` reports `-race=true` under `-race`, and not otherwise), so the flag genuinely reaches the spawned binary.

Cost: the pmon suite goes ~26s → ~64s, since every E2E test now builds and exercises an instrumented binary.

Independent of #72 — this works whether the gate passes `-race` or not; under a plain run `raceEnabled` is false and both halves are no-ops.