### PR TITLE
feat(cp): one owner for the catalog

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ConnectionCatalog.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ConnectionCatalog.kt
@@ -1,6 +1,7 @@
 package com.ridi.oss.proxymonster.controlplane
 
 import com.google.protobuf.ByteString
+import com.ridi.oss.proxymonster.grpc.CatalogRequest
 import com.ridi.oss.proxymonster.grpc.Refetch
 import com.ridi.oss.proxymonster.grpc.SchemaFragmentPush
 import com.ridi.oss.proxymonster.grpc.refetch
@@ -12,6 +13,9 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
 private const val CONNECTION_ID_BYTES = 16
+
+/** A hash-only reading naming content the pool does not hold; the proxy is asked for that schema's columns. */
+private const val NO_CONTENT_FOR_HASH = "no pooled content for the observed hash"
 
 /**
  * How long a connection may hold a schema fragment before re-measuring it. This is the backstop for drift the
@@ -49,22 +53,89 @@ data class PooledFragment(val fragment: SchemaFragment, val refCount: Int)
  * evidence a connection inherits when it adopts. It lives here rather than on [PooledFragment] because
  * identical content is pooled once and shared across datasources, while a reading only ever speaks for the
  * backend it came from.
+ *
+ * [dbClockMicros] and [backendId] are the reading's own version: the backend's clock at the instant it
+ * computed the hash, and which backend that was. They order observations across producers, which arrival
+ * time cannot — a whole-server scan takes tens of seconds, so a scan that read older state routinely lands
+ * after a connection refetch that read newer state. [epoch] survives as the tie-break for the exact-equal
+ * clock and for readings that carry no comparable version at all. [measuredNanos] stays the staleness
+ * input: version is the DB clock, age is the control-plane clock.
  */
 data class Authoritative(
     val hash: ContentHash,
     val pooledRef: PoolKey,
     val epoch: Long,
     val measuredNanos: Long,
+    val dbClockMicros: Long = 0,
+    val backendId: String = "",
 )
+
+/**
+ * One catalog reading of one schema, from any producer — the registration scan, an ambient refresh, or a
+ * connection's own refetch. Everything the manager needs to decide what the reading may update travels
+ * with it.
+ *
+ * [hash] is null when the producer could not measure one it trusts, and [columns] is null when the reading
+ * only claims the content is unchanged. [dirty] is the raw fact that the reading was taken inside an open
+ * transaction; the manager assigns the meaning, keeping the proxy free of interpretation.
+ */
+data class CatalogObservation(
+    val datasourceName: String,
+    val schema: String,
+    val hash: ContentHash?,
+    val columns: List<FragmentColumn>?,
+    val dbClockMicros: Long,
+    val backendId: String,
+    val dirty: Boolean,
+)
+
+/**
+ * Whether an observation may reach shared state, and why not when it cannot. A reading is shareable only
+ * when it carries a hash the producer measured and vouches for, and was taken outside a transaction: an
+ * untrusted hash may name content the producer itself proved stale, and a transactional reading may include
+ * the connection's own uncommitted DDL or miss committed DDL from elsewhere. Either way the observing
+ * connection still holds the content for its own decisions — this gates only what other connections can see.
+ */
+enum class ObservationTrust { SHAREABLE, UNTRUSTED_HASH, DIRTY }
+
+private fun CatalogObservation.trust(): ObservationTrust = when {
+    hash == null -> ObservationTrust.UNTRUSTED_HASH
+    dirty -> ObservationTrust.DIRTY
+    else -> ObservationTrust.SHAREABLE
+}
+
+/**
+ * The result of one configuration reading: how many column rows it stored, and which schemas it named a
+ * hash for that the manager holds no content behind — the proxy fetches exactly those next.
+ */
+data class ConfigCatalogResult(val columns: Int, val fetchSchemas: List<String>)
+
+/** What the manager did with one observation's claim on the shared authoritative pointer. */
+sealed interface AuthoritativeOutcome {
+    /** The pointer now names this observation's content. */
+    data object Installed : AuthoritativeOutcome
+
+    /** Same content already held; only the entry's control-plane measurement time moved. */
+    data object Confirmed : AuthoritativeOutcome
+
+    /** The observation carried differing content but lost the ordering rule, or may never share. */
+    data class Dropped(val reason: String) : AuthoritativeOutcome
+}
 
 data class Binding(val datasourceName: String, val principal: String, val tokenKind: String)
 
