### PR TITLE
docs: classification-as-code — proxy declares column tags, CP does not persist

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,8 @@ a facts layer.
 | [`facts-emission.md`](./facts-emission.md) | Statement facts + Cedar marshalling; dangerous-function gating; `analyzable` / `maskability` gates. |
 | [`statement-facts-contract.md`](./statement-facts-contract.md) | Go emits a complete `StatementFacts` / `RequiredGrant` contract; the CP is a pure Cedar grant-walk, no lexing. |
 | [`system-classification.md`](./system-classification.md) | Immutable per-engine/version manifest; exposed system schemas; curated dangerous set; open-unknown posture. |
+| [`classification-as-code.md`](./classification-as-code.md) | **Proposed.** Column classification declared by the proxy from config, not stored in the CP; live decisions use it, saved results snapshot it. |
+| [`stored-result-classification.md`](./stored-result-classification.md) | **Proposed.** A saved result re-masks against the tags captured at execution, not today's: strict snapshot, no tag history. |
 | [`diagnostic-redaction.md`](./diagnostic-redaction.md) | Closes the DB error/warning value-leak side-channel; fail-closed field strip; message tables from catalogs. |
 | [`derived-masking.md`](./derived-masking.md) | Lets a masked column pass through a provably-total builtin string transform and stay masked. |
 | [`relation-model.md`](./relation-model.md) | Whole-row / composite-value resolution: how a relation used in value position never leaks a protected column. |

