### PR TITLE
fix(analyzer): pin character_set_results = NULL to utf8mb4 for JDBC clients

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -109,6 +109,18 @@ analog of MySQL's Prepare-time freeze. No control-plane decision is ever stored.
 - `COM_INIT_DB` audit boundary. The MySQL database switch is enforced (dirty →
   re-probe) but is not audited as a statement because it carries no SQL text;
   the follow-on query's audit records the new effective namespace.
+- MySQL result charset is pinned to UTF-8. Masking decodes each result value as
+  UTF-8, so `character_set_results` must stay `utf8mb4`/`utf8`/`utf8mb3`; a
+  client that moves it elsewhere fails the session closed. The analyzer
+  recognizes a single, session-scoped `SET character_set_results = NULL` — the
+  default MySQL Connector/J (and so DBeaver) session-init, which requests each
+  column in its own charset for client-side decoding — and rewrites it to
+  `utf8mb4`, so those clients connect and results stay maskable. The client's
+  original statement is authorized and audited; only the bytes sent to the
+  backend are pinned. (A prepared-statement form is pinned too, but its
+  execute-time audit records the pinned statement.) Any other results charset —
+  an explicit non-UTF-8 one — is not rewritten and fails the session closed, and
+  returning results in a non-UTF-8 charset is not supported.
 - `DISCARD` routes through the datasource-wide `sql.unanalyzable` gate. The
   production posture denies it; a development datasource may relay it.
 - 🟡 First-in-transaction probe injection breaks `SET TRANSACTION` after an

--- a/analyzer/probe/charset_pin_test.go
+++ b/analyzer/probe/charset_pin_test.go
@@ -1,0 +1,58 @@
+package probe
+
+import "testing"
+
+// TestResultsCharsetPinFacts is the analyzer half of the #81 fix: the MySQL SET that Connector/J (and so
+// DBeaver) sends at session init is recognized on the parsed AST and emitted as a rewrite pinning the
+// results charset to utf8mb4, so the wire masker keeps decoding UTF-8. It stays a SESSION passthrough (no
+// grants); only the executed SQL changes. Because recognition is on the AST, every spelling MySQL accepts
+// collapses to the same pin, and anything that is not a single session-scoped `character_set_results = NULL`
+// is left untouched for the wire session invariant to fail closed.
+func TestResultsCharsetPinFacts(t *testing.T) {
+	const want = "SET character_set_results = utf8mb4"
+
+	pinned := []string{
+		"SET character_set_results = NULL",
+		"set character_set_results=null",
+		"SET character_set_results = NULL;",
+		"SET SESSION character_set_results = NULL",
+		"SET LOCAL character_set_results = NULL",
+		"SET @@character_set_results = NULL",
+		"SET @@session.character_set_results = NULL",
+		"SET @@local.character_set_results = null",
+	}
+	for _, sql := range pinned {
+		t.Run("pin/"+sql, func(t *testing.T) {
+			f := mysqlFacts(t, sql)
+			if got := resolve(t, sql); got != "session" {
+				t.Fatalf("classification = %q, want session", got)
+			}
+			if f.RewrittenSql == nil || f.GetRewrittenSql() != want {
+				t.Fatalf("rewrittenSql = (%q, has=%v), want %q", f.GetRewrittenSql(), f.RewrittenSql != nil, want)
+			}
+		})
+	}
+
+	untouched := []string{
+		"SET character_set_results = utf8mb4",              // already safe
+		"SET character_set_results = latin1",               // explicit non-utf8
+		"SET GLOBAL character_set_results = NULL",          // different variable (future-connection default)
+		"SET @@global.character_set_results = NULL",        // ditto, sigil form
+		"SET PERSIST character_set_results = NULL",         // persisted
+		"SET character_set_client = NULL",                  // different variable
+		"SET character_set_results = 'NULL'",               // string literal, not the NULL keyword
+		"SET NAMES latin1",                                 // not an assignment to character_set_results
+		"SET autocommit = 1, character_set_results = NULL", // compound
+		"SET character_set_results = NULL, autocommit = 1", // compound
+		"SET @character_set_results = NULL",                // a same-named USER variable, not the system one
+		"SET foo.character_set_results = NULL",             // qualified target, not the bare system variable
+		"SET @@bogus.character_set_results = NULL",         // an invalid @@ scope MySQL would reject
+	}
+	for _, sql := range untouched {
+		t.Run("untouched/"+sql, func(t *testing.T) {
+			if f := mysqlFacts(t, sql); f.RewrittenSql != nil {
+				t.Fatalf("rewrittenSql = %q, want none (must fail closed at the wire invariant, not be pinned)", f.GetRewrittenSql())
+			}
+		})
+	}
+}

