### PR TITLE
fix(web): give each action-reference group a unique resource key

### DIFF
--- a/web/src/components/policies/cedar-policies-tab.tsx
+++ b/web/src/components/policies/cedar-policies-tab.tsx
@@ -80,10 +80,6 @@ const ACTION_REFERENCE: { resource: string; actions: { name: string; noteKey: st
     ],
   },
   {
-    resource: 'Datasource',
-    actions: [{ name: 'task.request', noteKey: 'taskRequest' }],
-  },
-  {
     resource: 'AccessGrant',
     actions: [
       { name: 'task.read', noteKey: 'taskRead' },
@@ -100,6 +96,7 @@ const ACTION_REFERENCE: { resource: string; actions: { name: string; noteKey: st
   {
     resource: 'Datasource',
     actions: [
+      { name: 'task.request', noteKey: 'taskRequest' },
       { name: 'datasource.connect', noteKey: 'datasourceConnect' },
       { name: 'sql.select', noteKey: 'sqlSelect' },
       { name: 'sql.insert', noteKey: 'sqlInsert' },


### PR DESCRIPTION
`ACTION_REFERENCE` listed `Datasource` twice — once for `task.request`, once for `datasource.connect` and the `sql.*` actions — so the two groups collided on `key={group.resource}` and React warned about duplicate keys whenever the add/edit policy dialog expanded the action reference.

Datasource is one resource, so the two groups are now one. That also stops the reference from showing an admin two same-named blocks to reconcile.

Verified in the console: dialog opens, reference expands to five uniquely-named groups, `task.request` listed with the other Datasource actions, no duplicate-key warning in the browser console. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
