### PR TITLE
feat(analyzer): resolve catalog-changing DDL, gated by sql.ddl

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -235,6 +235,13 @@ tagging, table detail) and never feeds an enforcement decision.
   `LATERAL` / `VALUES` source is unresolved and follows the same
   `sql.unanalyzable` gate; that is a masking/lineage limitation, not a parse
   gap.
+- 🟡 `RENAME TABLE a TO b` is denied. It is ordinary MySQL table DDL, but
+  sqlglot-go leaves it as an unmodeled `Command` node, and classification is
+  taken only from what the parser resolves structurally — a `Command` carries
+  the verb as text with the remainder unparsed. Matching that verb would also
+  match `RENAME USER`, which is privilege management rather than schema DDL, so
+  the over-deny is deliberate. The structured equivalent is permitted:
+  `ALTER TABLE a RENAME TO b`.
 - 🟡 `EXPLAIN` of a query that requires masking is deliberately denied. The
   analyzer emits the wrapped query's grants with `explain_of_query=true`, so an
   unmasked inner query may proceed after its ordinary grants pass. If the

--- a/analyzer/probe/alter_index_test.go
+++ b/analyzer/probe/alter_index_test.go
@@ -1,0 +1,292 @@
+package probe
+
+import (
+	"testing"
+
+	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
+	"google.golang.org/protobuf/proto"
+)
+
+// readsColumn reports whether the facts carry a column grant for the named column — i.e. the read is
+// tracked and can be masked/denied, rather than silently copied out.
+func readsColumn(f *pb.StatementFacts, column string) bool {
+	for _, g := range f.RequiredGrants {
+		if c := g.GetColumn(); c != nil && c.Identity.Column == column {
+			return true
+		}
+	}
+	return false
+}
+
+func surfacesFunction(f *pb.StatementFacts, name string) bool {
+	for _, fn := range f.Functions {
+		if fn == name {
+			return true
+		}
+	}
+	return false
+}
+
+// valueFreeDdl reports whether the facts are a resolved statement authorized by a lone sql.ddl datasource
+// grant with nothing else — the shape schema-only DDL takes. A statement that READS (a column grant, a
+// hidden function) must not land here, or its read/function gate is silently dropped.
+func valueFreeDdl(f *pb.StatementFacts) bool {
+	if !f.Resolved || len(f.RequiredGrants) != 1 {
+		return false
+	}
+	g := f.RequiredGrants[0]
+	return g.GetDatasource() && g.Action == pb.GrantAction_GRANT_ACTION_SQL_DDL
+}
+
+// A catalog-changing statement resolves and carries exactly one sql.ddl datasource grant.
+//
+// The failure this guards is silent: reporting such a statement UNRESOLVED routes it through the
+// sql.unanalyzable gate, whose grant relays statements unmasked and ships scoped to
+// system:development — so on a production datasource every role is denied, including the
+// system:production-architect that the sql.ddl policy names, and approval role discovery (which
+// previews each candidate alone and drops the DENYs) offers no role at all.
+//
+// Emitting the grant is not enough on its own: an unresolved statement routes to the sql.unanalyzable
+// gate regardless of its grants, so resolution and the grant are asserted together here.
+func TestCatalogChangingDdlResolves(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+	}{
+		{"alter drop index", "ALTER TABLE users DROP INDEX idx_u_idx"},
+		// The index name collides with the users.id column; it must still emit no column grant (the assertions
+		// below reject any column/table resource), i.e. the index identifier is not read as a value.
+		{"alter drop index named like a column", "ALTER TABLE users DROP INDEX id"},
+		{"alter drop index qualified", "ALTER TABLE acme.users DROP INDEX idx_u_idx"},
+		{"alter drop index backticked", "ALTER TABLE `acme`.`users` DROP INDEX `idx_u_idx`"},
+		{"alter drop key spelling", "ALTER TABLE users DROP KEY idx_u_idx"},
+		{"alter add index", "ALTER TABLE users ADD INDEX idx_email (email)"},
+		{"alter add column", "ALTER TABLE users ADD c INT"},
+		{"alter drop column", "ALTER TABLE users DROP COLUMN rrn"},
+		{"alter rename", "ALTER TABLE users RENAME TO users2"},
+		{"drop table", "DROP TABLE users"},
+		{"drop index on table", "DROP INDEX idx_email ON users"},
+		{"truncate", "TRUNCATE TABLE users"},
+		{"create table", "CREATE TABLE t (id int)"},
+		{"create index", "CREATE INDEX idx_email ON users (email)"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := mysqlFacts(t, tc.sql)
+
+			if !f.Resolved {
+				t.Fatalf("resolved=false (class=%v detail=%q) — routes through sql.unanalyzable, which no "+
+					"production role holds", f.FailureClass, f.Detail)
+			}
+			// Resolves as ANALYZED (a recognized statement authorized off its grant), not a new DDL-only
+			// class: with a datasource grant and no columns it takes the same path as INSERT.
+			if f.StatementClass != pb.StatementClass_STATEMENT_CLASS_ANALYZED {
+				t.Errorf("statement_class = %v, want ANALYZED", f.StatementClass)
+			}
+			if f.FailureClass != pb.FailureClass_FAILURE_CLASS_UNSPECIFIED {
+				t.Errorf("failure_class = %v, want UNSPECIFIED on a resolved statement", f.FailureClass)
+			}
+
+			if len(f.RequiredGrants) != 1 {
+				t.Fatalf("required grants = %d, want exactly 1", len(f.RequiredGrants))
+			}
+			g := f.RequiredGrants[0]
+			if !g.GetDatasource() || g.Action != pb.GrantAction_GRANT_ACTION_SQL_DDL {
+				t.Errorf("grant = datasource:%v action:%v, want datasource sql.ddl", g.GetDatasource(), g.Action)
+			}
+			// No column/table grant: an index or schema change reads no values, so there is nothing to
+			// mask and nothing for catalog coverage to miss.
+			if g.GetColumn() != nil || g.GetTable() != nil {
+				t.Errorf("unexpected column/table resource on a schema-only DDL statement")
+			}
+			if !f.IsWrite {
+				t.Errorf("is_write = false, want true")
+			}
+			if !f.CatalogChanging {
+				t.Errorf("catalog_changing = false, want true — a connection must re-measure rather than "+
+					"keep serving the pre-change schema")
+			}
+		})
+	}
+}
+
+// A CREATE with a query body keeps its lineage analysis: it reads columns, so it must still emit the
+// per-column grants that masking binds to, not be swept into the value-free DDL path.
+func TestCreateWithQueryBodyKeepsLineage(t *testing.T) {
+	f := mysqlFacts(t, "CREATE VIEW v AS SELECT id, email FROM users")
+
+	if !f.Resolved {
+		t.Fatalf("resolved=false: class=%v detail=%q", f.FailureClass, f.Detail)
+	}
+	if f.StatementClass != pb.StatementClass_STATEMENT_CLASS_ANALYZED {
+		t.Errorf("statement_class = %v, want ANALYZED — it has a query body to trace", f.StatementClass)
+	}
+	var columns int
+	for _, g := range f.RequiredGrants {
+		if g.GetColumn() != nil {
+			columns++
+		}
+	}
+	if columns == 0 {
+		t.Errorf("no column grants — lineage was lost for a statement that reads columns")
+	}
+}
+
+// The statement exactly as production submits it, against a catalog covering the table.
+func TestAlterTableDropIndexProductionShape(t *testing.T) {
+	f := analyzeProto(t, &pb.AnalyzeRequest{
+		Sql: "ALTER TABLE bom.tb_set_book_sell_history DROP INDEX idx_u_idx",
+		EngineConfig: &pb.EngineConfig{
+			Engine: pb.Engine_MYSQL, EngineVersion: "8.0.44", MysqlLowerCaseTableNames: proto.Int32(0),
+		},
+		Namespace: &pb.Namespace{Catalog: "def", SearchPath: []string{"bom"}},
+		Catalog: []*pb.ColumnSpec{
+			columnSpec("def", "bom", "tb_set_book_sell_history", "id", "BIGINT"),
+			columnSpec("def", "bom", "tb_set_book_sell_history", "u_idx", "BIGINT"),
+			columnSpec("def", "bom", "tb_set_book_sell_history", "set_b_id", "VARCHAR"),
+		},
+	})
+
+	if !f.Resolved {
+		t.Fatalf("resolved=false: class=%v detail=%q", f.FailureClass, f.Detail)
+	}
+	if !valueFreeDdl(f) {
+		t.Errorf("not resolved value-free DDL: class=%v grants=%v", f.StatementClass, f.RequiredGrants)
+	}
+}
+
+// A temp-scoped target is session-local: it changes no shared catalog, so other connections must not
+// be forced to re-measure.
+func TestTemporaryDdlIsNotCatalogChanging(t *testing.T) {
+	f := mysqlFacts(t, "DROP TEMPORARY TABLE tmp_users")
+
+	if !f.Resolved {
+		t.Fatalf("resolved=false: class=%v detail=%q", f.FailureClass, f.Detail)
+	}
+	if f.CatalogChanging {
+		t.Errorf("catalog_changing = true for a TEMPORARY target, want false")
+	}
+}
+
+// Classification comes from what sqlglot structurally resolved, never from matching the SQL text.
+//
+// A Command node IS sqlglot reporting "I did not model this statement": the verb survives as a string
+// and the rest is unparsed text. Granting sql.ddl off that verb would hand a schema-DDL grant to
+// privilege management — `DROP USER`, `RENAME USER` — which are not schema changes and must stay
+// denied. Some genuine table DDL degrades to Command too (`RENAME TABLE a TO b`) and is denied along
+// with it; over-denying an unmodeled statement is the correct side to fail on, and the fix is for
+// sqlglot to model the form, not for this layer to guess from a prefix.
+func TestUnmodeledCommandStatementsStayDenied(t *testing.T) {
+	for _, sql := range []string{
+		"DROP USER 'x'@'%'",
+		"RENAME USER 'a'@'%' TO 'b'@'%'",
+		// Table DDL that also degrades to Command — denied, deliberately.
+		"RENAME TABLE users TO users2",
+	} {
+		f := mysqlFacts(t, sql)
+		if f.Resolved {
+			t.Errorf("%q resolved — a Command node is unmodeled SQL and must not be classified from its verb", sql)
+		}
+		for _, g := range f.RequiredGrants {
+			if g.Action == pb.GrantAction_GRANT_ACTION_SQL_DDL {
+				t.Errorf("%q was handed a sql.ddl grant off an unmodeled Command node", sql)
+			}
+		}
+	}
+}
+
+// A parenthesized query body must enforce identically to the bare one. Parentheses are real syntax, so
+// sqlglot wraps the body in a Subquery; testing the immediate child read `AS (SELECT …)` as body-less
+// and emitted zero column grants, which let a sql.ddl holder copy masked columns into a new
+// unclassified table — the exfiltration path authz-model.md requires to fail closed.
+func TestParenthesizedQueryBodyKeepsLineage(t *testing.T) {
+	bare := "CREATE TABLE copied AS SELECT rrn FROM users"
+	for _, sql := range []string{
+		"CREATE TABLE copied AS (SELECT rrn FROM users)",
+		"CREATE TABLE copied AS ((SELECT rrn FROM users))",
+		"CREATE VIEW copied AS (SELECT rrn FROM users)",
+		"CREATE TABLE copied AS (SELECT rrn FROM users UNION SELECT rrn FROM users)",
+	} {
+		f := mysqlFacts(t, sql)
+		if f.StatementClass != pb.StatementClass_STATEMENT_CLASS_ANALYZED {
+			t.Errorf("%q class = %v, want ANALYZED — it reads columns", sql, f.StatementClass)
+		}
+		// The write-payload rule is what denies the copy, and it needs a DENY_STATEMENT disposition on
+		// the protected column. Its absence is the whole bug, so assert it rather than a grant count.
+		var denies int
+		for _, g := range f.RequiredGrants {
+			if c := g.GetColumn(); c != nil && c.Identity.Column == "rrn" &&
+				g.MaskedDisposition == pb.MaskedDisposition_MASKED_DISPOSITION_DENY_STATEMENT {
+				denies++
+			}
+		}
+		if denies == 0 {
+			t.Errorf("%q emitted no DENY_STATEMENT grant on users.rrn — a sql.ddl holder could copy it out", sql)
+		}
+	}
+
+	// And the bare spelling still behaves the same way, so the two cannot drift apart.
+	f := mysqlFacts(t, bare)
+	if f.StatementClass != pb.StatementClass_STATEMENT_CLASS_ANALYZED {
+		t.Errorf("%q class = %v, want ANALYZED", bare, f.StatementClass)
+	}
+}
+
+// PostgreSQL hides a query inside a Values body: `AS VALUES ((SELECT …))` reads columns while its
+// immediate child is a Values, not a Select. It must not become value-free DDL (a lone sql.ddl grant,
+// no columns) — that is the same copy-into-a-new-table path as the parenthesized CTAS.
+//
+// It lands unresolved rather than fully analyzed (lineage does not model this shape), which routes it to
+// the sql.unanalyzable gate and denies it on the production floor. An over-deny, not a leak; the invariant
+// asserted here is only that it never becomes value-free DDL.
+func TestValuesBodyWithSubqueryIsNotValueFreeDdl(t *testing.T) {
+	f := postgresFacts(t, "CREATE TABLE leaked AS VALUES ((SELECT rrn FROM users))")
+	// The security invariant, stated so a regression cannot pass it: this must never be a statement
+	// decideQuery would ALLOW off a lone sql.ddl grant. So it either stays unresolved (routing to the
+	// sql.unanalyzable gate, denied on the production floor) or carries the users.rrn column grant that
+	// protects the read.
+	if valueFreeDdl(f) {
+		t.Error("classified as value-free DDL — it reads users.rrn, so its read gate would be dropped")
+	}
+	if f.Resolved && !readsColumn(f, "rrn") {
+		t.Errorf("resolved but emits no users.rrn column grant — decideQuery would ALLOW, leaking the copied column")
+	}
+
+	// A literal-only VALUES body reads nothing and stays ordinary DDL, so the guard above is not just
+	// "anything with VALUES is denied".
+	lit := postgresFacts(t, "CREATE TABLE fine AS VALUES (1), (2)")
+	if !valueFreeDdl(lit) {
+		t.Errorf("literal VALUES = resolved:%v grants:%v, want resolved value-free DDL", lit.Resolved, lit.RequiredGrants)
+	}
+}
+
+// PostgreSQL's `CREATE TABLE t AS TABLE src` copies every column of src — a body that carries no Select
+// node at all — so it is a third spelling of the copy-into-a-new-table path alongside the parenthesized
+// CTAS and the VALUES-with-subquery form. sqlglot-go v0.22.0 leaves `AS TABLE` unmodeled (a Command →
+// unresolved → denied on the production floor), an over-deny. The invariant guarded here is that it never
+// becomes value-free DDL with a bare sql.ddl grant, whatever a future parser does with it.
+func TestCreateAsTableIsNotValueFreeDdl(t *testing.T) {
+	f := postgresFacts(t, "CREATE TABLE copied AS TABLE users")
+	if valueFreeDdl(f) {
+		t.Error("classified as value-free DDL — AS TABLE copies every source column, so its read gate would be dropped")
+	}
+	if f.Resolved && !readsColumn(f, "rrn") {
+		t.Error("resolved but emits no users.rrn column grant — a sql.ddl holder could copy the table out")
+	}
+}
+
+// A VALUES body can carry a function call with no Select node — `AS VALUES (query_to_xml('SELECT rrn
+// …'))` runs arbitrary SQL server-side via a system:data-leak function. The value-free DDL path emits no
+// function grant, so a Select-only body check let a sql.ddl holder invoke it while the function gate the
+// `AS SELECT query_to_xml(…)` spelling triggers was dropped. It must route to lineage (unresolved →
+// denied on the production floor) and keep the function visible so the gate can act on it.
+func TestCreateValuesWithFunctionIsNotValueFreeDdl(t *testing.T) {
+	f := postgresFacts(t, "CREATE TABLE copied AS VALUES (query_to_xml('SELECT rrn FROM users', true, true, ''))")
+	if valueFreeDdl(f) {
+		t.Error("classified as value-free DDL — a VALUES body invoking a function drops the function gate")
+	}
+	if !surfacesFunction(f, "query_to_xml") {
+		t.Error("query_to_xml not surfaced in facts.functions — the data-leak function gate cannot act on it")
+	}
+}