--- a/analyzer/probe/engine.go
+++ b/analyzer/probe/engine.go
@@ -34,6 +34,9 @@ type engine interface {
 	// Engine-specific: PostgreSQL's pg_temp; MySQL has no temp-schema convention (its temporary tables
 	// are marked by the TEMPORARY keyword).
 	IsTempSchema(schema exp.Expression) bool
+	// RewriteStatement optionally rewrites a parsed statement into the SQL the proxy should relay to the
+	// backend, returning "" to leave it unchanged.
+	RewriteStatement(root exp.Expression) string
 }
 
 // createEngine builds the engine for config, validating its engine-specific settings (MySQL's
@@ -54,6 +57,8 @@ func createEngine(config *pb.EngineConfig) (engine, error) {
 	}
 }
 
+// TODO: split mysqlEngine and postgresEngine into engine_mysql.go / engine_postgres.go — this file should
+// hold only the shared interface + createEngine factory; the two impls share nothing but that interface.
 type mysqlEngine struct {
 	dialect *dialects.Dialect
 }
@@ -107,6 +112,61 @@ func (e *mysqlEngine) FoldColumn(column string) string {
 // temporary arg / TemporaryProperty on the DDL), which isTemporaryDDL detects directly off the tree.
 func (e *mysqlEngine) IsTempSchema(exp.Expression) bool { return false }
 
+// RewriteStatement pins a single, session-scoped `SET character_set_results = NULL` — the default MySQL
+// Connector/J (and so DBeaver) session-init, which asks the backend to return each column in its own charset
+// for client-side decoding — to utf8mb4, so the wire masker keeps decoding results as UTF-8. Only that exact
+// form is rewritten; a compound SET, GLOBAL/PERSIST scope, a same-named user variable, a qualified or
+// bogus-scoped target, or any non-NULL value is left untouched (and still fails closed at the wire session
+// invariant). Recognition is on the parsed AST, so every spelling MySQL accepts reduces to the same check.
+func (e *mysqlEngine) RewriteStatement(root exp.Expression) string {
+	if root.Kind() != exp.KindSet {
+		return ""
+	}
+	// setUtilityCommands is non-empty for GLOBAL/PERSIST/PERSIST_ONLY/PASSWORD; a single session assignment
+	// carries exactly one SetItem and no utility command.
+	items := root.FindAll(exp.KindSetItem)
+	if len(items) != 1 || len(setUtilityCommands(root)) != 0 {
+		return ""
+	}
+	eq := items[0].This()
+	if eq == nil || eq.Kind() != exp.KindEQ || eq.Left() == nil || eq.Right() == nil {
+		return ""
+	}
+	// The target must be the SYSTEM variable, not a same-named user variable or a qualified column. A bare
+	// `character_set_results` parses to an unqualified Column; `@@[session.]character_set_results` to a
+	// SessionParameter; but `@character_set_results` (a user variable) parses to a Parameter whose Name()
+	// still returns "character_set_results", and `x.character_set_results` to a qualified Column — both would
+	// otherwise be turned into a system-variable SET the client never asked for.
+	left := eq.Left()
+	switch left.Kind() {
+	case exp.KindColumn:
+		if left.TableName() != "" {
+			return ""
+		}
+	case exp.KindSessionParameter:
+		// `@@[session.|local.]character_set_results` is this session's variable; `@@global.` is excluded by
+		// setUtilityCommands above, but a bogus scope (`@@nonsense.…`) reaches here — MySQL would reject it,
+		// so it must not normalize into a successful pin.
+		switch strings.ToLower(fmt.Sprint(left.Arg("kind"))) {
+		case "<nil>", "", "session", "local":
+		default:
+			return ""
+		}
+	default:
+		return ""
+	}
+	// A system-variable name is ASCII and case-insensitive — MySQL matches it independent of
+	// lower_case_table_names — so it is compared case-folded, not through the dialect's schema-identifier
+	// folding (which is for table/column names). utf8mb4 is full Unicode, so the pin is lossless.
+	if !strings.EqualFold(left.Name(), "character_set_results") {
+		return ""
+	}
+	if eq.Right().Kind() != exp.KindNull {
+		return ""
+	}
+	return "SET character_set_results = utf8mb4"
+}
+
 type postgresEngine struct {
 	dialect *dialects.Dialect
 }
@@ -141,6 +201,10 @@ func (e *postgresEngine) IsTempSchema(schema exp.Expression) bool {
 	name := id.Name()
 	return name == "pg_temp" || strings.HasPrefix(name, "pg_temp_")
 }
+
+// PostgreSQL has no relay rewrite: client_encoding is handled on the wire, not by an analyzer rewrite,
+// so there is nothing to rewrite here.
+func (e *postgresEngine) RewriteStatement(exp.Expression) string { return "" }
 
 // mysqlNormalizationDialect returns a MySQL *Dialect configured with the identifier-normalization
 // strategy for the server's lower_case_table_names. Under lctn=0 the server is case-sensitive for

--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -5,12 +5,12 @@ import (
 	"sort"
 	"strings"
 
+	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
 	sqlglot "github.com/ridi-oss/sqlglot-go"
 	"github.com/ridi-oss/sqlglot-go/dialects"
 	exp "github.com/ridi-oss/sqlglot-go/expressions"
 	"github.com/ridi-oss/sqlglot-go/generator"
 	"github.com/ridi-oss/sqlglot-go/schema"
-	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
 )
 
 var safeNoFromFunctions = stringSet(
@@ -137,6 +137,15 @@ func EmitFacts(sql string, engineConfig *pb.EngineConfig, sch *schema.Mapping, n
 			facts = emitLineageFacts(root, eng, qualifySchema, validatedNamespace, false)
 		} else {
 			facts = unanalyzableFacts("PARSE", fmt.Sprintf("unsupported root %s", exp.ClassName(root.Kind())))
+		}
+	}
+	// The engine may rewrite the statement into what the proxy relays to the backend — MySQL pins
+	// `character_set_results = NULL` to utf8mb4 so results stay UTF-8 for the wire masker. Emitted as
+	// rewritten_sql: the data plane relays it while authorization and audit keep the client's original. A
+	// lineage-driven rewrite (the `*`-expansion) already set on an analyzed statement takes precedence.
+	if facts.RewrittenSql == nil {
+		if rewrite := eng.RewriteStatement(root); rewrite != "" {
+			facts.RewrittenSql = &rewrite
 		}
 	}
 	facts.SchemaQualifierCandidates = candidates

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -462,10 +462,11 @@ fun decideQuery(
                 passthrough = true,
                 contextTags = derivedTags,
                 schemaCandidates = facts.schemaQualifierCandidatesList.toSet(),
-            )
+            ).withAnalyzerRewrite(facts)
             StatementClass.STATEMENT_CLASS_SESSION -> when (channel) {
                 Channel.WIRE, Channel.EDITOR -> return passthroughAllow(roleList, "passthrough (session-mutating)", derivedTags)
                     .copy(schemaCandidates = facts.schemaQualifierCandidatesList.toSet())
+                    .withAnalyzerRewrite(facts)
                 Channel.WORKFLOW_EXECUTOR, Channel.WORKFLOW_VIEWER, Channel.MCP ->
                     return structuralDeny(EDITOR_SESSION_STATEMENT_DENY, roleList, contextTags = derivedTags)
             }
