### PR TITLE
fix(pmon): select the client's handshake database on the proxy connection

### DIFF
--- a/mysqlwire/mysql.go
+++ b/mysqlwire/mysql.go
@@ -146,12 +146,13 @@ const serverGreetingCapabilities = uint32(CapLongPassword | CapProtocol41 | CapS
 // NUL-terminated version string the greeting reports to the client.
 //
 // connectWithDB must reflect what THIS importer actually does with a handshake-supplied database, not
-// a package-wide default: a real client (e.g. the mysql CLI) still sets its OWN CapConnectWithDB bit
-// whenever it was given a database, but only WRITES the database field when the server's greeting
-// advertised the capability — declare it here without also relaying the field upstream (ports
-// ParseHandshakeResponse's connectWithDBSupported through to a real COM_INIT_DB, as goproxy's
-// mysqlproxy does) and a client's selected database is silently dropped. pmon's local broker does not
-// relay it and must pass false; goproxy/mysqlproxy does and passes true.
+// a package-wide default, and the two failure modes are opposite. A real client (e.g. the mysql CLI)
+// sets its OWN CapConnectWithDB bit whenever it was given a database, but only WRITES the database
+// field when the server's greeting advertised the capability. So declaring it without relaying the
+// field onward (porting ParseHandshakeResponse's connectWithDBSupported through to a real COM_INIT_DB)
+// drops a client's selected database, and NOT declaring it means the field never arrives to relay in
+// the first place — either way the client silently gets the default schema. Both importers here relay
+// it and pass true: goproxy/mysqlproxy to its backend, pmon's local broker to the proxy upstream.
 func ServerGreeting(connID uint32, scramble []byte, serverVersion string, connectWithDB bool) []byte {
 	return serverGreeting(connID, scramble, serverVersion, greetingCapabilities(connectWithDB))
 }

--- a/mysqlwire/mysql_test.go
+++ b/mysqlwire/mysql_test.go
@@ -76,9 +76,9 @@ func TestServerGreetingTLSCapabilities(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseHandshakeV10: %v", err)
 	}
-	// connectWithDB=false (e.g. pmon's local broker, which does not forward a handshake-supplied
-	// database upstream) must not advertise CONNECT_WITH_DB — advertising it would let a client's
-	// selected database be silently dropped.
+	// connectWithDB=false is for an importer that does nothing with a handshake-supplied database, and
+	// must not advertise CONNECT_WITH_DB — advertising it without relaying the field would let a
+	// client's selected database be silently dropped.
 	if greeting.Capabilities&CapConnectWithDB != 0 {
 		t.Fatalf("server capabilities = %#x, want CONNECT_WITH_DB not advertised", greeting.Capabilities)
 	}
@@ -86,8 +86,9 @@ func TestServerGreetingTLSCapabilities(t *testing.T) {
 
 func TestServerGreetingConnectWithDBOptIn(t *testing.T) {
 	scramble := bytes.Repeat([]byte{0x42}, 20)
-	// connectWithDB=true (e.g. goproxy/mysqlproxy, which relays a handshake-supplied database to the
-	// backend as COM_INIT_DB) must advertise CONNECT_WITH_DB, or a real client that gates writing the
+	// connectWithDB=true (both importers here: goproxy/mysqlproxy relays a handshake-supplied database
+	// to its backend as COM_INIT_DB, pmon's local broker to the proxy upstream) must advertise
+	// CONNECT_WITH_DB, or a real client that gates writing the
 	// database field on server-advertised support (unlike go-sql-driver/mysql, which writes it
 	// unconditionally) will set its own CapConnectWithDB bit without ever including the field.
 	greeting, err := ParseHandshakeV10(ServerGreetingSSL(7, scramble, "8.0.40-test", true))
@@ -269,13 +270,12 @@ func TestParseHandshakeResponseAuthModes(t *testing.T) {
 	}
 }
 
-// TestParseHandshakeResponseIgnoresUnsupportedConnectWithDB reproduces a real mysql CLI against this
-// proxy: it sets its own CapConnectWithDB bit whenever a database was given on the command line, but
-// only WRITES the database field when the SERVER'S greeting advertised that capability. Since
-// serverGreetingCapabilities never advertises CapConnectWithDB, a real client still reports the bit
-// but sends nothing for it — auth-response is directly followed by its plugin name, no database field
-// at all. connectWithDBSupported=false (what this proxy passes) must not misread that plugin name as
-// the database.
+// TestParseHandshakeResponseIgnoresUnsupportedConnectWithDB reproduces a real mysql CLI against a
+// greeting that did NOT advertise the capability: the client sets its own CapConnectWithDB bit whenever
+// a database was given on the command line, but only WRITES the database field when the SERVER'S
+// greeting advertised that capability. So the bit is reported with nothing behind it — auth-response is
+// directly followed by the plugin name, no database field at all — and connectWithDBSupported=false
+// must not misread that plugin name as the database.
 func TestParseHandshakeResponseIgnoresUnsupportedConnectWithDB(t *testing.T) {
 	caps := uint32(CapProtocol41 | CapSecureConn | CapPluginAuth | CapConnectWithDB)
 	var b []byte

--- a/pmon/internal/daemon/brokerconn.go
+++ b/pmon/internal/daemon/brokerconn.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"time"
@@ -19,7 +20,7 @@ func brokerMySQL(local net.Conn, proxyAddr, certChainPEM string, wireTLS bool, p
 	if err != nil {
 		return err
 	}
-	clientCaps, seq, err := localServerGreet(local, scramble, localPassword)
+	clientCaps, database, seq, err := localServerGreet(local, scramble, localPassword)
 	if err != nil {
 		// A rejected password never reaches the proxy: answer here and drop the connection, so a
 		// caller that cannot authenticate locally cannot spend the session's token upstream.
@@ -47,6 +48,37 @@ func brokerMySQL(local net.Conn, proxyAddr, certChainPEM string, wireTLS bool, p
 		_ = mysqlwire.WritePacket(local, seq, mysqlwire.ErrPacket(1045, "proxy-monster: "+err.Error()))
 		return err
 	}
+	// A client that selected a database at connect time expects to be in it, and the selection arrived on
+	// the local handshake response — consumed here, never relayed — so it has to be applied as a command.
+	// Applying it after the upstream handshake means the proxy's per-connection catalog opened on the
+	// datasource's default schemas; this one is fetched lazily on the client's first statement.
+	if database != "" {
+		res, initErr := selectDatabase(up, database)
+		if initErr != nil {
+			// Not the 1045 the failures above use: the proxy has already answered the handshake and
+			// authenticated this session, so an access-denied would send the operator after the wrong
+			// thing — and a driver that classifies 1045 as bad credentials will not retry what is a
+			// transport failure. The message covers both halves of a round trip that did not complete,
+			// because only it reaches the client — the error itself goes to the daemon's log.
+			_ = mysqlwire.WritePacket(local, seq, mysqlwire.ErrPacket(1105, "proxy-monster: the database selection failed"))
+			return initErr
+		}
+		switch {
+		// Relay the proxy's own refusal verbatim. Its "unknown database" carries the error code and the
+		// SQLSTATE a client branches on, which a message rewritten here would throw away.
+		case len(res) > 0 && res[0] == 0xff:
+			_ = mysqlwire.WritePacket(local, seq, res)
+			return errors.New(mysqlwire.ErrString(res))
+		// Only an OK means the session really is in that database, so anything else fails closed. Letting
+		// an unrecognized packet through to the caller's OK would report a session in the schema the client
+		// asked for while it sits in the datasource's default one — the silent wrong-schema failure this
+		// selection exists to prevent — and were that packet the first of several, the rest would be
+		// relayed as the answer to the client's first query.
+		case len(res) == 0 || res[0] != 0x00:
+			_ = mysqlwire.WritePacket(local, seq, mysqlwire.ErrPacket(1105, "proxy-monster: unexpected response selecting the database"))
+			return fmt.Errorf("unexpected COM_INIT_DB response from proxy (%d bytes): % x", len(res), res)
+		}
+	}
 	// The relay has no time bound — a session may idle legitimately — so drop the handshake deadline.
 	if err := proxy.SetDeadline(time.Time{}); err != nil {
 		return err
@@ -56,6 +88,19 @@ func brokerMySQL(local net.Conn, proxyAddr, certChainPEM string, wireTLS bool, p
 	}
 	pipe(up, local)
 	return nil
+}
+
+// selectDatabase sends COM_INIT_DB for database and returns the proxy's single response packet — an OK
+// or an ERR from a proxy that answered this command, whatever arrived otherwise, which the caller
+// judges. Switching the current database is not a gated action, so the proxy relays the command to the
+// backend mechanically. The response is consumed here because the local client is still waiting on one
+// auth result, and the caller's OK stands in for this exchange's own.
+func selectDatabase(up io.ReadWriter, database string) ([]byte, error) {
+	if err := mysqlwire.WritePacket(up, 0, append([]byte{mysqlwire.ComInitDB}, database...)); err != nil {
+		return nil, err
+	}
+	_, res, err := mysqlwire.ReadPacket(up)
+	return res, err
 }
 
 // pipe copies bytes both directions until either side closes.

--- a/pmon/internal/daemon/brokerconn_test.go
+++ b/pmon/internal/daemon/brokerconn_test.go
@@ -1,0 +1,303 @@
+package daemon
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/ridi-oss/proxy-monster/mysqlwire"
+)
+
+// fakeMySQLProxy plays the proxy half of pmon's upstream handshake — greeting, clear-password auth
+// switch, OK — then reports the first command packet the broker sends and answers it with response. A
+// real loopback listener rather than a pipe, because brokerMySQL dials an address.
+//
+// The returned channel is closed without a value when the connection ends before any command arrives,
+// so a test can tell "the broker sent nothing" from "the broker sent the wrong thing".
+func fakeMySQLProxy(t *testing.T, response []byte) (string, <-chan []byte) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	commands := make(chan []byte, 1)
+	go func() {
+		defer close(commands)
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		greeting := mysqlwire.ServerGreeting(1, bytes.Repeat([]byte{3}, 20), "8.0.40-fake", true)
+		if err := mysqlwire.WritePacket(conn, 0, greeting); err != nil {
+			return
+		}
+		if _, _, err := mysqlwire.ReadPacket(conn); err != nil { // the broker's handshake response
+			return
+		}
+		if err := mysqlwire.WritePacket(conn, 2, mysqlwire.AuthSwitchClearPassword()); err != nil {
+			return
+		}
+		if _, _, err := mysqlwire.ReadPacket(conn); err != nil { // the token, as the cleartext password
+			return
+		}
+		if err := mysqlwire.WritePacket(conn, 4, mysqlwire.OKPacket()); err != nil {
+			return
+		}
+		_, command, err := mysqlwire.ReadPacket(conn)
+		if err != nil {
+			return
+		}
+		commands <- command
+		if err := mysqlwire.WritePacket(conn, 1, response); err != nil {
+			return
+		}
+		// Stay open. On the success path the broker starts relaying after this, and an upstream that
+		// closed here would tear the relay down before the local client could read its auth result.
+		_, _ = io.Copy(io.Discard, conn)
+	}()
+	return listener.Addr().String(), commands
+}
+
+// localClientGreet plays the local client's half of the broker handshake: read the greeting, answer with
+// a native-password response naming database. It stops before the auth result, because which packet that
+// is is the assertion in the refusal case.
+func localClientGreet(t *testing.T, client net.Conn, password, database string) {
+	t.Helper()
+	_, greeting, err := mysqlwire.ReadPacket(client)
+	if err != nil {
+		t.Fatalf("read broker greeting: %v", err)
+	}
+	parsed, err := mysqlwire.ParseHandshakeV10(greeting)
+	if err != nil {
+		t.Fatalf("parse broker greeting: %v", err)
+	}
+	auth := mysqlwire.NativePassword(password, parsed.Scramble)
+	response := handshakeResponseWithDatabase(auth, "mysql_native_password", database)
+	if err := mysqlwire.WritePacket(client, 1, response); err != nil {
+		t.Fatalf("write client handshake response: %v", err)
+	}
+}
+
+// localClientGreetCachingSHA2 plays the local client's half through the caching_sha2_password switch —
+// what a MySQL 8 client does without being asked — naming database in its handshake response. It returns
+// the sequence the broker's auth result must carry, which is three packets past the direct path's.
+func localClientGreetCachingSHA2(t *testing.T, client net.Conn, password, database string) byte {
+	t.Helper()
+	if _, _, err := mysqlwire.ReadPacket(client); err != nil {
+		t.Fatalf("read broker greeting: %v", err)
+	}
+	// The plugin named with no digest: such a client waits to be switched rather than hash against a
+	// scramble issued under another plugin.
+	response := handshakeResponseWithDatabase(nil, "caching_sha2_password", database)
+	if err := mysqlwire.WritePacket(client, 1, response); err != nil {
+		t.Fatalf("write client handshake response: %v", err)
+	}
+	swSeq, sw, err := mysqlwire.ReadPacket(client)
+	if err != nil {
+		t.Fatalf("read auth switch: %v", err)
+	}
+	if len(sw) == 0 || sw[0] != 0xfe {
+		t.Fatalf("expected an AuthSwitchRequest, got % x", sw)
+	}
+	scramble := bytes.TrimSuffix(sw[bytes.IndexByte(sw, 0)+1:], []byte{0})
+	if err := mysqlwire.WritePacket(client, swSeq+1, mysqlwire.CachingSHA2Password(password, scramble)); err != nil {
+		t.Fatalf("write switch reply: %v", err)
+	}
+	moreSeq, more, err := mysqlwire.ReadPacket(client)
+	if err != nil {
+		t.Fatalf("read AuthMoreData: %v", err)
+	}
+	if len(more) < 2 || more[0] != mysqlwire.AuthMoreData || more[1] != mysqlwire.CachingSHA2FastAuthSuccess {
+		t.Fatalf("expected fast-auth success, got % x", more)
+	}
+	return moreSeq + 1
+}
+
+// startBroker runs brokerMySQL against addr and returns the local client end of it.
+func startBroker(t *testing.T, addr, password string) (net.Conn, <-chan error) {
+	t.Helper()
+	clientSide, brokerSide := net.Pipe()
+	t.Cleanup(func() { _ = clientSide.Close() })
+
+	done := make(chan error, 1)
+	go func() {
+		done <- brokerMySQL(brokerSide, addr, "", false, "you@example.com", "sekrit-token", password)
+	}()
+	return clientSide, done
+}
+
+const brokerTestPassword = "pmlocal_correct-horse"
+
+// TestBrokerMySQLSelectsHandshakeDatabase is what makes a DSN-selected database work at all: it arrives
+// on the local handshake response, which is consumed here and never reaches the proxy, so the broker has
+// to select it upstream with a COM_INIT_DB of its own. Without that the client silently lands on the
+// datasource's default schema and every unqualified table name resolves in the wrong place.
+func TestBrokerMySQLSelectsHandshakeDatabase(t *testing.T) {
+	addr, commands := fakeMySQLProxy(t, mysqlwire.OKPacket())
+	client, _ := startBroker(t, addr, brokerTestPassword)
+
+	localClientGreet(t, client, brokerTestPassword, "analytics")
+
+	command, ok := <-commands
+	if !ok {
+		t.Fatal("the proxy received no command: the selected database was never relayed")
+	}
+	if len(command) == 0 || command[0] != mysqlwire.ComInitDB {
+		t.Fatalf("first upstream command = % x, want a COM_INIT_DB (0x%02x)", command, mysqlwire.ComInitDB)
+	}
+	if got := string(command[1:]); got != "analytics" {
+		t.Fatalf("COM_INIT_DB names %q, want analytics", got)
+	}
+
+	_, result, err := mysqlwire.ReadPacket(client)
+	if err != nil {
+		t.Fatalf("read auth result: %v", err)
+	}
+	if len(result) == 0 || result[0] != 0x00 {
+		t.Fatalf("auth result = % x, want OK", result)
+	}
+}
+
+// TestBrokerMySQLRelaysRefusedDatabase: a proxy that refuses the selected database must not leave the
+// client with an OK for a session sitting in some other schema. The proxy's own ERR is relayed verbatim,
+// so the client keeps the error code and SQLSTATE it would have received connecting directly.
+func TestBrokerMySQLRelaysRefusedDatabase(t *testing.T) {
+	refusal := mysqlwire.ErrPacketState(1049, "42000", "Unknown database 'nope'")
+	addr, commands := fakeMySQLProxy(t, refusal)
+	client, done := startBroker(t, addr, brokerTestPassword)
+
+	localClientGreet(t, client, brokerTestPassword, "nope")
+
+	if _, ok := <-commands; !ok {
+		t.Fatal("the proxy received no command: the selected database was never relayed")
+	}
+	_, result, err := mysqlwire.ReadPacket(client)
+	if err != nil {
+		t.Fatalf("read auth result: %v", err)
+	}
+	if len(result) == 0 || result[0] != 0xff {
+		t.Fatalf("auth result = % x, want the proxy's ERR", result)
+	}
+	if got := mysqlwire.ErrString(result); !strings.Contains(got, "Unknown database") {
+		t.Fatalf("relayed error = %q, want the proxy's own message", got)
+	}
+	if err := <-done; err == nil {
+		t.Fatal("brokerMySQL returned nil after the proxy refused the selected database")
+	}
+}
+
+// TestBrokerMySQLSelectsHandshakeDatabaseAfterAnAuthSwitch runs the whole broker over the path the mysql
+// CLI actually takes — its default plugin is caching_sha2_password, so the local handshake ends three
+// packets later than the native one — with a database selected, which is what `pmon show --cli` hands out.
+// The selection has to survive the switch and reach the proxy, and the result has to arrive on the packet
+// the client is waiting for, or a working session is reported as a protocol error.
+func TestBrokerMySQLSelectsHandshakeDatabaseAfterAnAuthSwitch(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		response  []byte
+		wantFirst byte
+	}{
+		{"proxy accepts the database", mysqlwire.OKPacket(), 0x00},
+		{"proxy refuses the database", mysqlwire.ErrPacketState(1049, "42000", "Unknown database 'nope'"), 0xff},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			addr, commands := fakeMySQLProxy(t, test.response)
+			client, _ := startBroker(t, addr, brokerTestPassword)
+
+			resultSeq := localClientGreetCachingSHA2(t, client, brokerTestPassword, "analytics")
+
+			command, ok := <-commands
+			if !ok {
+				t.Fatal("the proxy received no command: the selected database was never relayed")
+			}
+			if len(command) == 0 || command[0] != mysqlwire.ComInitDB || string(command[1:]) != "analytics" {
+				t.Fatalf("first upstream command = % x, want a COM_INIT_DB naming analytics", command)
+			}
+
+			seq, result, err := mysqlwire.ReadPacket(client)
+			if err != nil {
+				t.Fatalf("read auth result: %v", err)
+			}
+			if seq != resultSeq {
+				t.Fatalf("auth result is packet %d, want %d — the client reads it as out of order", seq, resultSeq)
+			}
+			if len(result) == 0 || result[0] != test.wantFirst {
+				t.Fatalf("auth result = % x, want a packet starting 0x%02x", result, test.wantFirst)
+			}
+		})
+	}
+}
+
+// TestBrokerMySQLFailsClosedOnAnUnexpectedSelectResponse: only an OK means the session is in the selected
+// database. Answering anything else with the caller's OK would report a session in `analytics` while it
+// sits in the datasource's default schema — the silent wrong-schema failure this selection exists to
+// prevent — and a first-of-several packet would then be relayed as the answer to the client's first query.
+func TestBrokerMySQLFailsClosedOnAnUnexpectedSelectResponse(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		response []byte
+	}{
+		// A result-set column count: the shape of a response with more packets behind it.
+		{"result-set header", []byte{0x01}},
+		{"empty payload", []byte{}},
+		// 0xfe is the byte most likely to be mistaken for success here: the upstream connection mirrors
+		// the client's DEPRECATE_EOF, under which a 0xfe header is an OK packet where an EOF used to be.
+		// COM_INIT_DB is answered with a real OK, so 0x00 stays the only accepted header.
+		{"EOF", []byte{0xfe, 0x00, 0x00, 0x02, 0x00}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			addr, commands := fakeMySQLProxy(t, test.response)
+			client, done := startBroker(t, addr, brokerTestPassword)
+
+			localClientGreet(t, client, brokerTestPassword, "analytics")
+
+			if _, ok := <-commands; !ok {
+				t.Fatal("the proxy received no command: the selected database was never relayed")
+			}
+			_, result, err := mysqlwire.ReadPacket(client)
+			if err != nil {
+				t.Fatalf("read auth result: %v", err)
+			}
+			if len(result) == 0 || result[0] != 0xff {
+				t.Fatalf("auth result = % x, want an ERR: the client must not be told it is in analytics", result)
+			}
+			if err := <-done; err == nil {
+				t.Fatal("brokerMySQL returned nil after an unexpected COM_INIT_DB response")
+			}
+		})
+	}
+}
+
+// TestBrokerMySQLSelectsNothingWithoutADatabase: a client that selected none must not have one selected
+// for it. The first thing the proxy sees is the client's own command, not a COM_INIT_DB for an empty name.
+func TestBrokerMySQLSelectsNothingWithoutADatabase(t *testing.T) {
+	addr, commands := fakeMySQLProxy(t, mysqlwire.OKPacket())
+	client, _ := startBroker(t, addr, brokerTestPassword)
+
+	localClientGreet(t, client, brokerTestPassword, "")
+
+	_, result, err := mysqlwire.ReadPacket(client)
+	if err != nil {
+		t.Fatalf("read auth result: %v", err)
+	}
+	if len(result) == 0 || result[0] != 0x00 {
+		t.Fatalf("auth result = % x, want OK", result)
+	}
+	// The relay is up, so what the proxy reads next is whatever the client sends.
+	query := append([]byte{mysqlwire.ComQuery}, "SELECT 1"...)
+	if err := mysqlwire.WritePacket(client, 0, query); err != nil {
+		t.Fatalf("write client query: %v", err)
+	}
+	command, ok := <-commands
+	if !ok {
+		t.Fatal("the proxy received no command")
+	}
+	if !bytes.Equal(command, query) {
+		t.Fatalf("first upstream command = % x, want the client's own query % x", command, query)
+	}
+}

