### PR TITLE
fix(control-plane): a tag is a tag

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -204,3 +204,24 @@ deliberately never inferred from request headers.
 
 Every variable named here, with defaults and examples, is in
 [INSTALL.md](./INSTALL.md#configuration).
+
+## What `PM_SECRET_TOKEN` authorizes
+
+The proxy↔CP gRPC surface is gated by one shared secret, not by a user identity,
+and holding it is equivalent to instance-wide policy administration. `Register`
+is how a proxy declares its own datasource, and the `tags` it sends
+(`PM_DATASOURCE_TAGS`) land on that datasource and are inherited by every table
+and column under it — so a caller holding the secret can attach a tag the
+shipped presets key on and change what those presets grant. `system:catalog` is
+the sharpest: it matches an enabled bare-principal permit for unmasked reads.
+
+`Register` is keyed on the datasource NAME and carries no per-datasource
+binding, so one proxy's secret can re-register, and retag, a datasource it does
+not front. Treat the secret as a control-plane administrative credential: give
+it the same handling as `PM_SESSION_SECRET`, and do not hand it to anything you
+would not let edit policy. Leaving it unset opens the gate to any caller that
+reaches the port.
+
+This is a property of the transport, not of tag marshalling: a tag is a tag
+wherever it comes from, and the CP applies the same naming rule to this path as
+to the admin surfaces.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -62,6 +62,16 @@ configured per proxy under `PM_TARGET_*`.
 - `PM_SECRET_TOKEN` — _required_. The single shared secret gating all proxy↔CP
   gRPC + the HTTP ingest routes. Same value on the CP and every proxy; unset ⇒
   the gate is open (dev only). Example: `$(openssl rand -hex 32)`
+
+  **Holding this is equivalent to administering policy.** `Register` lets a
+  caller set a datasource's tags, every table and column under it inherits them,
+  and a tag the shipped presets key on changes what those presets grant —
+  `system:catalog` matches an enabled bare-principal unmasked-read permit.
+  Registration is keyed on the datasource name with no per-datasource binding,
+  so one proxy's secret can retag a datasource it does not front. Handle it like
+  `PM_SESSION_SECRET`, and do not give it to anything you would not let edit
+  policy ([ARCHITECTURE.md](./ARCHITECTURE.md#what-pm_secret_token-authorizes)).
+
 - `PM_MCP_RESOURCE` — _optional_. Public MCP resource URL; required only if MCP
   is used. Example: `https://console.example.com/mcp`
 - `PM_TRUSTED_PROXIES` — _optional, set behind an LB_. Comma-separated
@@ -112,8 +122,11 @@ configured per proxy under `PM_TARGET_*`.
   dialect this proxy speaks: `postgres` or `mysql`. Default `mysql`. Unrelated
   to `PM_DB_URL`, which is always PostgreSQL.
 - `PM_DATASOURCE_NAME` / `PM_DATASOURCE_TAGS` — _name required_. Logical id
-  (must match the CP's) + posture tags policy keys off. Example:
-  `analytics-prod` · `system:production`
+  (must match the CP's) + the tags policy keys off. Example: `analytics-prod` ·
+  `system:production`. These reach Cedar as written and every table and column
+  under the datasource inherits them, so a name the shipped presets key on
+  decides for the whole datasource — set the posture here and leave column
+  classification to the console.
 - `PM_PROXY_PORT` — _optional_. The wire port clients connect to. Defaults:
   `6033` (MySQL) · `6432` (PG).
 - `PM_TARGET_HOST` / `_PORT` / `_DB` / `_USER` / `_PASSWORD` — _optional with
@@ -367,11 +380,17 @@ advertised proxy address".
 the target's real db name. Optional: `PM_DATASOURCE_TAGS` (comma-separated tags
 — the recognized posture tags are `system:development` and `system:production`,
 per [docs/policy-store.md](docs/policy-store.md); the list is otherwise
-free-form and any non-posture tag is inert). Leave it unset and the datasource
-carries no posture, which is the production floor either way — Cedar's
-deny-by-default plus the shipped forbids give an untagged datasource that floor
-with no posture tag required. Tag it `system:development` to opt a datasource
-into the permissive development preset.
+free-form: any name that is not an invented `system:` one reaches Cedar as
+itself, so a policy may match it and every table and column under the datasource
+inherits it. It is the same tag vocabulary column classifications use, so
+reusing one of those names here decides for the whole datasource: `pii` both
+masks every column under the shipped presets and hands cleartext on every column
+to any role a `Tag::"pii"` permit grants. Name a datasource tag for the
+datasource — `analytics-prod`, `pci-zone` — not for a column classification).
+Leave it unset and the datasource carries no posture, which is the production
+floor either way — Cedar's deny-by-default plus the shipped forbids give an
+untagged datasource that floor with no posture tag required. Tag it
+`system:development` to opt a datasource into the permissive development preset.
 
 Client-facing TLS (`PM_TLS_CERT` + `PM_TLS_KEY`, both-or-neither) is recommended
 but not required for this loopback walkthrough — without it the proxy runs

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Datasources.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Datasources.kt
@@ -1,5 +1,6 @@
 package com.ridi.oss.proxymonster.controlplane
 
+import com.ridi.oss.proxymonster.classification.SystemTag
 import com.ridi.oss.proxymonster.controlplane.authz.Authz
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzDecision
@@ -153,8 +154,29 @@ class DatasourceStore(internal val dataSource: DataSource) {
     private val stringList = ListSerializer(String.serializer())
 
     companion object {
-        /** The `system:` tag namespace is owned by the shipped classification manifests — user column tags may not use it. */
+        /** The `system:` tag namespace is owned by the product — an operator may not coin a name in it. */
         const val RESERVED_TAG_PREFIX = "system:"
+
+        /**
+         * The `system:` names the product defines: the four shipped classification tags plus the two
+         * datasource postures. Any resource may carry any of them — reservation stops an operator inventing
+         * `system:whatever` and having it read as shipped provenance, nothing more.
+         */
+        /** The two datasource-posture names the shipped presets key on. Ordinary tags like any other. */
+        val POSTURE_TAG_NAMES: Set<String> = setOf("system:development", "system:production")
+
+        val SYSTEM_TAG_NAMES: Set<String> = SystemTag.entries.map { it.id }.toSet() + POSTURE_TAG_NAMES
+
+        /** True for a `system:`-prefixed name the product does not define — the one thing a write refuses. */
+        fun isReservedTagName(tag: String): Boolean =
+            tag.startsWith(RESERVED_TAG_PREFIX) && tag !in SYSTEM_TAG_NAMES
+
+        /** The gate every tag write goes through — admin, MCP, and the proxy's own Register. */
+        fun requireWritableTags(tags: List<String>) {
+            tags.firstOrNull { isReservedTagName(it) }?.let {
+                throw ManagementException(ApiError("datasource.reserved_tag", mapOf("tag" to it)))
+            }
+        }
     }
 
     fun list(): List<Datasource> = dataSource.connection.use { c ->
@@ -196,10 +218,12 @@ class DatasourceStore(internal val dataSource: DataSource) {
      * gRPC Register (docs/datasource-registration.md): upsert a datasource by its stable [name].
      * The proxy is the source of truth for its own identity, so a brand-new name self-creates a row.
      * No target credential is ever stored — the control-plane never dials the target.
-     * host/port/db_name are advisory (admin UI / triage). [tags] are a free-form bag; the posture ones
-     * (`system:development` / `system:production`) drive the preset policies, everything else is inert;
-     * an EMPTY list PRESERVES any admin-set tags on an existing row rather than clobbering them (a fresh
-     * row defaults to '[]'). Idempotent: a restart / redeploy / scaled replica re-registering converges.
+     * host/port/db_name are advisory (admin UI / triage). [tags] are a free-form bag: every one reaches Cedar
+     * as itself and every Table/Column under the datasource inherits it, so a policy may match on any of them.
+     * The posture names (`system:development` / `system:production`) are what the shipped presets key on.
+     * An EMPTY list PRESERVES any admin-set tags on an
+     * existing row rather than clobbering them (a fresh row defaults to '[]'). Idempotent: a restart /
+     * redeploy / scaled replica re-registering converges.
      * ENGINE IS IMMUTABLE: re-registering an existing [name] with a different [engine] than its
      * stored value throws [DatasourceEngineConflictException] instead of upserting — see that class's
      * kdoc for why. host/port/db_name stay mutable.
@@ -217,6 +241,9 @@ class DatasourceStore(internal val dataSource: DataSource) {
         advertiseCertChain: String?,
         advertiseWireTls: Boolean,
     ): Datasource {
+        // A proxy declaring its own posture (`PM_DATASOURCE_TAGS=system:production`) passes; an invented
+        // `system:*` name is refused here as on the admin surfaces, so no write path can coin one.
+        requireWritableTags(tags)
         dataSource.connection.use { c ->
             c.autoCommit = false
             try {
@@ -620,9 +647,7 @@ class DatasourceStore(internal val dataSource: DataSource) {
         dataSource.connection.use { c -> upsertClassification(id, input, c) }
 
     fun upsertClassification(id: Long, input: ClassificationInput, c: java.sql.Connection): Classification {
-        input.tags.firstOrNull { it.startsWith(RESERVED_TAG_PREFIX) }?.let {
-            throw IllegalArgumentException("tag '$it' is reserved: the '$RESERVED_TAG_PREFIX' namespace is owned by system classification")
-        }
+        requireWritableTags(input.tags)
         // A blank schema is absent, not a name. Taking it literally writes a row keyed on "" that no
         // enforcement lookup can ever match (decide joins classifications by exact schema/table/column),
         // so the caller sees a tagged column while the real one stays untagged and reads cleartext.

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Decision.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Decision.kt
@@ -27,6 +27,7 @@ data class AuditEvent(
     val failedStage: String? = null,   // parse|validate|convert|lineage
     val effectiveNamespace: List<String> = emptyList(),
     val maskedColumns: List<String> = emptyList(),
+    // The tagged columns touched, not only `pii`-tagged ones; see decideQuery (Query.kt).
     val piiTouched: List<String> = emptyList(),
     val latencyMs: Long = 0,
     val detail: String? = null,

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -97,6 +97,7 @@ data class QueryResponse(
     val decisionId: Long? = null,
     val denyReason: String? = null,
     val maskedColumns: List<String> = emptyList(),
+    // The tagged columns touched, not only `pii`-tagged ones; see decideQuery (Query.kt).
     val piiTouched: List<String> = emptyList(),
     val effectiveRoles: List<String> = emptyList(),
     val columns: List<String> = emptyList(),
@@ -124,6 +125,7 @@ data class DecisionContext(
     val action: EnfAction,
     val denyReason: String?,
     val masks: List<ColumnMask>,
+    // The tagged columns touched, not only `pii`-tagged ones; see decideQuery (Query.kt).
     val piiTouched: List<String>,
     val effectiveRoles: List<String>,
     val failedStage: String?,
@@ -672,7 +674,14 @@ fun decideQuery(
     if (facts.explainOfQuery && action == EnfAction.MASK) {
         return structuralDeny(EXPLAIN_MASK_DENY, roleList, failedStage = "explain-masked", contextTags = derivedTags)
     }
-    val pii = columnKeys.keys.filter { catalogIndex.rowsByKey.getValue(it).classification?.tags?.contains("pii") == true }
+    // Every classified column the statement touched, whatever its tags are named: `pii` is a deployment's
+    // own tag, so keying this on that one string leaves auditmon's mass-export detector blind on a
+    // deployment that classifies with `pci`.
+    // TODO: rename to tagged_columns_touched. Needs a migration plus the Go verifier, the SIEM export name,
+    // and the console; the canonical form is positional, so CHAIN_VERSION is unaffected.
+    val tagged = columnKeys.keys.filter {
+        catalogIndex.rowsByKey.getValue(it).classification?.tags?.isNotEmpty() == true
+    }
     val referencedSchemas = buildSet {
         facts.sourcesList.mapTo(this) { it.schema }
         columnGrants.mapTo(this) { it.column.identity.schema }
@@ -689,7 +698,7 @@ fun decideQuery(
         action = action,
         denyReason = null,
         masks = masks,
-        piiTouched = pii,
+        piiTouched = tagged,
         effectiveRoles = roleList,
         failedStage = facts.failedStage.takeIf { facts.hasFailedStage() }?.lowercase(),
         detail = facts.detail,

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
@@ -215,36 +215,26 @@ private val FUNCTION_TYPE: EntityTypeName = EntityTypeName.parse("Function").get
 private val UTILITY_TYPE: EntityTypeName = EntityTypeName.parse("Utility").get()
 
 /**
- * The `system:` (and `udf:`) tag namespaces are TYPE-SCOPED (facts-emission.md, system-classification.md)
- * — a security invariant enforced HERE, at Cedar marshalling, not just at the admin write API:
- *   - `system:development` / `system:production` (datasource posture) → marshalled ONLY onto a **Datasource**;
- *   - every other `system:*` tag (the shipped classification: system:critical/activity/data-leak/catalog) is
- *     attached to a Table/Column/Function ONLY from the shipped manifest, never honored from user column tags;
- *   - `udf:output-vouched` → valid only on a UDF **Function**.
- * Without this, a Column whose catalog row carried a hand-written `system:development` (or a forged
- * `system:critical`) tag would satisfy a preset permit / bypass a shipped forbid and leak cleartext. So each
- * resource attaches ONLY the reserved tags valid for its own type, plus its ordinary user tags; every other
- * reserved tag is dropped before the Cedar graph is built. Datasource tags are otherwise free-form: any
- * non-reserved tag is carried but inert. [DATASOURCE_POSTURE_TAGS] is the allowlist for a Datasource;
- * [isReservedTag] identifies a `system:`/`udf:` tag a Column/Table/Function must NOT carry directly (its
- * shipped `system:` classification is attached separately, from the manifest, not here).
+ * Marshalling attaches every tag a resource carries, whatever it is named and whatever type carries it. What
+ * a tag means is the policy's business; the only rule is a naming rule at the write
+ * ([DatasourceStore.isReservedTagName]). Shipped `system:` classification is resolved from the manifest per
+ * statement (`Query.kt`) and attached separately, so it is never read from a tag row.
+ *
+ * A datasource's tags are inherited by every Table/Column/Function beneath it, so one decides for the whole
+ * datasource. That cuts both ways on a name policy keys on: `pii` makes the shipped presets mask every column
+ * under it, and hands cleartext to any role a `Tag::"pii"` permit grants. Classify columns to decide columns.
  */
-private val DATASOURCE_POSTURE_TAGS = setOf("system:development", "system:production")
-private fun isReservedTag(t: String): Boolean =
-    t.startsWith("system:") || t == "udf:output-vouched"
 
-/** The Datasource entity carrying ONLY its recognized posture Tag parents (others dropped), so a policy's
- *  `resource in Tag::"system:development"` matches this datasource AND — transitively via the Datasource
- *  parent — every Table/Column/Function under it. [tagEuids] is the caller's shared dedup map. */
+/** The Datasource entity carrying every tag it holds as a Tag parent — so a policy's `resource in Tag::"…"`
+ *  matches this datasource AND, transitively via the Datasource parent, every Table/Column/Function under
+ *  it. [tagEuids] is the caller's shared dedup map. */
 private fun datasourceEntity(
     dsEuid: EntityUID,
     name: String,
     datasourceTags: List<String>,
     tagEuids: HashMap<String, EntityUID>,
 ): Entity {
-    val parents = datasourceTags.filter { it in DATASOURCE_POSTURE_TAGS }
-        .map { tagEuids.getOrPut(it) { TAG_TYPE.of(it) } }
-        .toSet()
+    val parents = datasourceTags.mapTo(HashSet()) { tagEuids.getOrPut(it) { TAG_TYPE.of(it) } }
     return Entity(dsEuid, mapOf("name" to PrimString(name)), parents)
 }
 
@@ -457,9 +447,9 @@ fun Authz.authorizeColumns(
     // attached to the Table entity so its Columns inherit it transitively — a column of `pg_authid`
     // is `in Tag::"system:critical"` through its Table parent. Empty = no system object touched.
     systemTags: Map<Triple<String, String, String>, String> = emptyMap(),
-    // The datasource's own `system:*` posture tags. Attached to the Datasource entity
-    // so the shipped conditional forbids / preset permits match transitively (a Column is `in system:development`
-    // through its Datasource parent). Reserved tags on a Column itself are stripped (isReservedTag).
+    // The datasource's own tags. Attached to the Datasource entity so a policy matches transitively (a
+    // Column is `in Tag::"…"` through its Datasource parent), which is how the shipped conditional forbids
+    // and preset permits reach a column.
     datasourceTags: List<String> = emptyList(),
 ): Map<String, ColumnVerdict> {
     val roleEuids = roles.map { ROLE_TYPE.of(it) }
@@ -495,10 +485,7 @@ fun Authz.authorizeColumns(
         }
         val colEuid = COLUMN_TYPE.of("$datasource/${col.catalog}/${col.schema}/${col.table}/${col.column}")
         columnEuids[col.key] = colEuid
-        // Strip reserved tags off the Column (the type-scoping invariant): a catalog/legacy `system:development`
-        // or `system:*` on a column must NOT be honored — it would satisfy the dev unmasked permit / forge a
-        // shipped classification. The column's real system tag is inherited from its Table parent, not here.
-        val tagParents = col.tags.filterNot { isReservedTag(it) }.map { tag -> tagEuids.getOrPut(tag) { TAG_TYPE.of(tag) } }
+        val tagParents = col.tags.map { tag -> tagEuids.getOrPut(tag) { TAG_TYPE.of(tag) } }
         columnEntities += Entity(colEuid, emptyMap(), (setOf(tableEuid, dsEuid) + tagParents).toSet())
     }
     // Each Table entity carries its datasource parent + its system tag, so a Column inherits

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/ControlPlaneGrpcService.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/ControlPlaneGrpcService.kt
@@ -10,6 +10,7 @@ import com.ridi.oss.proxymonster.controlplane.CatalogMutationResult
 import com.ridi.oss.proxymonster.controlplane.Channel
 import com.ridi.oss.proxymonster.controlplane.ControlPlaneCore
 import com.ridi.oss.proxymonster.controlplane.DatasourceEngineConflictException
+import com.ridi.oss.proxymonster.controlplane.management.ManagementException
 import com.ridi.oss.proxymonster.controlplane.catalogIsConnectionIndependent
 import com.ridi.oss.proxymonster.controlplane.catalogName
 import com.ridi.oss.proxymonster.controlplane.EnforcementOutcome
@@ -357,6 +358,10 @@ class ControlPlaneGrpcService(
             // Engine is immutable at register — a mismatched re-register is a client precondition
             // failure (fix the caller's engine or delete-and-recreate), not a server error.
             throw StatusException(Status.FAILED_PRECONDITION.withDescription(e.message))
+        } catch (e: ManagementException) {
+            // A refused tag name (PM_DATASOURCE_TAGS naming a `system:` tag the product does not define) is
+            // the proxy's own misconfiguration, so it must read as one rather than an opaque server error.
+            throw StatusException(Status.INVALID_ARGUMENT.withDescription(e.error.code))
         }
         // The catalog push that follows registration cannot repair this: it only confirms content it agrees
         // with, and a retarget is precisely the case where it disagrees. So the held structure would survive,

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementServices.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementServices.kt
@@ -140,9 +140,7 @@ class DatasourceManagementService(
         if (schema == null && store.defaultSchema(datasource.id, connection) == null) {
             throw ManagementException(ApiError("datasource.schema_required"))
         }
-        tags.firstOrNull { it.startsWith(DatasourceStore.RESERVED_TAG_PREFIX) }?.let {
-            throw ManagementException(ApiError("datasource.reserved_tag", mapOf("tag" to it)))
-        }
+        DatasourceStore.requireWritableTags(tags)
         store.upsertClassification(datasource.id, ClassificationInput(schema, table, column, tags, maskFnId), connection)
     }
 
@@ -161,9 +159,7 @@ class DatasourceManagementService(
         if (schema == null && store.defaultSchema(datasource.id, connection) == null) {
             throw ManagementException(ApiError("datasource.schema_required"))
         }
-        tags.firstOrNull { it.startsWith(DatasourceStore.RESERVED_TAG_PREFIX) }?.let {
-            throw ManagementException(ApiError("datasource.reserved_tag", mapOf("tag" to it)))
-        }
+        DatasourceStore.requireWritableTags(tags)
         return store.upsertClassification(datasource.id, ClassificationInput(schema, table, column, tags, maskFnId), connection)
     }
 
@@ -198,9 +194,7 @@ class DatasourceManagementService(
             required("column", input.column)
             val schema = input.schema?.takeIf(String::isNotBlank) ?: defaultSchema
                 ?: throw ManagementException(ApiError("datasource.schema_required"))
-            input.tags.firstOrNull { it.startsWith(DatasourceStore.RESERVED_TAG_PREFIX) }?.let {
-                throw ManagementException(ApiError("datasource.reserved_tag", mapOf("tag" to it)))
-            }
+            DatasourceStore.requireWritableTags(input.tags)
             if (!seen.add(Triple(schema, input.table, input.column))) {
                 throw ManagementException(
                     ApiError(

--- a/control-plane/src/main/resources/authz/schema.cedarschema
+++ b/control-plane/src/main/resources/authz/schema.cedarschema
@@ -55,11 +55,11 @@ entity Utility in [Datasource, Tag];
 entity User in [Role];
 
 // A brokered datasource (DESIGN.md's `datasource` table). `name` is best-effort/optional so
-// callers that only have the id can still authorize. It gains a `Tag` parent so its shipped
-// posture tags (`system:development` / `system:production`) attach to it AND — transitively via
-// the Datasource parent every Table/Column/Function carries — govern the conditional forbids / preset
-// permits over the objects under it. Only those reserved tags are ever marshaled onto a Datasource
-// (Authz.datasourceEntity); a Column/Table/Function can never carry them (the type-scoping invariant).
+// callers that only have the id can still authorize. It gains a `Tag` parent so every tag it carries
+// attaches to it AND — transitively via the Datasource parent every Table/Column/Function carries —
+// governs the conditional forbids / preset permits over the objects under it. The posture tags
+// (`system:development` / `system:production`) are what the shipped presets key on; marshalling filters
+// nothing by resource type, so any resource may carry any tag name (Authz.datasourceEntity).
 entity Datasource in [Tag] = {
     name?: String,
 };

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AuthzDatasourceActionTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AuthzDatasourceActionTest.kt
@@ -141,4 +141,67 @@ class AuthzDatasourceActionTest {
         )
         assertIs<AuthzDecision.Deny>(decision)
     }
+
+    @Test
+    fun `every datasource tag reaches policy as itself, whatever it is named`() {
+        // Marshalling does not ask what a tag is called or what type carries it, so an operator's own
+        // `pci` and a product `system:` name both match a policy written against them.
+        val authz = Authz(
+            CedarEngine(
+                listOf(
+                    1L to """permit(principal, action == Action::"sql.select", resource)
+                             when { resource in Tag::"pci" };""",
+                    2L to """permit(principal, action == Action::"sql.delete", resource)
+                             when { resource in Tag::"system:critical" };""",
+                ),
+            ),
+            CedarPolicyStore(UnusedDataSource),
+            RoleSource { emptySet() },
+        )
+        assertEquals(
+            AuthzDecision.Allow,
+            authz.authorizeDatasourceAction(
+                principal = "alice",
+                roles = setOf("anyone"),
+                action = AuthzAction.SQL_SELECT,
+                datasource = "acme-mysql",
+                datasourceTags = listOf("pci"),
+            ),
+            "an ordinary datasource tag must reach Cedar as itself",
+        )
+        assertEquals(
+            AuthzDecision.Allow,
+            authz.authorizeDatasourceAction(
+                principal = "alice",
+                roles = setOf("anyone"),
+                action = AuthzAction.SQL_DELETE,
+                datasource = "acme-mysql",
+                datasourceTags = listOf("system:critical"),
+            ),
+            "a product `system:` name is a tag too — no type-scoping drops it off a datasource",
+        )
+        assertIs<AuthzDecision.Deny>(
+            authz.authorizeDatasourceAction(
+                principal = "alice",
+                roles = setOf("anyone"),
+                action = AuthzAction.SQL_SELECT,
+                datasource = "acme-mysql",
+                datasourceTags = emptyList(),
+            ),
+            "and the verdict comes from the tag: untagged, the same action is denied",
+        )
+    }
+
+    @Test
+    fun `the naming rule refuses an invented system name and admits the six the product defines`() {
+        for (legal in DatasourceStore.SYSTEM_TAG_NAMES) {
+            assertEquals(false, DatasourceStore.isReservedTagName(legal), "'$legal' is a product tag and must be writable")
+        }
+        for (invented in listOf("system:whatever", "system:", "system:Production", "system:critical-ish")) {
+            assertEquals(true, DatasourceStore.isReservedTagName(invented), "'$invented' is not a product tag and must be refused")
+        }
+        for (ordinary in listOf("pci", "pii", "udf:output-vouched", "systematic", "SYSTEM:critical")) {
+            assertEquals(false, DatasourceStore.isReservedTagName(ordinary), "'$ordinary' is an ordinary name and must be writable")
+        }
+    }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ColumnAuthzTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ColumnAuthzTest.kt
@@ -212,4 +212,196 @@ class ColumnAuthzTest {
         )
         assertEquals(mapOf("acme.public.users.region" to ColumnVerdict.DENIED), verdicts)
     }
+
+    @Test
+    fun `an operator's own datasource tag reaches a column through the datasource parent`() {
+        // The transitive path is what a datasource tag is FOR: one tag on the datasource decides every
+        // column under it.
+        val authz = Authz(
+            CedarEngine(
+                listOf(
+                    1L to """permit(principal, action == Action::"result.read.unmasked", resource)
+                             when { resource in Tag::"pci" };""",
+                ),
+            ),
+            CedarPolicyStore(UnusedDataSource),
+            RoleSource { emptySet() },
+        )
+        val col = listOf(column("acme.public.users.region", "users", "region"))
+        assertEquals(
+            mapOf("acme.public.users.region" to ColumnVerdict.UNMASKED),
+            authz.authorizeColumns(
+                principal = "alice",
+                roles = setOf("anyone"),
+                datasource = "acme-pg",
+                columns = col,
+                datasourceTags = listOf("pci"),
+            ),
+        )
+        assertEquals(
+            mapOf("acme.public.users.region" to ColumnVerdict.DENIED),
+            authz.authorizeColumns(
+                principal = "alice",
+                roles = setOf("anyone"),
+                datasource = "acme-pg",
+                columns = col,
+                datasourceTags = emptyList(),
+            ),
+            "the verdict must come from the tag, not from something else in the policy",
+        )
+    }
+
+    /**
+     * A datasource tag is inherited by every column under it, so one named after a classification the
+     * shipped presets key on decides for the whole datasource: `pii` flips an unclassified column from
+     * cleartext to masked, whatever the column itself says.
+     */
+    @Test
+    fun `a datasource tagged pii masks a column the shipped preset would otherwise read cleartext`() {
+        val authz = Authz(
+            CedarEngine(
+                listOf(
+                    // The shipped pair, verbatim in shape: -256 grants cleartext unless the resource is
+                    // pii; -257 grants masked when it is.
+                    1L to """permit(principal, action == Action::"result.read.unmasked", resource)
+                             when { resource in Tag::"system:production" }
+                             unless { resource in Tag::"pii" };""",
+                    2L to """permit(principal, action == Action::"result.read.masked", resource)
+                             when { resource in Tag::"system:production" && resource in Tag::"pii" };""",
+                ),
+            ),
+            CedarPolicyStore(UnusedDataSource),
+            RoleSource { emptySet() },
+        )
+        // No classification of its own — every bit of the decision comes from the datasource's tags.
+        val col = listOf(column("acme.public.users.region", "users", "region"))
+        assertEquals(
+            mapOf("acme.public.users.region" to ColumnVerdict.UNMASKED),
+            authz.authorizeColumns(
+                principal = "alice",
+                roles = setOf("anyone"),
+                datasource = "acme-pg",
+                columns = col,
+                datasourceTags = listOf("system:production"),
+            ),
+            "an unclassified column on a production datasource reads cleartext",
+        )
+        assertEquals(
+            mapOf("acme.public.users.region" to ColumnVerdict.MASKED),
+            authz.authorizeColumns(
+                principal = "alice",
+                roles = setOf("anyone"),
+                datasource = "acme-pg",
+                columns = col,
+                datasourceTags = listOf("system:production", "pii"),
+            ),
+            "adding pii to the DATASOURCE masks that same column, inherited through the datasource parent",
+        )
+    }
+
+    /**
+     * The other direction: a permit keyed on `resource in Tag::"pii"` — the `pii-reader` grant in
+     * authz-model.md — reaches every column under a `pii`-tagged datasource, including columns nobody
+     * classified.
+     */
+    @Test
+    fun `a datasource tagged pii hands a pii-keyed permit every column under it`() {
+        val authz = Authz(
+            CedarEngine(
+                listOf(
+                    1L to """permit(principal in Role::"pii-reader", action == Action::"result.read.unmasked",
+                                    resource in Tag::"pii");""",
+                ),
+            ),
+            CedarPolicyStore(UnusedDataSource),
+            RoleSource { emptySet() },
+        )
+        val col = listOf(column("acme.public.users.region", "users", "region"))
+        assertEquals(
+            mapOf("acme.public.users.region" to ColumnVerdict.DENIED),
+            authz.authorizeColumns(
+                principal = "alice",
+                roles = setOf("pii-reader"),
+                datasource = "acme-pg",
+                columns = col,
+                datasourceTags = emptyList(),
+            ),
+            "an unclassified column is not pii, so the pii-keyed permit does not reach it",
+        )
+        assertEquals(
+            mapOf("acme.public.users.region" to ColumnVerdict.UNMASKED),
+            authz.authorizeColumns(
+                principal = "alice",
+                roles = setOf("pii-reader"),
+                datasource = "acme-pg",
+                columns = col,
+                datasourceTags = listOf("pii"),
+            ),
+            "tagging the DATASOURCE pii extends that same permit to a column that was never classified",
+        )
+    }
+
+    /**
+     * The shipped `system:catalog` permit is bare-principal cleartext, so a datasource carrying that name
+     * opens every column under it. The widest reach any single tag has.
+     */
+    @Test
+    fun `a datasource tagged system-catalog opens the bare-principal catalog permit for every column`() {
+        val authz = Authz(
+            CedarEngine(
+                listOf(
+                    1L to """permit(principal, action == Action::"result.read.unmasked", resource)
+                             when { resource in Tag::"system:catalog" };""",
+                ),
+            ),
+            CedarPolicyStore(UnusedDataSource),
+            RoleSource { emptySet() },
+        )
+        val col = listOf(column("acme.public.users.region", "users", "region"))
+        assertEquals(
+            mapOf("acme.public.users.region" to ColumnVerdict.DENIED),
+            authz.authorizeColumns("alice", emptySet(), "acme-pg", col, datasourceTags = emptyList()),
+            "untagged, deny-by-default holds",
+        )
+        assertEquals(
+            mapOf("acme.public.users.region" to ColumnVerdict.UNMASKED),
+            authz.authorizeColumns("alice", emptySet(), "acme-pg", col, datasourceTags = listOf("system:catalog")),
+            "on the datasource it reaches every column, no role required",
+        )
+    }
+
+    /** A column's own `system:critical` reaches the shipped forbid, which overrides any read grant. */
+    @Test
+    fun `a column tagged system-critical is denied by the shipped forbid`() {
+        val authz = Authz(
+            CedarEngine(
+                listOf(
+                    1L to """permit(principal, action == Action::"result.read.unmasked", resource)
+                             when { resource in Tag::"ok" };""",
+                    2L to """forbid(principal, action in [Action::"result.read.unmasked", Action::"result.read.masked"], resource)
+                             when { resource in Tag::"system:critical" };""",
+                ),
+            ),
+            CedarPolicyStore(UnusedDataSource),
+            RoleSource { emptySet() },
+        )
+        assertEquals(
+            mapOf("acme.public.users.region" to ColumnVerdict.UNMASKED),
+            authz.authorizeColumns(
+                "alice", emptySet(), "acme-pg",
+                listOf(column("acme.public.users.region", "users", "region", tags = listOf("ok"))),
+                datasourceTags = listOf("ok"),
+            ),
+            "the read grant alone unmasks",
+        )
+        assertEquals(
+            mapOf("acme.public.users.region" to ColumnVerdict.DENIED),
+            authz.authorizeColumns(
+                "alice", emptySet(), "acme-pg",
+                listOf(column("acme.public.users.region", "users", "region", tags = listOf("ok", "system:critical"))),
+                datasourceTags = listOf("ok"),
+            ),
+            "adding system:critical to the COLUMN reaches the forbid, which overrides the grant",
+        )
+    }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PresetPolicyDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PresetPolicyDbTest.kt
@@ -269,18 +269,29 @@ class PresetPolicyDbTest {
     }
 
     @Test
-    fun `a forged preset-development tag is honored on a datasource but stripped off a column`() {
-        // Type-scoping security invariant: a reserved preset tag is valid ONLY on a Datasource. A column whose
-        // (forged/legacy) catalog row carries system:development must NOT unmask a PRODUCTION column — the
-        // marshaller strips reserved tags off a Column. Proven by calling authorizeColumns directly.
-        val forged = ColumnRef(key = "k", catalog = "pm", schema = "public", table = "users", column = "rrn", tags = listOf("system:development"))
+    fun `the shipped development permit matches a system-development tag wherever it sits`() {
+        // `system:development` reaches the shipped -200 permit whether it sits on the datasource or on the
+        // column. Either write takes the same instance-wide admin.datasources authority.
+        val tagged = ColumnRef(key = "k", catalog = "pm", schema = "public", table = "users", column = "rrn", tags = listOf("system:development"))
+        val plain = ColumnRef(key = "k", catalog = "pm", schema = "public", table = "users", column = "rrn")
         val nobody = "nobody@example.com" // no preset role; relies solely on the shipped -200 preset permit
-        // Production datasource: the forged column tag is stripped, so -200 (dev cleartext) cannot fire → deny.
-        val stripped = fx.authz.authorizeColumns(nobody, emptySet(), fx.datasource.name, listOf(forged), datasourceTags = listOf("system:production"))
-        assertEquals(ColumnVerdict.DENIED, stripped["k"], "a forged system:development on a COLUMN is stripped → deny-by-default")
-        // The SAME tag on the DATASOURCE is honored: the column is in system:development via its datasource
-        // parent, so the -200 cleartext read unmasks it — proving the strip is type-scoped, not a blanket drop.
-        val honored = fx.authz.authorizeColumns(nobody, emptySet(), fx.datasource.name, listOf(forged), datasourceTags = listOf("system:development"))
-        assertEquals(ColumnVerdict.UNMASKED, honored["k"], "system:development on the DATASOURCE unmasks its columns (the -200 permit)")
+        // On the DATASOURCE: every column under it is in system:development via its datasource parent.
+        assertEquals(
+            ColumnVerdict.UNMASKED,
+            fx.authz.authorizeColumns(nobody, emptySet(), fx.datasource.name, listOf(plain), datasourceTags = listOf("system:development"))["k"],
+            "system:development on the DATASOURCE unmasks its columns (the -200 permit)",
+        )
+        // On the COLUMN: the same name, reaching the same permit directly.
+        assertEquals(
+            ColumnVerdict.UNMASKED,
+            fx.authz.authorizeColumns(nobody, emptySet(), fx.datasource.name, listOf(tagged), datasourceTags = listOf("system:production"))["k"],
+            "system:development on the COLUMN reaches the same permit — no tag is filtered by resource type",
+        )
+        // And the verdict comes from the tag: with neither, -200 cannot fire and deny-by-default holds.
+        assertEquals(
+            ColumnVerdict.DENIED,
+            fx.authz.authorizeColumns(nobody, emptySet(), fx.datasource.name, listOf(plain), datasourceTags = listOf("system:production"))["k"],
+            "untagged on a production datasource, the same read is denied",
+        )
     }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationEnforcementDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationEnforcementDbTest.kt
@@ -2,6 +2,7 @@ package com.ridi.oss.proxymonster.controlplane
 
 import com.ridi.oss.proxymonster.grpc.EnfAction
 import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
+import com.ridi.oss.proxymonster.controlplane.management.ManagementException
 import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
 import org.junit.jupiter.api.BeforeAll
@@ -55,18 +56,27 @@ class SystemClassificationEnforcementDbTest {
     }
 
     @Test
-    fun `a user column classification cannot claim a reserved system tag`() {
-        // The `system:` namespace is owned by the shipped manifests — a user-authored column tag must be
-        // rejected at write time (fail-closed), not silently stored to be ignored later at Cedar marshalling.
-        val ex = assertFailsWith<IllegalArgumentException> {
+    fun `a column classification may name a product system tag but not invent one`() {
+        // The six names the product defines are writable on anything; an invented `system:` name is
+        // refused. A column carrying `system:critical` reaches the shipped critical forbid like any other
+        // tag, which denies it — the write is honest about what it asks for.
+        val ex = assertFailsWith<ManagementException> {
             fx.datasourceStore.upsertClassification(
                 fx.datasource.id,
-                ClassificationInput(schema = "public", table = "users", column = "rrn", tags = listOf("pii", "system:critical")),
+                ClassificationInput(schema = "public", table = "users", column = "rrn", tags = listOf("pii", "system:invented")),
             )
         }
-        assertTrue("system:critical" in ex.message.orEmpty(), "the error must name the reserved tag: ${ex.message}")
+        assertEquals("datasource.reserved_tag", ex.error.code, "the refusal must use the one shared error code")
+        assertEquals("system:invented", ex.error.params["tag"], "and must name the offending tag: ${ex.error.params}")
 
-        // A non-reserved tag still writes fine (positive control — the guard only rejects the `system:` prefix).
+        // A product `system:` name writes fine — it is a tag like any other.
+        val product = fx.datasourceStore.upsertClassification(
+            fx.datasource.id,
+            ClassificationInput(schema = "public", table = "users", column = "rrn", tags = listOf("pii", "system:critical")),
+        )
+        assertEquals(listOf("pii", "system:critical"), product.tags)
+
+        // And an ordinary tag, the common case.
         val ok = fx.datasourceStore.upsertClassification(
             fx.datasource.id,
             ClassificationInput(schema = "public", table = "users", column = "rrn", tags = listOf("pii")),

--- a/docs/access-model.md
+++ b/docs/access-model.md
@@ -102,11 +102,11 @@ User columns use freeform tags such as `pii` (not a reserved `system:` prefix);
 the production package masks `Tag::"pii"` and unmasks only for
 `system:production-pii-accessor` when `context.tags` contains `trusted-network`.
 
-Placement is enforced: `system:development` / `system:production` are
-Datasource-only (the marshaller attaches only those posture tags to a
-Datasource; Columns/Tables/Functions never carry them). The `system:` namespace
-is reserved — user classification cannot claim it, and invalid reserved tags are
-rejected or stripped before Cedar marshalling.
+Placement is not enforced: any resource may carry any tag, and marshalling
+attaches it as written. What is enforced is the NAME — the `system:` namespace
+belongs to the product, so an operator cannot coin `system:whatever`, while the
+six names it defines are writable anywhere. A posture tag therefore decides for
+whatever carries it: on a datasource, for everything beneath it.
 
 Tagging any datasource `system:development` gives it the whole dev posture with
 no per-datasource policy; tagging a column `pii` plus the production package

--- a/docs/audit-trail-hardening.md
+++ b/docs/audit-trail-hardening.md
@@ -179,18 +179,23 @@ the sole authority, and the monitor stays read-only on the DB.
 
 Signals come from the audit row (`principal`, `decision`, `datasource`,
 `statement`, `masked_columns`, `pii_touched`, `channel`, `ts`, `client_addr`,
-`latency_ms`) plus one added signal: result volume. The decision event is
-emitted at decide time (pre-execution), so it cannot carry a row count. Rather
-than mutate the immutable decision row, the data-plane proxy emits a
-post-execution completion event — its own append-only, chained `audit_event`
-(`kind = "completion"`) via gRPC `ReportCompletion`, referencing the decision
-`id` as `decision_id`, carrying `rows_returned` + `bytes_returned` (rows catch
-"many records," bytes catch "few wide rows / big blob"), terminal status in
-`outcome` (`ok|error|canceled`), and relay wall time in `latency_ms`. The proxy
-tallies as it relays. One completion is emitted at statement end, so mass-export
-is caught after the rows left, which is fine for alerting (Cedar is the
-enforcement gate). DENY → no completion; error/cancel → a completion with
-`outcome` + partial counts.
+`latency_ms`) plus one added signal: result volume.
+
+`pii_touched` holds every **tagged** column a statement touched, whatever those
+tags are named — a deployment classifying with `pci` or `confidential` populates
+it the same as one using `pii`. The column keeps its original name; renaming it
+is pending a migration. The decision event is emitted at decide time
+(pre-execution), so it cannot carry a row count. Rather than mutate the
+immutable decision row, the data-plane proxy emits a post-execution completion
+event — its own append-only, chained `audit_event` (`kind = "completion"`) via
+gRPC `ReportCompletion`, referencing the decision `id` as `decision_id`,
+carrying `rows_returned` + `bytes_returned` (rows catch "many records," bytes
+catch "few wide rows / big blob"), terminal status in `outcome`
+(`ok|error|canceled`), and relay wall time in `latency_ms`. The proxy tallies as
+it relays. One completion is emitted at statement end, so mass-export is caught
+after the rows left, which is fine for alerting (Cedar is the enforcement gate).
+DENY → no completion; error/cancel → a completion with `outcome` + partial
+counts.
 
 <!-- prettier-ignore -->
 | Rule | Fires on | Primary signal |

--- a/docs/facts-emission.md
+++ b/docs/facts-emission.md
@@ -65,8 +65,10 @@ The request graph is assembled from live data on every decision:
 - [system-classification.md](./system-classification.md) provides one immutable
   shipped tag on each classified Table, Function, or Utility (a Column inherits
   its Table's system tag rather than receiving a second direct system tag); and
-- the datasource provides its recognized posture
-  (`system:development`/`system:production`).
+- the datasource provides every tag it carries — no filtering, whatever the tag
+  is named — each usable as a policy match and each inherited by every
+  Table/Column/Function beneath it. The posture tags are what the shipped
+  presets match.
 
 ### Result-read semantics per resource
 
@@ -93,16 +95,20 @@ Table covers its Column children, and the Table entity itself satisfies the same
 selector. There is no separate `table.scan` or `function.call` action — result
 visibility is one capability across every data-producing resource.
 
-### Reserved tags are type-scoped
+### Reserved names, not reserved placements
 
-`system:*` is reserved for the shipped classifier and for datasource posture.
-User-authored Column tags under that namespace are rejected on write and
-stripped defensively by the Cedar marshaller. A shipped system tag attaches
-directly to Table, Function, or Utility; a Column inherits its Table's tag. A
-Datasource carries only `system:development` or `system:production`. This is a
-security invariant, not UI validation: without it, a production PII Column
-hand-tagged `system:development` would satisfy the development unmasked permit
-and leak cleartext. Ordinary custom Column tags such as `pii` remain valid.
+`system:` is the product's namespace: an operator may not coin a name in it, and
+the six the product defines — the four shipped classification tags and the two
+datasource postures — are writable on any resource. Marshalling filters nothing
+by resource type, so a tag reaches policy from wherever it sits.
+
+Shipped classification does not come from a tag row. It is resolved from the
+manifest per statement and attached to the Table, Function, or Utility; a Column
+inherits its Table's tag. Cedar sees one `Tag::` entity either way, so a policy
+cannot tell a manifest tag from a stored one — a column classified
+`system:critical` reaches the shipped critical forbid and is denied, and one
+classified `system:development` reaches the development permit. Both take the
+`admin.datasources` authority the classification API requires.
 
 ## Scanned Tables — the zero-column gap
 

--- a/docs/policy-store.md
+++ b/docs/policy-store.md
@@ -275,12 +275,31 @@ before toggling.
 
 Each preset ships a concrete, least-privilege role package. Posture tags are
 `system:development` / `system:production`; datasource tags are otherwise a
-free-form bag, and the marshaller honors only those two — anything else is
-inert, and there is no exact-one-posture constraint. Only the `system:`
-namespace is reserved, and only for type-scoping: a Column/Table/Function may
-not carry a `system:` tag directly (the shipped classification is attached from
-the manifest), so a hand-written `system:development` on a column can never
-satisfy a preset permit.
+free-form bag, and the marshaller carries every one of them onto the Datasource
+entity, so a policy may match an operator's own tag exactly as it matches a
+posture one. There is no exact-one-posture constraint. Reservation is a NAMING
+rule and nothing more: the six `system:` names the product defines are writable
+on any resource, and an invented `system:whatever` is refused at the write. No
+tag is filtered by resource type.
+
+The seed migration's own comment on `-200` says the development posture is
+type-scoped to a datasource and stripped from a column. That is no longer how
+marshalling works, and the comment cannot be corrected in place — an applied
+migration is immutable, since Flyway checksums the whole file.
+
+A datasource tag is inherited by every Table, Column, and Function under it, and
+it matches the same `Tag::` entity a column classification does. So naming one
+after a classification policy keys on applies it datasource-wide, and `pii` cuts
+both ways:
+
+- the shipped presets **close** — `production-non-pii-read` stops granting
+  cleartext and `production-pii-masked` masks every column, whatever each
+  column's own classification says;
+- a permit keyed on `resource in Tag::"pii"` **opens** — the `pii-reader` grant
+  in [authz-model.md](./authz-model.md) hands that role cleartext on every
+  column under the datasource, including columns nobody classified as PII.
+
+Classify columns to decide columns; a datasource tag decides the datasource.
 
 Roles: ten predefined roles in the `system:` namespace — five
 `system:development-{viewer, pii-accessor, updater, deleter, architect}` and

--- a/docs/system-classification.md
+++ b/docs/system-classification.md
@@ -661,14 +661,15 @@ separate shipped system parent; user column tags stay direct Column parents.
 
 Admin write APIs reject `system:*`: a classification write carrying any tag with
 that prefix fails with `datasource.reserved_tag`
-(`DatasourceStore.RESERVED_TAG_PREFIX`). The Cedar marshaller strips any
-`system:` or `udf:` tag it finds on a Column row, so a direct DB write cannot
-forge shipped provenance. The catalog API does not return computed system tags
-at all — `DatasourceStore.catalog` carries only the user-authored
-classification, so the console's catalog browser shows a system column as
-unclassified. Enforcement resolves the tags at decision time and is unaffected;
-the display gap is recorded in
-[`KNOWN_LIMITATIONS.md`](../KNOWN_LIMITATIONS.md).
+(`DatasourceStore.RESERVED_TAG_PREFIX`). The marshaller strips nothing — a tag
+is a tag — so a column row may carry `system:critical` and it reaches policy as
+`Tag::"system:critical"`. It does not forge shipped provenance: the shipped
+forbids are keyed on the classification the manifest resolves at decision time,
+never on a tag row. The catalog API does not return computed system tags at all
+— `DatasourceStore.catalog` carries only the user-authored classification, so
+the console's catalog browser shows a system column as unclassified. Enforcement
+resolves the tags at decision time and is unaffected; the display gap is
+recorded in [`KNOWN_LIMITATIONS.md`](../KNOWN_LIMITATIONS.md).
 
 ### No-manifest floor
 
@@ -789,9 +790,11 @@ means rather than which statements pass.
    forbid applies to it; a data-reading UDF's output passes unmasked (the UDF
    gap in [facts-emission.md](./facts-emission.md)). Known dangerous
    cross-schema names match the shipped `schema: "*"` rules.
-6. Forged `system:` user tag: rejected at classification write time, and any
-   `system:` tag found on a Column row is stripped before the Cedar graph is
-   built.
+6. Invented `system:` user tag: rejected at classification write time, so only
+   the six names the product defines can be stored. Those are marshalled as
+   written — a stored `system:critical` reaches the shipped critical forbid and
+   denies — and writing one takes the same `admin.datasources` authority as the
+   rest of classification.
 7. Same name in two schemas: relations match on the fully-qualified identity.
    Functions are the exception — sqlglot drops the schema qualifier, so a bare
    name resolves against every system and logical schema the manifest governs,

--- a/web/src/components/datasources/datasource-catalog.tsx
+++ b/web/src/components/datasources/datasource-catalog.tsx
@@ -43,7 +43,8 @@ function groupByTable(cols: CatalogColumn[]): TableGroup[] {
     let g = m.get(key)
     if (!g) m.set(key, (g = { key, label, columns: [], piiCount: 0 }))
     g.columns.push(c)
-    if (c.classification?.tags?.includes('pii')) g.piiCount += 1
+    // The badge counts classified columns, whatever the tag is named.
+    if ((c.classification?.tags?.length ?? 0) > 0) g.piiCount += 1
   }
   return [...m.values()]
 }

--- a/web/src/components/query/catalog-schema.ts
+++ b/web/src/components/query/catalog-schema.ts
@@ -59,7 +59,8 @@ export function buildTree(cols: CatalogColumn[]): TreeTable[] {
     }
     const tags = c.classification?.tags ?? []
     node.columns.push({ name: c.column, dataType: c.dataType, tags, nullable: c.nullable })
-    if (tags.includes('pii')) node.piiCount += 1
+    // The badge counts classified columns, whatever the tag is named.
+    if (tags.length > 0) node.piiCount += 1
   }
   return tree
 }

--- a/web/src/components/query/schema-tree.tsx
+++ b/web/src/components/query/schema-tree.tsx
@@ -226,8 +226,9 @@ function TableNode({
 
 function ColumnRow({ column, onInsert }: { column: TreeColumn; onInsert: (text: string) => void }) {
   const t = useTranslations('Query')
+  // Any tag makes a column classified; `pii` keeps the louder icon as the common case.
   const pii = column.tags.includes('pii')
-  const sensitive = column.tags.some((tag) => tag !== 'pii')
+  const sensitive = column.tags.length > 0
   return (
     <button
       type="button"


### PR DESCRIPTION
Marshalling filtered tags by resource type. A datasource kept only the two
posture names and dropped every other tag, so a policy written against an
operator's own tag — `resource in Tag::"pci"` — silently never matched; a column
had every `system:`-prefixed tag stripped. Neither filter was protecting
anything: shipped classification is resolved from the manifest per statement, not
read from a tag row.

Every tag now reaches Cedar as itself, on every resource type. Any resource may
carry any name, including the six `system:` names the product defines.

## Reservation is one naming rule, in one place

`system:` is the product's namespace: an operator may not coin a name in it, and
the six it defines are writable on anything. That rule was five copies of the
same predicate-and-throw across three files, in two exception types, and the
proxy's own `Register` enforced none of it. It is now `requireWritableTags`, one
error code, called by every write path including `Register`.

`isReservedTag` also reserved the `udf:` prefix for UDF-output vouching, which
`backlog.md` and `KNOWN_LIMITATIONS.md` both record as unbuilt. Nothing produces
or consumes such a tag, so the reservation is gone.

## Where it could bite

**The proxy secret is a policy-administration credential.** Datasource tags are
written by gRPC `Register`, gated by the shared `PM_SECRET_TOKEN` rather than by
`admin.datasources`, and registration is keyed on the datasource name with no
per-datasource binding. Those tags were already stored but mostly inert; now they
all reach policy, so holding the secret means being able to change what the
shipped presets grant — `system:catalog` matches an enabled bare-principal
unmasked permit. That is the trust model rather than a check to add: a proxy
already terminates the wire protocol and sees decrypted results. It is now stated
in ARCHITECTURE.md and beside the variable in INSTALL.md.

**Existing installs:** a non-posture tag already sitting in `datasource.tags`
starts enforcing on upgrade. Worth auditing before deploying.

Six documents described the removed type-scoping as a live protection, one of them
warning about the exact behavior adopted here. They are corrected. The same claim
in V8's comment on `-200` cannot be — an applied migration is immutable — so the
drift is recorded in `policy-store.md`.

## Audit

`piiTouched` matched the literal tag `pii`, so a deployment classifying with
`pci` reported nothing touched and left auditmon's mass-export detector with no
signal. It now counts every classified column. The field keeps its name; renaming
it needs a migration, the Go verifier, and the SIEM export name, so that is a
TODO. `CHAIN_VERSION` is deliberately not bumped — the canonical encoding is
unchanged, only the contents.

Known gap, not addressed here: a column masked *because* its datasource is tagged
`pii` is still absent from `piiTouched`, which reads the column's own row.

## Verification

`mise run verify` green; 895 control-plane tests re-run with `--rerun-tasks` (no
cache), 0 failures.

Reviewed by three independent reviewers. All three found that the `Register`
authority claim this change originally rested on was false — that finding is why
the trust model is documented rather than assumed. The two tests they identified
as missing (a datasource `system:catalog` opening the bare-principal permit, and a
column `system:critical` reaching the shipped forbid) are included.
