### PR TITLE
build(pmon): pin mysqlwire v0.1.2 for the auth-scramble fix

### DIFF
--- a/pmon/go.mod
+++ b/pmon/go.mod
@@ -2,7 +2,7 @@ module github.com/ridi-oss/proxy-monster/pmon
 
 go 1.26.0
 
-require github.com/ridi-oss/proxy-monster/mysqlwire v0.1.1
+require github.com/ridi-oss/proxy-monster/mysqlwire v0.1.2
 
 require (
 	github.com/alecthomas/kong v1.6.0

--- a/pmon/go.sum
+++ b/pmon/go.sum
@@ -95,8 +95,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/ridi-oss/proxy-monster/mysqlwire v0.1.1 h1:FuJhta/0hFjHv3ssPdWZ29/Rm7Bkf1S6qXSpUjEqB2o=
-github.com/ridi-oss/proxy-monster/mysqlwire v0.1.1/go.mod h1:yielY+j1TFdAdh9cn7WGFUwUtLwligQEwpO7Xmfvinc=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.2 h1:KM/b7PfadLw0drVrTU+/34eTJLLBRbIEfsPhp4+bzds=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.2/go.mod h1:yielY+j1TFdAdh9cn7WGFUwUtLwligQEwpO7Xmfvinc=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=


### PR DESCRIPTION
The pmon release binary builds with `GOWORK=off`, so it resolves mysqlwire from `pmon/go.mod`, not the workspace. Pinned at v0.1.1 it shipped the pre-fix scramble (bytes ≥ 0x80) that Connector/J and MariaDB corrupt — so a released pmon still failed JDBC/DBeaver auth even with CONNECT_WITH_DB. Pin v0.1.2 (first mysqlwire release with the printable scramble) so pmon 0.1.3 carries both halves of the DBeaver fix.

Verified: `GOWORK=off go build ./pmon` resolves v0.1.2 and its `Scramble()` is the printable-ASCII form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)