--- a/pmon/internal/daemon/daemon.go
+++ b/pmon/internal/daemon/daemon.go
@@ -42,9 +42,11 @@ const (
 	// dialTimeout bounds a broker's dial to a proxy. It covers refusal only — see handshakeTimeout for silence
 	// after accept.
 	dialTimeout = 10 * time.Second
-	// handshakeTimeout bounds the whole upstream handshake (greeting, TLS, auth). A proxy that accepts and then
-	// goes silent would otherwise park a goroutine and its two sockets forever, unreachable by logout or
-	// revocation, since closing the local side does not unblock a read on the upstream one.
+	// handshakeTimeout bounds everything before the relay: the upstream handshake (greeting, TLS, auth) and
+	// the database selection that follows it. A proxy that accepts and then goes silent would otherwise park
+	// a goroutine and its two sockets forever, unreachable by logout or revocation, since closing the local
+	// side does not unblock a read on the upstream one. One budget covers both steps, so a proxy slow enough
+	// to spend it answering the handshake leaves the selection none.
 	handshakeTimeout = 20 * time.Second
 	// acceptBackoff is the pause after a transient Accept error, so a persistent failure (e.g. fd
 	// exhaustion) can't spin the CPU.

--- a/pmon/internal/daemon/mysql.go
+++ b/pmon/internal/daemon/mysql.go
@@ -39,12 +39,18 @@ var errLocalAuth = errors.New("access denied")
 // nextSeq is the sequence the caller's reply (OK or ERR) must carry. It depends on how many packets
 // the plugin negotiation spent, so the caller must use it rather than assume the handshake ended at
 // a fixed point.
-func localServerGreet(c io.ReadWriter, scramble []byte, localPassword string) (clientCaps uint32, nextSeq byte, err error) {
-	// false: this greeting must not advertise CapConnectWithDB — the handshake response below is read
-	// only for its capability flags and auth response, never for a handshake-supplied database, so a
-	// client connecting with one here would have it silently dropped rather than relayed upstream.
+//
+// database is the one the client selected at connect time, empty when it selected none. The caller
+// must select it upstream — see brokerMySQL — because nothing after this point ever sees it again: it
+// travels in the handshake response, not as a command.
+func localServerGreet(c io.ReadWriter, scramble []byte, localPassword string) (clientCaps uint32, database string, nextSeq byte, err error) {
+	// true: this greeting advertises CapConnectWithDB because the caller relays the database this
+	// returns. The advertisement is what makes a client send the field at all — a real client (e.g. the
+	// mysql CLI) sets its own CapConnectWithDB bit whenever it was given a database, but only WRITES
+	// the field when the server offered the capability, so a greeting that stays silent about it turns
+	// `-D somedb` into a connection on the datasource's default schema with no error anywhere.
 	nextSeq = 2
-	if err = mysqlwire.WritePacket(c, 0, mysqlwire.ServerGreeting(1, scramble, serverVersion, false)); err != nil {
+	if err = mysqlwire.WritePacket(c, 0, mysqlwire.ServerGreeting(1, scramble, serverVersion, true)); err != nil {
 		return
 	}
 	_, resp, err := mysqlwire.ReadPacket(c) // handshake response (seq 1)
@@ -58,14 +64,19 @@ func localServerGreet(c io.ReadWriter, scramble []byte, localPassword string) (c
 	// An empty local password means one was never generated, which would otherwise make every
 	// password correct. Refuse rather than fall open.
 	if localPassword == "" {
-		return clientCaps, nextSeq, errLocalAuth
+		return clientCaps, "", nextSeq, errLocalAuth
 	}
-	parsed, err := mysqlwire.ParseHandshakeResponse(resp, false)
+	parsed, err := mysqlwire.ParseHandshakeResponse(resp, true)
 	if err != nil {
-		return clientCaps, nextSeq, errLocalAuth
+		return clientCaps, "", nextSeq, errLocalAuth
 	}
+	// The selected database is reported only once the password checks out. A caller that failed the
+	// local check is given no upstream connection, so there is nothing left to select it on.
 	nextSeq, err = verifyLocalPassword(c, scramble, localPassword, parsed)
-	return clientCaps, nextSeq, err
+	if err != nil {
+		return clientCaps, "", nextSeq, err
+	}
+	return clientCaps, parsed.Database, nextSeq, nil
 }
 
 // verifyLocalPassword checks the client's auth response against localPassword, for whichever plugin

--- a/pmon/internal/daemon/mysql_test.go
+++ b/pmon/internal/daemon/mysql_test.go
@@ -20,11 +20,12 @@ import (
 	"github.com/ridi-oss/proxy-monster/mysqlwire"
 )
 
-// TestLocalServerGreetDoesNotAdvertiseConnectWithDB guards a cross-module regression: pmon's broker
-// greeting must not advertise CONNECT_WITH_DB. pmon reads the local client's handshake but never forwards
-// a handshake-selected database upstream, so advertising the capability would let a pmon client whose DSN
-// selects a non-default database silently operate on the wrong one.
-func TestLocalServerGreetDoesNotAdvertiseConnectWithDB(t *testing.T) {
+// TestLocalServerGreetAdvertisesConnectWithDB guards a cross-module regression: pmon's broker greeting
+// must advertise CONNECT_WITH_DB, because brokerMySQL selects the database this reports. A client gates
+// WRITING the database field on the server having advertised the capability, so a greeting that stays
+// silent about it never receives the field at all and a client whose DSN names a database lands on the
+// datasource's default schema instead, with no error on any layer.
+func TestLocalServerGreetAdvertisesConnectWithDB(t *testing.T) {
 	clientSide, brokerSide := net.Pipe()
 	defer clientSide.Close()
 	defer brokerSide.Close()
@@ -35,7 +36,7 @@ func TestLocalServerGreetDoesNotAdvertiseConnectWithDB(t *testing.T) {
 	}
 	done := make(chan greetResult, 1)
 	go func() {
-		caps, _, err := localServerGreet(brokerSide, make([]byte, 20), "pmlocal_test")
+		caps, _, _, err := localServerGreet(brokerSide, make([]byte, 20), "pmlocal_test")
 		done <- greetResult{caps: caps, err: err}
 	}()
 
@@ -47,16 +48,9 @@ func TestLocalServerGreetDoesNotAdvertiseConnectWithDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse broker greeting: %v", err)
 	}
-	if parsed.Capabilities&mysqlwire.CapConnectWithDB != 0 {
-		t.Fatalf("pmon greeting caps = %#x advertise CONNECT_WITH_DB; a client's DSN database would be silently dropped", parsed.Capabilities)
+	if parsed.Capabilities&mysqlwire.CapConnectWithDB == 0 {
+		t.Fatalf("pmon greeting caps = %#x do not advertise CONNECT_WITH_DB; a client's DSN database would never be sent", parsed.Capabilities)
 	}
-	// The advertised plugin decides which digest a client computes, and the password check verifies
-	// against it. A greeting that named a different plugin would still authenticate — the switch paths
-	// cover that — but this is the one every client takes without extra configuration.
-	if parsed.AuthPlugin != "mysql_native_password" {
-		t.Fatalf("pmon greeting advertises %q, want mysql_native_password", parsed.AuthPlugin)
-	}
-
 	// Unblock localServerGreet with a minimal handshake response. It carries no auth response, so the
 	// password check rejects it — this test is about the greeting's capabilities, and the capability
 	// assertion above has already run against the real greeting.
@@ -65,6 +59,57 @@ func TestLocalServerGreetDoesNotAdvertiseConnectWithDB(t *testing.T) {
 	}
 	if res := <-done; !errors.Is(res.err, errLocalAuth) {
 		t.Fatalf("localServerGreet with no password: err = %v, want errLocalAuth", res.err)
+	}
+}
+
+// TestLocalServerGreetReportsSelectedDatabase covers the other half: the greeting advertises the
+// capability, so a client that selected a database writes the field, and localServerGreet has to hand
+// it back rather than parse past it. A client that selects none must report none — an empty string is
+// what tells brokerMySQL to send no COM_INIT_DB at all.
+func TestLocalServerGreetReportsSelectedDatabase(t *testing.T) {
+	const password = "pmlocal_correct-horse"
+	scramble := bytes.Repeat([]byte{7}, 20)
+
+	for _, test := range []struct {
+		name          string
+		database      string
+		connectWithDB bool
+	}{
+		{"database selected", "reporting", true},
+		{"no database selected", "", false},
+		// `-D ''`: the bit is set and the field is present but empty. It reports no database, same as a
+		// client that set neither — but the lone NUL still has to be consumed, or the plugin name behind
+		// it is read as the database and pmon selects a schema the client never named.
+		{"bit set over an empty field", "", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			clientSide, brokerSide := net.Pipe()
+			defer clientSide.Close()
+			defer brokerSide.Close()
+
+			done := make(chan string, 1)
+			errs := make(chan error, 1)
+			go func() {
+				_, database, _, err := localServerGreet(brokerSide, scramble, password)
+				done <- database
+				errs <- err
+			}()
+
+			if _, _, err := mysqlwire.ReadPacket(clientSide); err != nil {
+				t.Fatalf("read greeting: %v", err)
+			}
+			response := handshakeResponse(mysqlwire.NativePassword(password, scramble), "mysql_native_password", test.database, test.connectWithDB)
+			if err := mysqlwire.WritePacket(clientSide, 1, response); err != nil {
+				t.Fatalf("write handshake response: %v", err)
+			}
+
+			if err := <-errs; err != nil {
+				t.Fatalf("localServerGreet: %v", err)
+			}
+			if got := <-done; got != test.database {
+				t.Fatalf("database = %q, want %q", got, test.database)
+			}
+		})
 	}
 }
 
@@ -257,9 +302,28 @@ func TestProxyConnectAllowsPlaintextOnlyWhenTLSIsNotExpected(t *testing.T) {
 // secure-connection encoding a real MySQL client uses. An empty plugin omits the field entirely,
 // which is what a client that negotiated no CapPluginAuth sends.
 func handshakeResponseWith(authResp []byte, plugin string) []byte {
+	return handshakeResponseWithDatabase(authResp, plugin, "")
+}
+
+// handshakeResponseWithDatabase is handshakeResponseWith plus a connect-time database, encoded the way a
+// real client does it: the CapConnectWithDB bit AND the field, in the field's wire position between the
+// auth response and the plugin name. Setting the bit without the field is what a client does against a
+// server that never advertised the capability, and is covered in mysqlwire.
+func handshakeResponseWithDatabase(authResp []byte, plugin, database string) []byte {
+	return handshakeResponse(authResp, plugin, database, database != "")
+}
+
+// handshakeResponse is handshakeResponseWithDatabase with the capability bit stated rather than inferred
+// from the name, for the one shape the name cannot express: the bit set over an EMPTY field, which is
+// what a client given `-D ”` sends. The field is a NUL-terminated string, so an empty one is a lone NUL
+// that still has to be consumed — read as anything else it would swallow the plugin name behind it.
+func handshakeResponse(authResp []byte, plugin, database string, connectWithDB bool) []byte {
 	caps := uint32(mysqlwire.CapProtocol41 | mysqlwire.CapSecureConn)
 	if plugin != "" {
 		caps |= mysqlwire.CapPluginAuth
+	}
+	if connectWithDB {
+		caps |= mysqlwire.CapConnectWithDB
 	}
 	var b []byte
 	b = binary.LittleEndian.AppendUint32(b, caps)
@@ -270,6 +334,10 @@ func handshakeResponseWith(authResp []byte, plugin string) []byte {
 	b = append(b, 0)
 	b = append(b, byte(len(authResp)))
 	b = append(b, authResp...)
+	if connectWithDB {
+		b = append(b, database...)
+		b = append(b, 0)
+	}
 	if plugin != "" {
 		b = append(b, plugin...)
 		b = append(b, 0)
@@ -313,7 +381,7 @@ func TestLocalServerGreetChecksPassword(t *testing.T) {
 
 			done := make(chan error, 1)
 			go func() {
-				_, _, err := localServerGreet(brokerSide, scramble, test.stored)
+				_, _, _, err := localServerGreet(brokerSide, scramble, test.stored)
 				done <- err
 			}()
 
@@ -367,7 +435,7 @@ func TestLocalServerGreetSwitchesUnknownPlugin(t *testing.T) {
 			}
 			done := make(chan res, 1)
 			go func() {
-				_, seq, err := localServerGreet(brokerSide, scramble, password)
+				_, _, seq, err := localServerGreet(brokerSide, scramble, password)
 				done <- res{seq: seq, err: err}
 			}()
 
@@ -430,7 +498,7 @@ func TestLocalServerGreetSwitchesToCachingSHA2(t *testing.T) {
 
 			done := make(chan error, 1)
 			go func() {
-				_, _, err := localServerGreet(brokerSide, bytes.Repeat([]byte{7}, 20), password)
+				_, _, _, err := localServerGreet(brokerSide, bytes.Repeat([]byte{7}, 20), password)
 				done <- err
 			}()
 
@@ -499,7 +567,7 @@ func TestLocalServerGreetSequenceIsContiguous(t *testing.T) {
 		}
 		done := make(chan res, 1)
 		go func() {
-			_, seq, err := localServerGreet(brokerSide, scramble, password)
+			_, _, seq, err := localServerGreet(brokerSide, scramble, password)
 			done <- res{seq, err}
 		}()
 		if _, _, err := mysqlwire.ReadPacket(clientSide); err != nil {
@@ -529,7 +597,7 @@ func TestLocalServerGreetSequenceIsContiguous(t *testing.T) {
 		}
 		done := make(chan res, 1)
 		go func() {
-			_, seq, err := localServerGreet(brokerSide, scramble, password)
+			_, _, seq, err := localServerGreet(brokerSide, scramble, password)
 			done <- res{seq, err}
 		}()
 		if _, _, err := mysqlwire.ReadPacket(clientSide); err != nil {
@@ -583,7 +651,7 @@ func TestCachingSHA2SwitchFailureSequence(t *testing.T) {
 	}
 	done := make(chan res, 1)
 	go func() {
-		_, seq, err := localServerGreet(brokerSide, bytes.Repeat([]byte{7}, 20), password)
+		_, _, seq, err := localServerGreet(brokerSide, bytes.Repeat([]byte{7}, 20), password)
 		done <- res{seq, err}
 	}()
 


### PR DESCRIPTION
## What this changes

A client that names a database when it connects to the pmon broker — `mysql -D dbname`,
or the database in a DSN — had that selection silently dropped, and its session ran on
the datasource's default schema. Nothing errored: only unqualified table names resolved
somewhere the caller never asked for.

Two things caused it.

- **The local greeting did not advertise `CLIENT_CONNECT_WITH_DB`.** A real client (the
  mysql CLI) sets its own capability bit whenever it was given a database, but only
  *writes* the field when the server offered the capability — and it does not fall back
  to sending a command instead. So a greeting that stays silent turns `-D somedb` into a
  connection on the default schema with no trace. In the other direction,
  `go-sql-driver` writes the field unconditionally, so the old pairing of a silent
  greeting with `ParseHandshakeResponse(resp, false)` misread its auth-plugin name as
  the database. Advertising the capability and parsing with `true` makes both directions
  hold.
- **The selected database only ever rides in the local handshake response.** The broker
  builds its own upstream handshake, so that field is never relayed and nothing after
  that point sees it again. It has to be applied as a command: `COM_INIT_DB`, sent once
  the upstream authentication has completed.

The session is not opened unless the proxy confirms the selection. The proxy's own
refusal (an unknown database, say) is relayed verbatim so the client keeps the error code
and SQLSTATE it would have received connecting directly, and a response that is neither
an OK nor an ERR is treated as a failure. Letting an unrecognized packet through to the
caller's OK would report a session in the schema the client asked for while it sat in the
default one, and if that packet were the first of several, the rest would be relayed as
the answer to the client's first query.

The new failure paths get their own error: a selection round trip that does not complete,
and a response that is not an OK, both answer `1105` rather than the `1045` the failures
above them use. By then the proxy has answered the handshake and accepted the token, so
an access-denied would send the operator after the wrong thing, and a driver that reads
1045 as bad credentials will not retry a transport failure.

The error codes and SQLSTATEs of the pre-existing failure paths — unreachable proxy,
upstream handshake failure, local auth refusal — are untouched.

## Components

- [ ] `goproxy` — the wire proxy (data plane)
- [ ] `control-plane` — decisions, policy, catalog, admin API
- [ ] `analyzer` — SQL lineage and required grants
- [ ] `engine` — shared enforcement code the control plane calls
- [ ] `web` — the console
- [x] `pmon` / `auditmon`
- [ ] Build, deployment, or docs

`mysqlwire` is in the diff as comments only: `ServerGreeting`'s `connectWithDB` doc named
the pmon broker as the importer that must pass `false`, which is no longer true, so it now
describes the two opposite failure modes instead of pointing at one caller.

Engines affected: MySQL

## Enforcement

**No decision changes.** Switching the current database is not a gated action, and the
`COM_INIT_DB` goes out after the upstream handshake, so it enters the proxy's command loop
— the same path a directly connected client's `USE` takes, `MarkNamespaceDirty()`
included. The per-connection catalog for the newly selected schema is fetched lazily on
the client's first statement, and a miss there is covered by the existing catalog-miss
path. No new route around the gate: a pmon client could already switch schema with a
relayed `USE`.

What this does fix is the premise a decision is made under. Until now a statement could be
judged while the schema the client asked for and the schema the session actually sat in
disagreed, so unqualified table names resolved somewhere unintended. Where the selection
cannot be confirmed, the session is closed rather than opened.

## Verification

- [ ] `mise run verify` passes locally — not checked, because of the one pre-existing
      failure below. Every other stage passes.
- [x] Tests cover the change
- [ ] `mise run format` — not applicable (no `.md`/`.json`/`.yml`/`.css` changes)

Stage by stage:

- `mise run lint` — passes
- `:analyzer:jvm:test` `:engine:test` `:control-plane:test` — BUILD SUCCESSFUL
- `go test -race` over analyzer, auditmon, goproxy, mysqlwire — passes, including
  `pmon/internal/daemon`, the package this change lands in, under the race detector
- `pnpm -C web test:unit` 15/15, `pnpm -C web build` — passes

The gate stops at one test, `pmon/state`'s `TestSocketPathStaysInTheStateDirWhenItFits`,
which is unrelated to this branch — it fails identically on a detached `main`.
`maxSocketPath` is 100, and the path macOS `t.TempDir()` produces is 103 characters (the
test's own name is 41 of them), so `SocketPath()` falls back to a short path exactly as
designed while the test's "when it fits" premise does not hold. It passes on Linux CI,
where `TMPDIR` is `/tmp`. Worth fixing separately.

New and changed tests:

- `TestBrokerMySQLSelectsHandshakeDatabase` — the selected database actually reaches the
  proxy as a `COM_INIT_DB`. Without this the client lands on the default schema in
  silence.
- `TestBrokerMySQLSelectsHandshakeDatabaseAfterAnAuthSwitch` — the path the mysql CLI
  really takes (caching_sha2_password). The selection has to survive the switch, and the
  result has to arrive on the packet the client is waiting for.
- `TestBrokerMySQLRelaysRefusedDatabase` — the proxy's refusal reaches the client with its
  own code and SQLSTATE.
- `TestBrokerMySQLFailsClosedOnAnUnexpectedSelectResponse` — a result-set header, an empty
  payload, and an EOF packet each fail closed. `0xfe` is included deliberately: the
  upstream connection mirrors the client's `DEPRECATE_EOF`, under which a `0xfe` header is
  an OK packet elsewhere in the protocol, so it is the byte most likely to be mistaken for
  success here.
- `TestBrokerMySQLSelectsNothingWithoutADatabase` — a client that selected nothing does not
  have a selection made for it.
- `TestLocalServerGreetAdvertisesConnectWithDB` — the greeting advertises the capability.
- `TestLocalServerGreetReportsSelectedDatabase` — the field is parsed and handed back, for
  a named database and for both shapes that mean none: the capability bit unset, and the
  bit set over an empty field, which is what `-D ''` sends and whose lone NUL still has to
  be consumed.

## Conventions

- [x] English, US spelling; comments and docs describe the current state in present tense
- [x] Every new user-facing string is localized — not applicable. The new strings are
      MySQL wire ERR packet messages, not the control plane's HTTP `ApiError` path, so
      they have no key under `web/messages/`. Same treatment as the existing wire
      messages.
- [x] Docs updated where the change makes them stale — `handshakeTimeout`'s doc now says
      the budget covers the database selection too. No caveat added or closed, so
      `KNOWN_LIMITATIONS.md` is unchanged.
