### PR TITLE
build(proto): pin Go protobuf generators

### DIFF
--- a/analyzer/buf.gen.yaml
+++ b/analyzer/buf.gen.yaml
@@ -2,9 +2,8 @@ version: v2
 # Generates Go bindings for analyzer.proto plus the shared engine.proto it imports
 # (docs/statement-facts-contract.md) — the analyzer<->JVM FFM boundary. proto/src/main/proto/
 # also holds controlplane.proto (the separate proxy<->control-plane gRPC contract, owned by
-# goproxy/buf.gen.yaml); regenerate with explicit --path flags so this module's codegen never picks
-# that file up:
-#   cd analyzer && buf generate ../proto/src/main/proto --path ../proto/src/main/proto/analyzer.proto --path ../proto/src/main/proto/engine.proto
+# goproxy/buf.gen.yaml). `mise run proto-generate` uses explicit paths so this module's codegen
+# never picks that file up.
 managed:
   enabled: true
   override:

--- a/goproxy/buf.gen.yaml
+++ b/goproxy/buf.gen.yaml
@@ -1,9 +1,7 @@
 version: v2
-# Managed mode injects go_package (the shared controlplane.proto carries no Go options and only
-# declares java_package) — the .proto stays untouched. Regenerate with an explicit --path for
-# controlplane.proto only, so this module's codegen never picks up analyzer.proto (owned by
-# analyzer/buf.gen.yaml):
-#   cd goproxy && buf generate ../proto/src/main/proto --path ../proto/src/main/proto/controlplane.proto
+# The Mcontrolplane.proto option supplies the Go package without modifying the shared contract.
+# `mise run proto-generate` scopes this module to controlplane.proto so it never picks up
+# analyzer.proto (owned by analyzer/buf.gen.yaml).
 #
 # controlplane.proto imports the shared engine.proto (proxymonster.v1.Engine) but this module does
 # NOT generate a second copy of it: goproxy links analyzer/probe into the same binary (introspect.go,
@@ -12,15 +10,10 @@ version: v2
 # init ("file already registered") the instant both packages are imported into one process. The
 # M-option below instead points engine.proto's Go package AT analyzer/probe/pb, so RegisterRequest's
 # Engine field resolves to that ALREADY-REGISTERED type — one Go type, shared, not two colliding ones.
-managed:
-  enabled: true
-  override:
-    - file_option: go_package_prefix
-      value: github.com/ridi-oss/proxy-monster/goproxy/internal/pb
 plugins:
   - local: protoc-gen-go
     out: internal/pb
-    opt: paths=source_relative,Mengine.proto=github.com/ridi-oss/proxy-monster/analyzer/probe/pb
+    opt: paths=source_relative,Mcontrolplane.proto=github.com/ridi-oss/proxy-monster/goproxy/internal/pb;proxymonsterv1,Mengine.proto=github.com/ridi-oss/proxy-monster/analyzer/probe/pb
   - local: protoc-gen-go-grpc
     out: internal/pb
-    opt: paths=source_relative
+    opt: paths=source_relative,Mcontrolplane.proto=github.com/ridi-oss/proxy-monster/goproxy/internal/pb;proxymonsterv1,Mengine.proto=github.com/ridi-oss/proxy-monster/analyzer/probe/pb

--- a/mise.toml
+++ b/mise.toml
@@ -13,6 +13,10 @@ java = "temurin-24.0.2"
 # Gradle build; matches analyzer/go.mod. (Zig — the Linux cross C compiler for the all-targets fat-jar
 # build, -Psqlglot.native.all=true — is only needed for that; add it when CI is wired.)
 go = "1.26"
+# Go protobuf generation. Buf provides the compiler; the two local plugins emit the checked-in Go files.
+buf = "1.72.0"
+protoc-gen-go = "1.35.2"
+protoc-gen-go-grpc = "1.5.1"
 # web/ (Next.js). Pinned rather than "whatever's on PATH" so `pnpm install`'s lockfile resolution
 # and `next build` behavior stay reproducible across machines. Match web/Dockerfile's base image +
 # corepack pin when bumping either.
@@ -165,6 +169,36 @@ BANNER
 wait
 '''
 
+[tasks.proto-generate]
+description = "Regenerate the checked-in Go protobuf bindings"
+shell = "bash -c"
+run = '''
+set -euo pipefail
+(cd analyzer && buf generate ../proto/src/main/proto --path ../proto/src/main/proto/analyzer.proto --path ../proto/src/main/proto/engine.proto)
+(cd goproxy && buf generate ../proto/src/main/proto --path ../proto/src/main/proto/controlplane.proto)
+'''
+
+[tasks.proto-check]
+description = "Verify the checked-in Go protobuf bindings are current"
+shell = "bash -c"
+run = '''
+set -euo pipefail
+files=(
+  analyzer/probe/pb/analyzer.pb.go
+  analyzer/probe/pb/engine.pb.go
+  goproxy/internal/pb/controlplane.pb.go
+  goproxy/internal/pb/controlplane_grpc.pb.go
+)
+before=$(git hash-object "${files[@]}")
+mise run proto-generate
+after=$(git hash-object "${files[@]}")
+if [ "$before" != "$after" ]; then
+  git diff -- "${files[@]}"
+  echo "Go protobuf bindings are stale; run: mise run proto-generate" >&2
+  exit 1
+fi
+'''
+
 [tasks.lint]
 description = "Lint: prettier over docs/config (md, json, yaml, css) + eslint over the web sources"
 shell = "bash -c"
@@ -194,6 +228,7 @@ shell = "bash -c"
 run = '''
 set -euo pipefail
 mise run lint
+mise run proto-check
 # The JVM tests are DB-backed (Testcontainers) and fail rather than skip, so Docker must be running.
 # --no-daemon: a shared Gradle daemon is machine-wide state, so a build here can recycle a JVM another
 # process depends on. Without it, this gate is not self-contained.


### PR DESCRIPTION
## Summary

- pin Buf and the Go protobuf generator plugins in mise
- add canonical generation and stale-output checks to the repository gate
- preserve the existing generated bindings byte-for-byte

## Verification

- `mise run verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqQABkf5Jg452yEZsbwj46