+/**
+ * [trusted] false means the producer measured this content but could not vouch for the hash, so the hash
+ * cannot be offered back as a conditional-refetch token: a proxy replying `unchanged` against it would be
+ * matching bytes no measurement stands behind. Such a schema is always re-fetched unconditionally.
+ */
 data class HeldSchema(
     val pooledRef: PoolKey,
     val hash: ContentHash,
     val lastFetchNanos: Long,
     val lastVerifiedNanos: Long,
     val revalidatedAgainstAuthoritativeHash: ContentHash?,
+    val trusted: Boolean = true,
 )
 
 data class PendingRefetch(
@@ -97,16 +168,121 @@ sealed interface CatalogMutationResult {
     data class Rejected(val code: Status.Code, val description: String) : CatalogMutationResult
 }
 
+/** A reading's identity for ordering: what it saw, when the backend's own clock said it saw it, and where. */
+data class ReadingVersion(val hash: ContentHash, val dbClockMicros: Long, val backendId: String)
+
+/** How an arriving reading orders against the one currently held for the same `(datasource, schema)`. */
+enum class ReadingOrder {
+    /** Nothing is held; the first reading of a schema is never skipped. */
+    FIRST,
+
+    /** The same content, so only the measurement time moves. */
+    SAME,
+
+    /** Strictly newer in the backend's own clock. */
+    NEWER,
+
+    /** The clocks are exactly equal and cannot discriminate; accept order is the only remaining signal. */
+    TIED,
+
+    /** No shared clock domain, or no clock at all on one side; accept order decides. */
+    INCOMPARABLE,
+
+    /** Older than what is held. */
+    STALE,
+}
+
 /**
- * Ephemeral, fail-closed enforcement catalog state. The wire exposes datasource/principal/token-kind but no
- * proxy-instance identifier, so [Binding] binds exactly those authoritative fields; backend_generation binds
- * the first backend-connection instance that successfully pushes and thereafter advances monotonically.
+ * Order two readings of one schema by the backend's own clock.
+ *
+ * Arrival time cannot do this. A whole-server scan takes tens of seconds, so a scan that read state at
+ * time 100 routinely lands after a connection refetch that read newer state at 101 — under accept order
+ * the slow scan's stale content displaces the newer catalog and a trusting connection adopts it. An older
+ * reading with differing content is therefore dropped, never installed.
+ *
+ * A clock is only meaningful inside one backend, so the comparison runs only between readings carrying the
+ * same non-empty backend identity. Everything else falls back to accept order, which is where this started
+ * — degraded ordering, never a wrong reuse, since a reading with no comparable version can still never
+ * displace one that has a real clock.
+ */
+internal fun orderReading(current: ReadingVersion?, observed: ReadingVersion): ReadingOrder = when {
+    current == null -> ReadingOrder.FIRST
+    current.hash == observed.hash -> ReadingOrder.SAME
+    current.backendId.isEmpty() || observed.backendId.isEmpty() ||
+        current.backendId != observed.backendId -> ReadingOrder.INCOMPARABLE
+    // An unversioned reading may fill a hole but never overwrites a versioned one: it cannot be shown to
+    // be the newer of the two, and the whole point of the rule is to refuse exactly that claim.
+    observed.dbClockMicros == 0L ->
+        if (current.dbClockMicros == 0L) ReadingOrder.INCOMPARABLE else ReadingOrder.STALE
+    current.dbClockMicros == 0L -> ReadingOrder.NEWER
+    observed.dbClockMicros > current.dbClockMicros -> ReadingOrder.NEWER
+    observed.dbClockMicros == current.dbClockMicros -> ReadingOrder.TIED
+    else -> ReadingOrder.STALE
+}
+
+/** True when a reading ordered this way may replace the content held for its schema. */
+internal val ReadingOrder.installs: Boolean
+    get() = this == ReadingOrder.FIRST || this == ReadingOrder.NEWER ||
+        this == ReadingOrder.TIED || this == ReadingOrder.INCOMPARABLE
+
+/**
+ * The persisted side of catalog state — `catalog_column` and the per-schema versions behind it. The
+ * manager is its only caller; no handler writes the catalog directly, so one component decides what every
+ * reading may update.
+ */
+interface CatalogProjection {
+    /**
+     * Replace the columns of each schema in [observations] that carries content and is not ordered behind
+     * what is already stored, and record its version.
+     *
+     * [namespaceComplete] is the only thing that licenses deletion: when the reading enumerated every
+     * schema on the server, a stored schema missing from it has been dropped and its rows go with it. A
+     * scoped reading speaks only for the schemas it names — a privilege-filtered account reads a strict
+     * subset, and deleting on that would erase every schema it cannot see.
+     */
+    fun projectSchemas(
+        datasourceId: Long,
+        observations: List<ProjectedObservation>,
+        namespaceComplete: Boolean,
+        namespace: ProjectedNamespace?,
+    ): Int
+}
+
+/**
+ * One schema's reading as the projection writer sees it. [columns] null means the reading carries no
+ * content for this schema (it named the schema and its hash, nothing more); [version] null means the
+ * reading carries no version that could order it, so it lands by accept order and leaves no version behind.
+ */
+data class ProjectedObservation(
+    val schema: String,
+    val columns: List<DatasourceStore.PushedColumn>?,
+    val version: ReadingVersion?,
+)
+
+/** The namespace facts only a whole-server reading can establish, since only it probes the namespace. */
+data class ProjectedNamespace(
+    val defaultSchemas: List<String>,
+    val mysqlLowerCaseTableNames: Int?,
+    val engineVersion: String,
+)
+
+/**
+ * The single owner of catalog state: the in-memory fragment pool, the per-schema authoritative pointer, the
+ * per-connection held/pending maps, and — through [projection] — the persisted `catalog_column` rows and
+ * their versions. Every catalog reading enters through this class, from the registration scan, the ambient
+ * refresh, and every per-connection refetch alike, so one component decides what each reading may update.
+ *
+ * The wire exposes datasource/principal/token-kind but no proxy-instance identifier, so [Binding] binds
+ * exactly those authoritative fields; backend_generation binds the first backend-connection instance that
+ * successfully pushes and thereafter advances monotonically.
  */
 class ConnectionCatalogRegistry(
     private val clockNanos: () -> Long = System::nanoTime,
     private val secureRandom: SecureRandom = SecureRandom(),
     internal val stalenessNanos: Long = DEFAULT_STALENESS_NANOS,
+    private val projection: CatalogProjection? = null,
 ) {
+    private val log = org.slf4j.LoggerFactory.getLogger(ConnectionCatalogRegistry::class.java)
     private val pool = ConcurrentHashMap<PoolKey, PooledFragment>()
     private val authoritative = ConcurrentHashMap<Pair<String, String>, Authoritative>()
     private val connections = ConcurrentHashMap<ByteString, EnforcementConnection>()
@@ -268,8 +444,24 @@ class ConnectionCatalogRegistry(
         if (columns.any { it.schema != request.schema }) {
             return CatalogMutationResult.Rejected(Status.Code.INVALID_ARGUMENT, "fragment column schema mismatch")
         }
+        val observation = CatalogObservation(
+            datasourceName = ds.name,
+            schema = request.schema,
+            // An untrusted hash is not a content hash: the producer measured it and then proved its own
+            // reading stale (its two bracketing measurements disagreed). Dropping it here is what keeps such
+            // a reading out of the pool, where another connection could adopt columns already known stale.
+            hash = if (request.hashTrusted) pushedHash else null,
+            columns = columns,
+            dbClockMicros = request.dbClockMicros,
+            backendId = request.backendId,
+            dirty = request.measuredInTransaction,
+        )
         return synchronized(stateLock) {
-            val key = poolKey(ds, request.schema, pushedHash)
+            val key = if (request.hashTrusted) {
+                poolKey(ds, request.schema, pushedHash)
+            } else {
+                connectionScopedKey(connection, request.schema, pushedHash)
+            }
             val fragment = SchemaFragment(key, pushedHash, columns.toList())
             val existing = pool[key]
             if (existing != null && existing.fragment.columns != fragment.columns) {
@@ -282,9 +474,11 @@ class ConnectionCatalogRegistry(
             val previousHeld = connection.held[request.schema]
             val authKey = ds.name to request.schema
             val previousAuth = authoritative[authKey]
+            val outcome = shareabilityOf(observation, previousAuth)
+            val takesAuthoritative = outcome == AuthoritativeOutcome.Installed
             var retains = 0
             if (previousHeld?.pooledRef != key) retains++
-            if (previousAuth?.pooledRef != key) retains++
+            if (takesAuthoritative && previousAuth?.pooledRef != key) retains++
             // Also performs the alias check atomically with insertion when another thread created the key.
             val retained = retain(fragment, retains)
             if (retained.fragment.columns != fragment.columns) {
@@ -295,17 +489,103 @@ class ConnectionCatalogRegistry(
             }
 
             val now = clockNanos()
-            connection.held[request.schema] = HeldSchema(key, pushedHash, now, now, null)
-            // Authoritative is ACCEPT-ordered (last accepted push wins, via a monotonic epoch), NOT
-            // content-monotonic: an accepted push from a lagging read-replica may legitimately set an older
-            // content hash. This is a liveness hint, never a correctness input — every connection decides
-            // against exactly what ITS OWN backend binds (freshnessGate re-verifies per connection). Under a
-            // primary+replica pool a lagging push can regress this and cause bounded before_decide churn on
-            // siblings (each self-heals in one round-trip); damping that is a deferred liveness optimization.
-            authoritative[authKey] = Authoritative(pushedHash, key, authoritativeEpoch.incrementAndGet(), now)
+            connection.held[request.schema] =
+                HeldSchema(key, pushedHash, now, now, null, trusted = request.hashTrusted)
+            when (outcome) {
+                is AuthoritativeOutcome.Installed -> {
+                    authoritative[authKey] = Authoritative(
+                        pushedHash, key, authoritativeEpoch.incrementAndGet(), now,
+                        request.dbClockMicros, request.backendId,
+                    )
+                    if (previousAuth != null && previousAuth.pooledRef != key) release(previousAuth.pooledRef)
+                    projectObservation(ds, observation)
+                }
+                // The reading confirms what is held, so only the staleness clock moves. The version keeps
+                // the higher clock: two readings of identical content are equally good evidence of it, and
+                // taking the later one stops an old confirming reading from making the entry look older
+                // than a newer reading already proved it to be.
+                is AuthoritativeOutcome.Confirmed -> if (previousAuth != null) {
+                    authoritative[authKey] = previousAuth.copy(
+                        measuredNanos = now,
+                        dbClockMicros = maxOf(previousAuth.dbClockMicros, request.dbClockMicros),
+                    )
+                }
+                is AuthoritativeOutcome.Dropped -> log.warn(
+                    "datasource '{}' schema '{}': connection observation not shared ({})",
+                    ds.name, request.schema, outcome.reason,
+                )
+            }
             if (previousHeld != null && previousHeld.pooledRef != key) release(previousHeld.pooledRef)
-            if (previousAuth != null && previousAuth.pooledRef != key) release(previousAuth.pooledRef)
             accept(connection, request.schema, request.backendGeneration)
+        }
+    }
+
+    /**
+     * Decide what one observation may do to the shared pointer for its schema. Must be called under
+     * [stateLock], so the decision and the write it drives cannot straddle another writer.
+     */
+    private fun shareabilityOf(
+        observation: CatalogObservation,
+        current: Authoritative?,
+    ): AuthoritativeOutcome {
+        when (observation.trust()) {
+            ObservationTrust.UNTRUSTED_HASH -> return AuthoritativeOutcome.Dropped("hash is not a trusted measurement")
+            ObservationTrust.DIRTY -> return AuthoritativeOutcome.Dropped("measured inside an open transaction")
+            ObservationTrust.SHAREABLE -> Unit
+        }
+        val hash = observation.hash ?: return AuthoritativeOutcome.Dropped("no hash")
+        val observed = ReadingVersion(hash, observation.dbClockMicros, observation.backendId)
+        val held = current?.let { ReadingVersion(it.hash, it.dbClockMicros, it.backendId) }
+        return when (val order = orderReading(held, observed)) {
+            ReadingOrder.SAME -> AuthoritativeOutcome.Confirmed
+            ReadingOrder.STALE -> AuthoritativeOutcome.Dropped(
+                "older than the held reading (${observation.dbClockMicros} <= ${current?.dbClockMicros}) " +
+                    "on backend '${observation.backendId}'",
+            )
+            else -> {
+                if (order == ReadingOrder.TIED || order == ReadingOrder.INCOMPARABLE) {
+                    log.warn(
+                        "datasource '{}' schema '{}': installing by accept order ({})",
+                        observation.datasourceName, observation.schema, order,
+                    )
+                }
+                AuthoritativeOutcome.Installed
+            }
+        }
+    }
+
+    /**
+     * Write one connection observation's content through to the persisted catalog. Never namespace-complete:
+     * a connection measures the schemas it needs, so its silence about a sibling schema says nothing about
+     * whether that schema exists.
+     */
+    private fun projectObservation(ds: Datasource, observation: CatalogObservation) {
+        val projection = projection ?: return
+        val columns = observation.columns ?: return
+        val hash = observation.hash ?: return
+        runCatching {
+            projection.projectSchemas(
+                ds.id,
+                listOf(
+                    ProjectedObservation(
+                        observation.schema,
+                        columns.map {
+                            DatasourceStore.PushedColumn(it.schema, it.table, it.column, it.dataType, it.ordinal, it.nullable)
+                        },
+                        ReadingVersion(hash, observation.dbClockMicros, observation.backendId),
+                    ),
+                ),
+                namespaceComplete = false,
+                namespace = null,
+            )
+        }.onFailure {
+            // The in-memory state that enforcement decides against is already correct; the stored catalog
+            // feeds browse and classification joins and simply ages until the next reading. Failing the push
+            // would instead refuse the connection over a projection the decision path never reads.
+            log.warn(
+                "datasource '{}' schema '{}': persisting the observed catalog failed",
+                ds.name, observation.schema, it,
+            )
         }
     }
 
@@ -325,6 +605,19 @@ class ConnectionCatalogRegistry(
         }
         return PoolKey(scope, schema, hash)
     }
+
+    /**
+     * Where an untrusted measurement's content is kept: a scope only the observing connection names, so the
+     * content is stored without being content-addressed.
+     *
+     * The hash on such a push is a real measured value that simply failed its coherence bracket, so filing
+     * the columns under it in the shared scope would let a later genuine observation of that hash resolve to
+     * columns the producer already proved stale — the exact adoption of unproven content the trust flag
+     * exists to prevent. Keeping it out of the shared scope also stops it from colliding with that genuine
+     * observation and rejecting it as an alias.
+     */
+    private fun connectionScopedKey(connection: EnforcementConnection, schema: String, hash: ContentHash): PoolKey =
+        PoolKey("conn:" + connection.connectionId.toByteArray().joinToString("") { "%02x".format(it) }, schema, hash)
 
     private fun retain(fragment: SchemaFragment, count: Int): PooledFragment {
         var result: PooledFragment? = null
@@ -365,12 +658,20 @@ class ConnectionCatalogRegistry(
             }
     }
 
+    /**
+     * The hash a conditional REFETCH may carry for a connection's held schema, or null for an unconditional
+     * fetch. An untrusted held hash is never offered: the proxy would answer `unchanged` against bytes no
+     * coherent measurement stands behind, and the connection would keep columns the producer already proved
+     * did not match that hash. Absence of trust costs one full fetch, which is the fail-closed direction.
+     */
+    private fun heldRefetchToken(connection: EnforcementConnection, schema: String): ContentHash? =
+        connection.held[schema]?.takeIf { it.trusted }?.hash
+
     /** Issue or replay pending before-decide commands without changing an existing command's CAS token. */
     fun markBeforeDecide(connection: EnforcementConnection, schemas: Collection<String>): List<Refetch> =
         markPending(connection, schemas) { schema ->
-            val held = connection.held[schema]
             val auth = authoritative[connection.binding.datasourceName to schema]
-            PendingRefetch(held?.hash ?: auth?.hash, auth?.hash)
+            PendingRefetch(heldRefetchToken(connection, schema) ?: auth?.hash, auth?.hash)
         }
 
     /** A catalog-miss qualifier was never held: force one bounded unconditional fetch. */
@@ -382,7 +683,7 @@ class ConnectionCatalogRegistry(
     fun markAfterStatement(connection: EnforcementConnection, schemas: Collection<String>): List<Refetch> =
         markPending(connection, schemas) { schema ->
             PendingRefetch(
-                connection.held[schema]?.hash,
+                heldRefetchToken(connection, schema),
                 authoritative[connection.binding.datasourceName to schema]?.hash,
             )
         }
@@ -414,45 +715,173 @@ class ConnectionCatalogRegistry(
         connection.held.keys.filterTo(LinkedHashSet()) { freshnessGate(connection, listOf(it)).isEmpty() }
 
     /**
-     * Fold a whole-catalog measurement from the proxy's ambient refresh into this datasource's authoritative
-     * entries.
+     * Apply a whole-server or scoped configuration reading — the registration scan and the ambient refresh.
      *
-     * The refresh reads every schema from the backend with the same six fields a fragment holds, so for a
-     * schema whose columns are byte-identical it is a genuine re-measurement of exactly that content — the
-     * same evidence a connection's own hash probe produces. Recording it advances the authoritative entry's
-     * measurement time, so the staleness gate counts from this reading rather than from the first time the
-     * content happened to be pooled.
+     * This is the path that dissolves the two-catalog split. The reading carries a per-schema hash measured
+     * on the backend, so its content is content-addressable exactly like a connection's fragment: it seeds
+     * the pool and the authoritative pointer rather than merely confirming what some connection already
+     * measured. That is what lets the first connection after boot adopt instead of re-reading thousands of
+     * columns the control plane was handed seconds earlier.
      *
-     * Recorded on the authoritative entry, NOT on the pooled fragment: identical system-schema content is
-     * pooled once per engine version and shared by every datasource on it ([poolKey]), so writing the time
-     * there would let one datasource's refresh vouch for another's schema that nobody read. Freshness is
-     * evidence about one backend; only the content itself is shareable.
-     *
-     * Deliberately narrow: a schema whose columns differ is left untouched, so this can only ever confirm
-     * content, never install it. Divergence stays the job of the connection's own probe, which alone knows
-     * what that connection's backend binds.
-     *
-     * Returns the schemas confirmed, for logging.
+     * A schema whose hash is absent or untrusted seeds nothing: with no version a reading cannot be ordered,
+     * and content the manager cannot order is content it cannot safely install. Its columns are still
+     * stored, because the stored catalog is what browse and classification read and they are no worse off
+     * than before the reading carried versions at all.
      */
-    fun recordAmbientMeasurement(
-        datasourceName: String,
-        columnsBySchema: Map<String, List<FragmentColumn>>,
-    ): Set<String> = synchronized(stateLock) {
-        val confirmed = LinkedHashSet<String>()
-        val now = clockNanos()
-        for ((schema, columns) in columnsBySchema) {
-            val authKey = datasourceName to schema
-            val auth = authoritative[authKey] ?: continue
-            val pooled = pool[auth.pooledRef] ?: continue
-            // Compared as sets: the whole-catalog read and the per-schema fragment read are separate
-            // statements whose ORDER BY need not agree, and row order is not part of what a fragment
-            // asserts — the decide path sorts for itself. Comparing lists would silently stop confirming
-            // anything the moment the two orderings diverged, and nothing would report it.
-            if (pooled.fragment.columns.toSet() != columns.toSet()) continue
-            authoritative[authKey] = auth.copy(measuredNanos = now)
-            confirmed += schema
+    fun applyConfigCatalog(request: CatalogRequest, ds: Datasource): ConfigCatalogResult {
+        val columnsBySchema = request.columnsList
+            .groupBy({ it.schema }) { FragmentColumn(it.schema, it.table, it.column, it.dataType, it.ordinal, it.nullable) }
+        // A proxy that declares which schemas it carries is taken at its word, so "carried but empty" stays
+        // distinguishable from "not carried". One that declares nothing — an older proxy — is read the only
+        // way its message supports: the schemas its columns mention are the ones it carried.
+        val contentSchemas = if (request.contentSchemasList.isEmpty()) {
+            columnsBySchema.keys
+        } else {
+            request.contentSchemasList.toSet()
         }
-        confirmed
+        // Only a reading that says it enumerated every schema may imply deletion. A scoped set speaks for
+        // the schemas it names and nothing else: both engines filter information_schema by privilege, so a
+        // least-privilege account reads a strict subset, and deleting on that erases what it cannot see.
+        val namespaceComplete = request.namespaceComplete
+        // An old proxy sends no schema_hashes. Its columns still carry the schemas it read, so the stored
+        // catalog is written exactly as before — versionless, seeding nothing.
+        val versioned = request.schemaHashesList.associate { it.schema to it }
+
+        val observations = request.schemaHashesList.mapNotNull { pushed ->
+            if (!pushed.trusted || pushed.schema.isBlank()) return@mapNotNull null
+            CatalogObservation(
+                datasourceName = ds.name,
+                schema = pushed.schema,
+                hash = ContentHash(pushed.hash),
+                // "declared with no columns" and "not carried by this push" are different claims: a schema
+                // this push does not carry keeps its stored content and only records its version, while one
+                // declared present with no columns genuinely has none.
+                columns = if (pushed.schema in contentSchemas) columnsBySchema[pushed.schema].orEmpty() else null,
+                dbClockMicros = request.dbClockMicros,
+                backendId = request.backendId,
+                dirty = false,
+            )
+        }
+
+        val fetch = ArrayList<String>()
+        synchronized(stateLock) {
+            for (observation in observations) {
+                val applied = installShared(ds, observation)
+                if (applied is AuthoritativeOutcome.Dropped) {
+                    if (applied.reason == NO_CONTENT_FOR_HASH) fetch += observation.schema
+                    log.warn(
+                        "datasource '{}' schema '{}': configuration observation not installed ({})",
+                        ds.name, observation.schema, applied.reason,
+                    )
+                }
+            }
+            if (namespaceComplete) {
+                val present = request.schemaHashesList.map { it.schema }.toSet()
+                val dropped = dropSchemasAbsentFrom(ds.name, present)
+                if (dropped.isNotEmpty()) {
+                    log.info("datasource '{}': {} schema(s) gone from the server", ds.name, dropped.size)
+                }
+            }
+        }
+
+        // Present-but-untrusted and absent are different claims, and only the first is a statement about the
+        // reading's quality. A schema the producer declared it could not measure coherently keeps its stored
+        // rows — its columns may have been read while the backend moved under them. A reading that names no
+        // hashes at all is an older proxy saying nothing about quality either way, and its columns are
+        // stored exactly as before hashes existed.
+        val declaredUntrusted = request.schemaHashesList.filterNot { it.trusted }.map { it.schema }.toSet()
+        val projected = (contentSchemas + versioned.keys).map { schema ->
+            val pushed = versioned[schema]
+            ProjectedObservation(
+                schema = schema,
+                columns = if (schema in contentSchemas && schema !in declaredUntrusted) {
+                    columnsBySchema[schema].orEmpty().map {
+                        DatasourceStore.PushedColumn(it.schema, it.table, it.column, it.dataType, it.ordinal, it.nullable)
+                    }
+                } else {
+                    null
+                },
+                version = pushed?.takeIf { it.trusted }?.let {
+                    ReadingVersion(ContentHash(it.hash), request.dbClockMicros, request.backendId)
+                },
+            )
+        }
+        val stored = projection?.projectSchemas(
+            ds.id,
+            projected,
+            namespaceComplete,
+            ProjectedNamespace(
+                request.defaultSchemasList,
+                if (request.hasMysqlLowerCaseTableNames()) request.mysqlLowerCaseTableNames else null,
+                request.engineVersion,
+            ),
+        ) ?: 0
+        return ConfigCatalogResult(stored, fetch)
+    }
+
+    /**
+     * Install (or confirm) one datasource-scoped observation into the pool and the authoritative pointer.
+     * Must be called under [stateLock].
+     *
+     * A reading with no columns can only point at content the pool already holds. It may never leave the
+     * pointer naming a fragment nothing resolves: an adopting connection would then decide against an empty
+     * structure, and a connection sent that hash as a conditional-refetch token could reply `unchanged`
+     * against content that does not exist. The unresolvable case is reported so the proxy fetches it.
+     */
+    private fun installShared(ds: Datasource, observation: CatalogObservation): AuthoritativeOutcome {
+        val hash = observation.hash ?: return AuthoritativeOutcome.Dropped("no hash")
+        val authKey = ds.name to observation.schema
+        val previousAuth = authoritative[authKey]
+        val outcome = shareabilityOf(observation, previousAuth)
+        val now = clockNanos()
+        if (outcome is AuthoritativeOutcome.Confirmed) {
+            if (previousAuth != null) {
+                authoritative[authKey] = previousAuth.copy(
+                    measuredNanos = now,
+                    dbClockMicros = maxOf(previousAuth.dbClockMicros, observation.dbClockMicros),
+                )
+            }
+            return outcome
+        }
+        if (outcome !is AuthoritativeOutcome.Installed) return outcome
+
+        val key = poolKey(ds, observation.schema, hash)
+        val columns = observation.columns ?: pool[key]?.fragment?.columns
+            ?: return AuthoritativeOutcome.Dropped(NO_CONTENT_FOR_HASH)
+        val fragment = SchemaFragment(key, hash, columns)
+        val existing = pool[key]
+        if (existing != null && existing.fragment.columns != fragment.columns) {
+            return AuthoritativeOutcome.Dropped("content hash aliases different fragment columns")
+        }
+        val retained = retain(fragment, if (previousAuth?.pooledRef != key) 1 else 0)
+        if (retained.fragment.columns != fragment.columns) {
+            return AuthoritativeOutcome.Dropped("content hash aliases different fragment columns")
+        }
+        authoritative[authKey] = Authoritative(
+            hash, key, authoritativeEpoch.incrementAndGet(), now, observation.dbClockMicros, observation.backendId,
+        )
+        if (previousAuth != null && previousAuth.pooledRef != key) release(previousAuth.pooledRef)
+        return outcome
+    }
+
+    /**
+     * Drop the authoritative entries for schemas a namespace-complete reading proved gone.
+     *
+     * Only a reading that enumerated every schema on the server may do this, so the caller establishes that
+     * before calling: both engines filter `information_schema` by privilege, and a least-privilege account's
+     * subset presented as a complete enumeration would delete every schema it cannot see.
+     *
+     * Live connections keep what they hold, exactly as on a retarget — each re-verifies on its own clock,
+     * and emptying their structure mid-session would pull the catalog out from under an in-flight statement.
+     */
+    fun dropSchemasAbsentFrom(datasourceName: String, present: Set<String>): Set<String> = synchronized(stateLock) {
+        val dropped = LinkedHashSet<String>()
+        for (key in authoritative.keys.filter { it.first == datasourceName && it.second !in present }) {
+            val auth = authoritative.remove(key) ?: continue
+            release(auth.pooledRef)
+            dropped += key.second
+        }
+        dropped
     }
 
     /**

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ControlPlaneCore.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ControlPlaneCore.kt
@@ -41,7 +41,9 @@ class ControlPlaneCore(val dataSource: DataSource) {
     // Open proxy Events streams (docs/datasource-registration.md) — liveness + refresh/run push.
     // Shared so the gRPC handlers and the HTTP routes agree on attached proxies and pending run dials.
     val proxyEventsHub = ProxyEventsHub()
-    val connectionCatalog = ConnectionCatalogRegistry()
+    // The catalog manager owns every catalog store, the persisted projection included — so one component
+    // decides what each reading may update, instead of two writers maintaining two stores.
+    val connectionCatalog = ConnectionCatalogRegistry(projection = datasourceStore)
     val runChannels = RunChannelRegistry()
     val tableDetailChannels = TableDetailChannelRegistry()
 

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Datasources.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Datasources.kt
@@ -148,9 +148,16 @@ fun sqlTypeFor(dataType: String): String = when (dataType.lowercase().trim()) {
 
 // ---- Store -------------------------------------------------------------------------------
 
-class DatasourceStore(internal val dataSource: DataSource) {
+class DatasourceStore(internal val dataSource: DataSource) : CatalogProjection {
     private val json = Json
     private val stringList = ListSerializer(String.serializer())
+
+    override fun projectSchemas(
+        datasourceId: Long,
+        observations: List<ProjectedObservation>,
+        namespaceComplete: Boolean,
+        namespace: ProjectedNamespace?,
+    ): Int = projectCatalogSchemas(datasourceId, observations, namespaceComplete, namespace)
 
     companion object {
         /** The `system:` tag namespace is owned by the shipped classification manifests — user column tags may not use it. */
@@ -321,8 +328,15 @@ class DatasourceStore(internal val dataSource: DataSource) {
                 // `catalogCleared` reflects the ATOMIC old→new transition (RETURNING catalog_synced_at IS NULL),
                 // not the pre-read `prior`, so it's race-free; the delete is idempotent (a fresh insert or a
                 // same-db_name re-register has no rows to drop). A host/port-only move keeps the catalog.
+                // The versions go with the rows. A version left behind describes a reading of the database
+                // that is no longer there, and the ordering rule would then measure the new target's first
+                // reading against the old target's clock — on a backend whose clock runs behind, silently
+                // refusing the only reading that describes what is actually there.
                 if (catalogCleared) {
                     c.prepareStatement("DELETE FROM catalog_column WHERE datasource_id = ?").use { ps ->
+                        ps.setLong(1, upsertedId); ps.executeUpdate()
+                    }
+                    c.prepareStatement("DELETE FROM catalog_schema WHERE datasource_id = ?").use { ps ->
                         ps.setLong(1, upsertedId); ps.executeUpdate()
                     }
                 }
@@ -354,11 +368,12 @@ class DatasourceStore(internal val dataSource: DataSource) {
     )
 
     /**
-     * gRPC PushCatalog: replace datasource [id]'s catalog with the columns the PROXY introspected and
-     * pushed — the control-plane never connects to the target itself (that's the headline of this design).
-     * Transactionally delete-then-batch-insert `catalog_column` (deriving each `sql_type` from the raw
-     * `data_type` via [sqlTypeFor]), then stamp the connection's live `default_schemas` /
-     * `mysql_lower_case_table_names` / `catalog_synced_at`. Returns the number of columns stored.
+     * Replace datasource [id]'s whole catalog with [columns] and stamp its namespace fields — the shape of
+     * an unversioned whole-server reading, which is what a caller holding the complete column set has.
+     *
+     * Expressed through the per-schema projection rather than beside it, so there is one place that writes
+     * `catalog_column`. The reading carries no version, so nothing orders it and nothing is left behind to
+     * order the next one against; enumerating the whole server is what lets it delete the schemas it omits.
      */
     fun storePushedCatalog(
         id: Long,
@@ -367,50 +382,77 @@ class DatasourceStore(internal val dataSource: DataSource) {
         engineVersion: String,
         columns: List<PushedColumn>,
     ): Int {
+        val bySchema = columns.groupBy { it.schema }
+        projectCatalogSchemas(
+            id,
+            bySchema.map { (schema, rows) -> ProjectedObservation(schema, rows, version = null) },
+            namespaceComplete = true,
+            namespace = ProjectedNamespace(defaultSchemas, mysqlLowerCaseTableNames, engineVersion),
+        )
+        return columns.size
+    }
+
+    /**
+     * The manager's persisted projection: replace exactly the schemas a reading spoke for, and record the
+     * version behind each.
+     *
+     * Per schema rather than whole-table, because the readings are per schema. A whole-table
+     * delete-and-insert would make every reading speak for every schema — a connection's measurement of one
+     * schema would erase the rest, and a scan overtaken by a newer connection measurement would erase that
+     * one's newer rows on its way past.
+     *
+     * The version guards the write the same way it guards the in-memory pointer: a reading older than the
+     * one behind the stored rows leaves them alone. Rows and version move together in one transaction, so
+     * the stored version always describes the stored rows.
+     */
+    fun projectCatalogSchemas(
+        id: Long,
+        observations: List<ProjectedObservation>,
+        namespaceComplete: Boolean,
+        namespace: ProjectedNamespace?,
+    ): Int {
+        var written = 0
         dataSource.connection.use { c ->
             c.autoCommit = false
             try {
-                // Lock the datasource row so concurrent pushes (multiple proxy replicas fronting one name)
-                // serialize instead of interleaving their DELETE/INSERT — otherwise the second push's insert
-                // races the first's delete and trips the (datasource, schema, table, column) UNIQUE. Also
-                // doubles as the disappeared-datasource check.
+                // Serializes concurrent pushes for one datasource, exactly as the whole-table writer did:
+                // two interleaved per-schema replacements would otherwise race delete against insert and
+                // trip the (datasource, schema, table, column) UNIQUE. Also the disappeared-datasource check.
                 c.prepareStatement("SELECT id FROM datasource WHERE id = ? FOR UPDATE").use { ps ->
                     ps.setLong(1, id)
                     ps.executeQuery().use { rs -> check(rs.next()) { "datasource $id disappeared before catalog push" } }
                 }
-                c.prepareStatement("DELETE FROM catalog_column WHERE datasource_id = ?").use { ps ->
-                    ps.setLong(1, id); ps.executeUpdate()
-                }
-                c.prepareStatement(
-                    """INSERT INTO catalog_column
-                       (datasource_id, schema_name, table_name, column_name, data_type, sql_type, ordinal, nullable)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-                ).use { ps ->
-                    for (col in columns) {
-                        ps.setLong(1, id)
-                        ps.setString(2, col.schema)
-                        ps.setString(3, col.table)
-                        ps.setString(4, col.column)
-                        ps.setString(5, col.dataType)
-                        ps.setString(6, sqlTypeFor(col.dataType))
-                        ps.setInt(7, col.ordinal)
-                        ps.setBoolean(8, col.nullable)
-                        ps.addBatch()
+                val storedVersions = catalogSchemaVersions(id, c)
+                for (observation in observations) {
+                    val stored = storedVersions[observation.schema]
+                    val version = observation.version
+                    val order = version?.let { orderReading(stored, it) }
+                    // A reading of the SAME content is not stale — it re-observes what is stored, so the
+                    // rows stand and only the version's clock moves forward. Skipping it outright would
+                    // leave the stored version reading older than the backend was last proved to be, and
+                    // the next genuine reading would then be ordered against that understated clock.
+                    if (order == ReadingOrder.STALE) continue
+                    if (order != ReadingOrder.SAME) {
+                        observation.columns?.let { columns ->
+                            replaceSchemaColumns(c, id, observation.schema, columns)
+                            written += columns.size
+                        }
                     }
-                    ps.executeBatch()
+                    if (version != null) {
+                        writeSchemaVersion(
+                            c, id, observation.schema,
+                            if (order == ReadingOrder.SAME && stored != null) {
+                                version.copy(dbClockMicros = maxOf(stored.dbClockMicros, version.dbClockMicros))
+                            } else {
+                                version
+                            },
+                        )
+                    }
                 }
-                c.prepareStatement(
-                    """UPDATE datasource
-                       SET default_schemas = ?::jsonb, mysql_lower_case_table_names = ?, engine_version = ?,
-                           catalog_synced_at = now()
-                       WHERE id = ?""",
-                ).use { ps ->
-                    ps.setString(1, json.encodeToString(stringList, defaultSchemas))
-                    setNullableInt(ps, 2, mysqlLowerCaseTableNames)
-                    ps.setString(3, engineVersion.ifBlank { null })
-                    ps.setLong(4, id)
-                    check(ps.executeUpdate() == 1) { "datasource $id disappeared during catalog push" }
+                if (namespaceComplete) {
+                    deleteSchemasAbsentFrom(c, id, observations.map { it.schema }.toSet())
                 }
+                namespace?.let { writeNamespace(c, id, it) }
                 c.commit()
             } catch (e: Exception) {
                 c.rollback(); throw e
@@ -418,7 +460,104 @@ class DatasourceStore(internal val dataSource: DataSource) {
                 c.autoCommit = true
             }
         }
-        return columns.size
+        return written
+    }
+
+    /** The version behind each schema's stored rows, for the ordering check. */
+    private fun catalogSchemaVersions(id: Long, c: java.sql.Connection): Map<String, ReadingVersion> =
+        c.prepareStatement(
+            "SELECT schema_name, hash, db_clock_micros, backend_id FROM catalog_schema WHERE datasource_id = ?",
+        ).use { ps ->
+            ps.setLong(1, id)
+            ps.executeQuery().use { rs ->
+                val out = HashMap<String, ReadingVersion>()
+                while (rs.next()) {
+                    out[rs.getString(1)] = ReadingVersion(
+                        ContentHash(com.google.protobuf.ByteString.copyFrom(rs.getBytes(2))),
+                        rs.getLong(3),
+                        rs.getString(4),
+                    )
+                }
+                out
+            }
+        }
+
+    private fun replaceSchemaColumns(c: java.sql.Connection, id: Long, schema: String, columns: List<PushedColumn>) {
+        c.prepareStatement("DELETE FROM catalog_column WHERE datasource_id = ? AND schema_name = ?").use { ps ->
+            ps.setLong(1, id); ps.setString(2, schema); ps.executeUpdate()
+        }
+        c.prepareStatement(
+            """INSERT INTO catalog_column
+               (datasource_id, schema_name, table_name, column_name, data_type, sql_type, ordinal, nullable)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        ).use { ps ->
+            for (col in columns) {
+                ps.setLong(1, id)
+                ps.setString(2, col.schema)
+                ps.setString(3, col.table)
+                ps.setString(4, col.column)
+                ps.setString(5, col.dataType)
+                ps.setString(6, sqlTypeFor(col.dataType))
+                ps.setInt(7, col.ordinal)
+                ps.setBoolean(8, col.nullable)
+                ps.addBatch()
+            }
+            ps.executeBatch()
+        }
+    }
+
+    private fun writeSchemaVersion(c: java.sql.Connection, id: Long, schema: String, version: ReadingVersion) {
+        c.prepareStatement(
+            """INSERT INTO catalog_schema (datasource_id, schema_name, hash, db_clock_micros, backend_id, observed_at)
+               VALUES (?, ?, ?, ?, ?, now())
+               ON CONFLICT (datasource_id, schema_name) DO UPDATE SET
+                   hash = EXCLUDED.hash,
+                   db_clock_micros = EXCLUDED.db_clock_micros,
+                   backend_id = EXCLUDED.backend_id,
+                   observed_at = EXCLUDED.observed_at""",
+        ).use { ps ->
+            ps.setLong(1, id)
+            ps.setString(2, schema)
+            ps.setBytes(3, version.hash.bytes.toByteArray())
+            ps.setLong(4, version.dbClockMicros)
+            ps.setString(5, version.backendId)
+            ps.executeUpdate()
+        }
+    }
+
+    /** Only ever reached for a reading that enumerated the whole server — the caller establishes that. */
+    private fun deleteSchemasAbsentFrom(c: java.sql.Connection, id: Long, present: Set<String>) {
+        val stored = c.prepareStatement("SELECT DISTINCT schema_name FROM catalog_column WHERE datasource_id = ?").use { ps ->
+            ps.setLong(1, id)
+            ps.executeQuery().use { rs ->
+                val out = ArrayList<String>()
+                while (rs.next()) out += rs.getString(1)
+                out
+            }
+        }
+        for (schema in stored.filterNot { it in present }) {
+            c.prepareStatement("DELETE FROM catalog_column WHERE datasource_id = ? AND schema_name = ?").use { ps ->
+                ps.setLong(1, id); ps.setString(2, schema); ps.executeUpdate()
+            }
+            c.prepareStatement("DELETE FROM catalog_schema WHERE datasource_id = ? AND schema_name = ?").use { ps ->
+                ps.setLong(1, id); ps.setString(2, schema); ps.executeUpdate()
+            }
+        }
+    }
+
+    private fun writeNamespace(c: java.sql.Connection, id: Long, namespace: ProjectedNamespace) {
+        c.prepareStatement(
+            """UPDATE datasource
+               SET default_schemas = ?::jsonb, mysql_lower_case_table_names = ?, engine_version = ?,
+                   catalog_synced_at = now()
+               WHERE id = ?""",
+        ).use { ps ->
+            ps.setString(1, json.encodeToString(stringList, namespace.defaultSchemas))
+            setNullableInt(ps, 2, namespace.mysqlLowerCaseTableNames)
+            ps.setString(3, namespace.engineVersion.ifBlank { null })
+            ps.setLong(4, id)
+            check(ps.executeUpdate() == 1) { "datasource $id disappeared during catalog push" }
+        }
     }
 
     fun create(input: DatasourceInput): Datasource {
@@ -443,6 +582,9 @@ class DatasourceStore(internal val dataSource: DataSource) {
      *  both leave a catalog that now describes a DIFFERENT schema, a fail-OPEN unless invalidated. */
     private fun invalidateCatalog(c: java.sql.Connection, id: Long) {
         c.prepareStatement("DELETE FROM catalog_column WHERE datasource_id = ?").use { ps ->
+            ps.setLong(1, id); ps.executeUpdate()
+        }
+        c.prepareStatement("DELETE FROM catalog_schema WHERE datasource_id = ?").use { ps ->
             ps.setLong(1, id); ps.executeUpdate()
         }
         c.prepareStatement(

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/ControlPlaneGrpcService.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/ControlPlaneGrpcService.kt
@@ -4,7 +4,6 @@ import com.ridi.oss.proxymonster.controlplane.Attached
 import com.ridi.oss.proxymonster.controlplane.AttachedTableDetail
 import com.ridi.oss.proxymonster.controlplane.AuditEvent
 import com.ridi.oss.proxymonster.controlplane.CatalogColumn
-import com.ridi.oss.proxymonster.controlplane.FragmentColumn
 import com.ridi.oss.proxymonster.controlplane.Binding
 import com.ridi.oss.proxymonster.controlplane.CatalogMutationResult
 import com.ridi.oss.proxymonster.controlplane.Channel
@@ -13,7 +12,6 @@ import com.ridi.oss.proxymonster.controlplane.DatasourceEngineConflictException
 import com.ridi.oss.proxymonster.controlplane.catalogIsConnectionIndependent
 import com.ridi.oss.proxymonster.controlplane.catalogName
 import com.ridi.oss.proxymonster.controlplane.EnforcementOutcome
-import com.ridi.oss.proxymonster.controlplane.DatasourceStore
 import com.ridi.oss.proxymonster.controlplane.TokenKind
 import com.ridi.oss.proxymonster.controlplane.decideConnection
 import com.ridi.oss.proxymonster.controlplane.inTx
@@ -378,31 +376,9 @@ class ControlPlaneGrpcService(
             ?: throw StatusException(
                 Status.NOT_FOUND.withDescription("unknown datasource '${request.datasourceName}' — Register first"),
             )
-        val pushedColumns = request.columnsList.map {
-            DatasourceStore.PushedColumn(it.schema, it.table, it.column, it.dataType, it.ordinal, it.nullable)
-        }
-        val mysqlLowerCaseTableNames =
-            if (request.hasMysqlLowerCaseTableNames()) request.mysqlLowerCaseTableNames else null
-        val stored = core.datasourceStore.storePushedCatalog(
-            id = ds.id,
-            defaultSchemas = request.defaultSchemasList,
-            mysqlLowerCaseTableNames = mysqlLowerCaseTableNames,
-            engineVersion = request.engineVersion,
-            columns = pushedColumns,
-        )
-        // This push is a fresh whole-catalog read of the backend, so where it agrees with content the
-        // enforcement pool already holds it re-measures that content — the ambient refresh keeps held
-        // fragments verified instead of only feeding the config catalog, and a connection is not made to
-        // re-probe a schema the proxy just confirmed.
-        val confirmed = core.connectionCatalog.recordAmbientMeasurement(
-            ds.name,
-            pushedColumns.groupBy({ it.schema }) {
-                FragmentColumn(it.schema, it.table, it.column, it.dataType, it.ordinal, it.nullable)
-            },
-        )
-        if (confirmed.isNotEmpty()) {
-            log.debug("datasource '{}': ambient refresh re-verified {} pooled schema(s)", ds.name, confirmed.size)
-        }
+        // The manager owns every catalog store, so this handler holds no catalog logic: it hands the reading
+        // over whole and reports back what the manager could not resolve.
+        val stored = core.connectionCatalog.applyConfigCatalog(request, ds)
         // Which shipped system-classification manifest governs THIS datasource, resolved from the version the
         // proxy just pushed — so an operator sees at connect time whether its system schemas are classified,
         // on a fallback major, or uncertified (deny-by-default). Boot logs the available set; this logs the hit.
@@ -411,7 +387,10 @@ class ControlPlaneGrpcService(
             ds.name,
             core.systemClassification.describeManifestFor(ds.engine, request.engineVersion),
         )
-        return catalogResponse { columns = stored }
+        return catalogResponse {
+            columns = stored.columns
+            fetchSchemas.addAll(stored.fetchSchemas)
+        }
     }
 
     /**

--- a/control-plane/src/main/resources/db/migration/V14__catalog_schema.sql
+++ b/control-plane/src/main/resources/db/migration/V14__catalog_schema.sql
@@ -1,0 +1,27 @@
+-- The per-schema version behind the stored catalog.
+--
+-- catalog_column holds a datasource's columns; this holds, per schema, the reading those columns came
+-- from: the content hash the backend computed, the backend's own clock at that instant, and which
+-- backend it was. A schema's columns are replaced only by a reading that is newer in the backend's own
+-- clock, so a slow whole-server scan cannot overwrite a newer per-connection measurement that arrived
+-- first.
+--
+-- A row exists only for a schema whose reading could be believed. A schema whose hash measurement
+-- failed keeps its columns and carries no version, which reads as "no ordering evidence" rather than as
+-- an ordering claim.
+
+CREATE TABLE catalog_schema (
+    id              BIGSERIAL PRIMARY KEY,
+    datasource_id   BIGINT NOT NULL REFERENCES datasource(id) ON DELETE CASCADE,
+    schema_name     TEXT NOT NULL,
+    -- The backend-computed content hash of this schema's columns, as raw bytes.
+    hash            BYTEA NOT NULL,
+    -- The backend's own clock, in microseconds, read in the same statement as the hash. 0 = the backend
+    -- could not supply a clock that a session variable cannot move, so the reading carries no version.
+    db_clock_micros BIGINT NOT NULL DEFAULT 0,
+    -- The server the reading came from (MySQL @@server_uuid / PostgreSQL system_identifier). Empty when
+    -- unreadable under the service account; clocks are only ever compared within one non-empty identity.
+    backend_id      TEXT NOT NULL DEFAULT '',
+    observed_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (datasource_id, schema_name)
+);

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/CatalogProjectionDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/CatalogProjectionDbTest.kt
@@ -1,0 +1,223 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.google.protobuf.ByteString
+import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import javax.sql.DataSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The persisted half of the manager: `catalog_column` written per schema, versioned by `catalog_schema`,
+ * with deletion licensed only by a reading that enumerated the whole server.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CatalogProjectionDbTest {
+    private lateinit var dataSource: DataSource
+    private lateinit var store: DatasourceStore
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_catalog_projection"))
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        store = DatasourceStore(dataSource)
+    }
+
+    private fun datasource(name: String): Datasource =
+        store.create(DatasourceInput(name = name, engine = "mysql", host = "h", port = 3306, dbName = "app"))
+
+    private fun column(schema: String, table: String, column: String) =
+        DatasourceStore.PushedColumn(schema, table, column, "bigint", 1, false)
+
+    private fun version(hash: String, clock: Long, backend: String = "srv") =
+        ReadingVersion(ContentHash(ByteString.copyFromUtf8(hash)), clock, backend)
+
+    private fun schemasOf(id: Long): Set<String> = store.catalog(id).map { it.schema }.toSet()
+
+    private fun storedVersion(id: Long, schema: String): Pair<String, Long>? = dataSource.connection.use { c ->
+        c.prepareStatement("SELECT hash, db_clock_micros FROM catalog_schema WHERE datasource_id = ? AND schema_name = ?").use { ps ->
+            ps.setLong(1, id); ps.setString(2, schema)
+            ps.executeQuery().use { rs -> if (rs.next()) String(rs.getBytes(1)) to rs.getLong(2) else null }
+        }
+    }
+
+    @Test
+    fun `a reading replaces only the schemas it spoke for`() {
+        // The readings are per schema, so the write must be too. A whole-table delete-and-insert would make
+        // every reading speak for every schema — one connection's measurement of `app` would erase `other`.
+        val ds = datasource("proj-scoped")
+        store.projectCatalogSchemas(
+            ds.id,
+            listOf(
+                ProjectedObservation("app", listOf(column("app", "users", "id")), version("h-app", 100)),
+                ProjectedObservation("other", listOf(column("other", "logs", "id")), version("h-other", 100)),
+            ),
+            namespaceComplete = false,
+            namespace = null,
+        )
+        assertEquals(setOf("app", "other"), schemasOf(ds.id))
+
+        store.projectCatalogSchemas(
+            ds.id,
+            listOf(ProjectedObservation("app", listOf(column("app", "users", "renamed")), version("h-app2", 200))),
+            namespaceComplete = false,
+            namespace = null,
+        )
+
+        assertEquals(setOf("app", "other"), schemasOf(ds.id), "a scoped reading must leave its siblings alone")
+        assertEquals(listOf("renamed"), store.catalog(ds.id).filter { it.schema == "app" }.map { it.column })
+        assertEquals(listOf("id"), store.catalog(ds.id).filter { it.schema == "other" }.map { it.column })
+    }
+
+    @Test
+    fun `an older reading does not overwrite the stored rows`() {
+        // The same ordering rule the in-memory pointer follows, applied to the rows browse and the
+        // classification joins read: a slow scan that arrives late must not replace newer stored columns.
+        val ds = datasource("proj-stale")
+        store.projectCatalogSchemas(
+            ds.id,
+            listOf(ProjectedObservation("app", listOf(column("app", "users", "new")), version("h-new", 101))),
+            namespaceComplete = false,
+            namespace = null,
+        )
+
+        store.projectCatalogSchemas(
+            ds.id,
+            listOf(ProjectedObservation("app", listOf(column("app", "users", "stale")), version("h-old", 100))),
+            namespaceComplete = false,
+            namespace = null,
+        )
+
+        assertEquals(listOf("new"), store.catalog(ds.id).map { it.column }, "the older reading must be dropped")
+        assertEquals("h-new" to 101L, storedVersion(ds.id, "app"), "and the version must still describe the stored rows")
+    }
+
+    @Test
+    fun `a newer reading replaces the rows and the version together`() {
+        val ds = datasource("proj-newer")
+        store.projectCatalogSchemas(
+            ds.id,
+            listOf(ProjectedObservation("app", listOf(column("app", "users", "old")), version("h-old", 100))),
+            namespaceComplete = false,
+            namespace = null,
+        )
+        store.projectCatalogSchemas(
+            ds.id,
+            listOf(ProjectedObservation("app", listOf(column("app", "users", "new")), version("h-new", 200))),
+            namespaceComplete = false,
+            namespace = null,
+        )
+
+        assertEquals(listOf("new"), store.catalog(ds.id).map { it.column })
+        assertEquals("h-new" to 200L, storedVersion(ds.id, "app"))
+    }
+
+    @Test
+    fun `only a namespace-complete reading deletes an absent schema`() {
+        val ds = datasource("proj-delete")
+        store.projectCatalogSchemas(
+            ds.id,
+            listOf(
+                ProjectedObservation("app", listOf(column("app", "users", "id")), version("h-app", 100)),
+                ProjectedObservation("dropped", listOf(column("dropped", "t", "c")), version("h-drop", 100)),
+            ),
+            namespaceComplete = true,
+            namespace = null,
+        )
+        assertEquals(setOf("app", "dropped"), schemasOf(ds.id))
+
+        // A SCOPED reading omitting `dropped` says nothing about it — a privilege-filtered account reads a
+        // strict subset, and deleting on that would erase every schema it cannot see.
+        store.projectCatalogSchemas(
+            ds.id,
+            listOf(ProjectedObservation("app", listOf(column("app", "users", "id")), version("h-app", 200))),
+            namespaceComplete = false,
+            namespace = null,
+        )
+        assertEquals(setOf("app", "dropped"), schemasOf(ds.id), "a scoped reading must never imply deletion")
+
+        // The same omission from a reading that enumerated the whole server IS the schema being gone.
+        store.projectCatalogSchemas(
+            ds.id,
+            listOf(ProjectedObservation("app", listOf(column("app", "users", "id")), version("h-app", 300))),
+            namespaceComplete = true,
+            namespace = null,
+        )
+        assertEquals(setOf("app"), schemasOf(ds.id))
+        assertNull(storedVersion(ds.id, "dropped"), "the version goes with the rows")
+    }
+
+    @Test
+    fun `an unversioned reading lands and leaves nothing to order against`() {
+        // An older proxy sends no hashes. Its columns are still the catalog, so they are stored; recording a
+        // version would invent an ordering claim the reading never made.
+        val ds = datasource("proj-unversioned")
+        store.projectCatalogSchemas(
+            ds.id,
+            listOf(ProjectedObservation("app", listOf(column("app", "users", "id")), version = null)),
+            namespaceComplete = false,
+            namespace = null,
+        )
+
+        assertEquals(listOf("id"), store.catalog(ds.id).map { it.column })
+        assertNull(storedVersion(ds.id, "app"))
+    }
+
+    @Test
+    fun `a version-only reading records the version without touching the rows`() {
+        // The economy form: a reading that confirms a schema's hash without re-sending its columns. Treating
+        // its silence as "no columns" would empty a schema that never changed.
+        val ds = datasource("proj-version-only")
+        store.projectCatalogSchemas(
+            ds.id,
+            listOf(ProjectedObservation("app", listOf(column("app", "users", "id")), version("h1", 100))),
+            namespaceComplete = false,
+            namespace = null,
+        )
+
+        store.projectCatalogSchemas(
+            ds.id,
+            listOf(ProjectedObservation("app", columns = null, version = version("h1", 200))),
+            namespaceComplete = false,
+            namespace = null,
+        )
+
+        assertEquals(listOf("id"), store.catalog(ds.id).map { it.column }, "the rows must survive a version-only reading")
+        assertEquals("h1" to 200L, storedVersion(ds.id, "app"))
+    }
+
+    @Test
+    fun `the whole-catalog writer still replaces everything and stamps the namespace`() {
+        // storePushedCatalog is now expressed through the per-schema projection; its callers still hand it
+        // the complete column set and expect the whole catalog replaced.
+        val ds = datasource("proj-whole")
+        store.storePushedCatalog(
+            ds.id,
+            defaultSchemas = listOf("app"),
+            mysqlLowerCaseTableNames = 0,
+            engineVersion = "8.4.0",
+            columns = listOf(column("app", "users", "id"), column("gone", "t", "c")),
+        )
+        assertEquals(setOf("app", "gone"), schemasOf(ds.id))
+
+        store.storePushedCatalog(
+            ds.id,
+            defaultSchemas = listOf("app"),
+            mysqlLowerCaseTableNames = 0,
+            engineVersion = "8.4.0",
+            columns = listOf(column("app", "users", "id")),
+        )
+
+        assertEquals(setOf("app"), schemasOf(ds.id))
+        val refreshed = store.get(ds.id)!!
+        assertEquals(listOf("app"), refreshed.defaultSchemas)
+        assertEquals("8.4.0", refreshed.engineVersion)
+        assertTrue(refreshed.catalogSyncedAt != null)
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PerConnectionCatalogAdversarialDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PerConnectionCatalogAdversarialDbTest.kt
@@ -49,6 +49,19 @@ abstract class PerConnectionCatalogAdversarialDbContract {
         return opened
     }
 
+    /**
+     * Re-measure [schema] on a connection that has no refetch outstanding.
+     *
+     * A push is a compare-and-set against a command the control plane issued, so a test that changes the
+     * backend out of band has to ask for the re-read before it can deliver one — exactly as the proxy does
+     * when a statement's verdict carries no after-statement command.
+     */
+    protected suspend fun remeasure(opened: OpenConnection, target: Connection, schema: String) {
+        val connection = fixture.core.connectionCatalog.find(opened.connectionId)!!
+        fixture.core.connectionCatalog.markAfterStatement(connection, listOf(schema))
+        fixture.pushFromTarget(target, opened.connectionId, schema)
+    }
+
     protected suspend fun decide(
         opened: OpenConnection,
         principal: String,
@@ -115,7 +128,7 @@ abstract class PerConnectionCatalogAdversarialDbContract {
                 )
                 assertEquals(EnfAction.ALLOW, firstDdl.ctx.action, firstDdl.ctx.denyReason)
                 siblingTarget.createStatement().use { it.execute("CREATE TABLE ${qualified(schema, "pccat_version_one")} (id BIGINT)") }
-                fixture.pushFromTarget(siblingTarget, sibling.connectionId, schema)
+                remeasure(sibling, siblingTarget, schema)
 
                 val stale = assertIs<EnforcementOutcome.BeforeDecide>(
                     decide(held, "analyst@example.com", "SELECT id FROM users", listOf(schema)),
@@ -146,13 +159,14 @@ abstract class PerConnectionCatalogAdversarialDbContract {
                 )
                 assertEquals(EnfAction.ALLOW, secondDdl.ctx.action, secondDdl.ctx.denyReason)
                 siblingTarget.createStatement().use { it.execute("CREATE TABLE ${qualified(schema, "pccat_version_two")} (id BIGINT)") }
-                fixture.pushFromTarget(siblingTarget, sibling.connectionId, schema)
+                remeasure(sibling, siblingTarget, schema)
 
                 assertIs<EnforcementOutcome.BeforeDecide>(
                     decide(held, "analyst@example.com", "SELECT id FROM users", listOf(schema)),
                 )
             }
         }
+        Unit
     }
 
     @Test

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PerConnectionCatalogStateTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PerConnectionCatalogStateTest.kt
@@ -2,15 +2,19 @@ package com.ridi.oss.proxymonster.controlplane
 
 import com.google.protobuf.ByteString
 import com.ridi.oss.proxymonster.grpc.Engine
+import com.ridi.oss.proxymonster.grpc.catalogRequest
 import com.ridi.oss.proxymonster.grpc.column
 import com.ridi.oss.proxymonster.grpc.schemaFragmentPush
+import com.ridi.oss.proxymonster.grpc.schemaHash
 import io.grpc.Status
 import kotlinx.coroutines.runBlocking
 import java.security.SecureRandom
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class PerConnectionCatalogStateTest {
@@ -26,6 +30,10 @@ class PerConnectionCatalogStateTest {
         generation: Long = 1,
         unchanged: Boolean = false,
         columnName: String = "id",
+        clockMicros: Long = 0,
+        backend: String = "",
+        trusted: Boolean = true,
+        inTransaction: Boolean = false,
     ) = schemaFragmentPush {
         connectionId = opened.connectionId
         datasourceName = ds.name
@@ -33,9 +41,47 @@ class PerConnectionCatalogStateTest {
         contentHash = ByteString.copyFromUtf8(hash)
         this.unchanged = unchanged
         backendGeneration = generation
+        dbClockMicros = clockMicros
+        backendId = backend
+        hashTrusted = trusted
+        measuredInTransaction = inTransaction
         if (!unchanged) {
             columns.add(column {
                 this.schema = schema; table = "users"; column = columnName
+                dataType = "bigint"; ordinal = 1; nullable = false
+            })
+        }
+    }
+
+    /** A configuration reading — what registration and the ambient refresh push, carrying per-schema hashes. */
+    private fun config(
+        schema: String,
+        hash: String,
+        columnName: String? = "id",
+        clockMicros: Long = 0,
+        backend: String = "",
+        trusted: Boolean = true,
+        complete: Boolean = false,
+        extraSchemas: Map<String, String> = emptyMap(),
+    ) = catalogRequest {
+        datasourceName = ds.name
+        defaultSchemas.add("app")
+        schemaHashes.add(schemaHash { this.schema = schema; this.hash = ByteString.copyFromUtf8(hash); this.trusted = trusted })
+        extraSchemas.forEach { (name, h) ->
+            schemaHashes.add(schemaHash { this.schema = name; this.hash = ByteString.copyFromUtf8(h); this.trusted = true })
+            contentSchemas.add(name)
+            columns.add(column {
+                this.schema = name; table = "t"; this.column = "c"
+                dataType = "bigint"; ordinal = 1; nullable = false
+            })
+        }
+        dbClockMicros = clockMicros
+        backendId = backend
+        namespaceComplete = complete
+        if (columnName != null) {
+            contentSchemas.add(schema)
+            columns.add(column {
+                this.schema = schema; table = "users"; this.column = columnName
                 dataType = "bigint"; ordinal = 1; nullable = false
             })
         }
@@ -171,7 +217,7 @@ class PerConnectionCatalogStateTest {
     }
 
     @Test
-    fun `an ambient refresh re-measures pooled content so adopters stay fresh`() = runBlocking {
+    fun `a configuration reading of the same content refreshes the staleness clock`() = runBlocking {
         // The staleness ceiling sits above the ambient refresh interval on the premise that the refresh
         // itself keeps pooled content verified. Without that, content pooled once would age out no matter
         // how recently the backend was read, and every new session would refetch.
@@ -181,50 +227,56 @@ class PerConnectionCatalogStateTest {
         registry.applyPush(push(first, "app", "h1"), ds)
 
         now = 8
-        val confirmed = registry.recordAmbientMeasurement(
-            ds.name,
-            mapOf("app" to listOf(FragmentColumn("app", "users", "id", "bigint", 1, false))),
-        )
-        assertEquals(setOf("app"), confirmed)
+        registry.applyConfigCatalog(config("app", "h1"), ds)
 
-        now = 15 // past the original measurement, inside the window from the ambient one
+        now = 15 // past the original measurement, inside the window from the configuration reading
         val second = registry.open(Binding(ds.name, "second", "USER"), listOf("app"), adoptHeldContent = true)
         assertTrue(second.onOpen.isEmpty())
         assertTrue(
             registry.freshnessGate(registry.find(second.connectionId)!!, listOf("app")).isEmpty(),
-            "the ambient re-measurement must reset the staleness clock for later adopters",
+            "the configuration reading must reset the staleness clock for later adopters",
         )
     }
 
     @Test
-    fun `an ambient refresh whose columns differ never overwrites pooled content`() = runBlocking {
-        // Confirmation only. Divergence belongs to the connection's own probe, which alone knows what that
-        // connection's backend binds; installing a differing ambient read here would decide against a
-        // catalog no connection measured.
-        var now = 0L
-        val registry = ConnectionCatalogRegistry(clockNanos = { now }, stalenessNanos = 10)
-        val first = registry.open(Binding(ds.name, "first", "USER"), listOf("app"))
-        registry.applyPush(push(first, "app", "h1"), ds)
+    fun `the first connection adopts content a configuration reading installed`() = runBlocking {
+        // The point of the whole step. A registration scan holds the same six fields a fragment does and now
+        // carries the backend's own hash for each schema, so its content is content-addressable exactly like
+        // a connection's — meaning connection #1 starts from it instead of re-reading what the control plane
+        // was handed seconds earlier.
+        val registry = ConnectionCatalogRegistry()
+        registry.applyConfigCatalog(config("app", "h1", clockMicros = 100, backend = "srv"), ds)
 
-        now = 8
-        val confirmed = registry.recordAmbientMeasurement(
-            ds.name,
-            mapOf("app" to listOf(FragmentColumn("app", "users", "DIFFERENT", "bigint", 1, false))),
-        )
-        assertTrue(confirmed.isEmpty(), "a differing ambient read must not count as a re-measurement")
-
-        now = 15
-        val second = registry.open(Binding(ds.name, "second", "USER"), listOf("app"), adoptHeldContent = true)
-        assertEquals(
-            setOf("app"),
-            registry.freshnessGate(registry.find(second.connectionId)!!, listOf("app")),
-            "unconfirmed content must still go stale on its original clock",
-        )
-        // And the pooled structure is untouched: still the originally measured column.
+        val opened = registry.open(Binding(ds.name, "first", "USER"), listOf("app"), adoptHeldContent = true)
+        assertTrue(opened.onOpen.isEmpty(), "the first connection must adopt, not fetch")
         assertEquals(
             listOf("id"),
-            registry.structuralRows(registry.find(second.connectionId)!!).map { it.column },
+            registry.structuralRows(registry.find(opened.connectionId)!!).map { it.column },
+            "it must adopt the scan's actual columns",
         )
+    }
+
+    @Test
+    fun `an untrusted configuration hash installs nothing`() = runBlocking {
+        // A hash the producer could not vouch for names content it may already have proved stale. Installing
+        // it would hand exactly that content to the next connection to adopt.
+        val registry = ConnectionCatalogRegistry()
+        registry.applyConfigCatalog(config("app", "h1", trusted = false), ds)
+
+        assertNull(registry.authoritativeFor(ds.name, "app"), "an untrusted reading must not become authoritative")
+        val opened = registry.open(Binding(ds.name, "first", "USER"), listOf("app"), adoptHeldContent = true)
+        assertEquals(listOf("app"), opened.onOpen.map { it.schema }, "there is nothing proven to adopt")
+    }
+
+    @Test
+    fun `a configuration reading naming a hash with no content asks for that schema`() = runBlocking {
+        // A pointer that names content nothing resolves is worse than no pointer: an adopting connection
+        // decides against an empty structure. The manager reports the gap instead so the proxy fills it.
+        val registry = ConnectionCatalogRegistry()
+        val result = registry.applyConfigCatalog(config("app", "h1", columnName = null), ds)
+
+        assertEquals(listOf("app"), result.fetchSchemas)
+        assertNull(registry.authoritativeFor(ds.name, "app"))
     }
 
     @Test
@@ -327,7 +379,7 @@ class PerConnectionCatalogStateTest {
     }
 
     @Test
-    fun `one datasource's ambient refresh cannot vouch for another's schema`() = runBlocking {
+    fun `one datasource's configuration reading cannot vouch for another's schema`() = runBlocking {
         // System-schema content is pooled once per engine version and shared by every datasource on it, so a
         // measurement recorded against the shared content would let a datasource nobody read look freshly
         // verified. Freshness is evidence about one backend; only the content is shareable.
@@ -339,15 +391,19 @@ class PerConnectionCatalogStateTest {
         registry.openPushSystem(dsB, "information_schema", "sys-h1")
 
         now = 8
-        // Only dsA is re-read. Its columns match, so dsA is confirmed — dsB must not be.
-        val confirmed = registry.recordAmbientMeasurement(
-            dsA.name,
-            mapOf(
-                "information_schema" to
-                    listOf(FragmentColumn("information_schema", "t", "c", "bigint", 1, false)),
-            ),
+        // Only dsA is re-read.
+        registry.applyConfigCatalog(
+            catalogRequest {
+                datasourceName = dsA.name
+                schemaHashes.add(schemaHash { schema = "information_schema"; hash = ByteString.copyFromUtf8("sys-h1"); trusted = true })
+                contentSchemas.add("information_schema")
+                columns.add(column {
+                    schema = "information_schema"; table = "t"; this.column = "c"
+                    dataType = "bigint"; ordinal = 1; nullable = false
+                })
+            },
+            dsA,
         )
-        assertEquals(setOf("information_schema"), confirmed)
 
         now = 15
         val onA = registry.open(
@@ -365,6 +421,245 @@ class PerConnectionCatalogStateTest {
         )
     }
 
+    @Test
+    fun `an older reading of the same backend is dropped, never installed`() = runBlocking {
+        // The ordering rule's whole point. A whole-server scan takes tens of seconds, so a scan that read
+        // state at time 100 routinely lands after a connection refetch that read newer state at 101. Under
+        // accept order the slow scan displaces the newer catalog and a trusting connection adopts it.
+        val registry = ConnectionCatalogRegistry()
+        val opened = registry.open(Binding(ds.name, "fast", "USER"), listOf("app"))
+        registry.applyPush(push(opened, "app", "new", clockMicros = 101, backend = "srv"), ds)
+
+        registry.applyConfigCatalog(config("app", "old", columnName = "stale", clockMicros = 100, backend = "srv"), ds)
+
+        assertEquals(
+            "new",
+            registry.authoritativeFor(ds.name, "app")!!.hash.bytes.toStringUtf8(),
+            "an older reading must not displace the newer content",
+        )
+        val adopter = registry.open(Binding(ds.name, "later", "USER"), listOf("app"), adoptHeldContent = true)
+        assertEquals(
+            listOf("id"),
+            registry.structuralRows(registry.find(adopter.connectionId)!!).map { it.column },
+            "and no connection may adopt the stale scan's columns",
+        )
+    }
+
+    @Test
+    fun `a strictly newer reading of the same backend installs`() = runBlocking {
+        // The other half of the rule: it must still let genuine progress through, or the shared state would
+        // simply freeze on whatever landed first.
+        val registry = ConnectionCatalogRegistry()
+        val opened = registry.open(Binding(ds.name, "slow", "USER"), listOf("app"))
+        registry.applyPush(push(opened, "app", "old", clockMicros = 100, backend = "srv"), ds)
+
+        registry.applyConfigCatalog(config("app", "new", columnName = "fresh", clockMicros = 101, backend = "srv"), ds)
+
+        assertEquals("new", registry.authoritativeFor(ds.name, "app")!!.hash.bytes.toStringUtf8())
+        val adopter = registry.open(Binding(ds.name, "later", "USER"), listOf("app"), adoptHeldContent = true)
+        assertEquals(listOf("fresh"), registry.structuralRows(registry.find(adopter.connectionId)!!).map { it.column })
+    }
+
+    @Test
+    fun `an unclocked reading fills a hole but never overwrites a clocked one`() = runBlocking {
+        // A reading with no clock cannot be shown to be the newer of the two, and refusing exactly that
+        // claim is what the version exists for. It may still seed a schema nothing is held for.
+        val registry = ConnectionCatalogRegistry()
+        registry.applyConfigCatalog(config("app", "seed", clockMicros = 0, backend = "srv"), ds)
+        assertEquals("seed", registry.authoritativeFor(ds.name, "app")!!.hash.bytes.toStringUtf8())
+
+        val opened = registry.open(Binding(ds.name, "clocked", "USER"), listOf("app"))
+        registry.applyPush(push(opened, "app", "clocked", clockMicros = 500, backend = "srv"), ds)
+        registry.applyConfigCatalog(config("app", "unclocked", columnName = "x", clockMicros = 0, backend = "srv"), ds)
+
+        assertEquals(
+            "clocked",
+            registry.authoritativeFor(ds.name, "app")!!.hash.bytes.toStringUtf8(),
+            "an unversioned reading must not displace a versioned one",
+        )
+    }
+
+    @Test
+    fun `readings from different backends fall back to accept order`() = runBlocking {
+        // A wall clock is only meaningful inside one backend. Comparing across two would let one server's
+        // clock skew decide the other's content, so the comparison is skipped entirely — degraded ordering,
+        // never a cross-backend clock claim.
+        val registry = ConnectionCatalogRegistry()
+        val opened = registry.open(Binding(ds.name, "a", "USER"), listOf("app"))
+        registry.applyPush(push(opened, "app", "from-a", clockMicros = 900, backend = "srv-a"), ds)
+
+        registry.applyConfigCatalog(config("app", "from-b", columnName = "b", clockMicros = 100, backend = "srv-b"), ds)
+
+        assertEquals(
+            "from-b",
+            registry.authoritativeFor(ds.name, "app")!!.hash.bytes.toStringUtf8(),
+            "a lower clock on a DIFFERENT backend is not an older reading; accept order decides",
+        )
+    }
+
+    @Test
+    fun `an untrusted connection push stays connection-only`() = runBlocking {
+        // The producer measured this hash and then proved its own reading stale — its two bracketing
+        // measurements disagreed. Its columns are the connection's to decide against, and nobody else's.
+        val registry = ConnectionCatalogRegistry()
+        val opened = registry.open(Binding(ds.name, "measurer", "USER"), listOf("app"))
+        val applied = registry.applyPush(
+            push(opened, "app", "h-untrusted", columnName = "leaked", trusted = false, clockMicros = 100, backend = "srv"),
+            ds,
+        )
+        assertTrue(applied is CatalogMutationResult.Applied, "the connection still gets its own content")
+        assertEquals(
+            listOf("leaked"),
+            registry.structuralRows(registry.find(opened.connectionId)!!).map { it.column },
+        )
+
+        assertNull(registry.authoritativeFor(ds.name, "app"), "an untrusted push must never become authoritative")
+        val adopter = registry.open(Binding(ds.name, "adopter", "USER"), listOf("app"), adoptHeldContent = true)
+        assertEquals(listOf("app"), adopter.onOpen.map { it.schema }, "no connection may adopt it")
+        assertTrue(
+            registry.structuralRows(registry.find(adopter.connectionId)!!).isEmpty(),
+            "and none may resolve its columns",
+        )
+    }
+
+    @Test
+    fun `an untrusted hash is never handed back as a refetch token`() = runBlocking {
+        // The proxy would answer `unchanged` against bytes no coherent measurement stands behind, and the
+        // connection would keep columns the producer already proved did not match that hash.
+        var now = 0L
+        val registry = ConnectionCatalogRegistry(clockNanos = { now }, stalenessNanos = 10)
+        val opened = registry.open(Binding(ds.name, "measurer", "USER"), listOf("app"))
+        registry.applyPush(push(opened, "app", "h-untrusted", trusted = false), ds)
+
+        now = 20 // aged past the staleness bound, so the next decide re-checks
+        val connection = registry.find(opened.connectionId)!!
+        assertEquals(setOf("app"), registry.freshnessGate(connection, listOf("app")))
+        val commands = registry.markBeforeDecide(connection, listOf("app"))
+        assertTrue(
+            commands.single().ifHashDiffers.isEmpty,
+            "an untrusted hash must force an unconditional fetch",
+        )
+    }
+
+    @Test
+    fun `a dirty connection push stays connection-only`() = runBlocking {
+        // Measured inside an open transaction, so its view is transactionally private: it may include the
+        // connection's own uncommitted DDL, or miss committed DDL from elsewhere.
+        val registry = ConnectionCatalogRegistry()
+        val opened = registry.open(Binding(ds.name, "in-tx", "USER"), listOf("app"))
+        registry.applyPush(
+            push(opened, "app", "h-dirty", columnName = "uncommitted", inTransaction = true, clockMicros = 100, backend = "srv"),
+            ds,
+        )
+
+        assertEquals(
+            listOf("uncommitted"),
+            registry.structuralRows(registry.find(opened.connectionId)!!).map { it.column },
+            "the measuring connection still decides against what it read",
+        )
+        assertNull(registry.authoritativeFor(ds.name, "app"), "a dirty push must never become authoritative")
+        val adopter = registry.open(Binding(ds.name, "adopter", "USER"), listOf("app"), adoptHeldContent = true)
+        assertEquals(listOf("app"), adopter.onOpen.map { it.schema }, "no connection may adopt it")
+    }
+
+    @Test
+    fun `a namespace-complete reading drops a schema it no longer sees`() = runBlocking {
+        val registry = ConnectionCatalogRegistry()
+        registry.applyConfigCatalog(
+            config("app", "h1", clockMicros = 100, backend = "srv", complete = true, extraSchemas = mapOf("gone" to "g1")),
+            ds,
+        )
+        assertNotNull(registry.authoritativeFor(ds.name, "gone"))
+
+        registry.applyConfigCatalog(config("app", "h1", clockMicros = 200, backend = "srv", complete = true), ds)
+
+        assertNull(registry.authoritativeFor(ds.name, "gone"), "a schema absent from a complete enumeration is gone")
+        assertNotNull(registry.authoritativeFor(ds.name, "app"), "the schemas it did name survive")
+        Unit
+    }
+
+    @Test
+    fun `a scoped reading never implies deletion`() = runBlocking {
+        // Both engines filter information_schema by privilege, so a least-privilege account reads a strict
+        // subset. Deleting on a reading that never claimed completeness erases every schema it cannot see.
+        val registry = ConnectionCatalogRegistry()
+        registry.applyConfigCatalog(
+            config("app", "h1", clockMicros = 100, backend = "srv", complete = true, extraSchemas = mapOf("unseen" to "u1")),
+            ds,
+        )
+        assertNotNull(registry.authoritativeFor(ds.name, "unseen"))
+
+        registry.applyConfigCatalog(config("app", "h1", clockMicros = 200, backend = "srv", complete = false), ds)
+
+        assertNotNull(
+            registry.authoritativeFor(ds.name, "unseen"),
+            "a reading that did not enumerate the server says nothing about the schemas it omitted",
+        )
+        Unit
+    }
+
+    @Test
+    fun `a schema declared present with no columns is distinct from one not carried`() = runBlocking {
+        // "carried but empty" and "not carried by this push" are different claims. Collapsing them would let
+        // an economy push that omits unchanged schemas read as those schemas having lost every column.
+        val registry = ConnectionCatalogRegistry()
+        registry.applyConfigCatalog(config("app", "h1", clockMicros = 100, backend = "srv"), ds)
+        val pooled = registry.authoritativeFor(ds.name, "app")!!.pooledRef
+
+        // A later reading names the same schema's NEW hash but carries no columns for it.
+        val result = registry.applyConfigCatalog(config("app", "h2", columnName = null, clockMicros = 200, backend = "srv"), ds)
+
+        assertEquals(listOf("app"), result.fetchSchemas, "the manager must ask for the content it lacks")
+        assertEquals(
+            "h1",
+            registry.authoritativeFor(ds.name, "app")!!.hash.bytes.toStringUtf8(),
+            "the pointer must not move to a hash with nothing behind it",
+        )
+        assertNotNull(registry.pooledFor(pooled), "and the resolvable content stays")
+        Unit
+    }
+
+    @Test
+    fun `a same-content reading keeps the higher clock`() = runBlocking {
+        // Two readings of identical content are equally good evidence of it. Taking the later clock stops an
+        // old confirming reading from making the entry look older than a newer reading already proved.
+        val registry = ConnectionCatalogRegistry()
+        registry.applyConfigCatalog(config("app", "h1", clockMicros = 500, backend = "srv"), ds)
+        registry.applyConfigCatalog(config("app", "h1", clockMicros = 100, backend = "srv"), ds)
+
+        assertEquals(500, registry.authoritativeFor(ds.name, "app")!!.dbClockMicros)
+        // And the entry still refuses an older differing reading measured against that higher clock.
+        registry.applyConfigCatalog(config("app", "h2", columnName = "x", clockMicros = 200, backend = "srv"), ds)
+        assertEquals("h1", registry.authoritativeFor(ds.name, "app")!!.hash.bytes.toStringUtf8())
+    }
+
+    @Test
+    fun `the ordering rule discriminates every case it claims to`() {
+        // Without this the rule above is only exercised where a test happens to reach it; a predicate that
+        // returned INCOMPARABLE for everything would still pass those, since accept order installs too.
+        val h1 = ContentHash(ByteString.copyFromUtf8("h1"))
+        val h2 = ContentHash(ByteString.copyFromUtf8("h2"))
+        fun v(hash: ContentHash, clock: Long, backend: String) = ReadingVersion(hash, clock, backend)
+
+        assertEquals(ReadingOrder.FIRST, orderReading(null, v(h1, 100, "srv")))
+        assertEquals(ReadingOrder.SAME, orderReading(v(h1, 100, "srv"), v(h1, 200, "srv")))
+        assertEquals(ReadingOrder.NEWER, orderReading(v(h1, 100, "srv"), v(h2, 101, "srv")))
+        assertEquals(ReadingOrder.TIED, orderReading(v(h1, 100, "srv"), v(h2, 100, "srv")))
+        assertEquals(ReadingOrder.STALE, orderReading(v(h1, 100, "srv"), v(h2, 99, "srv")))
+        assertEquals(ReadingOrder.STALE, orderReading(v(h1, 100, "srv"), v(h2, 0, "srv")))
+        assertEquals(ReadingOrder.NEWER, orderReading(v(h1, 0, "srv"), v(h2, 100, "srv")))
+        assertEquals(ReadingOrder.INCOMPARABLE, orderReading(v(h1, 0, "srv"), v(h2, 0, "srv")))
+        assertEquals(ReadingOrder.INCOMPARABLE, orderReading(v(h1, 100, "srv-a"), v(h2, 99, "srv-b")))
+        assertEquals(ReadingOrder.INCOMPARABLE, orderReading(v(h1, 100, ""), v(h2, 99, "srv")))
+        assertEquals(ReadingOrder.INCOMPARABLE, orderReading(v(h1, 100, "srv"), v(h2, 99, "")))
+
+        // Only STALE and SAME withhold installation; everything else must be able to land.
+        assertFalse(ReadingOrder.STALE.installs)
+        assertFalse(ReadingOrder.SAME.installs)
+        listOf(ReadingOrder.FIRST, ReadingOrder.NEWER, ReadingOrder.TIED, ReadingOrder.INCOMPARABLE)
+            .forEach { assertTrue(it.installs, "$it must install") }
+    }
+
     /** Open a connection on [ds] scoped to one system [schema] and push a single-column fragment for it. */
     private suspend fun ConnectionCatalogRegistry.openPushSystem(ds: Datasource, schema: String, hash: String): OpenConnection {
         val opened = open(Binding(ds.name, "p", "USER"), listOf(schema))
@@ -374,6 +669,7 @@ class PerConnectionCatalogStateTest {
                 datasourceName = ds.name
                 this.schema = schema
                 contentHash = ByteString.copyFromUtf8(hash)
+                hashTrusted = true
                 backendGeneration = 1
                 columns.add(column {
                     this.schema = schema; table = "t"; column = "c"

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/GrpcRegistrationHandlerDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/GrpcRegistrationHandlerDbTest.kt
@@ -513,64 +513,97 @@ class GrpcRegistrationHandlerDbTest {
     }
 
     @Test
-    fun `pushCatalog re-measures the enforcement catalog, not only the stored one`() = runBlocking {
-        // The staleness ceiling is set above the ambient refresh interval on the premise that the refresh
-        // keeps enforcement content verified. That premise is a single call in this handler: exercise it
-        // through the RPC, because a registry-level test would stay green if the wiring were removed and
-        // the refresh went back to feeding only the stored catalog.
-        stub.register(registerRequest { name = "reg-ambient"; engine = Engine.MYSQL; host = "h"; port = 1; dbName = "app" })
-        val ds = core.datasourceStore.getByName("reg-ambient")!!
+    fun `pushCatalog seeds the enforcement catalog so the first connection adopts`() = runBlocking {
+        // The headline of the manager: a configuration reading carries the backend's own per-schema hash, so
+        // its content is content-addressable exactly like a connection's fragment and SEEDS the pool. Before
+        // this, the first connection re-read thousands of columns the control plane was handed seconds
+        // earlier, because the reading could only confirm what some connection had already measured.
+        //
+        // Exercised through the RPC rather than the registry: a registry-level test would stay green if the
+        // handler stopped routing through the manager and went back to writing only the stored catalog.
+        stub.register(registerRequest { name = "reg-seed"; engine = Engine.MYSQL; host = "h"; port = 1; dbName = "app" })
+        val ds = core.datasourceStore.getByName("reg-seed")!!
 
-        // A connection measures `app` itself, so the control plane holds enforcement content for it.
-        val opened = core.connectionCatalog.open(Binding(ds.name, "p", "USER"), listOf("app"))
-        val applied = core.connectionCatalog.applyPush(
-            schemaFragmentPush {
-                connectionId = opened.connectionId
-                datasourceName = ds.name
-                schema = "app"
-                contentHash = ByteString.copyFromUtf8("h1")
-                backendGeneration = 1
-                columns.add(
-                    column { schema = "app"; table = "users"; this.column = "id"; dataType = "bigint"; ordinal = 1; nullable = false },
-                )
-            },
-            ds,
-        )
-        assertIs<CatalogMutationResult.Applied>(applied)
-        val measuredBefore = core.connectionCatalog.measuredNanosFor(ds.name, "app")!!
-
-        // The ambient refresh reports the same content for that schema.
         stub.pushCatalog(
             catalogRequest {
                 datasourceName = ds.name
                 defaultSchemas.add("app")
+                schemaHashes.add(schemaHash { schema = "app"; hash = ByteString.copyFromUtf8("h1"); trusted = true })
+                dbClockMicros = 1_000
+                backendId = "srv"
+                contentSchemas.add("app")
+                namespaceComplete = true
                 columns.add(
                     column { schema = "app"; table = "users"; this.column = "id"; dataType = "bigint"; ordinal = 1; nullable = false },
                 )
             },
         )
 
-        // The recorded measurement time must have MOVED. Asserting that instead of "the adopter looks
-        // fresh" is deliberate: the adopter would look fresh anyway from the original measurement seconds
-        // earlier, so a freshness assertion holds even with this handler unwired and proves nothing.
-        val afterAmbient = core.connectionCatalog.measuredNanosFor(ds.name, "app")
-        assertNotNull(afterAmbient, "the enforcement entry must survive the push")
-        assertTrue(
-            afterAmbient > measuredBefore,
-            "pushCatalog must record its read against the enforcement catalog " +
-                "(before=$measuredBefore after=$afterAmbient)",
-        )
-
-        // The push confirms content; it never installs it.
+        // No connection has measured this backend, so nothing but the push could have put content here.
         val adopter = core.connectionCatalog.open(
-            Binding(ds.name, "later", "USER"), listOf("app"), adoptHeldContent = true,
+            Binding(ds.name, "first", "USER"), listOf("app"), adoptHeldContent = true,
         )
-        assertTrue(adopter.onOpen.isEmpty(), "the ambient push must leave the adopter with nothing to fetch")
+        assertTrue(adopter.onOpen.isEmpty(), "the first connection must adopt the pushed content, not fetch it")
         assertEquals(
             listOf("id"),
             core.connectionCatalog.structuralRows(
                 core.connectionCatalog.find(adopter.connectionId)!!,
             ).map { it.column },
+            "and it must resolve the columns the push actually carried",
+        )
+    }
+
+    @Test
+    fun `pushCatalog refuses to install a reading older than a connection's own`() = runBlocking {
+        // The race the version exists to reject: a whole-server scan takes tens of seconds, so a scan that
+        // read state at time 100 routinely lands after a connection refetch that read newer state at 101.
+        // Under accept order the slow scan's stale content displaces the newer catalog and the next
+        // trusting connection adopts it.
+        stub.register(registerRequest { name = "reg-stale"; engine = Engine.MYSQL; host = "h"; port = 1; dbName = "app" })
+        val ds = core.datasourceStore.getByName("reg-stale")!!
+
+        val opened = core.connectionCatalog.open(Binding(ds.name, "fast", "USER"), listOf("app"))
+        val applied = core.connectionCatalog.applyPush(
+            schemaFragmentPush {
+                connectionId = opened.connectionId
+                datasourceName = ds.name
+                schema = "app"
+                contentHash = ByteString.copyFromUtf8("h-new")
+                hashTrusted = true
+                dbClockMicros = 101
+                backendId = "srv"
+                backendGeneration = 1
+                columns.add(
+                    column { schema = "app"; table = "users"; this.column = "current"; dataType = "bigint"; ordinal = 1; nullable = false },
+                )
+            },
+            ds,
+        )
+        assertIs<CatalogMutationResult.Applied>(applied)
+
+        stub.pushCatalog(
+            catalogRequest {
+                datasourceName = ds.name
+                defaultSchemas.add("app")
+                schemaHashes.add(schemaHash { schema = "app"; hash = ByteString.copyFromUtf8("h-old"); trusted = true })
+                dbClockMicros = 100
+                backendId = "srv"
+                contentSchemas.add("app")
+                columns.add(
+                    column { schema = "app"; table = "users"; this.column = "stale"; dataType = "bigint"; ordinal = 1; nullable = false },
+                )
+            },
+        )
+
+        val adopter = core.connectionCatalog.open(
+            Binding(ds.name, "later", "USER"), listOf("app"), adoptHeldContent = true,
+        )
+        assertEquals(
+            listOf("current"),
+            core.connectionCatalog.structuralRows(
+                core.connectionCatalog.find(adopter.connectionId)!!,
+            ).map { it.column },
+            "the older scan must not become what the next connection adopts",
         )
     }
 

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/PerConnectionCatalogFixture.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/PerConnectionCatalogFixture.kt
@@ -83,6 +83,9 @@ class PerConnectionCatalogFixture(val enforcement: EnforcementFixture) {
                 datasourceName = datasource.name
                 this.schema = schema
                 contentHash = hash(rows)
+                // The fixture reads the schema straight off the target and computes the hash over exactly
+                // the rows it pushes, which is what a coherent bracket asserts.
+                hashTrusted = true
                 this.unchanged = unchanged
                 this.backendGeneration = backendGeneration
                 if (!unchanged) {


### PR DESCRIPTION
One component now owns catalog state. Registration, the ambient refresh, and each
connection's measurements all land in the same manager, which decides per schema
whether an arriving reading is newer than what it holds and keeps the pooled
fragments and the persisted projection in step.

Adds `catalog_schema` (V14) so the pool survives a control-plane restart: the
manager rebuilds from the stored projection instead of forcing every live
connection to re-measure.

Stacked on #99.

**Parked** pending review; not for merge yet.