### PR TITLE
fix(control-plane): view an authorized passthrough result instead of denying it

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
@@ -231,7 +231,23 @@ internal fun decideResultView(
         return ResultViewDecision.Denied(ctx.denyReason ?: ctx.detail ?: "view decision denied")
     }
     if (ctx.passthrough) {
-        return ResultViewDecision.Denied("stored query result re-decided as passthrough")
+        // The re-decision already ran full Cedar authorization under {R} in the viewer's live context and
+        // returned non-DENY (checked above). A passthrough carries no column-masking model — there is nothing
+        // to narrow for the viewer — so "authorized to run" IS "authorized to see the raw output": that is the
+        // definition of the sql.unanalyzable relay and of an authorized SHOW/DESCRIBE. Release the stored
+        // bytes; a viewer whose context should forbid it got DENY above. Context-sensitivity of unmasked
+        // relays / critical-utility reads belongs in their Cedar grants, not a hardcoded view gate.
+        //
+        // Every decideQuery passthrough site constructs ALLOW with no masks (a passthrough has no column
+        // model to mask). Assert it here so a future passthrough that ever carried a MASK verdict fails
+        // CLOSED rather than releasing its stored bytes unmasked.
+        if (ctx.action != EnfAction.ALLOW || ctx.masks.isNotEmpty()) {
+            return ResultViewDecision.Denied("passthrough result carries a masking verdict")
+        }
+        if (decrypted.rows.any { it.size != decrypted.columns.size }) {
+            return ResultViewDecision.Denied("stored result row width does not match its columns")
+        }
+        return ResultViewDecision.Allowed(decrypted.columns, decrypted.rows)
     }
     if (
         ctx.outputColumns.size != decrypted.columns.size ||

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultAssumeMysqlDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultAssumeMysqlDbTest.kt
@@ -163,4 +163,93 @@ class ApprovalResultAssumeMysqlDbTest {
         assertEquals("rrn", viewedOffNetwork.masks.single().column)
         assertEquals(EnfAction.ALLOW, decide(Channel.WORKFLOW_VIEWER, "100.100.1.10").action)
     }
+
+    @Test
+    fun `an authorized passthrough result is released as-is`() {
+        // SHOW CREATE TABLE (and every SHOW / DESCRIBE) re-decides as an ALLOW passthrough — it carries no
+        // column-masking model, so the view has nothing to narrow. Once the live re-decision under {R}
+        // authorizes it, "authorized to run" is "authorized to see": the stored bytes are released verbatim
+        // rather than fail-closing on "re-decided as passthrough".
+        val ddl = "CREATE TABLE `users` (\n  `rrn` varchar(20) DEFAULT NULL\n)"
+        val stored = DecryptedResult(listOf("Table", "Create Table"), listOf(listOf("users", ddl)))
+        val redecide = decideQuery(
+            principal = requester, ds = datasource, sql = "SHOW CREATE TABLE users", channel = Channel.EDITOR,
+            catalog = fx.datasourceStore.catalog(datasource.id), policyStore = fx.policyStore,
+            accessStore = fx.accessStore, userGroupStore = fx.userGroupStore, roleResolver = fx.roleResolver,
+            authz = fx.authz, providedRoles = setOf(roleName), context = AuthzContext(requesterIp = "100.99.1.10"),
+        )
+        assertEquals(EnfAction.ALLOW, redecide.action)
+        assertTrue(redecide.passthrough, "SHOW CREATE TABLE re-decides as a passthrough")
+
+        val view = decideResultView(
+            viewer = requester,
+            req = request(),
+            childSql = "SHOW CREATE TABLE users",
+            ds = datasource,
+            decrypted = stored,
+            callerContext = AuthzContext(requesterIp = "100.99.1.10"),
+            datasourceStore = fx.datasourceStore,
+            policyStore = fx.policyStore,
+            accessStore = fx.accessStore,
+            userGroupStore = fx.userGroupStore,
+            roleResolver = fx.roleResolver,
+            authz = fx.authz,
+            systemClassification = null,
+            channel = Channel.EDITOR,
+        )
+        val allowed = assertIs<ResultViewDecision.Allowed>(view)
+        assertEquals(listOf("Table", "Create Table"), allowed.columns)
+        assertEquals(listOf(listOf("users", ddl)), allowed.rows)
+        assertTrue(allowed.maskedColumns.isEmpty(), "a passthrough view masks nothing")
+    }
+
+    @Test
+    fun `a passthrough that re-decides DENY via Cedar is refused, not released`() {
+        // A passthrough is released only when the live re-decision authorizes it. Under a development-only
+        // role with no datasource.connect on this system:production datasource, SHOW CREATE TABLE re-decides
+        // DENY at the Cedar connect gate, so the view refuses it — the DENY branch, not a blanket passthrough
+        // deny. (Contrast the released-as-is case above, which runs under the connect-holding {R}.)
+        val stored = DecryptedResult(listOf("Table", "Create Table"), listOf(listOf("users", "CREATE TABLE `users` ()")))
+        val view = decideResultView(
+            viewer = requester,
+            req = request().copy(roleName = "system:development-viewer", executeAs = listOf("system:development-viewer")),
+            childSql = "SHOW CREATE TABLE users",
+            ds = datasource,
+            decrypted = stored,
+            callerContext = AuthzContext(requesterIp = "100.99.1.10"),
+            datasourceStore = fx.datasourceStore,
+            policyStore = fx.policyStore,
+            accessStore = fx.accessStore,
+            userGroupStore = fx.userGroupStore,
+            roleResolver = fx.roleResolver,
+            authz = fx.authz,
+            systemClassification = null,
+            channel = Channel.EDITOR,
+        )
+        assertIs<ResultViewDecision.Denied>(view)
+    }
+
+    @Test
+    fun `a passthrough result with a mismatched row width is refused`() {
+        // The passthrough release path's structural check: stored bytes whose row width does not match the
+        // column count are refused rather than released (two columns, a one-cell row).
+        val stored = DecryptedResult(listOf("Table", "Create Table"), listOf(listOf("users")))
+        val view = decideResultView(
+            viewer = requester,
+            req = request(),
+            childSql = "SHOW CREATE TABLE users",
+            ds = datasource,
+            decrypted = stored,
+            callerContext = AuthzContext(requesterIp = "100.99.1.10"),
+            datasourceStore = fx.datasourceStore,
+            policyStore = fx.policyStore,
+            accessStore = fx.accessStore,
+            userGroupStore = fx.userGroupStore,
+            roleResolver = fx.roleResolver,
+            authz = fx.authz,
+            systemClassification = null,
+            channel = Channel.EDITOR,
+        )
+        assertIs<ResultViewDecision.Denied>(view)
+    }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultViewContextDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultViewContextDbTest.kt
@@ -468,12 +468,38 @@ class ApprovalResultViewContextDbTest {
     }
 
     @Test
-    fun `a stored query result that re-decides as passthrough is denied without sentinel data`() = testApplication {
+    fun `an authorized passthrough result is released to the viewer`() = testApplication {
+        // A passthrough (SHOW / DESCRIBE / a session-config read) carries no column-masking model, so the view
+        // has nothing to narrow. Once the live re-decision under {R} authorizes the statement, "authorized to
+        // run" is "authorized to see" — the stored bytes are released as-is. The DENY branch is the boundary
+        // (see the SET and ungranted-table cases below), not a blanket passthrough deny.
         resetMutableAuthzState()
-        val sentinel = "LEAK-SENTINEL-PASSTHROUGH"
+        val value = "reporting, public"
         val id = seedResult(
             sql = "SHOW search_path",
             columns = listOf("search_path"),
+            rows = listOf(listOf(value)),
+        )
+        val client = wire()
+        client.login(executor)
+
+        val response = client.get("/api/approvals/$id/result")
+        assertEquals(HttpStatusCode.OK, response.status)
+        val view = response.body<QueryResultView>()
+        assertEquals(listOf("search_path"), view.columns)
+        assertEquals(value, view.rows.single().single())
+    }
+
+    @Test
+    fun `a passthrough that re-decides DENY is still refused without stored data`() = testApplication {
+        // Dropping the blanket passthrough deny must not widen the DENY branch: a session statement re-decides
+        // DENY on the workflow-viewer channel (each view runs on a fresh connection, no session to mutate), so
+        // its stored bytes stay locked.
+        resetMutableAuthzState()
+        val sentinel = "LEAK-SENTINEL-SESSION"
+        val id = seedResult(
+            sql = "SET search_path TO reporting",
+            columns = listOf("ok"),
             rows = listOf(listOf(sentinel)),
         )
         val client = wire()
@@ -483,7 +509,7 @@ class ApprovalResultViewContextDbTest {
         assertEquals(HttpStatusCode.Forbidden, response.status)
         val responseBody = response.bodyAsText()
         assertEquals("approval.result_view_denied", Json.decodeFromString<ApiError>(responseBody).code)
-        assertFalse(responseBody.contains(sentinel), "a passthrough decision must never release stored values")
+        assertFalse(responseBody.contains(sentinel), "a denied passthrough must not release stored values")
     }
 
     @Test


### PR DESCRIPTION
## Problem
`decideResultView` denied every stored result whose live re-decision was a passthrough, so `SHOW CREATE TABLE` / `SHOW COLUMNS` / `DESCRIBE` — authorized ALLOW and executed — had their result blocked with *"You do not have permission to view this result"* in both the editor and query-approval paths, regardless of role.

## Change
Drop the blanket passthrough-view deny. The view already re-runs full Cedar authorization under `{R}` in the viewer's live context and honors its DENY; a passthrough that survives that is authorized, and a passthrough carries no column-masking model — so "authorized to run" is "authorized to see the raw output" (the `sql.unanalyzable` relay, an authorized `SHOW`). Release the stored bytes on any non-DENY re-decision.

Fail-closed guard: release only when `action == ALLOW && masks.isEmpty()` (a future passthrough that ever carried a mask denies instead of leaking), plus a row-width sanity check.

## Where it could bite
This also opens viewing of `sql.unanalyzable` **relay** results, not only `SHOW`/`DESCRIBE` — intended under the same principle. Execution-vs-view network-posture sensitivity of those relay grants belongs in the Cedar grants themselves and is a **separate follow-up**, not this PR.

## Verification
Full `:control-plane:test` green. Tests: authorized passthrough released; a passthrough that re-decides DENY (Cedar connect-gate + structural session) refused with no stored data; row-width mismatch refused; `SHOW CREATE TABLE` released verbatim. Pre-push dual-review (Codex / Sol / Grok) — no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)