--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -106,10 +106,7 @@ func EmitFacts(sql string, engineConfig *pb.EngineConfig, sch *schema.Mapping, n
 	// Peel a whole-statement parenthesized wrapper: `(SELECT 1)` parses to a Subquery whose `this` is the
 	// real statement. Classification/lineage must run on the inner statement, not fail closed on the
 	// wrapper (a wrapped SELECT is ordinary chatter, a wrapped write is still a write).
-	root := stmts[0]
-	for root != nil && root.Kind() == exp.KindSubquery && root.This() != nil {
-		root = root.This()
-	}
+	root := unwrapSubquery(stmts[0])
 	candidates := schemaQualifierCandidates(root)
 
 	var facts *pb.StatementFacts
@@ -129,9 +126,22 @@ func EmitFacts(sql string, engineConfig *pb.EngineConfig, sch *schema.Mapping, n
 		// Command and is denied there; it never reaches this Reset-node case.)
 		facts = passthroughFacts(pb.StatementClass_STATEMENT_CLASS_SESSION)
 	case exp.KindAlter, exp.KindDrop, exp.KindTruncateTable:
-		facts = unanalyzableFacts("LINEAGE", fmt.Sprintf("unsupported root %s", exp.ClassName(root.Kind())))
-		facts.CatalogChanging = !isTemporaryDDL(root, eng)
-		facts.RequiredGrants = append(facts.RequiredGrants, datasourceGrant(pb.GrantAction_GRANT_ACTION_SQL_DDL))
+		facts = ddlFacts(root, eng)
+	case exp.KindCreate:
+		// A CREATE that reads columns (CREATE TABLE AS SELECT, CREATE VIEW) has lineage to trace and goes
+		// down the lineage path. One that reads none — CREATE INDEX, a bare CREATE TABLE with a column
+		// list — has no lineage, so it would fail there ("CREATE without analyzable query") and route a
+		// plainly-classifiable DDL through the unmasked sql.unanalyzable relay.
+		//
+		// The test is "does the body contain a query", not "is the body a Select": both a parenthesis
+		// wrapper (`AS (SELECT …)` is a Subquery) and a PostgreSQL `AS VALUES ((SELECT …))` hide one, and
+		// either would otherwise be read as body-less and emit NO column grants — the same statement
+		// enforced differently for a pair of parentheses, which is the copy-PII-into-a-new-table path.
+		if createReadsColumns(root) {
+			facts = emitLineageFacts(root, eng, qualifySchema, validatedNamespace, false)
+		} else {
+			facts = ddlFacts(root, eng)
+		}
 	default:
 		if isKnownRoot(root) {
 			facts = emitLineageFacts(root, eng, qualifySchema, validatedNamespace, false)
@@ -932,6 +942,27 @@ func unanalyzableFacts(stage, detail string) *pb.StatementFacts {
 		FailedStage:    strPtr(stage),
 		Detail:         truncateDetail(detail),
 		StatementClass: pb.StatementClass_STATEMENT_CLASS_UNSPECIFIED,
+	}
+}
+
+// A DDL statement (ALTER / DROP / TRUNCATE / a body-less CREATE) is RESOLVED: its meaning is fully
+// determined and it reads no column values, so there is no lineage to trace and its whole authorization
+// is the sql.ddl datasource grant. It resolves as ANALYZED with that single grant and no columns —
+// exactly the shape a grant-only write like INSERT already takes, so decideQuery authorizes it off the
+// datasource grant with no DDL-specific branch. Reporting it unresolved instead would route it through
+// the sql.unanalyzable gate — a grant that relays statements UNMASKED and ships scoped to
+// system:development only — so a statement whose safety is trivially provable would be authorized only by
+// the escape hatch built for statements nobody can prove safe, and denied outright anywhere else.
+func ddlFacts(root exp.Expression, eng engine) *pb.StatementFacts {
+	return &pb.StatementFacts{
+		Resolved:       true,
+		FailureClass:   pb.FailureClass_FAILURE_CLASS_UNSPECIFIED,
+		StatementClass: pb.StatementClass_STATEMENT_CLASS_ANALYZED,
+		IsWrite:        true,
+		// A temp-scoped DDL target is session-local, so it changes no shared catalog and must not force
+		// every other connection to re-measure.
+		CatalogChanging: !isTemporaryDDL(root, eng),
+		RequiredGrants:  []*pb.RequiredGrant{datasourceGrant(pb.GrantAction_GRANT_ACTION_SQL_DDL)},
 	}
 }
 

--- a/analyzer/probe/mysql_statement_coverage_test.go
+++ b/analyzer/probe/mysql_statement_coverage_test.go
@@ -165,42 +165,50 @@ var mysqlStatements = []mysqlStatement{
 	{"LOAD XML", "LOAD XML INFILE 'f' INTO TABLE users", "unanalyzable→sql.unanalyzable"},
 	{"IMPORT TABLE", "IMPORT TABLE FROM 'users.sdi'", "unanalyzable→sql.unanalyzable"},
 
-	// ---- DDL (§15.1) — all catalog-changing, all sql.ddl ----
-	{"CREATE TABLE", "CREATE TABLE t (id INT)", "sql.ddl + unanalyzable→sql.unanalyzable"},
+	// ---- DDL (§15.1) ----
+	// Table/index/view/schema DDL that sqlglot models structurally (Create / Alter / Drop / TruncateTable)
+	// is catalog-changing: fully determined, reads no column values, gated by sql.ddl alone. Forms sqlglot
+	// leaves as a Command (routines, events, servers, tablespaces, SRS, RENAME TABLE) stay unresolved and
+	// route to the sql.unanalyzable gate — an over-deny, not a leak.
+	{"CREATE TABLE", "CREATE TABLE t (id INT)", "sql.ddl"},
 	{"CREATE TABLE AS SELECT", "CREATE TABLE t AS SELECT id FROM users", "result.read + sql.ddl"},
-	{"CREATE TABLE LIKE", "CREATE TABLE t LIKE users", "sql.ddl + unanalyzable→sql.unanalyzable"},
-	{"CREATE INDEX", "CREATE INDEX i ON users (id)", "sql.ddl + unanalyzable→sql.unanalyzable"},
+	{"CREATE TABLE LIKE", "CREATE TABLE t LIKE users", "sql.ddl"},
+	{"CREATE INDEX", "CREATE INDEX i ON users (id)", "sql.ddl"},
 	{"CREATE VIEW", "CREATE VIEW v AS SELECT 1", "sql.ddl"},
-	{"CREATE DATABASE", "CREATE DATABASE d", "sql.ddl + unanalyzable→sql.unanalyzable"},
+	{"CREATE DATABASE", "CREATE DATABASE d", "sql.ddl"},
 	{"CREATE TRIGGER", "CREATE TRIGGER trg BEFORE INSERT ON users FOR EACH ROW SET @a = 1", "unanalyzable→sql.unanalyzable"},
 	{"CREATE PROCEDURE", "CREATE PROCEDURE p() SELECT 1", "unanalyzable→sql.unanalyzable"},
-	{"CREATE FUNCTION (stored)", "CREATE FUNCTION f() RETURNS INT RETURN 1", "sql.ddl + unanalyzable→sql.unanalyzable"},
-	{"CREATE FUNCTION (UDF)", "CREATE FUNCTION f RETURNS INTEGER SONAME 'f.so'", "sql.ddl + unanalyzable→sql.unanalyzable"},
+	{"CREATE FUNCTION (stored)", "CREATE FUNCTION f() RETURNS INT RETURN 1", "sql.ddl"},
+	// A routine body carrying a query (RETURN (SELECT …)) is not a CTAS: the read happens at invocation,
+	// not at CREATE. Lineage cannot analyze the routine body, so it over-denies (unresolved) rather than
+	// resolving catalog-changing like the bare form above — a fail-closed asymmetry, not a leak.
+	{"CREATE FUNCTION (stored, query body)", "CREATE FUNCTION f() RETURNS INT RETURN (SELECT id FROM users)", "sql.ddl + unanalyzable→sql.unanalyzable"},
+	{"CREATE FUNCTION (UDF)", "CREATE FUNCTION f RETURNS INTEGER SONAME 'f.so'", "sql.ddl"},
 	{"CREATE EVENT", "CREATE EVENT e ON SCHEDULE AT NOW() DO SET @a = 1", "unanalyzable→sql.unanalyzable"},
 	{"CREATE SERVER", "CREATE SERVER s FOREIGN DATA WRAPPER mysql OPTIONS (USER 'u')", "unanalyzable→sql.unanalyzable"},
 	{"CREATE TABLESPACE", "CREATE TABLESPACE ts ADD DATAFILE 'ts.ibd'", "unanalyzable→sql.unanalyzable"},
 	{"CREATE SRS", "CREATE SPATIAL REFERENCE SYSTEM 4000 NAME 'x' DEFINITION 'y'", "unanalyzable→sql.unanalyzable"},
-	{"ALTER TABLE", "ALTER TABLE users ADD COLUMN x INT", "sql.ddl + unanalyzable→sql.unanalyzable"},
+	{"ALTER TABLE", "ALTER TABLE users ADD COLUMN x INT", "sql.ddl"},
 	{"ALTER DATABASE", "ALTER DATABASE d CHARACTER SET utf8mb4", "unanalyzable→sql.unanalyzable"},
-	{"ALTER VIEW", "ALTER VIEW v AS SELECT 1", "sql.ddl + unanalyzable→sql.unanalyzable"},
+	{"ALTER VIEW", "ALTER VIEW v AS SELECT 1", "sql.ddl"},
 	{"ALTER EVENT", "ALTER EVENT e DISABLE", "unanalyzable→sql.unanalyzable"},
 	{"ALTER PROCEDURE", "ALTER PROCEDURE p COMMENT 'x'", "unanalyzable→sql.unanalyzable"},
 	{"ALTER FUNCTION", "ALTER FUNCTION f COMMENT 'x'", "unanalyzable→sql.unanalyzable"},
 	{"ALTER SERVER", "ALTER SERVER s OPTIONS (USER 'u')", "unanalyzable→sql.unanalyzable"},
 	{"ALTER TABLESPACE", "ALTER TABLESPACE ts RENAME TO ts2", "unanalyzable→sql.unanalyzable"},
 	{"ALTER INSTANCE", "ALTER INSTANCE ROTATE INNODB MASTER KEY", "unanalyzable→sql.unanalyzable"},
-	{"DROP TABLE", "DROP TABLE users", "sql.ddl + unanalyzable→sql.unanalyzable"},
-	{"DROP INDEX", "DROP INDEX i ON users", "sql.ddl + unanalyzable→sql.unanalyzable"}, // sqlglot-go v0.22.0: parses as a structured Drop (was Command)
-	{"DROP VIEW", "DROP VIEW v", "sql.ddl + unanalyzable→sql.unanalyzable"},
-	{"DROP DATABASE", "DROP DATABASE d", "sql.ddl + unanalyzable→sql.unanalyzable"},
-	{"DROP TRIGGER", "DROP TRIGGER trg", "sql.ddl + unanalyzable→sql.unanalyzable"},
-	{"DROP PROCEDURE", "DROP PROCEDURE p", "sql.ddl + unanalyzable→sql.unanalyzable"},
-	{"DROP FUNCTION", "DROP FUNCTION f", "sql.ddl + unanalyzable→sql.unanalyzable"},
+	{"DROP TABLE", "DROP TABLE users", "sql.ddl"},
+	{"DROP INDEX", "DROP INDEX i ON users", "sql.ddl"}, // sqlglot-go v0.22.0 models this as a structured Drop, unlike RENAME TABLE
+	{"DROP VIEW", "DROP VIEW v", "sql.ddl"},
+	{"DROP DATABASE", "DROP DATABASE d", "sql.ddl"},
+	{"DROP TRIGGER", "DROP TRIGGER trg", "sql.ddl"},
+	{"DROP PROCEDURE", "DROP PROCEDURE p", "sql.ddl"},
+	{"DROP FUNCTION", "DROP FUNCTION f", "sql.ddl"},
 	{"DROP EVENT", "DROP EVENT e", "unanalyzable→sql.unanalyzable"},
 	{"DROP SERVER", "DROP SERVER s", "unanalyzable→sql.unanalyzable"},
 	{"DROP TABLESPACE", "DROP TABLESPACE ts", "unanalyzable→sql.unanalyzable"},
 	{"DROP SRS", "DROP SPATIAL REFERENCE SYSTEM 4000", "unanalyzable→sql.unanalyzable"},
-	{"TRUNCATE TABLE", "TRUNCATE TABLE users", "sql.ddl + unanalyzable→sql.unanalyzable"},
+	{"TRUNCATE TABLE", "TRUNCATE TABLE users", "sql.ddl"},
 	{"RENAME TABLE", "RENAME TABLE users TO u2", "unanalyzable→sql.unanalyzable"},
 
 	// ---- Transaction / locking (§15.3) ----

--- a/analyzer/probe/probe.go
+++ b/analyzer/probe/probe.go
@@ -576,9 +576,11 @@ func (p *prober) classifyWrite() *ProbeResult {
 
 	switch p.root.Kind() {
 	case exp.KindCreate:
-		if isSelectOrSet(p.root.Expr()) {
+		// Unwrapped, and the UNWRAPPED body is what gets analyzed: lineage over a Subquery wrapper finds
+		// no source columns, so a parenthesized CTAS would be a write with an empty grant set.
+		if body := unwrapSubquery(p.root.Expr()); isSelectOrSet(body) {
 			p.isWrite = true
-			p.analyzeQuery = p.root.Expr()
+			p.analyzeQuery = body
 		} else {
 			fail := failResult("VALIDATE", "CREATE without analyzable query")
 			return &fail
@@ -667,6 +669,64 @@ func isKnownRoot(e exp.Expression) bool {
 	switch e.Kind() {
 	case exp.KindSelect, exp.KindInsert, exp.KindUpdate, exp.KindDelete, exp.KindMerge, exp.KindCreate:
 		return true
+	}
+	return false
+}
+
+// unwrapSubquery peels parenthesis wrappers off an expression, returning the statement inside.
+//
+// Parentheses are real syntax, so sqlglot models `(SELECT …)` as a Subquery around the Select. Any
+// check that asks "is this a query?" has to look through that wrapper, or the same statement is
+// classified two ways depending on whether the author wrote a pair of parentheses — and for a CREATE
+// body, the parenthesized spelling would emit no column grants at all. Loops rather than unwrapping
+// once, since nothing stops `((SELECT …))`.
+func unwrapSubquery(e exp.Expression) exp.Expression {
+	for e != nil && e.Kind() == exp.KindSubquery && e.This() != nil {
+		e = e.This()
+	}
+	return e
+}
+
+// createReadsColumns reports whether a CREATE's AS-body reads or computes a value, and therefore needs
+// lineage rather than the catalog-changing class (which emits no column/function grants and no masks).
+//
+// It inspects only the `AS <body>` clause (root.Expr()); a bare column list, CREATE INDEX, generated
+// columns, and DEFAULT/CHECK expressions live in other args and stay catalog-only DDL — the uniform-DDL
+// model. Within the body it is deliberately broad: a query, a column reference, or a function call
+// anywhere inside means the value is not free. A VALUES row hides all three from a check on the immediate
+// child — `AS (SELECT …)` is a Subquery, `AS VALUES ((SELECT …))` buries a Select, and
+// `AS VALUES (query_to_xml('SELECT rrn …'))` invokes a data-leak function the function gate must still
+// see — each of which the catalog-only path would drop on the floor. A literal-only VALUES matches none
+// and stays value-free DDL.
+func createReadsColumns(root exp.Expression) bool {
+	body := unwrapSubquery(root.Expr())
+	if body == nil {
+		return false
+	}
+	if isSelectOrSet(body) {
+		return true
+	}
+	// VALUES is the one non-query CTAS/VIEW body that still materializes computed values: a row can hide a
+	// subquery, a column reference, or a function call (a data-leak function like query_to_xml) with no
+	// top-level Select, each of which the catalog-only path would drop. Literal-only VALUES matches none.
+	// Any other AS-body — a CREATE FUNCTION routine definition, say — is not a data-materializing query, so
+	// it keeps the narrow Select probe and stays catalog-only DDL.
+	if body.Kind() == exp.KindValues {
+		return bodyReferencesData(body)
+	}
+	return len(body.FindAll(exp.KindSelect)) > 0
+}
+
+// bodyReferencesData reports whether an expression subtree reads a column, runs a query, or calls a
+// function — anything the value-free catalog-changing path would fail to gate.
+func bodyReferencesData(body exp.Expression) bool {
+	if len(body.FindAll(exp.KindSelect)) > 0 || len(body.FindAll(exp.KindColumn)) > 0 {
+		return true
+	}
+	for _, node := range body.Walk() {
+		if node != nil && node.Is(exp.TraitFunc) {
+			return true
+		}
 	}
 	return false
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DdlEnforcementDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DdlEnforcementDbTest.kt
@@ -1,0 +1,215 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
+import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.grpc.EnfAction
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.assertEquals
+
+/**
+ * DDL is authorized by its `sql.ddl` datasource grant, on a production-tagged datasource.
+ *
+ * The shipped `system:production-ddl` preset was unreachable: the analyzer reported every DDL form
+ * UNRESOLVED, so even after its `sql.ddl` grant passed the datasource-grant loop, the `!resolved`
+ * branch below it routed the statement to the `sql.unanalyzable` gate. That grant ships scoped to
+ * `system:development` only, which denied production DDL for every role — including the architect the
+ * DDL policy names. Resolving DDL is what lets its `sql.ddl` grant alone authorize it.
+ *
+ * DDL resolves as ANALYZED carrying that lone `sql.ddl` grant — the same shape a grant-only write like
+ * INSERT takes — so decideQuery authorizes it off the datasource grant with no DDL-specific branch.
+ *
+ * These cases go through the real decideQuery against a live database, so they fail if the analyzer marks
+ * DDL unresolved again and it falls back through the `sql.unanalyzable` gate.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DdlEnforcementDbTest {
+    private lateinit var fx: EnforcementFixture
+
+    private val architect = "architect@example.com"
+    private val connector = "connector@example.com"
+    private val noRole = "nobody@example.com"
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        fx = EnforcementFixture.mysql()
+        fx.dataSource.connection.use { c ->
+            c.prepareStatement("UPDATE datasource SET tags = '[\"system:production\"]'::jsonb WHERE id = ?").use { ps ->
+                ps.setLong(1, fx.datasource.id)
+                ps.executeUpdate()
+            }
+        }
+        // The shipped production shape: one role, granted sql.ddl on production-tagged datasources only.
+        val role = fx.policyStore.createRole(RoleInput("ddl-architect"))
+        fx.policyStore.createAssignment(RoleAssignmentInput(architect, role.id))
+        fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "architect-production-ddl",
+                cedarSrc = """permit(principal in Role::"ddl-architect", action == Action::"sql.ddl", resource) when { resource in Tag::"system:production" };""",
+            ),
+            updatedBy = "test-fixture",
+        )
+        fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "architect-production-connect",
+                cedarSrc = """permit(principal in Role::"ddl-architect", action == Action::"datasource.connect", resource) when { resource in Tag::"system:production" };""",
+            ),
+            updatedBy = "test-fixture",
+        )
+        // A principal that may CONNECT but holds no sql.ddl, so a DDL deny for it isolates the missing
+        // sql.ddl grant rather than passing at the earlier datasource.connect gate.
+        val connectRole = fx.policyStore.createRole(RoleInput("connect-only"))
+        fx.policyStore.createAssignment(RoleAssignmentInput(connector, connectRole.id))
+        fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "connect-only-production-connect",
+                cedarSrc = """permit(principal in Role::"connect-only", action == Action::"datasource.connect", resource) when { resource in Tag::"system:production" };""",
+            ),
+            updatedBy = "test-fixture",
+        )
+    }
+
+    private fun decide(sql: String, who: String) = decideQuery(
+        principal = who,
+        ds = fx.datasourceStore.get(fx.datasource.id)!!,
+        sql = sql,
+        channel = Channel.WIRE,
+        catalog = fx.datasourceStore.catalog(fx.datasource.id),
+        policyStore = fx.policyStore,
+        accessStore = fx.accessStore,
+        userGroupStore = fx.userGroupStore,
+        roleResolver = fx.roleResolver,
+        authz = fx.authz,
+    )
+
+    private val ddlForms = listOf(
+        "ALTER TABLE users DROP INDEX idx_rrn",
+        "ALTER TABLE users ADD c INT",
+        "ALTER TABLE users RENAME TO users2",
+        "CREATE INDEX idx_email ON users (email)",
+        "DROP INDEX idx_email ON users",
+        "DROP TABLE users",
+        "TRUNCATE TABLE users",
+        "CREATE TABLE t (id int)",
+    )
+
+    @Test
+    fun `the sql-ddl grant alone authorizes every DDL form on a production datasource`() {
+        for (sql in ddlForms) {
+            val ctx = decide(sql, architect)
+            assertEquals(
+                EnfAction.ALLOW,
+                ctx.action,
+                "$sql denied for the sql.ddl holder: ${ctx.denyReason} (stage=${ctx.failedStage})",
+            )
+            // The relay must not be the unmasked sql.unanalyzable passthrough — that grant is a whole-
+            // statement unmasked relay and is NOT what authorizes DDL.
+            assertEquals(
+                false,
+                ctx.detail?.contains("unanalyz") ?: false,
+                "$sql was relayed through the unanalyzable hatch: ${ctx.detail}",
+            )
+        }
+    }
+
+    @Test
+    fun `a principal that can connect but lacks the sql-ddl grant is denied every DDL form`() {
+        // `connector` clears datasource.connect (checked before sql.ddl), so each DENY isolates the
+        // missing sql.ddl grant rather than passing at the connect gate.
+        for (sql in ddlForms) {
+            val ctx = decide(sql, connector)
+            assertEquals(EnfAction.DENY, ctx.action, "$sql must stay denied without sql.ddl")
+        }
+    }
+
+    /**
+     * A statement sqlglot degrades to a Command node is one it did not model: the verb survives as text
+     * and the rest is unparsed. Classification comes from sqlglot's structure alone, so these stay denied
+     * even for a sql.ddl holder — matching a verb string would also match DROP USER / RENAME USER, which
+     * are privilege management rather than schema DDL. Over-denying an unmodeled form is the correct side
+     * to fail on; the fix belongs in the parser, not in a prefix guess here.
+     */
+    @Test
+    fun `a statement sqlglot leaves unmodeled stays denied even with the ddl grant`() {
+        for (sql in listOf(
+            "RENAME TABLE users TO users2",
+            "DROP USER 'x'@'%'",
+            "RENAME USER 'a'@'%' TO 'b'@'%'",
+        )) {
+            val ctx = decide(sql, architect)
+            assertEquals(EnfAction.DENY, ctx.action, "$sql must stay denied: unmodeled by the parser")
+        }
+    }
+
+    /**
+     * The exfiltration path authz-model.md requires to fail closed: copying a masked column into a new,
+     * unclassified table. The DDL grant authorizes the schema change, but every column the write READS is
+     * a non-maskable reference, so a masked source column denies the statement.
+     *
+     * Both spellings are asserted because parentheses put a Subquery around the query body — the bug this
+     * covers classified `AS (SELECT …)` as body-less, emitted no column grants, and allowed the copy.
+     */
+    @Test
+    fun `a ddl holder cannot copy a masked column into a new table, parenthesized or not`() {
+        for (sql in listOf(
+            "CREATE TABLE stolen AS SELECT rrn FROM users",
+            "CREATE TABLE stolen AS (SELECT rrn FROM users)",
+            "CREATE TABLE stolen AS ((SELECT rrn FROM users))",
+            "CREATE VIEW stolen AS (SELECT rrn FROM users)",
+        )) {
+            val ctx = decide(sql, architect)
+            assertEquals(
+                EnfAction.DENY,
+                ctx.action,
+                "$sql must DENY — it copies a masked column into an unclassified table (detail=${ctx.detail})",
+            )
+        }
+    }
+
+    /**
+     * A CTAS is a read as well as a write, so sql.ddl alone never authorizes one: the columns it reads
+     * need their own grant. That is what separates plain DDL (schema only) from data-bearing DDL, and it
+     * is why the copy above denies on the mask rather than on the DDL grant.
+     */
+    @Test
+    fun `a ddl holder cannot copy even an unclassified column without a read grant`() {
+        val ctx = decide("CREATE TABLE fine AS SELECT id FROM users", architect)
+        assertEquals(
+            EnfAction.DENY,
+            ctx.action,
+            "a CTAS reads its source columns; sql.ddl alone is not a read grant",
+        )
+    }
+
+    /**
+     * The reason the architect vanished from the approval picker: discovery previews each candidate role
+     * ALONE and drops any whose decision is DENY, with no per-candidate reason surfaced. A DDL statement
+     * that cannot be decided under a single role therefore offers no role at all.
+     */
+    @Test
+    fun `role discovery offers the ddl role for a DDL statement`() {
+        val response = discoverRoles(ownRoles = emptySet(), allRoles = fx.policyStore.listRoles()) { roles, channel ->
+            decideQuery(
+                principal = noRole,
+                ds = fx.datasourceStore.get(fx.datasource.id)!!,
+                sql = "ALTER TABLE users DROP INDEX idx_rrn",
+                channel = channel,
+                catalog = fx.datasourceStore.catalog(fx.datasource.id),
+                policyStore = fx.policyStore,
+                accessStore = fx.accessStore,
+                userGroupStore = fx.userGroupStore,
+                roleResolver = fx.roleResolver,
+                authz = fx.authz,
+                providedRoles = roles,
+            )
+        }
+        assertEquals(
+            listOf("ddl-architect"),
+            response.options.map { it.roleName }.filter { it == "ddl-architect" },
+            "the sql.ddl role must be offered; discovery drops DENY candidates silently",
+        )
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/StatementFactsGrantLoopTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/StatementFactsGrantLoopTest.kt
@@ -325,6 +325,16 @@ class StatementFactsGrantLoopTest {
     }
 
     @Test
+    fun `a resolved DDL statement authorizes off its sql-ddl grant like any grant-only write`() {
+        // DDL resolves as ANALYZED carrying a single sql.ddl datasource grant and no columns — the same
+        // shape INSERT takes. The fixture analyst holds no sql.ddl, so this is a POLICY deny at the
+        // datasource-grant loop, not a structural one: it reaches Cedar and is denied on the grant.
+        val ctx = decide(analyzed(datasourceGrant(GrantAction.GRANT_ACTION_SQL_DDL), isWrite = true))
+        assertEquals(EnfAction.DENY, ctx.action)
+        assertTrue(!ctx.structural, "a resolved DDL fact is authorized off its grant, not structurally denied")
+    }
+
+    @Test
     fun `ungranted table grant denies through table dispatch`() {
         val tableGrant = requiredGrant {
             action = GrantAction.GRANT_ACTION_RESULT_READ

--- a/docs/authz-model.md
+++ b/docs/authz-model.md
@@ -223,15 +223,15 @@ The analyzer and proxy never evaluate Cedar, roles, tags, or context.
 
 Writes and DDL. A write must pass its emitted `sql.*` action; and since every
 column a write reads or targets is a _reference_ (non-maskable), any
-masked-or-denied column in a write is a DENY (you cannot mask a write). Plain
-DDL with a supported analyzer shape, such as `CREATE TABLE (cols)`, is gated by
-`sql.ddl` (no data flow, no lineage), fully audited. `ALTER`, `DROP`, and
-`TRUNCATE` currently also require `sql.unanalyzable` because their roots are not
-lineage-analyzed. DDL that reads data — `CREATE TABLE … AS SELECT` (CTAS),
-`CREATE VIEW` — is _also_ a write: it needs `sql.ddl` and is subject to the
-write rule, so a masked/denied column in its `SELECT` is a DENY. This is the
-classic exfiltration path (copy PII into a fresh, unprotected table), so it must
-fail closed.
+masked-or-denied column in a write is a DENY (you cannot mask a write). DDL that
+only changes the catalog — `CREATE TABLE (cols)`, `CREATE INDEX`, `ALTER`,
+`DROP`, `TRUNCATE` — resolves as _catalog-changing_: its meaning is fully
+determined but it reads no column values, so there is no lineage to trace and
+`sql.ddl` is the whole gate (fully audited). DDL that reads data —
+`CREATE TABLE … AS SELECT` (CTAS), `CREATE VIEW` — is _also_ a write: it needs
+`sql.ddl` and is subject to the write rule, so a masked/denied column in its
+`SELECT` is a DENY. This is the classic exfiltration path (copy PII into a
+fresh, unprotected table), so it must fail closed.
 
 Worked walk-throughs — policies + column config from
 [Worked examples](#worked-examples) above; `alice` holds `analyst`


### PR DESCRIPTION
## What

Catalog-only DDL (`ALTER` / `DROP` / `TRUNCATE` / `CREATE INDEX` / bare `CREATE TABLE`) came back `resolved=false` and routed to the dev-only `sql.unanalyzable` gate, so the shipped `system:production-ddl` policy was unreachable — production DDL was denied for every role. The analyzer now resolves such statements as `ANALYZED` carrying a single `sql.ddl` datasource grant and no lineage — the same shape a grant-only write like `INSERT` takes — so `decideQuery` authorizes them off that grant with no DDL-specific branch. **The control plane is unchanged.**

DDL that reads columns (`CREATE TABLE AS SELECT`, `CREATE VIEW AS SELECT`, including the parenthesized `AS (SELECT …)` spelling) keeps the lineage path and its per-column grants, so the copy-PII-into-a-new-table exfil path still fails closed.

**Model: uniform DDL.** Every `ALTER` is DDL; `sql.ddl` authorizes all of it. Value-reading ALTER forms (`ALTER VIEW AS SELECT`, generated columns, expression indexes) emit no column grants, unlike their CREATE equivalents — a deliberate asymmetry, since DDL is a classification-changing primitive by design and the operator's Cedar policy governs.

## Where it could bite

- A `CREATE … AS VALUES(…)` row hiding a subquery, column, or function call — e.g. `AS VALUES (query_to_xml('SELECT rrn …'))` — is steered off the value-free path so its data-leak function gate isn't dropped; lineage can't model it, so it over-denies as unresolved.
- `sqlglot-go v0.22.0` models `DROP INDEX <idx> ON <table>` as a structured `Drop` (resolved DDL); `RENAME TABLE` stays an unmodeled `Command` and is denied.
- No new `StatementClass` value: DDL reuses `ANALYZED`, so nothing is added to the enum the statement-typing redesign (#96) plans to retire.

## Verify

`mise run verify` green. `DdlEnforcementDbTest` drives the real `decideQuery` + Cedar path on a production-tagged datasource (6/6); `StatementFactsGrantLoopTest` covers the fail-closed contract branches (22/22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEjU1hSpgtkqsFPHkRVTgJ
