### PR TITLE
feat(web): rename and delete a group from its detail page

### DIFF
--- a/web/messages/en/groups.json
+++ b/web/messages/en/groups.json
@@ -49,7 +49,12 @@
     "toastMemberRemoved": "Removed {principal} from {group}.",
     "removeMemberFailed": "failed to remove member",
     "toastRoleRemoved": "Removed {roleName} from {group}.",
-    "removeRoleFailed": "failed to remove role"
+    "removeRoleFailed": "failed to remove role",
+    "rename": "Rename",
+    "deleteGroup": "Delete group",
+    "deleteConfirm": "Delete group <code>{name}</code>? Members and role mappings will be removed.",
+    "deleteOidcWarning": "This group came from the IdP. Deleting it here does not remove it there, so it returns the next time a member signs in.",
+    "systemImmutable": "System-managed groups cannot be renamed or deleted."
   },
   "addMember": {
     "title": "Add member",

--- a/web/messages/ko/groups.json
+++ b/web/messages/ko/groups.json
@@ -49,7 +49,12 @@
     "toastMemberRemoved": "{group}에서 {principal}을(를) 제거했습니다.",
     "removeMemberFailed": "구성원을 제거하지 못했습니다.",
     "toastRoleRemoved": "{group}에서 {roleName} 역할을 제거했습니다.",
-    "removeRoleFailed": "역할을 제거하지 못했습니다."
+    "removeRoleFailed": "역할을 제거하지 못했습니다.",
+    "rename": "이름 변경",
+    "deleteGroup": "그룹 삭제",
+    "deleteConfirm": "<code>{name}</code> 그룹을 삭제할까요? 구성원과 역할 매핑이 함께 삭제됩니다.",
+    "deleteOidcWarning": "IdP에서 만들어진 그룹입니다. 여기서 삭제해도 IdP에는 남아 있어, 구성원이 다음에 로그인하면 다시 생성됩니다.",
+    "systemImmutable": "시스템 관리 그룹은 이름을 바꾸거나 삭제할 수 없습니다."
   },
   "addMember": {
     "title": "구성원 추가",

--- a/web/src/app/(app)/admin/groups/page.tsx
+++ b/web/src/app/(app)/admin/groups/page.tsx
@@ -158,7 +158,12 @@ export default function GroupsPage() {
                             <MoreHorizontal className="size-3.5" />
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end" side="bottom">
-                            <DropdownMenuItem onClick={() => openEdit(group)}>
+                            {/* The server rejects both on a SYSTEM group; disabling explains why
+                                instead of failing the call. */}
+                            <DropdownMenuItem
+                              disabled={group.source === 'SYSTEM'}
+                              onClick={() => openEdit(group)}
+                            >
                               <Pencil className="size-3.5" />
                               {t('list.edit')}
                             </DropdownMenuItem>
@@ -169,6 +174,7 @@ export default function GroupsPage() {
                             <DropdownMenuSeparator />
                             <DropdownMenuItem
                               variant="destructive"
+                              disabled={group.source === 'SYSTEM'}
                               onClick={() => {
                                 setDeleteError(null)
                                 setDeleting((prev) => (prev?.id === group.id ? null : group))
@@ -192,6 +198,11 @@ export default function GroupsPage() {
                                   code: (chunks) => <code className="font-mono">{chunks}</code>,
                                 })}
                               </p>
+                              {group.source === 'OIDC' && (
+                                <p className="text-muted-foreground mt-1 text-xs">
+                                  {t('detail.deleteOidcWarning')}
+                                </p>
+                              )}
                               {deleteError && <p className="mt-1 text-xs text-red-500">{deleteError}</p>}
                             </div>
                             <div className="flex items-center gap-2">

--- a/web/src/components/groups/group-detail.tsx
+++ b/web/src/components/groups/group-detail.tsx
@@ -5,11 +5,18 @@
 
 import { Fragment, useState } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
-import { ArrowLeft, Loader2, Plus, ShieldCheck, Trash2, Users } from 'lucide-react'
+import { ArrowLeft, Loader2, Pencil, Plus, ShieldCheck, Trash2, Users } from 'lucide-react'
 import { toast } from 'sonner'
 import { mutate } from 'swr'
-import { addGroupMember, addGroupRole, removeGroupMember, removeGroupRole } from '@/lib/api/client'
+import {
+  addGroupMember,
+  addGroupRole,
+  deleteGroup,
+  removeGroupMember,
+  removeGroupRole,
+} from '@/lib/api/client'
 import {
   swrKeys,
   useGroupMembers,
@@ -46,9 +53,11 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { EmptyState, ErrorState, LoadingState } from '@/components/page-scaffold'
+import { GroupFormDialog } from '@/components/groups/group-form-dialog'
 
 export function GroupDetail({ id }: { id: number }) {
   const t = useTranslations('Groups')
+  const router = useRouter()
   const { data: groups } = useGroups()
   const { data: users } = useUsers()
   const { data: roles } = useRoles()
@@ -65,6 +74,31 @@ export function GroupDetail({ id }: { id: number }) {
   const [removeRoleBusy, setRemoveRoleBusy] = useState(false)
   const [removeMemberError, setRemoveMemberError] = useState<string | null>(null)
   const [removeRoleError, setRemoveRoleError] = useState<string | null>(null)
+  const [renaming, setRenaming] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [deleteBusy, setDeleteBusy] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  // The server rejects both on a SYSTEM group; disabling here explains why instead of failing the call.
+  const immutable = group?.source === 'SYSTEM'
+
+  const handleDelete = async () => {
+    if (!group) return
+    setDeleteBusy(true)
+    setDeleteError(null)
+    try {
+      await deleteGroup(group.id)
+      await mutate(swrKeys.groups)
+      await mutate(swrKeys.users)
+      await mutate(swrKeys.groupMembers(group.id))
+      await mutate(swrKeys.groupRoles(group.id))
+      toast.success(t('list.toastDeleted', { name: group.name }))
+      router.push('/admin/groups')
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : t('list.deleteFailed'))
+      setDeleteBusy(false)
+    }
+  }
 
   const handleRemoveMember = async (member: GroupMember) => {
     setRemoveMemberBusy(true)
@@ -111,11 +145,57 @@ export function GroupDetail({ id }: { id: number }) {
           <span className="text-muted-foreground text-sm">{group.description}</span>
         )}
         {group && (
-          <Badge variant="outline" className="ml-auto font-mono text-xs">
-            {group.source}
-          </Badge>
+          <>
+            <Badge variant="outline" className="ml-auto font-mono text-xs">
+              {group.source}
+            </Badge>
+            <div className="flex items-center gap-2" title={immutable ? t('detail.systemImmutable') : undefined}>
+              <Button size="xs" variant="outline" disabled={immutable} onClick={() => setRenaming(true)}>
+                <Pencil className="size-3" />
+                {t('detail.rename')}
+              </Button>
+              <Button
+                size="xs"
+                variant="outline"
+                disabled={immutable}
+                onClick={() => {
+                  setDeleteError(null)
+                  setDeleting((prev) => !prev)
+                }}
+              >
+                <Trash2 className="size-3" />
+                {t('detail.deleteGroup')}
+              </Button>
+            </div>
+          </>
         )}
       </div>
+
+      {group && deleting && (
+        <div className="flex flex-wrap items-center justify-between gap-2 border-b bg-red-500/5 px-6 py-3">
+          <div>
+            <p className="text-sm font-medium text-red-500">
+              {t.rich('detail.deleteConfirm', {
+                name: group.name,
+                code: (chunks) => <code className="font-mono">{chunks}</code>,
+              })}
+            </p>
+            {group.source === 'OIDC' && (
+              <p className="text-muted-foreground mt-1 text-xs">{t('detail.deleteOidcWarning')}</p>
+            )}
+            {deleteError && <p className="mt-1 text-xs text-red-500">{deleteError}</p>}
+          </div>
+          <div className="flex items-center gap-2">
+            <Button size="xs" variant="outline" onClick={() => setDeleting(false)} disabled={deleteBusy}>
+              {t('list.cancel')}
+            </Button>
+            <Button size="xs" variant="destructive" onClick={handleDelete} disabled={deleteBusy}>
+              {deleteBusy ? <Loader2 className="size-3 animate-spin" /> : null}
+              {t('detail.deleteGroup')}
+            </Button>
+          </div>
+        </div>
+      )}
 
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto w-full max-w-6xl space-y-6 px-6 py-6">
@@ -333,6 +413,7 @@ export function GroupDetail({ id }: { id: number }) {
           onClose={() => setMappingRole(false)}
         />
       )}
+      <GroupFormDialog open={renaming} onOpenChange={setRenaming} editing={group ?? null} />
     </div>
   )
 }

--- a/web/tests/group-admin.spec.ts
+++ b/web/tests/group-admin.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test, type Page } from 'playwright/test'
+
+// Renaming and deleting a group, over the real console against a stubbed control plane. The source a
+// group came from decides what is allowed, so each case fixes one: LOCAL is freely editable, SYSTEM is
+// immutable server-side, and an OIDC group returns on the next login however it is deleted here.
+
+const SESSION_CONFIG = {
+  heartbeatMs: 90_000,
+  idleWarnLeadMs: 60_000,
+  absoluteWarnLeadMs: 300_000,
+  absoluteCapAmount: 2,
+  absoluteCapUnit: 'hours',
+}
+
+const GROUPS = [
+  { id: 1, name: 'pii-readers', description: 'local', source: 'LOCAL', memberCount: 0, roles: [] },
+  { id: 2, name: 'system:admin', description: 'seeded', source: 'SYSTEM', memberCount: 0, roles: [] },
+  { id: 3, name: 'idp-analysts', description: 'from okta', source: 'OIDC', memberCount: 0, roles: [] },
+]
+
+async function boot(page: Page) {
+  await page.route('**/auth/config', (r) => r.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({ oidcEnabled: false, authDebug: true, session: SESSION_CONFIG }),
+  }))
+  await page.route('**/auth/me', (r) => r.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({ principal: 'admin@example.com', roles: ['system:admin'], admin: true }),
+  }))
+  await page.route('**/api/me/permissions', (r) => r.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({ isAdmin: true }),
+  }))
+  await page.route('**/api/groups', (r) => r.fulfill({
+    contentType: 'application/json', body: JSON.stringify(GROUPS),
+  }))
+  await page.route('**/api/groups/*/members', (r) => r.fulfill({ contentType: 'application/json', body: '[]' }))
+  await page.route('**/api/groups/*/roles', (r) => r.fulfill({ contentType: 'application/json', body: '[]' }))
+  await page.route('**/api/users', (r) => r.fulfill({ contentType: 'application/json', body: '[]' }))
+  await page.route('**/api/roles', (r) => r.fulfill({ contentType: 'application/json', body: '[]' }))
+}
+
+test('detail page offers rename and delete for a LOCAL group', async ({ page }) => {
+  await boot(page)
+  await page.goto('/admin/groups/1')
+  await expect(page.getByRole('button', { name: 'Rename' })).toBeEnabled()
+  await expect(page.getByRole('button', { name: 'Delete group' })).toBeEnabled()
+})
+
+test('rename opens the form dialog prefilled with the current name', async ({ page }) => {
+  await boot(page)
+  await page.goto('/admin/groups/1')
+  await page.getByRole('button', { name: 'Rename' }).click()
+  await expect(page.getByRole('dialog')).toBeVisible()
+  await expect(page.locator('#group-name')).toHaveValue('pii-readers')
+})
+
+test('delete asks for confirmation and calls DELETE', async ({ page }) => {
+  await boot(page)
+  let deleted = false
+  await page.route('**/api/groups/1', (r) => {
+    if (r.request().method() === 'DELETE') { deleted = true; return r.fulfill({ status: 204, body: '' }) }
+    return r.continue()
+  })
+  await page.goto('/admin/groups/1')
+  await page.getByRole('button', { name: 'Delete group' }).click()
+  await expect(page.getByText(/Delete group.*pii-readers/)).toBeVisible()
+  // The header button and the confirm button share a label, so the confirm is the second one.
+  await page.getByRole('button', { name: 'Delete group' }).last().click()
+  await expect.poll(() => deleted).toBe(true)
+})
+
+test('SYSTEM group cannot be renamed or deleted', async ({ page }) => {
+  await boot(page)
+  await page.goto('/admin/groups/2')
+  await expect(page.getByRole('button', { name: 'Rename' })).toBeDisabled()
+  await expect(page.getByRole('button', { name: 'Delete group' })).toBeDisabled()
+})
+
+test('OIDC group delete warns that the IdP will re-create it', async ({ page }) => {
+  await boot(page)
+  await page.goto('/admin/groups/3')
+  await page.getByRole('button', { name: 'Delete group' }).click()
+  await expect(page.getByText(/returns the next time a member signs in/)).toBeVisible()
+})
+
+test('list page disables edit and delete for a SYSTEM group', async ({ page }) => {
+  await boot(page)
+  await page.goto('/admin/groups')
+  const row = page.getByRole('row').filter({ hasText: 'system:admin' })
+  await row.getByRole('button', { name: 'More actions' }).click()
+  await expect(page.getByRole('menuitem', { name: 'Edit' })).toBeDisabled()
+  await expect(page.getByRole('menuitem', { name: 'Delete' })).toBeDisabled()
+})