--- a/docs/classification-as-code.md
+++ b/docs/classification-as-code.md
@@ -1,0 +1,159 @@
+# Column classification as proxy-declared config
+
+Proposed, not built. This replaces where column classification lives and how it
+reaches a decision. It does not change masking, lineage, or the Cedar model —
+only who owns "which columns carry which tags."
+
+## Decision
+
+Column classification — a column's `tags` and its `mask_fn` — is **declared by
+the proxy** from its own config, not stored in the control plane. The proxy
+pushes classification alongside the catalog it already introspects; the control
+plane uses it for the live decision and keeps **no durable copy**. A saved
+workflow result freezes the classification it was decided under, so a view can
+re-decide with no live proxy
+([stored-result-classification.md](./stored-result-classification.md)).
+
+Three consequences fall out, each its own section below:
+
+- No control-plane classification store, so no runtime admin CRUD and no
+  cross-datasource dedup machinery (the parked profile abstraction).
+- When a proxy is gone the control plane cannot decide a live query anyway, so
+  there is nothing to persist for the live path — fail-closed is automatic.
+- The one path that decides without a live proxy — viewing a saved result —
+  reads the per-result snapshot, which becomes the only durable classification
+  the control plane holds.
+
+## Classification is config, not state
+
+`column_classification` today is a control-plane table mutated by a runtime
+admin API. But the data is authored, not discovered:
+
+- It references only `datasource` and `mask_fn`, never `catalog_column`
+  (`V2__catalog.sql`). It is keyed by `(schema, table, column)` **name**, and a
+  write does not check the column exists — you can classify a column before it
+  is introspected.
+- The enforcement path reads it independently of the structural catalog
+  (`DatasourceStore.classificationsFor` — "keyed independently of
+  catalog_column").
+
+So classification is a name-keyed declaration that happens to sit in a table. It
+belongs in version control, authored next to the schema it describes — a runtime
+CRUD store, plus the profile dedup this supersedes, is machinery for a problem
+the file layer already solves.
+
+## The proxy already declares per-datasource config
+
+The proxy declares its datasource `tags` at Register (`controlplane.proto`,
+`RegisterRequest.tags`) — the posture (`system:development` /
+`system:production`) that every shipped preset keys on, authored in the proxy's
+own config block. Column classification is the same shape one level down:
+per-column tags plus a mask function, authored in the same block, next to the
+`tags` line an operator already writes.
+
+That is the single config surface the settings-file direction wants. The proxy's
+config is where per-datasource facts already live; classification joins them
+rather than becoming a second, control-plane-side surface an operator has to
+keep in sync.
+
+Delivery reuses **PushCatalog**, not Register: classification is per-column and
+changes with the schema, not with proxy identity, and PushCatalog already
+carries the per-column payload. The `Column` message (or a parallel per-column
+message) gains `tags` and a mask-function **name** — not the control plane's
+`mask_fn_id`, which the proxy cannot know. Mask-function definitions stay
+control-plane config; the declaration references them by name and the control
+plane resolves.
+
+## No persistence — fail-closed is automatic
+
+A live query is decided while its proxy is connected, so the control plane has
+the freshly-declared classification in hand. When the proxy is gone there is no
+connection to decide over — the statement fails closed for want of a backend,
+not for want of a tag. So the live path needs no durable classification at all.
+
+The control plane holds the last declaration transiently, per datasource,
+refreshed on each PushCatalog. A control-plane restart re-receives it on the
+next push; a datasource whose proxy has never attached has none, and any
+decision against it fails closed.
+
+This is the point the persisted design missed: it kept a durable
+`column_classification` table to answer a question — "what are this datasource's
+tags right now?" — that only has a live answer when a proxy is present, and when
+one is present the proxy can just say.
+
+## Saved results freeze that point's tags
+
+One path decides with no proxy in the loop: viewing a saved workflow result.
+`decideResultView` re-decides already-extracted bytes stored in `query_result`,
+and the proxy that produced them may be long gone.
+
+Under a persisted store this "worked" by reading today's classification — which
+is the fail-open bug
+[stored-result-classification.md](./stored-result-classification.md) describes:
+a `pii` tag removed after a cleanup unmasks bytes that still hold the old value.
+The fix there is to snapshot the touched columns' tags and the datasource
+posture at execution and re-decide the view against that snapshot, strictly — no
+union with current tags, no tag history.
+
+Under **this** model the snapshot is not a bug-fix bolted onto a persisted
+store. It is the only durable classification the control plane keeps, and it is
+exactly the right one: a saved result must be judged by the tags in force when
+its bytes were captured, never by tags declared afterward. The two proposals
+compose — this one removes the standing store, that one supplies the per-result
+record that makes removing it safe.
+
+## The trust boundary does not widen
+
+The obvious objection to sourcing tags from the proxy: the proxy is the
+internet-facing component, so letting it declare what is sensitive lets a
+compromised proxy declare nothing sensitive and unmask everything.
+
+It does not widen the boundary, because the proxy already holds the datasource's
+cleartext. It executes every statement against the backend and applies masks
+**inline on the result stream** (`AGENTS.md`: "masks those columns inline on the
+result stream") — it necessarily sees the unmasked rows in order to mask them,
+and it holds the only credential to the target. A compromised proxy is already
+total for that datasource's data; trusting it to declare classification adds no
+exposure it did not already have. The control plane, which never dials a target,
+is not made more trusting by this — it was already trusting the proxy with the
+data itself.
+
+## Presence — a failed read must not read as "nothing sensitive"
+
+Each PushCatalog is a full declaration; there is no "keep what's stored" merge,
+because nothing is stored. But the fail-open shape the persisted `tags` upsert
+guards against still applies: a proxy that **fails to read** its config file
+must not be indistinguishable from one that genuinely declares "no
+classification." The wire needs an explicit present-vs-absent signal (as
+`advertise_cert_chain` carries `optional` presence today), so a missing or
+unreadable config denies rather than silently unmasking. A declaration that is
+present and empty is a deliberate "no tags"; an absent one is "I could not tell
+you," and the control plane treats the datasource as unclassifiable —
+fail-closed — until a real declaration arrives.
+
+## What stays control-plane config
+
+Classification is per-datasource, so it goes with the proxy. The rest of the
+config-as-code surface is **global** and has no per-proxy home — Cedar policies,
+roles, the `group_role` map, and `mask_fn` definitions are one set shared across
+every datasource. Those remain control-plane settings, reconciled separately;
+this doc does not cover them. Mask-function definitions in particular stay
+control-plane-owned precisely so a per-datasource declaration can reference one
+by name.
+
+## Migration and open questions
+
+- **Retire the store.** `column_classification`, its admin CRUD routes and MCP
+  tools, and the parked profile abstraction all go. The proxy config becomes the
+  source; the control plane's per-datasource in-memory classification and the
+  per-result snapshot are the only readers left.
+- **The proto change** — extend `Column` with `tags` + a mask-function name, or
+  add a parallel per-column classification message — plus the presence signal,
+  is the concrete wire work.
+- **The compose-preview and approval-discover paths** call `decideQuery` with
+  `catalog(ds.id)` server-side. They must read the transient declared
+  classification and fail closed when no proxy is attached; confirm neither runs
+  in a state where it would otherwise silently see empty classification.
+- **Where the proxy's classification config lives** — inline in the proxy's
+  existing config block, or a sibling file it loads — is a proxy-config-format
+  decision this doc leaves open.

--- a/docs/stored-result-classification.md
+++ b/docs/stored-result-classification.md
@@ -1,0 +1,155 @@
+# Stored-result classification — snapshot the tags at execution
+
+Proposed, not built. The view path currently reads classification live, which is
+the defect [The failure it closes](#the-failure-it-closes) describes.
+
+This is also the record that lets classification stop being a control-plane
+store: under [classification-as-code.md](./classification-as-code.md) the proxy
+declares classification live and the control plane keeps no durable copy, so the
+per-result snapshot below is the only classification it retains — and the only
+one a saved result may be judged by.
+
+## Decision
+
+A saved result records the classification of every column it touched, at the
+moment it executed. Viewing it re-decides against that snapshot, not against
+today's classification.
+
+Tags are a fact about the bytes captured in the result. Context is a fact about
+the request doing the viewing. Only the first is knowable at execution, so only
+the first is snapshotted: `context`, the resolved roles, and the policy set all
+stay live, which is what keeps a view able to mask _further_ than the run did
+([task-execution.md](./task-execution.md)).
+
+Snapshotted per stored result, over the touched columns only:
+
+- each column's `tags` and `mask_fn`
+- the datasource's `system:*` posture tags
+
+Not snapshotted:
+
+- **System-classification tags.** They resolve from an immutable, version-pinned
+  JSON manifest bundled with the binary
+  ([system-classification.md](./system-classification.md)), so no operator
+  action can edit them out from under a stored result. Freezing them would add
+  churn and close nothing.
+- **Context, roles, policy, the mask decision.** Freezing any of these would
+  break the tightening property below.
+
+## The failure it closes
+
+`decideResultView` (`control-plane/.../Approvals.kt`) re-decides an
+already-extracted result. It reads classification live, through
+`datasourceStore.catalog(ds.id)`. Two routes reach it: the approval result view
+and the editor saved-result view (`Query.kt`).
+
+The stored ciphertext is fixed at execution. Only the mask _decision_ is
+recomputed. So a classification change after execution is applied to bytes that
+predate it, and in one direction that reveals data:
+
+1. `users.ssn` carries `pii`. An approved run executes as
+   `system:production-pii-accessor` on the `workflow-executor` channel, so the
+   preset `system:production-pii-unmasked-workflow-executor` permit fires and
+   the column is stored **unmasked** — the maximal result `{R}` is entitled to.
+   The ciphertext holds real values.
+2. A data cleanup nulls the live column, and the `pii` tag is removed. That is
+   correct about the table as it now stands.
+3. A viewer assumes `{R}` and reads the saved result. The broad production read
+   (`system:production-non-pii-read`) permits every `production-*` role unmasked
+   `unless resource in Tag::"pii"`. With the tag gone that exclusion no longer
+   matches, so the permit applies and the stored values are returned in
+   cleartext.
+
+Step 3 is worth being precise about: at view time the leak does not come from a
+channel-conditioned permit. The executor-channel permit is what put unmasked
+bytes into the result at step 1; what returns them at step 3 is the broad
+production read, whose only protection for this column was the tag that has
+since been removed. Both preset policies are seeded in `V8__seed.sql`
+([policy-store.md](./policy-store.md)).
+
+The untag was right about the live column and wrong about the stored bytes;
+nothing distinguished them. This is the fail-open shape
+[authz-model.md](./authz-model.md) names — a column that is not `in Tag::"pii"`
+falls out of the exclusion and is returned cleartext — reached by a correct
+administrative action rather than a mistake.
+
+Deny-by-default does not cover it. That protects a column a principal must be
+granted to read; here the grant exists and the tag is what decides masked versus
+cleartext.
+
+## Strict snapshot, not a union with current tags
+
+The rule is the snapshot alone. Not the snapshot unioned with present-day tags,
+which is unsound: a union sees two endpoints and misses everything between them.
+
+- Result stored while the column is untagged → snapshot `{}`.
+- Later the column is tagged `pii` — someone establishes it is sensitive.
+- Later still the cleanup lands and it is untagged again → current `{}`.
+
+`{} ∪ {} = {}`, so the column reads cleartext even though it was classified
+`pii` inside the result's lifetime. Catching that needs the full history of
+every tag change, and then whether a result leaks depends on a window nothing
+tracks.
+
+Strict snapshot needs no history. Tags at execution are correct for the bytes
+captured at execution, which is the whole premise; a later change describes the
+live column, and a stored result is not the live column.
+
+### What strict snapshot gives up, and the remedy
+
+A tag added _after_ a result is stored does not retroactively mask it. That is
+bounded: `QueryResultStore.RESULT_RETENTION_SEC` is 24 hours, so the exposure is
+one retention window of results, not the archive.
+
+The remedy for "we have found PII in extracted results" is to **purge** them,
+not to silently re-mask. `purgeExpired` already drops the payload (`ciphertext`,
+`row_count`, `columns`) while keeping the row for audit, and
+`deleteResultsForTask` removes a task's children outright. Purge is explicit,
+auditable, and complete; re-masking a result somebody may already have read is
+none of those.
+
+The snapshot makes purge-by-column answerable for the first time — which stored
+results touched `users.ssn` — since the classification of each result's columns
+is now recorded rather than inferred. That is additive and not required by this
+change.
+
+## Worked example — the tightening property still holds
+
+From [task-execution.md](./task-execution.md): `R` =
+`system:production-pii-accessor`, which the production preset lets read `pii`
+unmasked `when context.channel == "workflow-executor"`.
+
+- **Execute.** Channel `workflow-executor`, so the permit fires and `users.ssn`
+  is stored unmasked. Snapshot records `users.ssn → [pii]`.
+- **View, off-network.** Channel is `workflow-viewer`, which that permit does
+  not match. Evaluation falls through to the masked grant → masked. The snapshot
+  supplied `pii`; the _context_ did the narrowing, exactly as before.
+- **View, after the tag is removed.** The snapshot still carries `pii`, so the
+  verdict is unchanged. Under live classification this is the case that returned
+  cleartext.
+- **View, after a policy change.** The policy set is live, so a newly added
+  `forbid` applies immediately. Only classification is frozen.
+
+## Shape
+
+The snapshot belongs on the `query_result` row, beside the payload it describes,
+and is written by the same statement that stores the ciphertext — a result whose
+snapshot could be missing is a result that cannot be safely viewed.
+
+`purgeExpired` must clear it with the rest of the payload. It is classification
+metadata about extracted data and must not outlive the extract.
+
+A stored result written before this change has no snapshot. Absence must deny
+the view rather than fall back to live classification: the fallback is the
+behavior being removed, and a silent fallback would keep the leak for exactly
+the rows most likely to hit it. The deny carries its own `ApiError` code, so "no
+classification snapshot" is distinguishable from "no tags configured" — those
+justify different operator responses.
+
+## Consequence for the docs
+
+[task-execution.md](./task-execution.md) states that masking always reflects the
+current schema, and that there is no stored plan to go stale. That stays true of
+the run, which is decided against the live per-connection catalog. It is no
+longer true of the view: the view is decided against the snapshot for
+classification, and live for everything else. That section needs to say so.


### PR DESCRIPTION
Parked design proposal (draft). Not built.

## What it proposes

Column classification (a column's `tags` + `mask_fn`) is **declared by the proxy** from its own config — next to the datasource `tags` it already declares at Register — and pushed via PushCatalog. The control plane keeps **no durable copy**:

- **Live query:** decided while the proxy is connected, using the declared classification. No proxy → no connection to decide over → fail-closed for want of a backend, not a tag. So the live path needs no persisted classification.
- **Saved workflow result:** the one path the CP re-decides with no proxy in the loop. It reads the execution-time **snapshot** (the sibling `stored-result-classification.md`, brought along here), which becomes the only classification the CP retains — and the only one a saved result may be judged by.

## Why

Classification is authored config, not discovered state: it references no `catalog_column`, is keyed by column **name**, and a write doesn't check the column exists. It belongs in version control, authored with the schema — a runtime CRUD store plus cross-datasource dedup (the parked profile abstraction in [#82](https://github.com/ridi-oss/proxy-monster/pull/82)) is machinery for a problem the file layer solves.

The trust boundary doesn't widen: the proxy already executes every statement and masks the result stream inline, so it already holds the datasource's cleartext.

## Status

Two docs, both marked **Proposed**: `docs/classification-as-code.md` (delivery model) and `docs/stored-result-classification.md` (the per-result snapshot it relies on). Open questions — the proto change, the presence signal, the compose-preview/approval-discover paths — are listed in the doc, not resolved.

Parked pending review of the direction before any implementation.