### PR TITLE
fix(goproxy): pin mysqlwire v0.1.2 so the release image builds

### DIFF
--- a/goproxy/go.mod
+++ b/goproxy/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/ridi-oss/proxy-monster/analyzer v0.0.0-00010101000000-000000000000
-	github.com/ridi-oss/proxy-monster/mysqlwire v0.1.1
+	github.com/ridi-oss/proxy-monster/mysqlwire v0.1.2
 	github.com/testcontainers/testcontainers-go v0.34.0
 	golang.org/x/crypto v0.27.0
 	google.golang.org/grpc v1.68.1
@@ -58,7 +58,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
-	github.com/ridi-oss/sqlglot-go v0.20.0 // indirect
+	github.com/ridi-oss/sqlglot-go v0.22.0 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/goproxy/go.sum
+++ b/goproxy/go.sum
@@ -105,10 +105,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/ridi-oss/proxy-monster/mysqlwire v0.1.1 h1:FuJhta/0hFjHv3ssPdWZ29/Rm7Bkf1S6qXSpUjEqB2o=
-github.com/ridi-oss/proxy-monster/mysqlwire v0.1.1/go.mod h1:yielY+j1TFdAdh9cn7WGFUwUtLwligQEwpO7Xmfvinc=
-github.com/ridi-oss/sqlglot-go v0.20.0 h1:k+t+wD4YHPYjP8m3CEouCTXIGtMKIkpQ/5tMp9jhY+o=
-github.com/ridi-oss/sqlglot-go v0.20.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.2 h1:KM/b7PfadLw0drVrTU+/34eTJLLBRbIEfsPhp4+bzds=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.2/go.mod h1:yielY+j1TFdAdh9cn7WGFUwUtLwligQEwpO7Xmfvinc=
+github.com/ridi-oss/sqlglot-go v0.22.0 h1:uPRNk6iFJYy46PsGz3Tjduejg+WcLzd7aNiyJ0bMQpM=
+github.com/ridi-oss/sqlglot-go v0.22.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=


### PR DESCRIPTION
goproxy's frontend greeting calls `mysqlwire.Scramble()` (added in 5f307b3), which only exists as of mysqlwire v0.1.2 — but go.mod still pinned v0.1.1. Local/CI builds use the workspace and were unaffected; the **release image** builds with the workspace off (the Dockerfile doesn't copy `go.work`), so it resolves go.mod, and v0.1.1 has no `Scramble` → the goproxy image fails to build. This blocks the `server-v0.1.7` image build.

Also reconciles the stale indirect `sqlglot-go` pin to v0.22.0 (what the local analyzer already requires); the workspace-off build fails without it too.

Verified: `GOWORK=off go build ./...` and a full `docker build -f goproxy/Dockerfile .` both pass; workspace build + `go vet` green. Must merge before server 0.1.7 (#85) is cut.