### PR DESCRIPTION
The group detail page is where you go to manage a group, but it could only edit membership and role mappings. Renaming or deleting the group itself meant going back to the list and opening an unlabeled `⋯` menu in the far-right column — which is easy to miss entirely. The detail page now carries both as visible buttons, reusing the existing form dialog for the rename.

Two cases the list page got wrong, fixed on both surfaces:

**SYSTEM groups** are rejected server-side (`group.system_immutable` via `rejectSystem`), yet the row menu still offered Edit and Delete — the only way to find out was to click and read the error. Both are disabled now, with a tooltip saying why.

**OIDC groups** come back after deletion: `ensureGroupByName` re-creates any group the IdP still asserts on the next login. The delete succeeded and the group silently reappeared. Behavior is unchanged — the confirmation now says so instead of leaving it to be discovered.

No API change; `PUT`/`DELETE /api/groups/{id}` already existed and were already wrapped in the web client.

Verified with a new Playwright spec (`web/tests/group-admin.spec.ts`, 6 tests) driving the real console in Chromium against a stubbed control plane: the rename dialog prefills the current name, delete confirms and issues `DELETE`, SYSTEM is disabled on both surfaces, and the OIDC warning renders. Plus `tsc`, `pnpm test:unit` (message parity for the 5 new keys in `en` + `ko`), and `mise run lint`.