### PR TITLE
build: require mysqlwire v0.1.1

### DIFF
--- a/goproxy/go.mod
+++ b/goproxy/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/ridi-oss/proxy-monster/analyzer v0.0.0-00010101000000-000000000000
-	github.com/ridi-oss/proxy-monster/mysqlwire v0.1.0
+	github.com/ridi-oss/proxy-monster/mysqlwire v0.1.1
 	github.com/testcontainers/testcontainers-go v0.34.0
 	golang.org/x/crypto v0.27.0
 	google.golang.org/grpc v1.68.1

--- a/goproxy/go.sum
+++ b/goproxy/go.sum
@@ -105,8 +105,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/ridi-oss/proxy-monster/mysqlwire v0.1.0 h1:EqhwGXb2TZnu54s7Xk3BCZomUbTooHV66vZz5XEmmAk=
-github.com/ridi-oss/proxy-monster/mysqlwire v0.1.0/go.mod h1:aLgJkOM6Sjm6AnQEzYk+1HameNl/O1jE7j8xFxjQR80=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.1 h1:FuJhta/0hFjHv3ssPdWZ29/Rm7Bkf1S6qXSpUjEqB2o=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.1/go.mod h1:yielY+j1TFdAdh9cn7WGFUwUtLwligQEwpO7Xmfvinc=
 github.com/ridi-oss/sqlglot-go v0.20.0 h1:k+t+wD4YHPYjP8m3CEouCTXIGtMKIkpQ/5tMp9jhY+o=
 github.com/ridi-oss/sqlglot-go v0.20.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=

--- a/pmon/go.mod
+++ b/pmon/go.mod
@@ -2,6 +2,6 @@ module github.com/ridi-oss/proxy-monster/pmon
 
 go 1.26.0
 
-require github.com/ridi-oss/proxy-monster/mysqlwire v0.1.0
+require github.com/ridi-oss/proxy-monster/mysqlwire v0.1.1
 
 require github.com/alecthomas/kong v1.6.0

--- a/pmon/go.sum
+++ b/pmon/go.sum
@@ -6,5 +6,5 @@ github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-github.com/ridi-oss/proxy-monster/mysqlwire v0.1.0 h1:EqhwGXb2TZnu54s7Xk3BCZomUbTooHV66vZz5XEmmAk=
-github.com/ridi-oss/proxy-monster/mysqlwire v0.1.0/go.mod h1:aLgJkOM6Sjm6AnQEzYk+1HameNl/O1jE7j8xFxjQR80=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.1 h1:FuJhta/0hFjHv3ssPdWZ29/Rm7Bkf1S6qXSpUjEqB2o=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.1/go.mod h1:yielY+j1TFdAdh9cn7WGFUwUtLwligQEwpO7Xmfvinc=


### PR DESCRIPTION
Blocks the pmon release. `pmon` calls `mysqlwire.Scramble()`, `HandshakeResponse.AuthPlugin`, and `HandshakeResponse.AuthResponse` — all added alongside the caching_sha2 support in #67, none present in the published v0.1.0.

Local builds pass because `go.work` shadows the pin with the workspace copy. The release job does not: `pmon-release-binaries.yml` builds with `GOWORK=off` so the binary resolves the same module a fresh clone or a Homebrew formula build would. Verified before this change:

```
internal/daemon/brokerconn.go:18:29: undefined: mysqlwire.Scramble
internal/daemon/mysql.go:84:16: parsed.AuthPlugin undefined
```

After it, `GOWORK=off CGO_ENABLED=0 go build -trimpath` produces a binary.

`goproxy` moves too. Its image copies `mysqlwire` into the build context so it never consults the proxy and is unaffected today — but two modules sitting on different versions of a module they share is what let this go unnoticed.

Release-please does not do this: its `go` type updates the manifest and changelog, not another module's `require` line. This has to land before pmon 0.1.2 is cut.