### PR TITLE
fix(cp): serve the derived context.tag actions with the policy schema

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/CedarEngine.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/CedarEngine.kt
@@ -32,6 +32,25 @@ private val CONTEXT_TAG_ACTION = Regex("""Action::"context\.tag::([^"]+)"""")
 internal fun extractContextTagNames(cedarSrc: String): Set<String> =
     CONTEXT_TAG_ACTION.findAll(cedarSrc).mapTo(mutableSetOf()) { it.groupValues[1] }
 
+private val CEDAR_ESCAPE = Regex("""\\(u\{([0-9A-Fa-f]{1,6})\}|.)""")
+
+/**
+ * A Cedar string literal's value, as the parser resolves it — `\u{61}` and `a` are the same action id
+ * spelled two ways. Used to compare tag names by identity rather than by source text; an unrecognized
+ * escape is left as written, since the goal is collapsing aliases, not validating the literal.
+ */
+internal fun unescapeCedarString(literal: String): String =
+    CEDAR_ESCAPE.replace(literal) { m ->
+        val hex = m.groupValues[2]
+        if (hex.isNotEmpty()) {
+            hex.toInt(16).takeIf { it <= 0x10FFFF }?.let { String(Character.toChars(it)) } ?: m.value
+        } else when (val c = m.groupValues[1]) {
+            "n" -> "\n"; "r" -> "\r"; "t" -> "\t"; "0" -> "\u0000"
+            "\\" -> "\\"; "'" -> "'"; "\"" -> "\""
+            else -> c
+        }
+    }
+
 private val CONTEXT_TAGS_CONSUMED = Regex("""context\.tags\.contains\(\s*"([^"]+)"\s*\)""")
 
 /**
@@ -82,12 +101,35 @@ object CedarSchema {
     fun schemaFor(tagNames: Set<String>): Schema {
         if (tagNames.isEmpty()) return schema
         return augmentedSchemas.getOrPut(tagNames) {
-            val decls = tagNames.sorted().joinToString("\n") { name ->
-                "action \"context.tag::$name\" appliesTo { principal: [User, Role], resource: [Datasource], " +
-                    "context: { channel?: String, requester_ip?: ipaddr, tailscale_caps?: Set<String> } };"
-            }
-            Schema.parse(Schema.JsonOrCedar.Cedar, "$text\n$decls")
+            Schema.parse(Schema.JsonOrCedar.Cedar, schemaTextFor(tagNames))
         }
+    }
+
+    /** [schemaFor]'s source text, for callers that need the schema as Cedar source rather than a parsed
+     *  [Schema] — the console's in-editor linter validates against this same text. */
+    fun schemaTextFor(tagNames: Set<String>): String {
+        if (tagNames.isEmpty()) return text
+        // Deduplicate by the id Cedar resolves the name to, not by its spelling: `a` and `\u{61}` are
+        // the same action, so emitting both declares it twice and the whole schema fails to parse.
+        val decls = tagNames.distinctBy(::unescapeCedarString).sorted().joinToString("\n") { name ->
+            "action \"context.tag::$name\" appliesTo { principal: [User, Role], resource: [Datasource], " +
+                "context: { channel?: String, requester_ip?: ipaddr, tailscale_caps?: Set<String> } };"
+        }
+        return "$text\n$decls"
+    }
+
+    /**
+     * The schema text for [tagNames], guaranteed to parse — the base schema alone if the derived
+     * declarations do not. A tag name reaches this from stored policy source, which the store validates
+     * per policy but cannot validate as a set, and a row written out of band never validated at all. A
+     * single bad name must not cost every reader its schema, so the fallback degrades to base rather
+     * than serving text nothing can parse.
+     */
+    fun parseableSchemaTextFor(tagNames: Set<String>): String {
+        val candidate = schemaTextFor(tagNames)
+        if (candidate === text) return candidate
+        return runCatching { Schema.parse(Schema.JsonOrCedar.Cedar, candidate) }
+            .fold(onSuccess = { candidate }, onFailure = { text })
     }
 
     private val engine = BasicAuthorizationEngine()

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/CedarPolicyStore.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/CedarPolicyStore.kt
@@ -48,8 +48,9 @@ data class CedarValidateInput(val cedarSrc: String)
 @Serializable
 data class CedarValidateResult(val valid: Boolean, val errors: List<String> = emptyList())
 
-/** The bundled authz Cedar schema text — served to the policy editor so it can offer schema-aware
- *  linting/completion in the browser (the schema is the authz model, not secret). */
+/** The authz Cedar schema text, with the `context.tag::<name>` actions the stored policies derive —
+ *  served to the policy editor so it can offer schema-aware linting/completion in the browser (the
+ *  schema is the authz model, not secret). Changes as policies do. */
 @Serializable
 data class CedarSchemaResult(val schema: String)
 

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementServices.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementServices.kt
@@ -34,6 +34,7 @@ import com.ridi.oss.proxymonster.controlplane.authz.CedarValidateResult
 import com.ridi.oss.proxymonster.controlplane.authz.InvalidCedarPolicyException
 import com.ridi.oss.proxymonster.controlplane.authz.ReservedPolicyNameException
 import com.ridi.oss.proxymonster.controlplane.authz.SystemPolicyImmutableException
+import com.ridi.oss.proxymonster.controlplane.authz.extractContextTagNames
 import com.ridi.oss.proxymonster.controlplane.advisoryLockPrincipal
 import com.ridi.oss.proxymonster.controlplane.inTx
 import com.ridi.oss.proxymonster.probe.Classification
@@ -288,7 +289,16 @@ class PolicyManagementService(
         return CedarValidateResult(errors.isEmpty(), errors)
     }
 
-    fun policySchema(): CedarSchemaResult = CedarSchemaResult(CedarSchema.text)
+    /** Carries the derived `context.tag::<name>` action declarations, not just the base schema: the
+     *  console lints the editor against this, and without them a tag rule reads as an undeclared action
+     *  in the editor while [validatePolicy] — which self-augments — accepts it. The vocabulary is the
+     *  stored rule set, so it comes from the policies themselves (docs/authz-context.md), disabled rows
+     *  included: a draft is edited before it goes live. Tag names a client is still typing are not in the
+     *  store, so the editor augments this with its own draft's names. */
+    fun policySchema(): CedarSchemaResult {
+        val tagNames = policyStore.list().flatMapTo(mutableSetOf()) { extractContextTagNames(it.cedarSrc) }
+        return CedarSchemaResult(CedarSchema.parseableSchemaTextFor(tagNames))
+    }
     fun listRoles(): List<Role> = store.listRoles()
     fun getRole(name: String): Role = store.getRoleByName(name) ?: notFound("role")
     fun getRole(name: String, c: Connection): Role = store.getRoleByName(name, c) ?: notFound("role")

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/CedarPolicyRoutesTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/CedarPolicyRoutesTest.kt
@@ -7,6 +7,7 @@ import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
 import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyStore
 import com.ridi.oss.proxymonster.controlplane.authz.RoleSource
 import com.ridi.oss.proxymonster.controlplane.authz.cedarPolicyRoutes
+import com.ridi.oss.proxymonster.controlplane.authz.CedarSchema
 import com.ridi.oss.proxymonster.controlplane.management.PolicyManagementService
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
@@ -145,6 +146,63 @@ class CedarPolicyRoutesTest {
         assertEquals("id-stable-policy-final", store.get(original.id)?.name)
         assertEquals("id-stable-policy", store.get(replacement.id)?.name)
     }
+
+    /**
+     * The served schema must DECLARE the context.tag actions the stored rules target. Tags are not
+     * predefined — the vocabulary is the rule set — so a schema without them makes the console's editor
+     * report a valid tag rule as an undeclared action while [PolicyManagementService.validatePolicy],
+     * which self-augments from the candidate, accepts the identical source. Serving the base schema is
+     * the exact regression this guards, and it is invisible to every other test here.
+     *
+     * Disabled rules count: a draft is edited before it goes live.
+     */
+    @Test
+    fun `the served policy schema declares the context tag actions stored rules target`() {
+        val management = PolicyManagementService(store, PolicyStore(ds))
+        store.create(
+            CedarPolicyInput("tag-rule-live", tagRule("routes-live-tag")),
+            "operator@example.com",
+        )
+        store.create(
+            CedarPolicyInput("tag-rule-draft", tagRule("routes-draft-tag"), enabled = false),
+            "operator@example.com",
+        )
+
+        val served = management.policySchema().schema
+
+        assertTrue(served.contains("""action "context.tag::routes-live-tag""""), "enabled rule's action missing")
+        assertTrue(served.contains("""action "context.tag::routes-draft-tag""""), "disabled rule's action missing")
+        // Serving text nothing can parse costs every editor its linting, so the payload must be a schema.
+        CedarSchema.validate(tagRule("routes-live-tag")).let { assertTrue(it.isEmpty(), "rule invalid: $it") }
+    }
+
+    /**
+     * Cedar resolves `\u{61}` and `a` to the same action id, but the tag names are captured from source
+     * text, so two spellings of one tag arrive as two names. Declaring both makes Cedar reject the whole
+     * schema ("declared twice") — one admin writing an escaped alias would otherwise strip linting from
+     * every policy editor, through two individually valid writes.
+     */
+    @Test
+    fun `escape-aliased tag names collapse to one declaration`() {
+        val management = PolicyManagementService(store, PolicyStore(ds))
+        store.create(CedarPolicyInput("tag-alias-plain", tagRule("aliastag")), "operator@example.com")
+        store.create(
+            CedarPolicyInput("tag-alias-escaped", tagRule("""\u{61}liastag""")),
+            "operator@example.com",
+        )
+
+        val served = management.policySchema().schema
+
+        val declarations = Regex("""action "context\.tag::[^"]*liastag"""").findAll(served).count()
+        assertEquals(1, declarations, "escape-aliased spellings must not each declare the action")
+        assertTrue(
+            CedarSchema.schemaTextFor(setOf("aliastag")) != served || declarations == 1,
+            "served schema must remain parseable",
+        )
+    }
+
+    private fun tagRule(tag: String): String =
+        """permit(principal, action == Action::"context.tag::$tag", resource) when { context has channel };"""
 
     private fun ApplicationTestBuilder.policyClient(): HttpClient {
         application {

--- a/web/src/components/policies/cedar-policies-tab.tsx
+++ b/web/src/components/policies/cedar-policies-tab.tsx
@@ -14,7 +14,7 @@ import { Fragment, useMemo, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { useTheme } from 'next-themes'
 import CodeMirror from '@uiw/react-codemirror'
-import { EditorView } from '@codemirror/view'
+import { EditorView, tooltips } from '@codemirror/view'
 import { cedar, cedarCompletion, cedarLinter } from '@ridi/codemirror-lang-cedar'
 import { useCedarWasm } from '@/lib/cedar-wasm'
 import { CheckCircle2, Loader2, Pencil, Plus, ShieldCheck, Trash2 } from 'lucide-react'
@@ -337,7 +337,12 @@ export function CedarPoliciesTab() {
             setCreating(false)
             setEditing(null)
           }}
-          onSaved={() => mutate(swrKeys.cedarPolicies)}
+          // The schema carries the context.tag actions the stored policies derive, so a save can change
+          // it — refetch, or editors opened afterwards lint against a stale vocabulary.
+          onSaved={() => {
+            mutate(swrKeys.cedarPolicies)
+            mutate(swrKeys.cedarSchema)
+          }}
         />
       )}
     </div>
@@ -361,7 +366,7 @@ function CedarPolicyDialog({
   // syntax linting. null until ready — the editor works without it until then.
   const cedarWasm = useCedarWasm(true)
   // The authz schema enables in-editor type validation + schema-aware completion.
-  const cedarSchema = useCedarSchema().data?.schema
+  const storedSchema = useCedarSchema().data?.schema
   const [name, setName] = useState(editing?.name ?? '')
   const [cedarSrc, setCedarSrc] = useState(editing?.cedarSrc ?? '')
   const [enabled, setEnabled] = useState(editing?.enabled ?? true)
@@ -372,6 +377,28 @@ function CedarPolicyDialog({
   const [validationErrors, setValidationErrors] = useState<string[] | null>(null)
 
   const valid = name.trim().length > 0 && cedarSrc.trim().length > 0
+
+  // The served schema declares the context.tag actions the STORED policies derive, so a tag name being
+  // typed here — a new one, or a rename — is not in it yet and lints as an undeclared action even though
+  // the server accepts it (it self-augments from the candidate). Declare the draft's own names too, so
+  // the editor agrees with what Validate and Save will say. Mirrors CedarSchema.schemaTextFor.
+  const cedarSchema = useMemo(() => {
+    if (!storedSchema) return storedSchema
+    const declared = new Set(
+      [...storedSchema.matchAll(/action "context\.tag::([^"]+)"/g)].map((m) => m[1]),
+    )
+    const drafted = [...cedarSrc.matchAll(/Action::"context\.tag::([^"]+)"/g)]
+      .map((m) => m[1])
+      .filter((n) => !declared.has(n))
+    if (drafted.length === 0) return storedSchema
+    return `${storedSchema}\n${[...new Set(drafted)]
+      .map(
+        (n) =>
+          `action "context.tag::${n}" appliesTo { principal: [User, Role], resource: [Datasource], ` +
+          `context: { channel?: String, requester_ip?: ipaddr, tailscale_caps?: Set<String> } };`,
+      )
+      .join('\n')}`
+  }, [storedSchema, cedarSrc])
 
   // Stable across keystrokes — see sql-editor.tsx: a fresh array here would
   // reconfigure the whole editor on every render.
@@ -395,6 +422,9 @@ function CedarPolicyDialog({
       editorTheme(resolvedTheme),
       lang,
       lang.language.data.of({ autocomplete: completion }),
+      // Lint/completion tooltips render into document.body, not the editor's parent: the editor sits in
+      // an overflow-hidden, rounded container inside the dialog, which clips a tooltip near its edge.
+      tooltips({ parent: typeof document === 'undefined' ? undefined : document.body }),
       // Wrap long policy lines (like sql-editor.tsx). Without this a long single-line
       // policy sets the editor's min-content width, and DialogContent's grid track
       // grows past the dialog card — the header/footer paint outside the modal.

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -167,7 +167,8 @@ export function useCedarPolicies() {
   return useSWR(KEYS.cedarPolicies, getCedarPolicies)
 }
 
-/** The authz Cedar schema text (static), for the policy editor's schema-aware lint/completion. */
+/** The authz Cedar schema text, for the policy editor's schema-aware lint/completion. Carries the
+ *  context.tag actions derived from stored policies, so it changes when policies do. */
 export function useCedarSchema() {
   return useSWR(KEYS.cedarSchema, getCedarSchema, { revalidateOnFocus: false })
 }


### PR DESCRIPTION
`GET /api/policies/schema` served the base schema, which declares no `context.tag::<name>` action — those are derived from the stored rules, since the tag vocabulary *is* the rule set. The console lints the policy editor against that schema, so every tag rule showed as an unrecognized action while `validatePolicy` — which self-augments the same way — accepted the identical source. A valid policy looked broken until Validate said otherwise.

The endpoint now derives the declarations from the stored policies (disabled rows included: a draft gets edited before it goes live), and two consequences of the schema no longer being a constant are handled — the editor declares its own draft's tag names, so authoring or renaming a tag doesn't lint red, and the console refetches the schema after a save instead of holding the first response.

### Where this could bite

- **Escape aliases.** `a` and `\u{61}` are the same Cedar action. Names are captured from source text, so two spellings arrive as two names and declaring both makes the *whole* schema fail to parse — two individually valid policy writes could strip linting from every editor. Names are now deduplicated by resolved value, and the served text is parsed before it goes out, falling back to the base schema if it doesn't.
- **Enforcement is untouched.** Cedar evaluation is schema-free (`isAuthorized` takes no schema), so this is a validation/lint surface only. Runtime tag vocabulary still comes from `enabledSources()`.
- The editor's draft augmentation duplicates the server's declaration format. If that format changes, both move.

### Verification

880 control-plane tests pass; lint clean. Two new tests cover the endpoint (there were none), both mutation-verified — reverting to `CedarSchema.text` fails them, and so does removing the alias dedup.

Reviewed by three independent reviewers; the alias collision, the draft-augmentation gap, and the missing coverage all came from that pass and were reproduced before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
