### PR TITLE
build(analyzer): adopt sqlglot-go v0.22.0

### DIFF
--- a/analyzer/README.md
+++ b/analyzer/README.md
@@ -25,7 +25,7 @@ compile-time mismatch, not a silent runtime one.
 ```
 analyzer/
   go.mod                     Go module github.com/ridi-oss/proxy-monster/analyzer;
-                             pins github.com/ridi-oss/sqlglot-go v0.21.0
+                             pins github.com/ridi-oss/sqlglot-go v0.22.0
   probe/                     the analyzer (package probe)
     facts.go                 EmitFacts: classify the statement + emit every RequiredGrant (100% AST)
     probe.go, helpers.go     internal column lineage + reference bucketing + SELECT * expansion
@@ -47,7 +47,7 @@ analyzer/
 ## The sqlglot-go dependency
 
 sqlglot-go is a version-pinned `go mod` dependency — no subtree, no vendored
-source. `analyzer/go.mod` pins `github.com/ridi-oss/sqlglot-go v0.21.0` and
+source. `analyzer/go.mod` pins `github.com/ridi-oss/sqlglot-go v0.22.0` and
 `analyzer/go.sum` locks its checksum, so a fresh clone / CI builds with a plain
 `go build`. Bump the pin with:
 

--- a/analyzer/go.mod
+++ b/analyzer/go.mod
@@ -8,7 +8,7 @@ module github.com/ridi-oss/proxy-monster/analyzer
 
 go 1.26.0
 
-require github.com/ridi-oss/sqlglot-go v0.21.0
+require github.com/ridi-oss/sqlglot-go v0.22.0
 
 require google.golang.org/protobuf v1.35.2
 

--- a/analyzer/go.sum
+++ b/analyzer/go.sum
@@ -1,6 +1,6 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/ridi-oss/sqlglot-go v0.21.0 h1:hcjLCLkMsEN599xLJi/jiIU9Q70yWz8KiRWvYfppyvA=
-github.com/ridi-oss/sqlglot-go v0.21.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
+github.com/ridi-oss/sqlglot-go v0.22.0 h1:uPRNk6iFJYy46PsGz3Tjduejg+WcLzd7aNiyJ0bMQpM=
+github.com/ridi-oss/sqlglot-go v0.22.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
 google.golang.org/protobuf v1.35.2 h1:8Ar7bF+apOIoThw1EdZl0p1oWvMqTHmpA2fRTyZO8io=
 google.golang.org/protobuf v1.35.2/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=

--- a/analyzer/probe/mysql_statement_coverage_test.go
+++ b/analyzer/probe/mysql_statement_coverage_test.go
@@ -190,7 +190,7 @@ var mysqlStatements = []mysqlStatement{
 	{"ALTER TABLESPACE", "ALTER TABLESPACE ts RENAME TO ts2", "unanalyzable→sql.unanalyzable"},
 	{"ALTER INSTANCE", "ALTER INSTANCE ROTATE INNODB MASTER KEY", "unanalyzable→sql.unanalyzable"},
 	{"DROP TABLE", "DROP TABLE users", "sql.ddl + unanalyzable→sql.unanalyzable"},
-	{"DROP INDEX", "DROP INDEX i ON users", "unanalyzable→sql.unanalyzable"},
+	{"DROP INDEX", "DROP INDEX i ON users", "sql.ddl + unanalyzable→sql.unanalyzable"}, // sqlglot-go v0.22.0: parses as a structured Drop (was Command)
 	{"DROP VIEW", "DROP VIEW v", "sql.ddl + unanalyzable→sql.unanalyzable"},
 	{"DROP DATABASE", "DROP DATABASE d", "sql.ddl + unanalyzable→sql.unanalyzable"},
 	{"DROP TRIGGER", "DROP TRIGGER trg", "sql.ddl + unanalyzable→sql.unanalyzable"},


### PR DESCRIPTION
Bumps sqlglot-go v0.21.0 → v0.22.0, which structures MySQL `DROP INDEX … ON table` as a real `Drop` node (was a raw `Command`). The analyzer's existing `Drop` branch already emits `sql.ddl` + the unanalyzable gate, so `DROP INDEX` now requires a DDL grant like `DROP TABLE`/`DROP VIEW` instead of only the unanalyzable gate — **one coverage-test row changes, no analyzer code change**. The c-shared native lib is rebuilt from the new pin.

Verification: full `mise run verify` green (analyzer Go suite, JVM FFM tests against the rebuilt lib, web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK83USBkxzao4uFfjxzy8n