@@ -703,7 +704,6 @@ fun decideQuery(
         failedStage = facts.failedStage.takeIf { facts.hasFailedStage() }?.lowercase(),
         detail = facts.detail,
         passthrough = false,
-        rewrittenSql = facts.rewrittenSql.takeIf { facts.hasRewrittenSql() && !facts.explainOfQuery },
         outputColumns = facts.outputColumnsList,
         contextTags = derivedTags,
         unmaskablePermitted = unmaskablePermitted,
@@ -711,7 +711,7 @@ fun decideQuery(
         catalogChanging = facts.catalogChanging || facts.functionsList.isNotEmpty(),
         referencedSchemas = referencedSchemas,
         schemaCandidates = facts.schemaQualifierCandidatesList.toSet(),
-    )
+    ).withAnalyzerRewrite(facts)
 }
 
 // A resolved statement always classifies as one of these; anything else (UNSPECIFIED/UNRECOGNIZED on a
@@ -806,6 +806,15 @@ private fun grantAction(action: GrantAction): AuthzAction? = when (action) {
     GrantAction.GRANT_ACTION_RESULT_READ,
     GrantAction.UNRECOGNIZED -> null
 }
+
+// Relay the analyzer's optional rewritten SQL on a decision we allow. rewrittenSql is Go-analyzer output
+// (the `SELECT *` expansion, the MySQL charset pin) independent of statement class, so every
+// understood-and-allowed decision — analyzed, metadata, session — routes it through this one point rather
+// than each building its own. An EXPLAIN-of-query keeps its original text (the rewrite is for the inner query
+// it plans). The sql.unanalyzable escape hatches deliberately relay the original whole statement, so they do
+// not call this.
+private fun DecisionContext.withAnalyzerRewrite(facts: StatementFacts): DecisionContext =
+    if (facts.hasRewrittenSql() && !facts.explainOfQuery) copy(rewrittenSql = facts.rewrittenSql) else this
 
 private fun passthroughAllow(
     roles: List<String>,

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/GateSqlglotRegressionTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/GateSqlglotRegressionTest.kt
@@ -126,4 +126,15 @@ class GateSqlglotRegressionTest {
         denied(mysql, "RESET MASTER")
         denied(postgres, """SELECT U&"set_confi\0067"('search_path','restricted',false)""")
     }
+
+    @Test
+    fun `results-charset NULL is pinned to utf8mb4 through the real analyzer`() {
+        // Real analyzer -> decideQuery seam for issue #81: Connector/J's session-init is recognized and
+        // emitted as rewrittenSql on the session passthrough. A non-NULL charset is left for the wire
+        // invariant to fail closed, not pinned.
+        val pinned = mysql.decide("SET character_set_results = NULL")
+        assertEquals(EnfAction.ALLOW, pinned.action, pinned.denyReason)
+        assertEquals("SET character_set_results = utf8mb4", pinned.rewrittenSql)
+        assertEquals(null, mysql.decide("SET character_set_results = latin1").rewrittenSql)
+    }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/StatementFactsGrantLoopTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/StatementFactsGrantLoopTest.kt
@@ -364,4 +364,22 @@ class StatementFactsGrantLoopTest {
         assertEquals(EnfAction.DENY, decide(session, Channel.MCP).action)
         assertEquals(EnfAction.DENY, decide(session, Channel.WORKFLOW_EXECUTOR).action)
     }
+
+    @Test
+    fun `session rewrite rides the passthrough on persistent-connection channels`() {
+        // The analyzer's results-charset pin (issue #81) is emitted as a rewrite on a session SET; it must
+        // survive the session passthrough so the data plane relays utf8mb4 to the backend. Denied channels
+        // (MCP/workflow) never execute the SET, so no rewrite reaches them.
+        val pinned = statementFacts {
+            resolved = true
+            statementClass = StatementClass.STATEMENT_CLASS_SESSION
+            rewrittenSql = "SET character_set_results = utf8mb4"
+        }
+        val wire = decide(pinned, Channel.WIRE)
+        assertEquals(EnfAction.ALLOW, wire.action)
+        assertTrue(wire.passthrough)
+        assertEquals("SET character_set_results = utf8mb4", wire.rewrittenSql)
+        assertEquals("SET character_set_results = utf8mb4", decide(pinned, Channel.EDITOR).rewrittenSql)
+        assertEquals(EnfAction.DENY, decide(pinned, Channel.MCP).action)
+    }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/EnforcementFixture.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/EnforcementFixture.kt
@@ -2,7 +2,10 @@ package com.ridi.oss.proxymonster.controlplane.support
 
 import com.ridi.oss.proxymonster.controlplane.AccessStore
 import com.ridi.oss.proxymonster.controlplane.AuditStore
+import com.ridi.oss.proxymonster.controlplane.Channel
 import com.ridi.oss.proxymonster.controlplane.ClassificationInput
+import com.ridi.oss.proxymonster.controlplane.DecisionContext
+import com.ridi.oss.proxymonster.controlplane.decideQuery
 import com.ridi.oss.proxymonster.controlplane.PrincipalSessionStore
 import com.ridi.oss.proxymonster.controlplane.Datasource
 import com.ridi.oss.proxymonster.controlplane.DatasourceInput
@@ -154,6 +157,17 @@ class EnforcementFixture(
         authz = authz,
         execute = { sql, maxRows -> execOnTarget(targetJdbcUrl, targetUser, targetPassword, sql, maxRows) },
     )
+
+    /**
+     * The real analyzer → [decideQuery] decision for [sql] (no execution), so a test can assert on the
+     * DecisionContext itself — e.g. the analyzer-emitted `rewrittenSql` — through the production seam rather
+     * than injecting synthetic facts.
+     */
+    fun decide(sql: String, principal: String = "analyst@example.com", channel: Channel = Channel.WIRE): DecisionContext =
+        decideQuery(
+            principal, datasource, sql, channel, datasourceStore.catalog(datasource.id),
+            policyStore, accessStore, userGroupStore, roleResolver, authz,
+        )
 
     /** Run raw SQL directly against the target (test setup/teardown; no enforcement gate). */
     fun execOnTarget(sql: String): QueryRows = execOnTarget(targetJdbcUrl, targetUser, targetPassword, sql, 1000)

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -278,6 +278,25 @@ Fixes for gaps documented in
   fast-path, and similar features so a trusted datasource can opt in (denied
   today; MySQL and PostgreSQL binary-result relay is built). Each feature is a
   per-protocol implementation gated by a real-client end-to-end test.
+- Honor `character_set_results` instead of pinning it to UTF-8. Masking decodes
+  each result value as UTF-8, so the proxy requires the result charset to stay
+  UTF-8 and rewrites only a single session-scoped
+  `SET character_set_results = NULL` (MySQL Connector/J's default) to `utf8mb4`;
+  any other non-UTF-8 results charset fails the session closed. To let a client
+  receive results in each column's own charset — or `NULL` for raw per-column
+  bytes — make the row masker charset-aware: decode each value by its column's
+  result charset from the field metadata, mask, and re-encode, and only then
+  relax the UTF-8 session invariant. See KNOWN_LIMITATIONS.md (Live namespace
+  tracking).
+- Re-probe the session invariants before every `COM_STMT_EXECUTE`. The prepared
+  path authorizes against the prepare-time namespace/`ANSI_QUOTES` snapshot (by
+  design) but never runs the live charset/`sql_mode` probe that `COM_QUERY`
+  runs, so a client that first defeats `SESSION_TRACK` and then flips to an
+  unsafe charset/`sql_mode` can run an already-prepared statement past the
+  invariant. Not a cleartext leak today — a binary-protocol `MASK` is refused
+  and MySQL does not accept a prepared generic `SET` — but the fail-closed
+  invariant should hold on this path too: live-probe before EXECUTE for the
+  invariant check while keeping the frozen snapshot for authorization.
 - Proxy-side cancel brokering: issue synthetic `BackendKeyData` and broker
   cancels proxy-side, so `CancelRequest` can require TLS without breaking psql's
   Ctrl-C.

--- a/goproxy/mysqlproxy/charset_e2e_test.go
+++ b/goproxy/mysqlproxy/charset_e2e_test.go
@@ -1,0 +1,85 @@
+package mysqlproxy_test
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	pb "github.com/ridi-oss/proxy-monster/goproxy/internal/pb"
+	"github.com/ridi-oss/proxy-monster/mysqlwire"
+)
+
+// TestResultsCharsetPinAppliedFromControlPlane proves the wire path applies a control-plane rewrite on a
+// session passthrough: when the CP pins `SET character_set_results = NULL` to utf8mb4 (its rewritten_sql),
+// the proxy relays the pinned statement to the backend, so the SET succeeds and a following masked read
+// still returns the mask. Authorization and audit still see the client's original statement. (The
+// recognition — that the real analyzer emits this pin — is covered by the analyzer and control-plane tests.)
+func TestResultsCharsetPinAppliedFromControlPlane(t *testing.T) {
+	const setNULL = "SET character_set_results = NULL"
+	const pinned = "SET character_set_results = utf8mb4"
+	const maskedRead = "SELECT id, name, ssn FROM people ORDER BY id"
+
+	h := startBroker(t)
+	h.fake.decideFn = func(req *pb.DecisionRequest) (*pb.WireDecision, error) {
+		switch req.GetSql() {
+		case setNULL:
+			// The control plane pins the results charset via rewritten_sql on the session passthrough.
+			return wireVerdict(&pb.Verdict{Decision: pb.EnfAction_ALLOW, RewrittenSql: proto.String(pinned)}), nil
+		case maskedRead:
+			return wireVerdict(&pb.Verdict{
+				Decision: pb.EnfAction_MASK,
+				Masks:    []*pb.ColumnMask{{Column: "ssn", Kind: "FIXED", Ordinal: proto.Int32(2)}},
+			}), nil
+		default:
+			return wireVerdict(&pb.Verdict{Decision: pb.EnfAction_ALLOW}), nil
+		}
+	}
+	client := openRawClient(t, h.addr, validToken)
+
+	// The pinned SET reaches the backend as utf8mb4, so it succeeds instead of tripping the charset invariant.
+	response := client.firstQueryPacket(t, setNULL)
+	if len(response) == 0 || response[0] != 0x00 {
+		t.Fatalf("SET character_set_results = NULL response = %x, want OK (pinned to utf8mb4)", response)
+	}
+	// Masking still works: had the original NULL reached the backend, the invariant would have closed the
+	// session and this read would fail; instead ssn is masked and the NULL row is preserved.
+	rows := client.textRows(t, maskedRead, 3)
+	if len(rows) != 2 {
+		t.Fatalf("masked read rows = %d, want 2", len(rows))
+	}
+	if rows[0][2] == nil || *rows[0][2] != "####" {
+		t.Fatalf("row 0 ssn = %v, want masked \"####\"", rows[0][2])
+	}
+	if rows[1][2] != nil {
+		t.Fatalf("row 1 ssn = %v, want NULL preserved", rows[1][2])
+	}
+
+	// Authorization and audit saw the client's original statement, not the pin.
+	var sawOriginal bool
+	for _, req := range h.fake.requests() {
+		if req.GetSql() == setNULL {
+			sawOriginal = true
+		}
+	}
+	if !sawOriginal {
+		t.Fatalf("no Decide request carried the original %q", setNULL)
+	}
+}
+
+// TestResultsCharsetNonNullStillFailsClosed proves the wire session charset invariant is the fail-closed
+// backstop: an explicit non-UTF-8 results charset the control plane does not pin still trips the invariant
+// and closes the session.
+func TestResultsCharsetNonNullStillFailsClosed(t *testing.T) {
+	h := startBroker(t)
+	h.fake.decideFn = allowAllDecide
+	client := openRawClient(t, h.addr, validToken)
+
+	response := client.firstQueryPacket(t, "SET character_set_results = latin1")
+	if len(response) == 0 || response[0] != 0xff {
+		t.Fatalf("SET character_set_results = latin1 response = %x, want fail-closed ERR", response)
+	}
+	if got := mysqlwire.ErrString(response); !strings.Contains(got, "utf8mb4/utf8") {
+		t.Fatalf("SET character_set_results = latin1 error = %q, want an unsafe-charset fail-closed", got)
+	}
+}


### PR DESCRIPTION
## What

MySQL Connector/J (and so DBeaver) sends `SET character_set_results = NULL` on connect, asking the backend to return each column in its own charset for client-side decoding. The proxy masks result rows by decoding their bytes as UTF-8, so the wire session invariant refuses a non-UTF-8 results charset and closes the connection — leaving these clients unable to connect (#81).

The **analyzer** recognizes that exact statement on the parsed AST and emits it as a rewrite to `SET character_set_results = utf8mb4` via the existing `rewritten_sql` channel (the same one the `SELECT *` mask-ordinal expansion uses). The control plane carries the rewrite on the session passthrough, and the data plane applies it for both the wire and editor paths. Authorization and audit see the client's original statement; only the backend-bound bytes are pinned, so results stay UTF-8 (masking-safe).

The proxy does **not** parse SQL to make this decision — statement meaning stays in the analyzer/control plane.

## Fail-closed

Only a single, session-scoped `character_set_results = NULL` is pinned. A compound SET, `GLOBAL`/`PERSIST` scope, a same-named user variable (`@x`), a qualified or bogus-scoped target, or any non-NULL value is left untouched and still fails closed at the wire session invariant — the fail-closed backstop for everything not pinned. Recognition is on the AST, so every spelling MySQL accepts collapses to one check.

## Scope

Unblocks JDBC/DBeaver; does **not** honor a non-UTF-8 result charset (charset-aware masking, so a client can receive raw per-column bytes) — that stays a documented known limitation and backlog item. References #81 without closing it.

## Verify

Layered across the three planes: the analyzer recognition accept/reject set (`analyzer/probe/charset_pin_test.go`); a real-analyzer → `decideQuery` → `rewritten_sql` test (`GateSqlglotRegressionTest`) plus the session-passthrough carry (`StatementFactsGrantLoopTest`); and a DB-backed wire test that the proxy applies the rewrite so a masked read still returns the mask, while an explicit `latin1` still fails closed (`goproxy/mysqlproxy/charset_e2e_test.go`).

Refs #81
