### PR TITLE
feat(control-plane): audit config-change admin actions

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -9,8 +9,11 @@ import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
 import com.ridi.oss.proxymonster.controlplane.authz.authorizeWithContext
 import com.ridi.oss.proxymonster.controlplane.authz.cedarPolicyRoutes
 import com.ridi.oss.proxymonster.controlplane.authz.contextTagLint
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import com.ridi.oss.proxymonster.controlplane.management.AuditSource
 import com.ridi.oss.proxymonster.controlplane.management.DatasourceManagementService
 import com.ridi.oss.proxymonster.controlplane.management.IdentityManagementService
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
 import com.ridi.oss.proxymonster.controlplane.management.ManagementException
 import com.ridi.oss.proxymonster.controlplane.management.PolicyManagementService
 import com.ridi.oss.proxymonster.controlplane.mcp.installMcp
@@ -559,10 +562,11 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
     installMcpOAuthProtocolGuard()
 
     // MCPA transport adapters share these service instances with the REST surface and the one live core.
-    val datasourceManagement = DatasourceManagementService(datasourceStore, core.proxyEventsHub, tableDetailService)
-    val policyManagement = PolicyManagementService(cedarPolicyStore, policyStore)
+    val managementAudit = ManagementAuditRecorder(core.auditStore)
+    val datasourceManagement = DatasourceManagementService(datasourceStore, core.proxyEventsHub, tableDetailService, managementAudit)
+    val policyManagement = PolicyManagementService(cedarPolicyStore, policyStore, managementAudit)
     val identityManagement = IdentityManagementService(
-        dataSource, userGroupStore, policyStore, tokenStore, accessStore, principalSessionStore,
+        dataSource, userGroupStore, policyStore, tokenStore, accessStore, principalSessionStore, managementAudit,
     )
     installMcp(config, core, datasourceManagement, policyManagement, identityManagement)
 
@@ -727,7 +731,15 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
             // while the database says {B}. The response must describe the state the session actually resolves.
             val sessionId = try {
                 dataSource.inTx { c ->
-                    policyManagement.replaceDirectRoles(login.principal, roles, c)
+                    policyManagement.replaceDirectRoles(
+                        login.principal, roles,
+                        AuditActor(
+                            principal = login.principal,
+                            clientAddr = debugRequesterIp ?: call.httpRequesterIp(config),
+                            channel = AuditSource.CONSOLE,
+                        ),
+                        c,
+                    )
                     principalSessionStore.mintWeb(
                         login.principal,
                         null,

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Auth.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Auth.kt
@@ -1,5 +1,7 @@
 package com.ridi.oss.proxymonster.controlplane
 
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import com.ridi.oss.proxymonster.controlplane.management.AuditSource
 import io.ktor.http.Cookie
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.sessions.SessionSerializer
@@ -107,3 +109,10 @@ fun ApplicationCall.webSession(): WebSessionRow? {
 
 /** Resolve the current server-side web session, or null if unauthenticated. */
 fun ApplicationCall.userSession(): UserSession? = webSession()?.let { UserSession(it.principal) }
+
+// The fallback is reachable only when PM_AUTH_DEBUG admits a mutation without a session.
+fun ApplicationCall.auditActor(config: Config, channel: String = AuditSource.CONSOLE): AuditActor = AuditActor(
+    principal = userSession()?.principal ?: "unknown",
+    clientAddr = httpRequesterIp(config),
+    channel = channel,
+)

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Datasources.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Datasources.kt
@@ -9,6 +9,7 @@ import com.ridi.oss.proxymonster.controlplane.authz.requireAdmin
 import com.ridi.oss.proxymonster.controlplane.authz.resolveContextTags
 import com.ridi.oss.proxymonster.controlplane.management.DatasourceManagementService
 import com.ridi.oss.proxymonster.controlplane.grpc.inspectTrustChain
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
 import com.ridi.oss.proxymonster.controlplane.management.ManagementException
 import com.ridi.oss.proxymonster.grpc.Engine
 import com.ridi.oss.proxymonster.probe.Classification
@@ -448,21 +449,21 @@ class DatasourceStore(internal val dataSource: DataSource) {
         return columns.size
     }
 
-    fun create(input: DatasourceInput): Datasource {
-        val id = dataSource.connection.use { c ->
-            c.prepareStatement(
-                """INSERT INTO datasource (name, engine, host, port, db_name)
-                   VALUES (?, ?, ?, ?, ?) RETURNING id""",
-            ).use { ps ->
-                ps.setString(1, input.name)
-                ps.setString(2, input.engine)
-                ps.setString(3, input.host)
-                ps.setInt(4, input.port)
-                ps.setString(5, input.dbName)
-                ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) }
-            }
+    fun create(input: DatasourceInput): Datasource = dataSource.inTx { create(input, it) }
+
+    fun create(input: DatasourceInput, c: java.sql.Connection): Datasource {
+        val id = c.prepareStatement(
+            """INSERT INTO datasource (name, engine, host, port, db_name)
+               VALUES (?, ?, ?, ?, ?) RETURNING id""",
+        ).use { ps ->
+            ps.setString(1, input.name)
+            ps.setString(2, input.engine)
+            ps.setString(3, input.host)
+            ps.setInt(4, input.port)
+            ps.setString(5, input.dbName)
+            ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) }
         }
-        return get(id)!!
+        return get(id, c)!!
     }
 
     /** Drop [id]'s stored catalog and clear its sync stamps so decisions fail closed until a fresh
@@ -486,51 +487,39 @@ class DatasourceStore(internal val dataSource: DataSource) {
      * carries the unchanged engine and never trips this. A db_name change invalidates the stale catalog exactly
      * as a Register retarget does. Returns null if [id] doesn't exist.
      */
-    fun update(id: Long, input: DatasourceInput): Datasource? {
-        val existed = dataSource.connection.use { c ->
-            c.autoCommit = false
-            try {
-                data class Prior(val engine: String, val dbName: String)
-                val prior = c.prepareStatement("SELECT engine, db_name FROM datasource WHERE id = ? FOR UPDATE").use { ps ->
-                    ps.setLong(1, id)
-                    ps.executeQuery().use { rs -> if (rs.next()) Prior(rs.getString(1), rs.getString(2)) else null }
-                }
-                if (prior == null) {
-                    c.rollback()
-                    return@use false
-                }
-                if (prior.engine != input.engine) {
-                    throw DatasourceEngineConflictException(input.name, prior.engine, input.engine)
-                }
-                c.prepareStatement(
-                    "UPDATE datasource SET name=?, engine=?, host=?, port=?, db_name=? WHERE id=?",
-                ).use { ps ->
-                    ps.setString(1, input.name)
-                    ps.setString(2, input.engine)
-                    ps.setString(3, input.host)
-                    ps.setInt(4, input.port)
-                    ps.setString(5, input.dbName)
-                    ps.setLong(6, id)
-                    ps.executeUpdate()
-                }
-                if (prior.dbName != input.dbName) invalidateCatalog(c, id)
-                c.commit()
-                true
-            } catch (e: Exception) {
-                c.rollback(); throw e
-            } finally {
-                c.autoCommit = true
-            }
+    fun update(id: Long, input: DatasourceInput): Datasource? = dataSource.inTx { update(id, input, it) }
+
+    fun update(id: Long, input: DatasourceInput, c: java.sql.Connection): Datasource? {
+        data class Prior(val engine: String, val dbName: String)
+        val prior = c.prepareStatement("SELECT engine, db_name FROM datasource WHERE id = ? FOR UPDATE").use { ps ->
+            ps.setLong(1, id)
+            ps.executeQuery().use { rs -> if (rs.next()) Prior(rs.getString(1), rs.getString(2)) else null }
+        } ?: return null
+        if (prior.engine != input.engine) {
+            throw DatasourceEngineConflictException(input.name, prior.engine, input.engine)
         }
-        return if (existed) get(id) else null
+        c.prepareStatement(
+            "UPDATE datasource SET name=?, engine=?, host=?, port=?, db_name=? WHERE id=?",
+        ).use { ps ->
+            ps.setString(1, input.name)
+            ps.setString(2, input.engine)
+            ps.setString(3, input.host)
+            ps.setInt(4, input.port)
+            ps.setString(5, input.dbName)
+            ps.setLong(6, id)
+            ps.executeUpdate()
+        }
+        if (prior.dbName != input.dbName) invalidateCatalog(c, id)
+        return get(id, c)
     }
 
-    fun delete(id: Long): Boolean = dataSource.connection.use { c ->
+    fun delete(id: Long): Boolean = dataSource.inTx { delete(id, it) }
+
+    fun delete(id: Long, c: java.sql.Connection): Boolean =
         c.prepareStatement("DELETE FROM datasource WHERE id = ?").use { ps ->
             ps.setLong(1, id)
             ps.executeUpdate() > 0
         }
-    }
 
     /**
      * A creds-free liveness result: the control-plane does not dial the target, so "test" reports whether
@@ -793,7 +782,8 @@ fun Route.datasourceRoutes(
     tableDetailService: TableDetailService,
     tokenStore: TokenStore,
     userGroupStore: UserGroupStore,
-    management: DatasourceManagementService = DatasourceManagementService(store, eventsHub, tableDetailService),
+    management: DatasourceManagementService =
+        DatasourceManagementService(store, eventsHub, tableDetailService, ManagementAuditRecorder(AuditStore(store.dataSource))),
 ) {
     // A caller may connect to (and so browse the catalog of) a datasource iff Cedar grants
     // datasource.connect on it — the same name-keyed decision, with derived context tags, the proxy runs on
@@ -851,7 +841,7 @@ fun Route.datasourceRoutes(
         // the same set).
         val engine = engineFromWireOrNull(input.engine)
             ?: return@post call.respond(HttpStatusCode.BadRequest, ApiError("datasource.invalid_engine", mapOf("engine" to input.engine)))
-        call.respond(HttpStatusCode.Created, store.create(input.copy(engine = engine.wireName)))
+        call.respond(HttpStatusCode.Created, management.createDatasource(input.copy(engine = engine.wireName), call.auditActor(config)))
     }
     get("/api/datasources/{id}") {
         if (!call.requireApi(config)) return@get
@@ -870,7 +860,7 @@ fun Route.datasourceRoutes(
         // Engine is immutable — a PUT that changes it is a fail-closed 409 (delete + re-create to change
         // engine), mirroring the proxy Register path's FAILED_PRECONDITION.
         val updated = try {
-            store.update(id, input.copy(engine = engine.wireName))
+            management.updateDatasource(id, input.copy(engine = engine.wireName), call.auditActor(config))
         } catch (e: DatasourceEngineConflictException) {
             return@put call.respond(HttpStatusCode.Conflict, ApiError("datasource.engine_immutable"))
         }
@@ -879,7 +869,8 @@ fun Route.datasourceRoutes(
     delete("/api/datasources/{id}") {
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_DATASOURCES)) return@delete
         val id = call.idParam() ?: return@delete call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
-        if (store.delete(id)) call.respond(HttpStatusCode.NoContent) else call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "datasource")))
+        if (management.deleteDatasource(id, call.auditActor(config)).deleted) call.respond(HttpStatusCode.NoContent)
+        else call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "datasource")))
     }
     post("/api/datasources/{id}/test") {
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_DATASOURCES)) return@post
@@ -974,7 +965,7 @@ fun Route.datasourceRoutes(
         try {
             call.respond(
                 management.setColumnClassification(
-                    id, input.schema, input.table, input.column, input.tags, input.maskFnId,
+                    id, input.schema, input.table, input.column, input.tags, input.maskFnId, call.auditActor(config),
                 ),
             )
         } catch (e: ManagementException) {
@@ -986,7 +977,7 @@ fun Route.datasourceRoutes(
         val id = call.idParam() ?: return@delete call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         val body = call.receive<ClassificationDelete>()
         try {
-            management.clearColumnClassification(id, body.schema, body.table, body.column)
+            management.clearColumnClassification(id, body.schema, body.table, body.column, call.auditActor(config))
             call.respond(HttpStatusCode.NoContent)
         } catch (e: ManagementException) {
             call.respondManagementError(e)

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Policies.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Policies.kt
@@ -4,6 +4,7 @@ import com.ridi.oss.proxymonster.controlplane.authz.Authz
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
 import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyStore
 import com.ridi.oss.proxymonster.controlplane.authz.requireAdmin
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
 import com.ridi.oss.proxymonster.controlplane.management.ManagementException
 import com.ridi.oss.proxymonster.controlplane.management.PolicyManagementService
 import io.ktor.http.HttpStatusCode
@@ -150,14 +151,15 @@ fun Route.policyRoutes(
     config: Config,
     authz: Authz,
     store: PolicyStore,
-    management: PolicyManagementService = PolicyManagementService(CedarPolicyStore(store.dataSource), store),
+    management: PolicyManagementService =
+        PolicyManagementService(CedarPolicyStore(store.dataSource), store, ManagementAuditRecorder(AuditStore(store.dataSource))),
 ) {
     get("/api/roles") { if (!call.requireApi(config)) return@get; call.respond(management.listRoles()) }
     post("/api/roles") {
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_POLICIES)) return@post
         val input = call.receive<RoleInput>()
         try {
-            call.respond(HttpStatusCode.Created, management.createRole(input.name, input.description))
+            call.respond(HttpStatusCode.Created, management.createRole(input.name, input.description, call.auditActor(config)))
         } catch (e: ManagementException) {
             call.respondManagementError(e)
         }
@@ -167,7 +169,7 @@ fun Route.policyRoutes(
         val id = call.idParam() ?: return@put call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         val input = call.receive<RoleInput>()
         try {
-            call.respond(management.updateRole(id, input))
+            call.respond(management.updateRole(id, input, call.auditActor(config)))
         } catch (e: ManagementException) {
             call.respondManagementError(e)
         }
@@ -176,7 +178,7 @@ fun Route.policyRoutes(
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_POLICIES)) return@delete
         val id = call.idParam() ?: return@delete call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         try {
-            management.deleteRole(id)
+            management.deleteRole(id, call.auditActor(config))
             call.respond(HttpStatusCode.NoContent)
         } catch (e: ManagementException) {
             call.respondManagementError(e)
@@ -194,7 +196,7 @@ fun Route.policyRoutes(
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_IDENTITY)) return@post
         val input = call.receive<RoleAssignmentInput>()
         try {
-            call.respond(HttpStatusCode.Created, management.assignRole(input.principal, input.roleId))
+            call.respond(HttpStatusCode.Created, management.assignRole(input.principal, input.roleId, call.auditActor(config)))
         } catch (e: ManagementException) {
             call.respondManagementError(e)
         }
@@ -203,7 +205,7 @@ fun Route.policyRoutes(
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_IDENTITY)) return@delete
         val id = call.idParam() ?: return@delete call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         try {
-            management.unassignRole(id)
+            management.unassignRole(id, call.auditActor(config))
             call.respond(HttpStatusCode.NoContent)
         } catch (e: ManagementException) {
             call.respondManagementError(e)
@@ -215,7 +217,7 @@ fun Route.policyRoutes(
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_POLICIES)) return@post
         val input = call.receive<MaskFnInput>()
         try {
-            call.respond(HttpStatusCode.Created, management.createMaskFn(input))
+            call.respond(HttpStatusCode.Created, management.createMaskFn(input, call.auditActor(config)))
         } catch (e: ManagementException) {
             call.respondManagementError(e)
         }
@@ -224,7 +226,7 @@ fun Route.policyRoutes(
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_POLICIES)) return@put
         val id = call.idParam() ?: return@put call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         try {
-            call.respond(management.updateMaskFn(id, call.receive()))
+            call.respond(management.updateMaskFn(id, call.receive(), call.auditActor(config)))
         } catch (e: ManagementException) {
             call.respondManagementError(e)
         }
@@ -233,7 +235,7 @@ fun Route.policyRoutes(
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_POLICIES)) return@delete
         val id = call.idParam() ?: return@delete call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         try {
-            management.deleteMaskFn(id)
+            management.deleteMaskFn(id, call.auditActor(config))
             call.respond(HttpStatusCode.NoContent)
         } catch (e: ManagementException) {
             call.respondManagementError(e)

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Users.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Users.kt
@@ -4,6 +4,7 @@ import com.ridi.oss.proxymonster.controlplane.authz.Authz
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
 import com.ridi.oss.proxymonster.controlplane.authz.requireAdmin
 import com.ridi.oss.proxymonster.controlplane.management.IdentityManagementService
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
 import com.ridi.oss.proxymonster.controlplane.management.ManagementException
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.receive
@@ -898,6 +899,7 @@ fun Route.userGroupRoutes(
     daemonSessionStore: PrincipalSessionStore,
     management: IdentityManagementService = IdentityManagementService(
         store.dataSource, store, PolicyStore(store.dataSource), tokenStore, accessStore, daemonSessionStore,
+        ManagementAuditRecorder(AuditStore(store.dataSource)),
     ),
 ) {
     get("/api/users") {
@@ -908,7 +910,7 @@ fun Route.userGroupRoutes(
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_IDENTITY)) return@post
         val input = call.receive<AppUserInput>()
         try {
-            call.respond(HttpStatusCode.Created, management.createUser(input))
+            call.respond(HttpStatusCode.Created, management.createUser(input, call.auditActor(config)))
         } catch (e: ManagementException) {
             call.respondManagementError(e)
         }
@@ -921,7 +923,7 @@ fun Route.userGroupRoutes(
         val id = call.idParam() ?: return@put call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         val input = call.receive<AppUserInput>()
         try {
-            call.respond(management.updateUser(id, input))
+            call.respond(management.updateUser(id, input, call.auditActor(config)))
         } catch (e: ManagementException) {
             call.respondManagementError(e)
         }
@@ -932,7 +934,7 @@ fun Route.userGroupRoutes(
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_IDENTITY)) return@delete
         val id = call.idParam() ?: return@delete call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         try {
-            management.deprovisionUser(id)
+            management.deprovisionUser(id, call.auditActor(config))
             call.respond(HttpStatusCode.NoContent)
         } catch (e: ManagementException) {
             call.respondManagementError(e)
@@ -947,7 +949,7 @@ fun Route.userGroupRoutes(
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_IDENTITY)) return@post
         val input = call.receive<AppGroupInput>()
         try {
-            call.respond(HttpStatusCode.Created, management.createGroup(input))
+            call.respond(HttpStatusCode.Created, management.createGroup(input, call.auditActor(config)))
         } catch (e: ManagementException) {
             call.respondManagementError(e)
         }
@@ -957,7 +959,7 @@ fun Route.userGroupRoutes(
         val id = call.idParam() ?: return@put call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         val input = call.receive<AppGroupInput>()
         try {
-            call.respond(management.updateGroup(id, input))
+            call.respond(management.updateGroup(id, input, call.auditActor(config)))
         } catch (e: ManagementException) {
             call.respondManagementError(e)
         }
@@ -966,7 +968,7 @@ fun Route.userGroupRoutes(
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_IDENTITY)) return@delete
         val id = call.idParam() ?: return@delete call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         try {
-            management.deleteGroup(id)
+            management.deleteGroup(id, call.auditActor(config))
             call.respond(HttpStatusCode.NoContent)
         } catch (e: ManagementException) {
             call.respondManagementError(e)
@@ -984,7 +986,7 @@ fun Route.userGroupRoutes(
         val id = call.idParam() ?: return@post call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         val input = call.receive<GroupMemberInput>()
         try {
-            call.respond(HttpStatusCode.Created, management.addGroupMember(id, input.userId))
+            call.respond(HttpStatusCode.Created, management.addGroupMember(id, input.userId, call.auditActor(config)))
         } catch (e: ManagementException) {
             call.respondManagementError(e)
         }
@@ -994,7 +996,7 @@ fun Route.userGroupRoutes(
         val id = call.idParam() ?: return@delete call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         val userId = call.parameters["userId"]?.toLongOrNull() ?: return@delete call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         try {
-            if (management.removeGroupMember(id, userId).deleted) call.respond(HttpStatusCode.NoContent)
+            if (management.removeGroupMember(id, userId, call.auditActor(config)).deleted) call.respond(HttpStatusCode.NoContent)
             else call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "group member")))
         } catch (e: ManagementException) {
             call.respondManagementError(e)
@@ -1012,7 +1014,7 @@ fun Route.userGroupRoutes(
         val id = call.idParam() ?: return@post call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         val input = call.receive<GroupRoleInput>()
         try {
-            call.respond(HttpStatusCode.Created, management.addGroupRole(id, input.roleId))
+            call.respond(HttpStatusCode.Created, management.addGroupRole(id, input.roleId, call.auditActor(config)))
         } catch (e: ManagementException) {
             call.respondManagementError(e)
         }
@@ -1022,7 +1024,7 @@ fun Route.userGroupRoutes(
         val id = call.idParam() ?: return@delete call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         val roleId = call.parameters["roleId"]?.toLongOrNull() ?: return@delete call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         try {
-            if (management.removeGroupRole(id, roleId).deleted) call.respond(HttpStatusCode.NoContent)
+            if (management.removeGroupRole(id, roleId, call.auditActor(config)).deleted) call.respond(HttpStatusCode.NoContent)
             else call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "group role mapping")))
         } catch (e: ManagementException) {
             call.respondManagementError(e)

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/CedarPolicyStore.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/CedarPolicyStore.kt
@@ -3,12 +3,12 @@ package com.ridi.oss.proxymonster.controlplane.authz
 import com.ridi.oss.proxymonster.controlplane.ApiError
 import com.ridi.oss.proxymonster.controlplane.AuditStore
 import com.ridi.oss.proxymonster.controlplane.Config
-import com.ridi.oss.proxymonster.controlplane.Decision
-import com.ridi.oss.proxymonster.controlplane.AuditEvent
 import com.ridi.oss.proxymonster.controlplane.PolicyStore
+import com.ridi.oss.proxymonster.controlplane.auditActor
 import com.ridi.oss.proxymonster.controlplane.idParam
 import com.ridi.oss.proxymonster.controlplane.inTx
 import com.ridi.oss.proxymonster.controlplane.management.CedarValidationManagementException
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
 import com.ridi.oss.proxymonster.controlplane.management.ManagementException
 import com.ridi.oss.proxymonster.controlplane.management.PolicyManagementService
 import com.ridi.oss.proxymonster.controlplane.respondManagementError
@@ -70,7 +70,7 @@ class ReservedPolicyNameException : RuntimeException("policy names under 'system
  * `enabled` (or exist at all): both create and update reject a schema-invalid `cedarSrc` before
  * touching the database.
  */
-class CedarPolicyStore(internal val dataSource: DataSource, private val auditStore: AuditStore = AuditStore(dataSource)) {
+class CedarPolicyStore(internal val dataSource: DataSource) {
     // Bumped after every successful mutation (create/update/setEnabled/delete) — [CedarEngine] polls
     // this to know when its cached PolicySet is stale, instead of re-reading enabledSources() on
     // every isAuthorized() call. In-process only (not persisted): fine, since a fresh process always
@@ -173,18 +173,6 @@ class CedarPolicyStore(internal val dataSource: DataSource, private val auditSto
         c.prepareStatement("UPDATE policy SET enabled=?, updated_by=?, updated_at=now() WHERE id=?").use { ps ->
             ps.setBoolean(1, enabled); ps.setString(2, updatedBy); ps.setLong(3, id); ps.executeUpdate()
         }
-        if (existing.origin == "SYSTEM" && existing.enabled != enabled) {
-            auditStore.insert(
-                c,
-                AuditEvent(
-                    principal = updatedBy ?: "unknown",
-                    datasource = "control-plane",
-                    statement = "[ADMIN policy.toggle] policy $id (${existing.systemKey}) enabled ${existing.enabled}->$enabled",
-                    decision = Decision.ALLOW,
-                    detail = "SYSTEM_POLICY_TOGGLE",
-                ),
-            )
-        }
         return get(id, c)
     }
 
@@ -243,7 +231,8 @@ fun Route.cedarPolicyRoutes(
     config: Config,
     authz: Authz,
     store: CedarPolicyStore,
-    management: PolicyManagementService = PolicyManagementService(store, PolicyStore(store.dataSource)),
+    management: PolicyManagementService =
+        PolicyManagementService(store, PolicyStore(store.dataSource), ManagementAuditRecorder(AuditStore(store.dataSource))),
 ) {
     get("/api/policies") {
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_POLICIES)) return@get
@@ -255,7 +244,7 @@ fun Route.cedarPolicyRoutes(
         try {
             call.respond(
                 HttpStatusCode.Created,
-                management.createPolicy(input.name, input.cedarSrc, input.enabled, call.userSession()?.principal),
+                management.createPolicy(input.name, input.cedarSrc, input.enabled, call.userSession()?.principal, call.auditActor(config)),
             )
         } catch (e: CedarValidationManagementException) {
             call.respond(HttpStatusCode.BadRequest, mapOf("errors" to e.errors))
@@ -268,7 +257,7 @@ fun Route.cedarPolicyRoutes(
         val id = call.idParam() ?: return@put call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         val input = call.receive<CedarPolicyInput>()
         try {
-            call.respond(management.updatePolicy(id, input, call.userSession()?.principal))
+            call.respond(management.updatePolicy(id, input, call.userSession()?.principal, call.auditActor(config)))
         } catch (e: CedarValidationManagementException) {
             call.respond(HttpStatusCode.BadRequest, mapOf("errors" to e.errors))
         } catch (e: ManagementException) {
@@ -279,7 +268,7 @@ fun Route.cedarPolicyRoutes(
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_POLICIES)) return@delete
         val id = call.idParam() ?: return@delete call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         try {
-            management.deletePolicy(id)
+            management.deletePolicy(id, call.auditActor(config))
             call.respond(HttpStatusCode.NoContent)
         } catch (e: ManagementException) {
             call.respondManagementError(e)
@@ -302,7 +291,7 @@ fun Route.cedarPolicyRoutes(
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_POLICIES)) return@post
         val id = call.idParam() ?: return@post call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         try {
-            call.respond(management.setPolicyEnabled(id, true, call.userSession()?.principal))
+            call.respond(management.setPolicyEnabled(id, true, call.userSession()?.principal, call.auditActor(config)))
         } catch (e: CedarValidationManagementException) {
             call.respond(HttpStatusCode.BadRequest, mapOf("errors" to e.errors))
         } catch (e: ManagementException) {
@@ -313,7 +302,7 @@ fun Route.cedarPolicyRoutes(
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_POLICIES)) return@post
         val id = call.idParam() ?: return@post call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         try {
-            call.respond(management.setPolicyEnabled(id, false, call.userSession()?.principal))
+            call.respond(management.setPolicyEnabled(id, false, call.userSession()?.principal, call.auditActor(config)))
         } catch (e: ManagementException) {
             call.respondManagementError(e)
         }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementAudit.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementAudit.kt
@@ -1,0 +1,71 @@
+package com.ridi.oss.proxymonster.controlplane.management
+
+import com.ridi.oss.proxymonster.controlplane.AuditEvent
+import com.ridi.oss.proxymonster.controlplane.AuditStore
+import com.ridi.oss.proxymonster.controlplane.Decision
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
+import java.sql.Connection
+
+/**
+ * Who performed an audited management mutation, and over which transport. The transport layer (the HTTP
+ * admin routes, the MCP server) builds this and threads it into the service method, so a config-change
+ * audit event names the actor who made the change rather than the process that carried the request. The
+ * service never invents one: an audited mutation cannot be called without an actor.
+ */
+data class AuditActor(
+    val principal: String,
+    val roles: List<String> = emptyList(),
+    val clientAddr: String? = null,
+    val channel: String,
+)
+
+/**
+ * Audit source labels for the `channel` of a management event. Deliberately its own vocabulary rather
+ * than the Cedar [com.ridi.oss.proxymonster.controlplane.Channel]: that enum is overlaid onto the Cedar
+ * `context.channel` a query policy conditions on, and a config change is not a query decision.
+ */
+object AuditSource {
+    const val CONSOLE = "console"
+    const val MCP = "mcp"
+}
+
+/** A display label of the changed entity for the audit row (`Type::"id"`); never re-parsed as a Cedar UID. */
+internal fun auditEntity(type: String, id: String): String = "$type::\"$id\""
+
+/**
+ * Writes a `kind="admin"` config-change event through the one [AuditStore] chain chokepoint, on the
+ * caller's transaction so the record commits atomically with the mutation it describes — a mutation that
+ * rolls back leaves no audit row, and a recorded row is a change that happened.
+ *
+ * Both the HTTP admin routes and the MCP server reach the config-mutation service methods that call this,
+ * so a config change is audited once, the same way, regardless of transport.
+ */
+class ManagementAuditRecorder(private val auditStore: AuditStore) {
+    fun record(c: Connection, actor: AuditActor, action: AuthzAction, resource: String, summary: String) {
+        auditStore.insert(
+            c,
+            AuditEvent(
+                principal = actor.principal,
+                roles = actor.roles,
+                datasource = DATASOURCE,
+                clientAddr = actor.clientAddr,
+                statement = summary,
+                decision = Decision.ALLOW,
+                channel = actor.channel,
+                authzAction = action.cedarId,
+                authzResource = resource,
+                outcome = OUTCOME_ALLOW,
+                kind = KIND_ADMIN,
+            ),
+        )
+    }
+
+    companion object {
+        const val KIND_ADMIN = "admin"
+        const val OUTCOME_ALLOW = "ALLOW"
+
+        /** Admin events are instance-scoped, not tied to a target backend; the query-decision `datasource`
+         *  slot carries the control plane itself, matching the existing SYSTEM-policy-toggle event. */
+        private const val DATASOURCE = "control-plane"
+    }
+}

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementServices.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementServices.kt
@@ -10,6 +10,7 @@ import com.ridi.oss.proxymonster.controlplane.CatalogColumn
 import com.ridi.oss.proxymonster.controlplane.ClassificationInput
 import com.ridi.oss.proxymonster.controlplane.PrincipalSessionStore
 import com.ridi.oss.proxymonster.controlplane.Datasource
+import com.ridi.oss.proxymonster.controlplane.DatasourceInput
 import com.ridi.oss.proxymonster.controlplane.DatasourceStore
 import com.ridi.oss.proxymonster.controlplane.GroupMemberEntry
 import com.ridi.oss.proxymonster.controlplane.GroupRoleEntry
@@ -25,6 +26,7 @@ import com.ridi.oss.proxymonster.controlplane.TableDetailExecException
 import com.ridi.oss.proxymonster.controlplane.TableDetailService
 import com.ridi.oss.proxymonster.controlplane.TokenStore
 import com.ridi.oss.proxymonster.controlplane.UserGroupStore
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
 import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicy
 import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
 import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyStore
@@ -81,6 +83,7 @@ class DatasourceManagementService(
     private val store: DatasourceStore,
     private val eventsHub: ProxyEventsHub,
     private val tableDetailService: TableDetailService,
+    private val recorder: ManagementAuditRecorder,
 ) {
     fun listDatasources(): List<Datasource> = store.list()
 
@@ -115,15 +118,33 @@ class DatasourceManagementService(
         }
     }
 
-    fun setColumnClassification(
-        datasourceName: String,
-        schema: String?,
-        table: String,
-        column: String,
-        tags: List<String>,
-        maskFnId: Long?,
-    ): Classification = store.dataSource.inTx { connection ->
-        setColumnClassification(datasourceName, schema, table, column, tags, maskFnId, connection)
+    fun createDatasource(input: DatasourceInput, actor: AuditActor): Datasource =
+        store.dataSource.inTx { createDatasource(input, actor, it) }
+
+    fun createDatasource(input: DatasourceInput, actor: AuditActor, c: Connection): Datasource {
+        val created = store.create(input, c)
+        recordDatasource(c, actor, created.name, "create datasource '${created.name}'")
+        return created
+    }
+
+    fun updateDatasource(id: Long, input: DatasourceInput, actor: AuditActor): Datasource? =
+        store.dataSource.inTx { updateDatasource(id, input, actor, it) }
+
+    fun updateDatasource(id: Long, input: DatasourceInput, actor: AuditActor, c: Connection): Datasource? {
+        val before = store.get(id, c) ?: return null
+        val updated = store.update(id, input, c) ?: return null
+        recordDatasource(c, actor, updated.name, updateSummary("datasource", before.name, updated.name))
+        return updated
+    }
+
+    fun deleteDatasource(id: Long, actor: AuditActor): DeleteResult =
+        store.dataSource.inTx { deleteDatasource(id, actor, it) }
+
+    fun deleteDatasource(id: Long, actor: AuditActor, c: Connection): DeleteResult {
+        val current = store.get(id, c) ?: return DeleteResult(false)
+        val result = DeleteResult(store.delete(id, c))
+        if (result.deleted) recordDatasource(c, actor, current.name, "delete datasource '${current.name}'")
+        return result
     }
 
     fun setColumnClassification(
@@ -133,6 +154,7 @@ class DatasourceManagementService(
         column: String,
         tags: List<String>,
         maskFnId: Long?,
+        actor: AuditActor,
     ): Classification = store.dataSource.inTx { connection ->
         required("table", table)
         required("column", column)
@@ -141,7 +163,9 @@ class DatasourceManagementService(
             throw ManagementException(ApiError("datasource.schema_required"))
         }
         DatasourceStore.requireWritableTags(tags)
-        store.upsertClassification(datasource.id, ClassificationInput(schema, table, column, tags, maskFnId), connection)
+        val written = store.upsertClassification(datasource.id, ClassificationInput(schema, table, column, tags, maskFnId), connection)
+        recordClassification(connection, actor, datasource.name, written)
+        written
     }
 
     fun setColumnClassification(
@@ -151,6 +175,7 @@ class DatasourceManagementService(
         column: String,
         tags: List<String>,
         maskFnId: Long?,
+        actor: AuditActor,
         connection: Connection,
     ): Classification {
         required("table", table)
@@ -160,7 +185,9 @@ class DatasourceManagementService(
             throw ManagementException(ApiError("datasource.schema_required"))
         }
         DatasourceStore.requireWritableTags(tags)
-        return store.upsertClassification(datasource.id, ClassificationInput(schema, table, column, tags, maskFnId), connection)
+        val written = store.upsertClassification(datasource.id, ClassificationInput(schema, table, column, tags, maskFnId), connection)
+        recordClassification(connection, actor, datasource.name, written)
+        return written
     }
 
     /**
@@ -171,10 +198,14 @@ class DatasourceManagementService(
      * rather than silently letting the later one win: the caller cannot tell from the response which
      * of its conflicting tag sets survived, and for a masking decision that is the difference between
      * a column being masked and not.
+     *
+     * One audit row covers the batch, naming every column it wrote: the batch is one atomic change, and
+     * a row per column would let a partial trail imply a partial write that cannot happen.
      */
     fun setColumnClassifications(
         datasourceName: String,
         columns: List<ClassificationInput>,
+        actor: AuditActor,
         connection: Connection,
     ): List<Classification> {
         if (columns.isEmpty()) throw ManagementException(ApiError("common.field_required", mapOf("fields" to "columns")))
@@ -208,17 +239,13 @@ class DatasourceManagementService(
         // Written in a canonical order, not the caller's: each upsert row-locks its classification, so
         // two overlapping batches submitted in opposite orders would deadlock and one would die with an
         // internal error. A total order over the key means concurrent batches queue instead.
-        return resolved.sortedWith(compareBy({ it.schema }, { it.table }, { it.column }))
+        val written = resolved.sortedWith(compareBy({ it.schema }, { it.table }, { it.column }))
             .map { input -> store.upsertClassification(datasource.id, input, connection) }
-    }
-
-    fun clearColumnClassification(
-        datasourceName: String,
-        schema: String?,
-        table: String,
-        column: String,
-    ): DeleteResult = store.dataSource.inTx { connection ->
-        clearColumnClassification(datasourceName, schema, table, column, connection)
+        recordDatasource(
+            connection, actor, datasource.name,
+            "tag ${written.size} columns of '${datasource.name}' [${written.joinToString(", ") { it.path() }}]",
+        )
+        return written
     }
 
     fun clearColumnClassification(
@@ -226,13 +253,14 @@ class DatasourceManagementService(
         schema: String?,
         table: String,
         column: String,
+        actor: AuditActor,
     ): DeleteResult = store.dataSource.inTx { connection ->
         required("table", table)
         required("column", column)
         val datasource = store.get(datasourceId, connection) ?: notFound("datasource")
         val resolvedSchema = schema ?: store.defaultSchema(datasource.id, connection)
             ?: throw ManagementException(ApiError("datasource.schema_required"))
-        DeleteResult(store.deleteClassification(datasource.id, resolvedSchema, table, column, connection))
+        clearResolved(datasource.name, datasource.id, resolvedSchema, table, column, actor, connection)
     }
 
     fun clearColumnClassification(
@@ -240,6 +268,7 @@ class DatasourceManagementService(
         schema: String?,
         table: String,
         column: String,
+        actor: AuditActor,
         connection: Connection,
     ): DeleteResult {
         required("table", table)
@@ -247,8 +276,46 @@ class DatasourceManagementService(
         val datasource = datasource(datasourceName, connection)
         val resolvedSchema = schema ?: store.defaultSchema(datasource.id, connection)
             ?: throw ManagementException(ApiError("datasource.schema_required"))
-        return DeleteResult(store.deleteClassification(datasource.id, resolvedSchema, table, column, connection))
+        return clearResolved(datasource.name, datasource.id, resolvedSchema, table, column, actor, connection)
     }
+
+    private fun clearResolved(
+        datasourceName: String,
+        datasourceId: Long,
+        schema: String,
+        table: String,
+        column: String,
+        actor: AuditActor,
+        c: Connection,
+    ): DeleteResult {
+        val result = DeleteResult(store.deleteClassification(datasourceId, schema, table, column, c))
+        if (result.deleted) {
+            recordColumn(c, actor, datasourceName, schema, table, column, "clear tags on $datasourceName.$schema.$table.$column")
+        }
+        return result
+    }
+
+    private fun recordClassification(c: Connection, actor: AuditActor, datasourceName: String, written: Classification) =
+        recordColumn(
+            c, actor, datasourceName, written.schema, written.table, written.column,
+            "tag $datasourceName.${written.path()} [${written.tags.joinToString(", ")}]",
+        )
+
+    private fun recordColumn(
+        c: Connection,
+        actor: AuditActor,
+        datasourceName: String,
+        schema: String,
+        table: String,
+        column: String,
+        summary: String,
+    ) = recorder.record(
+        c, actor, AuthzAction.ADMIN_DATASOURCES,
+        "${auditEntity("Datasource", datasourceName)} col $schema.$table.$column", summary,
+    )
+
+    private fun recordDatasource(c: Connection, actor: AuditActor, name: String, summary: String) =
+        recorder.record(c, actor, AuthzAction.ADMIN_DATASOURCES, auditEntity("Datasource", name), summary)
 
     private fun datasource(name: String): Datasource = store.getByName(name)
         ?: throw ManagementException(ApiError("common.not_found", mapOf("resource" to "datasource")))
@@ -269,13 +336,12 @@ class DatasourceManagementService(
 class PolicyManagementService(
     private val policyStore: CedarPolicyStore,
     private val store: PolicyStore,
+    private val recorder: ManagementAuditRecorder,
 ) {
     fun listPolicies(): List<CedarPolicy> = policyStore.list()
 
-    fun getPolicy(name: String): CedarPolicy = policyStore.getByName(name)
-        ?: throw ManagementException(ApiError("common.not_found", mapOf("resource" to "policy")))
-    fun getPolicy(name: String, c: Connection): CedarPolicy = policyStore.getByName(name, c)
-        ?: throw ManagementException(ApiError("common.not_found", mapOf("resource" to "policy")))
+    fun getPolicy(name: String): CedarPolicy = policyStore.getByName(name) ?: notFound("policy")
+    fun getPolicy(name: String, c: Connection): CedarPolicy = policyStore.getByName(name, c) ?: notFound("policy")
 
     fun validatePolicy(cedarSrc: String): CedarValidateResult {
         required("cedarSrc", cedarSrc)
@@ -293,6 +359,7 @@ class PolicyManagementService(
         val tagNames = policyStore.list().flatMapTo(mutableSetOf()) { extractContextTagNames(it.cedarSrc) }
         return CedarSchemaResult(CedarSchema.parseableSchemaTextFor(tagNames))
     }
+
     fun listRoles(): List<Role> = store.listRoles()
     fun getRole(name: String): Role = store.getRoleByName(name) ?: notFound("role")
     fun getRole(name: String, c: Connection): Role = store.getRoleByName(name, c) ?: notFound("role")
@@ -302,20 +369,40 @@ class PolicyManagementService(
         return store.listAssignments(principal, roleId)
     }
 
+    fun listAssignmentsByRoleId(principal: String?, roleId: Long?): List<RoleAssignment> =
+        store.listAssignments(principal, roleId)
+
     fun listMaskFns(): List<MaskFn> = store.listMaskFns()
     fun getMaskFn(name: String): MaskFn = store.getMaskFnByName(name) ?: notFound("mask function")
     fun getMaskFn(name: String, c: Connection): MaskFn = store.getMaskFnByName(name, c) ?: notFound("mask function")
 
-    fun createPolicy(name: String, cedarSrc: String, enabled: Boolean, principal: String?): CedarPolicy {
-        val created = store.dataSource.inTx { connection -> createPolicy(name, cedarSrc, enabled, principal, connection) }
+    fun createPolicy(
+        name: String,
+        cedarSrc: String,
+        enabled: Boolean,
+        principal: String?,
+        actor: AuditActor,
+    ): CedarPolicy {
+        val created = store.dataSource.inTx { connection ->
+            createPolicy(name, cedarSrc, enabled, principal, actor, connection)
+        }
         policyStore.markCommittedMutation()
         return created
     }
 
-    fun createPolicy(name: String, cedarSrc: String, enabled: Boolean, principal: String?, c: Connection): CedarPolicy {
+    fun createPolicy(
+        name: String,
+        cedarSrc: String,
+        enabled: Boolean,
+        principal: String?,
+        actor: AuditActor,
+        c: Connection,
+    ): CedarPolicy {
         required("name", name)
         required("cedarSrc", cedarSrc)
-        return mapPolicyErrors { policyStore.create(CedarPolicyInput(name, cedarSrc, enabled), principal, c) }
+        val created = mapPolicyErrors { policyStore.create(CedarPolicyInput(name, cedarSrc, enabled), principal, c) }
+        recordPolicy(c, actor, created.id, "create policy '${created.name}'")
+        return created
     }
 
     fun updatePolicy(
@@ -324,28 +411,31 @@ class PolicyManagementService(
         cedarSrc: String,
         enabled: Boolean,
         principal: String?,
+        actor: AuditActor,
     ): CedarPolicy {
         val updated = store.dataSource.inTx { connection ->
-            updatePolicy(currentName, newName, cedarSrc, enabled, principal, connection)
+            updatePolicy(currentName, newName, cedarSrc, enabled, principal, actor, connection)
         }
         policyStore.markCommittedMutation()
         return updated
     }
 
     /** ID-shaped REST adapter: resolve and mutate the addressed row in one transaction. */
-    fun updatePolicy(id: Long, input: CedarPolicyInput, principal: String?): CedarPolicy {
+    fun updatePolicy(id: Long, input: CedarPolicyInput, principal: String?, actor: AuditActor): CedarPolicy {
         val updated = store.dataSource.inTx { connection ->
-            updatePolicy(id, input, principal, connection)
+            updatePolicy(id, input, principal, actor, connection)
         }
         policyStore.markCommittedMutation()
         return updated
     }
 
-    fun updatePolicy(id: Long, input: CedarPolicyInput, principal: String?, c: Connection): CedarPolicy {
+    fun updatePolicy(id: Long, input: CedarPolicyInput, principal: String?, actor: AuditActor, c: Connection): CedarPolicy {
         required("name", input.name)
         required("cedarSrc", input.cedarSrc)
-        if (policyStore.get(id, c) == null) notFound("policy")
-        return mapPolicyErrors { policyStore.update(id, input, principal, c) ?: notFound("policy") }
+        val current = policyStore.get(id, c) ?: notFound("policy")
+        val updated = mapPolicyErrors { policyStore.update(id, input, principal, c) ?: notFound("policy") }
+        recordPolicy(c, actor, updated.id, updateSummary("policy", current.name, updated.name))
+        return updated
     }
 
     fun updatePolicy(
@@ -354,6 +444,7 @@ class PolicyManagementService(
         cedarSrc: String,
         enabled: Boolean,
         principal: String?,
+        actor: AuditActor,
         c: Connection,
     ): CedarPolicy {
         required("name", currentName)
@@ -361,118 +452,151 @@ class PolicyManagementService(
         val current = policyStore.getByName(currentName, c) ?: notFound("policy")
         val targetName = newName ?: current.name
         required("newName", targetName)
-        return mapPolicyErrors {
+        val updated = mapPolicyErrors {
             policyStore.update(current.id, CedarPolicyInput(targetName, cedarSrc, enabled), principal, c)
                 ?: notFound("policy")
         }
+        recordPolicy(c, actor, updated.id, updateSummary("policy", current.name, updated.name))
+        return updated
     }
 
-    fun setPolicyEnabled(name: String, enabled: Boolean, principal: String?): CedarPolicy {
-        val updated = store.dataSource.inTx { connection -> setPolicyEnabled(name, enabled, principal, connection) }
+    fun setPolicyEnabled(name: String, enabled: Boolean, principal: String?, actor: AuditActor): CedarPolicy {
+        val updated = store.dataSource.inTx { connection -> setPolicyEnabled(name, enabled, principal, actor, connection) }
         policyStore.markCommittedMutation()
         return updated
     }
 
-    fun setPolicyEnabled(id: Long, enabled: Boolean, principal: String?): CedarPolicy {
+    fun setPolicyEnabled(id: Long, enabled: Boolean, principal: String?, actor: AuditActor): CedarPolicy {
         val updated = store.dataSource.inTx { connection ->
-            if (policyStore.get(id, connection) == null) notFound("policy")
+            val current = policyStore.get(id, connection) ?: notFound("policy")
             mapPolicyErrors { policyStore.setEnabled(id, enabled, principal, connection) ?: notFound("policy") }
+                .also { recordPolicyEnabled(connection, actor, current, enabled) }
         }
         policyStore.markCommittedMutation()
         return updated
     }
 
-    fun setPolicyEnabled(name: String, enabled: Boolean, principal: String?, c: Connection): CedarPolicy {
+    fun setPolicyEnabled(name: String, enabled: Boolean, principal: String?, actor: AuditActor, c: Connection): CedarPolicy {
         required("name", name)
         val current = policyStore.getByName(name, c) ?: notFound("policy")
-        return mapPolicyErrors { policyStore.setEnabled(current.id, enabled, principal, c) ?: notFound("policy") }
+        val updated = mapPolicyErrors { policyStore.setEnabled(current.id, enabled, principal, c) ?: notFound("policy") }
+        recordPolicyEnabled(c, actor, current, enabled)
+        return updated
     }
 
-    fun deletePolicy(name: String): DeleteResult {
-        val deleted = store.dataSource.inTx { connection -> deletePolicy(name, connection) }
+    fun deletePolicy(name: String, actor: AuditActor): DeleteResult {
+        val deleted = store.dataSource.inTx { connection -> deletePolicy(name, actor, connection) }
         if (deleted.deleted) policyStore.markCommittedMutation()
         return deleted
     }
 
-    fun deletePolicy(id: Long): DeleteResult {
+    fun deletePolicy(id: Long, actor: AuditActor): DeleteResult {
         val deleted = store.dataSource.inTx { connection ->
-            if (policyStore.get(id, connection) == null) notFound("policy")
-            try {
-                DeleteResult(policyStore.delete(id, connection))
-            } catch (_: SystemPolicyImmutableException) {
-                throw ManagementException(ApiError("policy.system_immutable"))
-            }
+            val current = policyStore.get(id, connection) ?: notFound("policy")
+            deletePolicy(current, actor, connection)
         }
         if (deleted.deleted) policyStore.markCommittedMutation()
         return deleted
     }
 
-    fun deletePolicy(name: String, c: Connection): DeleteResult {
+    fun deletePolicy(name: String, actor: AuditActor, c: Connection): DeleteResult {
         required("name", name)
-        val current = policyStore.getByName(name, c) ?: notFound("policy")
-        return try {
+        return deletePolicy(policyStore.getByName(name, c) ?: notFound("policy"), actor, c)
+    }
+
+    private fun deletePolicy(current: CedarPolicy, actor: AuditActor, c: Connection): DeleteResult {
+        val deleted = try {
             DeleteResult(policyStore.delete(current.id, c))
         } catch (_: SystemPolicyImmutableException) {
             throw ManagementException(ApiError("policy.system_immutable"))
         }
+        if (deleted.deleted) recordPolicy(c, actor, current.id, "delete policy '${current.name}'")
+        return deleted
     }
 
-    fun createRole(name: String, description: String?): Role = store.dataSource.inTx { createRole(name, description, it) }
+    private fun recordPolicy(c: Connection, actor: AuditActor, id: Long, summary: String) =
+        recorder.record(c, actor, AuthzAction.ADMIN_POLICIES, auditEntity("Policy", id.toString()), summary)
 
-    fun createRole(name: String, description: String?, c: Connection): Role {
+    private fun recordPolicyEnabled(c: Connection, actor: AuditActor, policy: CedarPolicy, enabled: Boolean) =
+        recordPolicy(c, actor, policy.id, "${if (enabled) "enable" else "disable"} policy '${policy.name}'")
+
+    fun createRole(name: String, description: String?, actor: AuditActor): Role =
+        store.dataSource.inTx { createRole(name, description, actor, it) }
+
+    fun createRole(name: String, description: String?, actor: AuditActor, c: Connection): Role {
         required("name", name)
-        return unique("role", name) { store.createRole(RoleInput(name, description), c) }
+        val created = unique("role", name) { store.createRole(RoleInput(name, description), c) }
+        recordRole(c, actor, created.name, "create role '${created.name}'")
+        return created
     }
 
-    fun updateRole(currentName: String, newName: String?, description: String?): Role =
-        store.dataSource.inTx { updateRole(currentName, newName, description, it) }
+    fun updateRole(currentName: String, newName: String?, description: String?, actor: AuditActor): Role =
+        store.dataSource.inTx { updateRole(currentName, newName, description, actor, it) }
 
-    fun updateRole(id: Long, input: RoleInput): Role = store.dataSource.inTx { c ->
+    fun updateRole(id: Long, input: RoleInput, actor: AuditActor): Role = store.dataSource.inTx { c ->
         val current = store.getRole(id, c) ?: notFound("role")
         if (store.isSystemRole(id, c)) throw ManagementException(ApiError("role.system_immutable"))
         required("name", input.name)
-        unique("role", input.name) { store.updateRole(current.id, input, c) ?: notFound("role") }
+        val updated = unique("role", input.name) { store.updateRole(current.id, input, c) ?: notFound("role") }
+        recordRole(c, actor, updated.name, updateSummary("role", current.name, updated.name))
+        updated
     }
 
-    fun updateRole(currentName: String, newName: String?, description: String?, c: Connection): Role {
+    fun updateRole(currentName: String, newName: String?, description: String?, actor: AuditActor, c: Connection): Role {
         required("name", currentName)
         val current = store.getRoleByName(currentName, c) ?: notFound("role")
         if (store.isSystemRole(current.id, c)) throw ManagementException(ApiError("role.system_immutable"))
         val targetName = newName ?: currentName
         required("newName", targetName)
-        return unique("role", targetName) {
+        val updated = unique("role", targetName) {
             store.updateRole(current.id, RoleInput(targetName, description), c) ?: notFound("role")
         }
+        recordRole(c, actor, updated.name, updateSummary("role", current.name, updated.name))
+        return updated
     }
 
-    fun deleteRole(name: String): DeleteResult = store.dataSource.inTx { deleteRole(name, it) }
+    fun deleteRole(name: String, actor: AuditActor): DeleteResult = store.dataSource.inTx { deleteRole(name, actor, it) }
 
-    fun deleteRole(id: Long): DeleteResult = store.dataSource.inTx { c ->
-        if (store.getRole(id, c) == null) notFound("role")
+    fun deleteRole(id: Long, actor: AuditActor): DeleteResult = store.dataSource.inTx { c ->
+        val current = store.getRole(id, c) ?: notFound("role")
         if (store.isSystemRole(id, c)) throw ManagementException(ApiError("role.system_immutable"))
-        DeleteResult(store.deleteRole(id, c))
+        deleteRole(current, actor, c)
     }
 
-    fun deleteRole(name: String, c: Connection): DeleteResult {
+    fun deleteRole(name: String, actor: AuditActor, c: Connection): DeleteResult {
         required("name", name)
         val current = store.getRoleByName(name, c) ?: notFound("role")
         if (store.isSystemRole(current.id, c)) throw ManagementException(ApiError("role.system_immutable"))
-        return DeleteResult(store.deleteRole(current.id, c))
+        return deleteRole(current, actor, c)
     }
 
-    fun assignRole(principal: String, roleName: String): RoleAssignment = store.dataSource.inTx { assignRole(principal, roleName, it) }
+    private fun deleteRole(current: Role, actor: AuditActor, c: Connection): DeleteResult {
+        val deleted = DeleteResult(store.deleteRole(current.id, c))
+        if (deleted.deleted) recordRole(c, actor, current.name, "delete role '${current.name}'")
+        return deleted
+    }
 
-    fun assignRole(principal: String, roleId: Long): RoleAssignment = store.dataSource.inTx { c ->
+    private fun recordRole(c: Connection, actor: AuditActor, name: String, summary: String) =
+        recorder.record(c, actor, AuthzAction.ADMIN_POLICIES, auditEntity("Role", name), summary)
+
+    fun assignRole(principal: String, roleName: String, actor: AuditActor): RoleAssignment =
+        store.dataSource.inTx { assignRole(principal, roleName, actor, it) }
+
+    fun assignRole(principal: String, roleId: Long, actor: AuditActor): RoleAssignment = store.dataSource.inTx { c ->
         required("principal", principal)
-        if (store.getRole(roleId, c) == null) notFound("role")
+        val role = store.getRole(roleId, c) ?: notFound("role")
+        val newlyAssigned = store.listAssignments(principal, roleId, c).isEmpty()
         store.createAssignment(RoleAssignmentInput(principal, roleId), c)
+            .also { if (newlyAssigned) recordAssignment(c, actor, role.name, principal, assigned = true) }
     }
 
-    fun assignRole(principal: String, roleName: String, c: Connection): RoleAssignment {
+    fun assignRole(principal: String, roleName: String, actor: AuditActor, c: Connection): RoleAssignment {
         required("principal", principal)
         required("roleName", roleName)
         val role = store.getRoleByName(roleName, c) ?: notFound("role")
+        val newlyAssigned = store.listAssignments(principal, role.id, c).isEmpty()
         return store.createAssignment(RoleAssignmentInput(principal, role.id), c)
+            .also { if (newlyAssigned) recordAssignment(c, actor, role.name, principal, assigned = true) }
     }
 
     /**
@@ -497,71 +621,112 @@ class PolicyManagementService(
      * login, which mints a session for exactly these roles — composes both onto one transaction under one lock
      * rather than committing twice.
      */
-    fun replaceDirectRoles(principal: String, roleNames: List<String>, c: Connection): List<RoleAssignment> {
+    fun replaceDirectRoles(
+        principal: String,
+        roleNames: List<String>,
+        actor: AuditActor,
+        c: Connection,
+    ): List<RoleAssignment> {
         required("principal", principal)
         c.advisoryLockPrincipal(principal)
         val roles = roleNames.map { name -> store.getRoleByName(name, c) ?: notFound("role '$name'") }
         store.listAssignments(principal, null, c).forEach { store.deleteAssignment(it.id, c) }
-        return roles.map { store.createAssignment(RoleAssignmentInput(principal, it.id), c) }
+        val replaced = roles.map { store.createAssignment(RoleAssignmentInput(principal, it.id), c) }
+        recorder.record(
+            c, actor, AuthzAction.ADMIN_IDENTITY, auditEntity("User", principal),
+            "replace direct roles of '$principal' [${replaced.joinToString(", ") { it.roleName }}]",
+        )
+        return replaced
     }
 
-    fun replaceDirectRoles(principal: String, roleNames: List<String>): List<RoleAssignment> =
-        store.dataSource.inTx { replaceDirectRoles(principal, roleNames, it) }
+    fun replaceDirectRoles(principal: String, roleNames: List<String>, actor: AuditActor): List<RoleAssignment> =
+        store.dataSource.inTx { replaceDirectRoles(principal, roleNames, actor, it) }
 
-    fun unassignRole(principal: String, roleName: String): DeleteResult = store.dataSource.inTx { unassignRole(principal, roleName, it) }
+    fun unassignRole(principal: String, roleName: String, actor: AuditActor): DeleteResult =
+        store.dataSource.inTx { unassignRole(principal, roleName, actor, it) }
 
-    fun unassignRole(id: Long): DeleteResult = store.dataSource.inTx { c ->
-        if (store.getAssignment(id, c) == null) notFound("role assignment")
-        DeleteResult(store.deleteAssignment(id, c))
+    fun unassignRole(id: Long, actor: AuditActor): DeleteResult = store.dataSource.inTx { c ->
+        val assignment = store.getAssignment(id, c) ?: notFound("role assignment")
+        DeleteResult(store.deleteAssignment(id, c)).also { result ->
+            if (result.deleted) recordAssignment(c, actor, assignment.roleName, assignment.principal, assigned = false)
+        }
     }
 
-    fun listAssignmentsByRoleId(principal: String?, roleId: Long?): List<RoleAssignment> =
-        store.listAssignments(principal, roleId)
-
-    fun unassignRole(principal: String, roleName: String, c: Connection): DeleteResult {
+    fun unassignRole(principal: String, roleName: String, actor: AuditActor, c: Connection): DeleteResult {
         required("principal", principal)
         required("roleName", roleName)
         val role = store.getRoleByName(roleName, c) ?: notFound("role")
-        return DeleteResult(store.deleteAssignment(principal, role.id, c))
+        return DeleteResult(store.deleteAssignment(principal, role.id, c)).also { result ->
+            if (result.deleted) recordAssignment(c, actor, role.name, principal, assigned = false)
+        }
     }
 
-    fun createMaskFn(input: MaskFnInput): MaskFn = store.dataSource.inTx { createMaskFn(input, it) }
+    private fun recordAssignment(
+        c: Connection,
+        actor: AuditActor,
+        roleName: String,
+        principal: String,
+        assigned: Boolean,
+    ) = recorder.record(
+        c, actor, AuthzAction.ADMIN_IDENTITY, auditEntity("Role", roleName),
+        if (assigned) "assign role '$roleName' to '$principal'" else "unassign role '$roleName' from '$principal'",
+    )
 
-    fun createMaskFn(input: MaskFnInput, c: Connection): MaskFn {
+    fun createMaskFn(input: MaskFnInput, actor: AuditActor): MaskFn =
+        store.dataSource.inTx { createMaskFn(input, actor, it) }
+
+    fun createMaskFn(input: MaskFnInput, actor: AuditActor, c: Connection): MaskFn {
         required("name", input.name)
         required("kind", input.kind)
-        return unique("mask function", input.name) { store.createMaskFn(input, c) }
+        val created = unique("mask function", input.name) { store.createMaskFn(input, c) }
+        recordMaskFn(c, actor, created.name, "create mask function '${created.name}'")
+        return created
     }
 
-    fun updateMaskFn(currentName: String, input: MaskFnInput): MaskFn = store.dataSource.inTx { updateMaskFn(currentName, input, it) }
+    fun updateMaskFn(currentName: String, input: MaskFnInput, actor: AuditActor): MaskFn =
+        store.dataSource.inTx { updateMaskFn(currentName, input, actor, it) }
 
-    fun updateMaskFn(id: Long, input: MaskFnInput): MaskFn = store.dataSource.inTx { c ->
-        if (store.getMaskFn(id, c) == null) notFound("mask function")
+    fun updateMaskFn(id: Long, input: MaskFnInput, actor: AuditActor): MaskFn = store.dataSource.inTx { c ->
+        val current = store.getMaskFn(id, c) ?: notFound("mask function")
         required("name", input.name)
         required("kind", input.kind)
-        unique("mask function", input.name) { store.updateMaskFn(id, input, c) ?: notFound("mask function") }
+        val updated = unique("mask function", input.name) { store.updateMaskFn(id, input, c) ?: notFound("mask function") }
+        recordMaskFn(c, actor, updated.name, updateSummary("mask function", current.name, updated.name))
+        updated
     }
 
-    fun updateMaskFn(currentName: String, input: MaskFnInput, c: Connection): MaskFn {
+    fun updateMaskFn(currentName: String, input: MaskFnInput, actor: AuditActor, c: Connection): MaskFn {
         required("name", currentName)
         val current = store.getMaskFnByName(currentName, c) ?: notFound("mask function")
         required("newName", input.name)
         required("kind", input.kind)
-        return unique("mask function", input.name) { store.updateMaskFn(current.id, input, c) ?: notFound("mask function") }
+        val updated = unique("mask function", input.name) {
+            store.updateMaskFn(current.id, input, c) ?: notFound("mask function")
+        }
+        recordMaskFn(c, actor, updated.name, updateSummary("mask function", current.name, updated.name))
+        return updated
     }
 
-    fun deleteMaskFn(name: String): DeleteResult = store.dataSource.inTx { deleteMaskFn(name, it) }
+    fun deleteMaskFn(name: String, actor: AuditActor): DeleteResult =
+        store.dataSource.inTx { deleteMaskFn(name, actor, it) }
 
-    fun deleteMaskFn(id: Long): DeleteResult = store.dataSource.inTx { c ->
-        if (store.getMaskFn(id, c) == null) notFound("mask function")
-        DeleteResult(store.deleteMaskFn(id, c))
+    fun deleteMaskFn(id: Long, actor: AuditActor): DeleteResult = store.dataSource.inTx { c ->
+        deleteMaskFn(store.getMaskFn(id, c) ?: notFound("mask function"), actor, c)
     }
 
-    fun deleteMaskFn(name: String, c: Connection): DeleteResult {
+    fun deleteMaskFn(name: String, actor: AuditActor, c: Connection): DeleteResult {
         required("name", name)
-        val current = store.getMaskFnByName(name, c) ?: notFound("mask function")
-        return DeleteResult(store.deleteMaskFn(current.id, c))
+        return deleteMaskFn(store.getMaskFnByName(name, c) ?: notFound("mask function"), actor, c)
     }
+
+    private fun deleteMaskFn(current: MaskFn, actor: AuditActor, c: Connection): DeleteResult {
+        val deleted = DeleteResult(store.deleteMaskFn(current.id, c))
+        if (deleted.deleted) recordMaskFn(c, actor, current.name, "delete mask function '${current.name}'")
+        return deleted
+    }
+
+    private fun recordMaskFn(c: Connection, actor: AuditActor, name: String, summary: String) =
+        recorder.record(c, actor, AuthzAction.ADMIN_POLICIES, auditEntity("MaskFn", name), summary)
 
     private fun <T> mapPolicyErrors(block: () -> T): T = try {
         block()
@@ -587,6 +752,7 @@ class IdentityManagementService(
     private val tokenStore: TokenStore,
     private val accessStore: AccessStore,
     private val daemonSessionStore: PrincipalSessionStore,
+    private val recorder: ManagementAuditRecorder,
 ) {
     fun listUsers(): List<AppUser> = store.listUsers()
     fun listGroups(): List<AppGroup> = store.listGroups()
@@ -595,13 +761,15 @@ class IdentityManagementService(
     fun getUser(principal: String, c: Connection): AppUser = store.getUserByPrincipal(principal, c) ?: notFound("user")
     fun getGroup(name: String, c: Connection): AppGroup = store.getGroupByName(name, c) ?: notFound("group")
 
-    fun createUser(input: AppUserInput): AppUser = dataSource.inTx { createUser(input, it) }
+    fun createUser(input: AppUserInput, actor: AuditActor): AppUser = dataSource.inTx { createUser(input, actor, it) }
 
-    fun createUser(input: AppUserInput, c: Connection): AppUser {
+    fun createUser(input: AppUserInput, actor: AuditActor, c: Connection): AppUser {
         required("principal", input.principal)
-        return unique("principal", input.principal) {
+        val created = unique("principal", input.principal) {
             store.createUser(input, tokenStore, accessStore, daemonSessionStore, c)
         }
+        recordUser(c, actor, created.principal, "create user '${created.principal}'")
+        return created
     }
 
     fun updateUser(
@@ -610,14 +778,17 @@ class IdentityManagementService(
         displayName: String?,
         email: String?,
         active: Boolean,
-    ): AppUser = dataSource.inTx { updateUser(currentPrincipal, newPrincipal, displayName, email, active, it) }
+        actor: AuditActor,
+    ): AppUser = dataSource.inTx { updateUser(currentPrincipal, newPrincipal, displayName, email, active, actor, it) }
 
-    fun updateUser(id: Long, input: AppUserInput): AppUser = dataSource.inTx { c ->
-        if (store.getUser(id, c) == null) notFound("user")
+    fun updateUser(id: Long, input: AppUserInput, actor: AuditActor): AppUser = dataSource.inTx { c ->
+        val current = store.getUser(id, c) ?: notFound("user")
         required("principal", input.principal)
-        unique("principal", input.principal) {
+        val updated = unique("principal", input.principal) {
             store.updateUser(id, input, tokenStore, accessStore, daemonSessionStore, c) ?: notFound("user")
         }
+        recordUser(c, actor, updated.principal, updateSummary("user", current.principal, updated.principal))
+        updated
     }
 
     fun updateUser(
@@ -626,6 +797,7 @@ class IdentityManagementService(
         displayName: String?,
         email: String?,
         active: Boolean,
+        actor: AuditActor,
         c: Connection,
     ): AppUser {
         required("principal", currentPrincipal)
@@ -633,124 +805,187 @@ class IdentityManagementService(
         val targetPrincipal = newPrincipal ?: currentPrincipal
         required("newPrincipal", targetPrincipal)
         val input = AppUserInput(targetPrincipal, displayName, email, active)
-        return unique("principal", input.principal) {
+        val updated = unique("principal", input.principal) {
             store.updateUser(current.id, input, tokenStore, accessStore, daemonSessionStore, c) ?: notFound("user")
         }
+        recordUser(c, actor, updated.principal, updateSummary("user", current.principal, updated.principal))
+        return updated
     }
 
-    fun deprovisionUser(principal: String): DeleteResult = dataSource.inTx { deprovisionUser(principal, it) }
+    fun deprovisionUser(principal: String, actor: AuditActor): DeleteResult =
+        dataSource.inTx { deprovisionUser(principal, actor, it) }
 
-    fun deprovisionUser(id: Long): DeleteResult = dataSource.inTx { c ->
-        if (store.getUser(id, c) == null) notFound("user")
-        DeleteResult(store.deleteUser(id, tokenStore, accessStore, daemonSessionStore, c))
+    fun deprovisionUser(id: Long, actor: AuditActor): DeleteResult = dataSource.inTx { c ->
+        deprovisionUser(store.getUser(id, c) ?: notFound("user"), actor, c)
     }
 
-    fun deprovisionUser(principal: String, c: Connection): DeleteResult {
+    fun deprovisionUser(principal: String, actor: AuditActor, c: Connection): DeleteResult {
         required("principal", principal)
-        val current = store.getUserByPrincipal(principal, c) ?: notFound("user")
-        return DeleteResult(store.deleteUser(current.id, tokenStore, accessStore, daemonSessionStore, c))
+        return deprovisionUser(store.getUserByPrincipal(principal, c) ?: notFound("user"), actor, c)
     }
 
-    fun createGroup(input: AppGroupInput): AppGroup = dataSource.inTx { createGroup(input, it) }
+    private fun deprovisionUser(current: AppUser, actor: AuditActor, c: Connection): DeleteResult {
+        val deleted = DeleteResult(store.deleteUser(current.id, tokenStore, accessStore, daemonSessionStore, c))
+        if (deleted.deleted) recordUser(c, actor, current.principal, "deprovision user '${current.principal}'")
+        return deleted
+    }
 
-    fun createGroup(input: AppGroupInput, c: Connection): AppGroup {
+    private fun recordUser(c: Connection, actor: AuditActor, principal: String, summary: String) =
+        recorder.record(c, actor, AuthzAction.ADMIN_IDENTITY, auditEntity("User", principal), summary)
+
+    fun createGroup(input: AppGroupInput, actor: AuditActor): AppGroup = dataSource.inTx { createGroup(input, actor, it) }
+
+    fun createGroup(input: AppGroupInput, actor: AuditActor, c: Connection): AppGroup {
         required("name", input.name)
-        return unique("group", input.name) { store.createGroup(input, c) }
+        val created = unique("group", input.name) { store.createGroup(input, c) }
+        recordGroup(c, actor, created.name, "create group '${created.name}'")
+        return created
     }
 
-    fun updateGroup(currentName: String, newName: String?, description: String?): AppGroup =
-        dataSource.inTx { updateGroup(currentName, newName, description, it) }
+    fun updateGroup(currentName: String, newName: String?, description: String?, actor: AuditActor): AppGroup =
+        dataSource.inTx { updateGroup(currentName, newName, description, actor, it) }
 
-    fun updateGroup(id: Long, input: AppGroupInput): AppGroup = dataSource.inTx { c ->
+    fun updateGroup(id: Long, input: AppGroupInput, actor: AuditActor): AppGroup = dataSource.inTx { c ->
         val current = store.getGroup(id, c) ?: notFound("group")
         rejectSystem(current, c)
         required("name", input.name)
-        unique("group", input.name) { store.updateGroup(id, input, c) ?: notFound("group") }
+        val updated = unique("group", input.name) { store.updateGroup(id, input, c) ?: notFound("group") }
+        recordGroup(c, actor, updated.name, updateSummary("group", current.name, updated.name))
+        updated
     }
 
-    fun updateGroup(currentName: String, newName: String?, description: String?, c: Connection): AppGroup {
+    fun updateGroup(
+        currentName: String,
+        newName: String?,
+        description: String?,
+        actor: AuditActor,
+        c: Connection,
+    ): AppGroup {
         required("name", currentName)
         val current = group(currentName, c)
         rejectSystem(current, c)
         val targetName = newName ?: currentName
         required("newName", targetName)
-        return unique("group", targetName) {
+        val updated = unique("group", targetName) {
             store.updateGroup(current.id, AppGroupInput(targetName, description), c) ?: notFound("group")
         }
+        recordGroup(c, actor, updated.name, updateSummary("group", current.name, updated.name))
+        return updated
     }
 
-    fun deleteGroup(name: String): DeleteResult = dataSource.inTx { deleteGroup(name, it) }
+    fun deleteGroup(name: String, actor: AuditActor): DeleteResult = dataSource.inTx { deleteGroup(name, actor, it) }
 
-    fun deleteGroup(id: Long): DeleteResult = dataSource.inTx { c ->
+    fun deleteGroup(id: Long, actor: AuditActor): DeleteResult = dataSource.inTx { c ->
         val current = store.getGroup(id, c) ?: notFound("group")
         rejectSystem(current, c)
-        DeleteResult(store.deleteGroup(id, c))
+        deleteGroup(current, actor, c)
     }
 
-    fun deleteGroup(name: String, c: Connection): DeleteResult {
+    fun deleteGroup(name: String, actor: AuditActor, c: Connection): DeleteResult {
         required("name", name)
         val current = group(name, c)
         rejectSystem(current, c)
-        return DeleteResult(store.deleteGroup(current.id, c))
+        return deleteGroup(current, actor, c)
     }
 
-    fun addGroupMember(groupName: String, principal: String): GroupMemberEntry =
-        dataSource.inTx { addGroupMember(groupName, principal, it) }
+    private fun deleteGroup(current: AppGroup, actor: AuditActor, c: Connection): DeleteResult {
+        val deleted = DeleteResult(store.deleteGroup(current.id, c))
+        if (deleted.deleted) recordGroup(c, actor, current.name, "delete group '${current.name}'")
+        return deleted
+    }
 
-    fun addGroupMember(groupId: Long, userId: Long): GroupMemberEntry = dataSource.inTx { c ->
+    private fun recordGroup(c: Connection, actor: AuditActor, name: String, summary: String) =
+        recorder.record(c, actor, AuthzAction.ADMIN_IDENTITY, auditEntity("Group", name), summary)
+
+    fun addGroupMember(groupName: String, principal: String, actor: AuditActor): GroupMemberEntry =
+        dataSource.inTx { addGroupMember(groupName, principal, actor, it) }
+
+    fun addGroupMember(groupId: Long, userId: Long, actor: AuditActor): GroupMemberEntry = dataSource.inTx { c ->
         val group = store.getGroup(groupId, c) ?: notFound("group")
         rejectSystem(group, c)
-        if (store.getUser(userId, c) == null) notFound("user")
-        store.addMember(groupId, userId, c)
-        store.listMembers(groupId, c).first { it.userId == userId }
+        val user = store.getUser(userId, c) ?: notFound("user")
+        if (store.addMember(group.id, user.id, c)) recordMember(c, actor, group.name, user.principal, added = true)
+        store.listMembers(group.id, c).first { it.userId == user.id }
     }
 
-    fun addGroupMember(groupName: String, principal: String, c: Connection): GroupMemberEntry {
+    fun addGroupMember(groupName: String, principal: String, actor: AuditActor, c: Connection): GroupMemberEntry {
         required("groupName", groupName)
         required("principal", principal)
         val group = group(groupName, c)
         rejectSystem(group, c)
         val user = store.getUserByPrincipal(principal, c) ?: notFound("user")
-        store.addMember(group.id, user.id, c)
+        if (store.addMember(group.id, user.id, c)) recordMember(c, actor, group.name, user.principal, added = true)
         return store.listMembers(group.id, c).first { it.userId == user.id }
     }
 
-    fun removeGroupMember(groupName: String, principal: String): DeleteResult =
-        dataSource.inTx { removeGroupMember(groupName, principal, it) }
+    fun removeGroupMember(groupName: String, principal: String, actor: AuditActor): DeleteResult =
+        dataSource.inTx { removeGroupMember(groupName, principal, actor, it) }
 
-    fun removeGroupMember(groupId: Long, userId: Long): DeleteResult = dataSource.inTx { c ->
+    fun removeGroupMember(groupId: Long, userId: Long, actor: AuditActor): DeleteResult = dataSource.inTx { c ->
         val group = store.getGroup(groupId, c) ?: notFound("group")
         rejectSystem(group, c)
-        if (store.getUser(userId, c) == null) notFound("user")
-        DeleteResult(store.removeMember(groupId, userId, c))
+        val user = store.getUser(userId, c) ?: notFound("user")
+        removeMember(group, user.principal, user.id, actor, c)
     }
 
-    fun removeGroupMember(groupName: String, principal: String, c: Connection): DeleteResult {
+    fun removeGroupMember(groupName: String, principal: String, actor: AuditActor, c: Connection): DeleteResult {
         required("groupName", groupName)
         required("principal", principal)
         val group = group(groupName, c)
         rejectSystem(group, c)
         val user = store.getUserByPrincipal(principal, c) ?: notFound("user")
-        return DeleteResult(store.removeMember(group.id, user.id, c))
+        return removeMember(group, user.principal, user.id, actor, c)
     }
 
-    fun setGroupRoles(groupName: String, roleNames: Set<String>): GroupRolesResult =
-        dataSource.inTx { setGroupRoles(groupName, roleNames, it) }
+    private fun removeMember(
+        group: AppGroup,
+        principal: String,
+        userId: Long,
+        actor: AuditActor,
+        c: Connection,
+    ): DeleteResult {
+        val deleted = DeleteResult(store.removeMember(group.id, userId, c))
+        if (deleted.deleted) recordMember(c, actor, group.name, principal, added = false)
+        return deleted
+    }
 
-    fun addGroupRole(groupId: Long, roleId: Long): GroupRoleEntry = dataSource.inTx { c ->
-        lockMutableGroup(groupId, c)
+    private fun recordMember(
+        c: Connection,
+        actor: AuditActor,
+        groupName: String,
+        principal: String,
+        added: Boolean,
+    ) = recordGroup(
+        c, actor, groupName,
+        if (added) "add '$principal' to group '$groupName'" else "remove '$principal' from group '$groupName'",
+    )
+
+    fun setGroupRoles(groupName: String, roleNames: Set<String>, actor: AuditActor): GroupRolesResult =
+        dataSource.inTx { setGroupRoles(groupName, roleNames, actor, it) }
+
+    fun addGroupRole(groupId: Long, roleId: Long, actor: AuditActor): GroupRoleEntry = dataSource.inTx { c ->
+        val groupName = lockMutableGroup(groupId, c)
         val role = policyStore.getRole(roleId, c) ?: notFound("role")
-        store.addGroupRole(groupId, roleId, c)
+        if (store.addGroupRole(groupId, role.id, c)) recordGroup(c, actor, groupName, "add role '${role.name}' to group '$groupName'")
         GroupRoleEntry(role.id, role.name)
     }
 
-    fun removeGroupRole(groupId: Long, roleId: Long): DeleteResult = dataSource.inTx { c ->
-        lockMutableGroup(groupId, c)
-        if (policyStore.getRole(roleId, c) == null) notFound("role")
-        DeleteResult(store.removeGroupRole(groupId, roleId, c))
+    fun removeGroupRole(groupId: Long, roleId: Long, actor: AuditActor): DeleteResult = dataSource.inTx { c ->
+        val groupName = lockMutableGroup(groupId, c)
+        val role = policyStore.getRole(roleId, c) ?: notFound("role")
+        DeleteResult(store.removeGroupRole(groupId, role.id, c)).also { deleted ->
+            if (deleted.deleted) {
+                recordGroup(c, actor, groupName, "remove role '${role.name}' from group '$groupName'")
+            }
+        }
     }
 
-    fun setGroupRoles(groupName: String, roleNames: Set<String>, c: Connection): GroupRolesResult {
+    fun setGroupRoles(
+        groupName: String,
+        roleNames: Set<String>,
+        actor: AuditActor,
+        c: Connection,
+    ): GroupRolesResult {
         required("groupName", groupName)
         roleNames.forEach { required("roleNames", it) }
         val group = c.prepareStatement("SELECT id, source FROM app_group WHERE name = ? FOR UPDATE").use { statement ->
@@ -765,23 +1000,39 @@ class IdentityManagementService(
         val current = store.listGroupRoles(group.first, c).associateBy(GroupRoleEntry::roleName)
         for (name in current.keys - roles.keys) store.removeGroupRole(group.first, current.getValue(name).roleId, c)
         for (name in roles.keys - current.keys) store.addGroupRole(group.first, roles.getValue(name).id, c)
-        return GroupRolesResult(groupName, store.listGroupRoles(group.first, c).map(GroupRoleEntry::roleName))
+        val result = GroupRolesResult(groupName, store.listGroupRoles(group.first, c).map(GroupRoleEntry::roleName))
+        recordGroup(c, actor, groupName, "set group '$groupName' roles [${result.roleNames.joinToString(", ")}]")
+        return result
     }
 
     private fun group(name: String, c: Connection): AppGroup = store.getGroupByName(name, c) ?: notFound("group")
 
-    private fun lockMutableGroup(id: Long, c: Connection) {
-        val source = c.prepareStatement("SELECT source FROM app_group WHERE id = ? FOR UPDATE").use { statement ->
+    /**
+     * Locks the `app_group` row, not just reading it: [setGroupRoles] holds the same lock while it lists
+     * the current roles and writes the difference, so a single-role add or remove that skipped the lock
+     * could land inside that window and be silently reverted by the diff.
+     */
+    /** Row-lock a mutable (non-SYSTEM) group, returning its name for the audit summary. */
+    private fun lockMutableGroup(id: Long, c: Connection): String {
+        val (source, name) = c.prepareStatement("SELECT source, name FROM app_group WHERE id = ? FOR UPDATE").use { statement ->
             statement.setLong(1, id)
-            statement.executeQuery().use { result -> if (result.next()) result.getString("source") else notFound("group") }
+            statement.executeQuery().use { result ->
+                if (result.next()) result.getString("source") to result.getString("name") else notFound("group")
+            }
         }
         if (source == "SYSTEM") throw ManagementException(ApiError("group.system_immutable"))
+        return name
     }
 
     private fun rejectSystem(group: AppGroup, c: Connection) {
         if (store.isSystemGroup(group.id, c)) throw ManagementException(ApiError("group.system_immutable"))
     }
 }
+
+private fun updateSummary(type: String, before: String, after: String): String =
+    if (before == after) "update $type '$before'" else "update $type '$before' -> '$after'"
+
+private fun Classification.path(): String = "$schema.$table.$column"
 
 private fun required(field: String, value: String) {
     if (value.isBlank()) throw ManagementException(ApiError("common.field_required", mapOf("fields" to field)))

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/mcp/McpServer.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/mcp/McpServer.kt
@@ -10,14 +10,19 @@ import com.ridi.oss.proxymonster.controlplane.Config
 import com.ridi.oss.proxymonster.controlplane.ControlPlaneCore
 import com.ridi.oss.proxymonster.controlplane.Decision
 import com.ridi.oss.proxymonster.controlplane.AuditEvent
+import com.ridi.oss.proxymonster.controlplane.AppGroupInput
+import com.ridi.oss.proxymonster.controlplane.AppUserInput
 import com.ridi.oss.proxymonster.controlplane.MaskFnInput
 import com.ridi.oss.proxymonster.controlplane.httpRequesterIp
 import com.ridi.oss.proxymonster.controlplane.resolveForwardedAuthority
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import com.ridi.oss.proxymonster.controlplane.management.AuditSource
 import com.ridi.oss.proxymonster.controlplane.management.CapabilityClassification
 import com.ridi.oss.proxymonster.controlplane.management.CedarValidationManagementException
 import com.ridi.oss.proxymonster.controlplane.management.ColumnClassificationBatch
 import com.ridi.oss.proxymonster.controlplane.management.DatasourceManagementService
 import com.ridi.oss.proxymonster.controlplane.management.IdentityManagementService
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
 import com.ridi.oss.proxymonster.controlplane.management.ManagementException
 import com.ridi.oss.proxymonster.controlplane.management.McpCapability
 import com.ridi.oss.proxymonster.controlplane.management.McpCapabilityRegistry
@@ -237,7 +242,7 @@ private class McpMutationExecutor(
         arguments: JsonObject,
         datasource: String = "control-plane",
         detail: String,
-        mutation: (Connection) -> JsonObject,
+        mutation: (Connection, AuditActor) -> JsonObject,
     ): JsonObject {
         val roles = try {
             authorizer.authorize(context, capability)
@@ -245,6 +250,9 @@ private class McpMutationExecutor(
             auditFailure(context, capability, e.roles, datasource, detail, Decision.DENY, e.error.code)
             throw ManagementException(e.error)
         }
+        // Built from the roles `authorize` just resolved, so the audit row names the authority the call
+        // actually ran under. Sorted because the row is hashed into the audit chain.
+        val actor = AuditActor(context.principal, roles.sorted(), context.requesterIp, AuditSource.MCP)
         try {
             validateArguments(capability, arguments)
         } catch (e: McpInputException) {
@@ -289,11 +297,7 @@ private class McpMutationExecutor(
                             return@use prior.second to true
                         }
                     }
-                    val structured = mutation(connection)
-                    auditStore.insert(
-                        connection,
-                        mcpAuditRecord(context, capability, roles, datasource, detail, Decision.ALLOW, "ALLOW"),
-                    )
+                    val structured = mutation(connection, actor)
                     if (key != null) {
                         connection.prepareStatement(
                             """INSERT INTO mcp_mutation_idempotency
@@ -372,6 +376,7 @@ private fun mcpAuditRecord(
     authzAction = capability.action.cedarId,
     authzResource = "System::\"system\"",
     outcome = outcome,
+    kind = ManagementAuditRecorder.KIND_ADMIN,
 )
 
 private fun createMcpServer(
@@ -489,7 +494,7 @@ private fun executeWrite(
 ): JsonObject {
     val datasourceName = safeDatasource(capability, args)
     val detail = mutationDetail(capability.toolName, args)
-    return mutations.execute(context, capability, args, datasource = datasourceName, detail = detail) { connection ->
+    return mutations.execute(context, capability, args, datasource = datasourceName, detail = detail) { connection, actor ->
         when (capability.toolName) {
             "set_column_classification" -> {
                 val maskFnId = args.string("maskFnName")?.let { name ->
@@ -499,7 +504,7 @@ private fun executeWrite(
                 structured(
                     datasources.setColumnClassification(
                         args.requiredString("datasource"), args.string("schema"), args.requiredString("table"),
-                        args.requiredString("column"), args.stringSet("tags").toList(), maskFnId, connection,
+                        args.requiredString("column"), args.stringSet("tags").toList(), maskFnId, actor, connection,
                     ),
                 )
             }
@@ -529,7 +534,7 @@ private fun executeWrite(
                                     entry.string("maskFnName")?.let(maskFnIds::getValue),
                                 )
                             },
-                            connection,
+                            actor, connection,
                         ),
                     ),
                 )
@@ -537,44 +542,44 @@ private fun executeWrite(
             "clear_column_classification" -> structured(
                 datasources.clearColumnClassification(
                     args.requiredString("datasource"), args.string("schema"), args.requiredString("table"),
-                    args.requiredString("column"), connection,
+                    args.requiredString("column"), actor, connection,
                 ),
             )
             "create_policy" -> structured(
-                policies.createPolicy(args.requiredString("name"), args.requiredString("cedarSrc"), args.boolean("enabled") ?: true, context.principal, connection),
+                policies.createPolicy(args.requiredString("name"), args.requiredString("cedarSrc"), args.boolean("enabled") ?: true, context.principal, actor, connection),
             )
             "update_policy" -> structured(
                 policies.getPolicy(args.requiredString("name"), connection).let { current ->
                     policies.updatePolicy(
                         current.name, args.string("newName"), args.requiredString("cedarSrc"),
                         if (args.has("enabled")) args.boolean("enabled") ?: current.enabled else current.enabled,
-                        context.principal, connection,
+                        context.principal, actor, connection,
                     )
                 },
             )
-            "enable_policy" -> structured(policies.setPolicyEnabled(args.requiredString("name"), true, context.principal, connection))
-            "disable_policy" -> structured(policies.setPolicyEnabled(args.requiredString("name"), false, context.principal, connection))
-            "delete_policy" -> structured(policies.deletePolicy(args.requiredString("name"), connection))
-            "create_role" -> structured(policies.createRole(args.requiredString("name"), args.string("description"), connection))
+            "enable_policy" -> structured(policies.setPolicyEnabled(args.requiredString("name"), true, context.principal, actor, connection))
+            "disable_policy" -> structured(policies.setPolicyEnabled(args.requiredString("name"), false, context.principal, actor, connection))
+            "delete_policy" -> structured(policies.deletePolicy(args.requiredString("name"), actor, connection))
+            "create_role" -> structured(policies.createRole(args.requiredString("name"), args.string("description"), actor, connection))
             "update_role" -> structured(
                 policies.getRole(args.requiredString("name"), connection).let { current ->
                     policies.updateRole(
                         current.name,
                         args.string("newName"),
                         if (args.has("description")) args.string("description") else current.description,
-                        connection,
+                        actor, connection,
                     )
                 },
             )
-            "delete_role" -> structured(policies.deleteRole(args.requiredString("name"), connection))
-            "assign_role" -> structured(policies.assignRole(args.requiredString("principal"), args.requiredString("roleName"), connection))
-            "unassign_role" -> structured(policies.unassignRole(args.requiredString("principal"), args.requiredString("roleName"), connection))
+            "delete_role" -> structured(policies.deleteRole(args.requiredString("name"), actor, connection))
+            "assign_role" -> structured(policies.assignRole(args.requiredString("principal"), args.requiredString("roleName"), actor, connection))
+            "unassign_role" -> structured(policies.unassignRole(args.requiredString("principal"), args.requiredString("roleName"), actor, connection))
             "create_user" -> structured(
                 identities.createUser(
-                    com.ridi.oss.proxymonster.controlplane.AppUserInput(
+                    AppUserInput(
                         args.requiredString("principal"), args.string("displayName"), args.string("email"), args.boolean("active") ?: true,
                     ),
-                    connection,
+                    actor, connection,
                 ),
             )
             "update_user" -> structured(
@@ -585,13 +590,13 @@ private fun executeWrite(
                         if (args.has("displayName")) args.string("displayName") else current.displayName,
                         if (args.has("email")) args.string("email") else current.email,
                         if (args.has("active")) args.boolean("active") ?: current.active else current.active,
-                        connection,
+                        actor, connection,
                     )
                 },
             )
-            "deprovision_user" -> structured(identities.deprovisionUser(args.requiredString("principal"), connection))
+            "deprovision_user" -> structured(identities.deprovisionUser(args.requiredString("principal"), actor, connection))
             "create_group" -> structured(
-                identities.createGroup(com.ridi.oss.proxymonster.controlplane.AppGroupInput(args.requiredString("name"), args.string("description")), connection),
+                identities.createGroup(AppGroupInput(args.requiredString("name"), args.string("description")), actor, connection),
             )
             "update_group" -> structured(
                 identities.getGroup(args.requiredString("name"), connection).let { current ->
@@ -599,22 +604,22 @@ private fun executeWrite(
                         current.name,
                         args.string("newName"),
                         if (args.has("description")) args.string("description") else current.description,
-                        connection,
+                        actor, connection,
                     )
                 },
             )
-            "delete_group" -> structured(identities.deleteGroup(args.requiredString("name"), connection))
+            "delete_group" -> structured(identities.deleteGroup(args.requiredString("name"), actor, connection))
             "add_group_member" -> structured(
-                identities.addGroupMember(args.requiredString("groupName"), args.requiredString("principal"), connection),
+                identities.addGroupMember(args.requiredString("groupName"), args.requiredString("principal"), actor, connection),
             )
             "remove_group_member" -> structured(
-                identities.removeGroupMember(args.requiredString("groupName"), args.requiredString("principal"), connection),
+                identities.removeGroupMember(args.requiredString("groupName"), args.requiredString("principal"), actor, connection),
             )
             "set_group_roles" -> structured(
-                identities.setGroupRoles(args.requiredString("groupName"), args.stringSet("roleNames"), connection),
+                identities.setGroupRoles(args.requiredString("groupName"), args.stringSet("roleNames"), actor, connection),
             )
             "create_mask_fn" -> structured(
-                policies.createMaskFn(MaskFnInput(args.requiredString("name"), args.requiredString("kind")), connection),
+                policies.createMaskFn(MaskFnInput(args.requiredString("name"), args.requiredString("kind")), actor, connection),
             )
             "update_mask_fn" -> structured(
                 policies.getMaskFn(args.requiredString("name"), connection).let { current ->
@@ -624,11 +629,11 @@ private fun executeWrite(
                             args.string("newName") ?: current.name,
                             args.requiredString("kind"),
                         ),
-                        connection,
+                        actor, connection,
                     )
                 },
             )
-            "delete_mask_fn" -> structured(policies.deleteMaskFn(args.requiredString("name"), connection))
+            "delete_mask_fn" -> structured(policies.deleteMaskFn(args.requiredString("name"), actor, connection))
             else -> throw ManagementException(ApiError("mcp.invalid_request"))
         }
     }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AuditChainDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AuditChainDbTest.kt
@@ -1,6 +1,8 @@
 package com.ridi.oss.proxymonster.controlplane
 
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
+import com.ridi.oss.proxymonster.controlplane.support.auditChainHead
+import com.ridi.oss.proxymonster.controlplane.support.verifyAuditChain
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
@@ -170,29 +172,7 @@ class AuditChainDbTest {
         contextTags = listOf("trusted", "alpha"),
     )
 
-    private fun verifyWalk() {
-        val rows = readRows(null)
-        val chainStartId = dataSource.connection.use { connection ->
-            connection.prepareStatement("SELECT COALESCE(MIN(id), 1) FROM audit_event WHERE row_hash IS NOT NULL").use { statement ->
-                statement.executeQuery().use { result -> result.next(); result.getLong(1) }
-            }
-        }
-        val baseLastId = chainStartId - 1
-        val genesis = "88d4f4719f26cf7f32839ac30b1d6a94edf3f9133fb75667d1415fff81bbcd08".hexBytes()
-        rows.forEachIndexed { index, row ->
-            val expectedPrev = if (index == 0) genesis else rows[index - 1].rowHash
-            assertContentEquals(expectedPrev, row.prevHash, "chain link at ${row.id}")
-            assertEquals(AuditCanonical.CHAIN_VERSION, row.chainVersion, "chain version at ${row.id}")
-            assertContentEquals(
-                AuditCanonical.rowHash(row.id, row.event, row.tsMicros, row.prevHash),
-                row.rowHash,
-                "row hash at ${row.id}",
-            )
-        }
-        val head = chainHead()
-        assertEquals(rows.lastOrNull()?.id ?: baseLastId, head.first)
-        if (rows.isEmpty()) assertContentEquals(genesis, head.second) else assertContentEquals(rows.last().rowHash, head.second)
-    }
+    private fun verifyWalk() = verifyAuditChain(dataSource)
 
     private fun readRows(ids: List<Long>?): List<PersistedRow> = dataSource.connection.use { connection ->
         val condition = if (ids == null) "row_hash IS NOT NULL" else "id IN (${ids.joinToString(",")})"
@@ -248,20 +228,13 @@ class AuditChainDbTest {
         }
     }
 
-    private fun chainHead(): Pair<Long, ByteArray> = dataSource.connection.use { connection ->
-        connection.prepareStatement("SELECT last_id, head_hash FROM audit_chain_head WHERE id = 1").use { statement ->
-            statement.executeQuery().use { result -> result.next(); result.getLong(1) to result.getBytes(2) }
-        }
-    }
+    private fun chainHead(): Pair<Long, ByteArray> = auditChainHead(dataSource)
 
     private fun decodeArray(value: String?): List<String> =
         json.decodeFromString(stringList, value ?: "[]")
 
     private fun java.sql.ResultSet.longOrNull(column: String): Long? =
         getLong(column).let { if (wasNull()) null else it }
-
-    private fun String.hexBytes(): ByteArray =
-        ByteArray(length / 2) { index -> substring(index * 2, index * 2 + 2).toInt(16).toByte() }
 
     private data class PersistedRow(
         val id: Long,

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/CedarPolicyOriginTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/CedarPolicyOriginTest.kt
@@ -16,7 +16,6 @@ import org.flywaydb.core.Flyway
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import java.sql.SQLException
 import javax.sql.DataSource
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -27,14 +26,13 @@ import kotlin.test.assertTrue
 /**
  * Store-level proof for docs/policy-store.md: migration-owned SYSTEM source cannot be
  * updated or deleted even outside HTTP routes, the reserved name cannot enter through USER writes,
- * toggle audit is atomic with the state change, and the shipped sources at negative ids leave the
- * effective Cedar decisions identical to the [AuthzTest] oracle.
+ * and the shipped sources at negative ids leave the effective Cedar decisions identical to the
+ * [AuthzTest] oracle.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CedarPolicyOriginTest {
     private lateinit var ds: DataSource
     private lateinit var store: CedarPolicyStore
-    private lateinit var audit: AuditStore
 
     @BeforeAll
     fun setup() {
@@ -42,7 +40,6 @@ class CedarPolicyOriginTest {
         ds = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_cedar_policy_origin"))
         Flyway.configure().dataSource(ds).load().migrate()
         store = CedarPolicyStore(ds)
-        audit = AuditStore(ds)
     }
 
     @Test
@@ -87,11 +84,9 @@ class CedarPolicyOriginTest {
     }
 
     @Test
-    fun `system toggle changes only mutable fields and writes a visible sentinel audit record`() {
+    fun `system toggle changes only mutable fields`() {
         store.setEnabled(-1, enabled = true, updatedBy = "setup@example.com")
         val before = store.get(-1)!!
-        val auditBefore = toggleAuditRows().size
-
         val disabled = store.setEnabled(-1, enabled = false, updatedBy = "operator@example.com")
         assertNotNull(disabled)
         assertFalse(disabled.enabled)
@@ -101,63 +96,7 @@ class CedarPolicyOriginTest {
         assertEquals(before.systemKey, disabled.systemKey)
         assertEquals(before.name, disabled.name)
         assertEquals(before.cedarSrc, disabled.cedarSrc)
-
-        val disableAudit = toggleAuditRows().single { it.statement.endsWith("enabled true->false") }
-        assertEquals("operator@example.com", disableAudit.principal)
-        assertEquals("control-plane", disableAudit.datasource)
-        assertEquals(Decision.ALLOW, disableAudit.decision)
-        assertEquals("SYSTEM_POLICY_TOGGLE", disableAudit.detail)
-        assertTrue(disableAudit.statement.contains("policy -1 (bootstrap.pm-admin)"))
-        assertNotNull(audit.get(disableAudit.id!!), "ADMIN toggle sentinels must remain visible in /api/audit")
-
-        store.setEnabled(-1, enabled = false, updatedBy = "operator@example.com")
-        assertEquals(auditBefore + 1, toggleAuditRows().size, "a no-op setEnabled call must not emit a false flip event")
-
-        val enabled = store.setEnabled(-1, enabled = true, updatedBy = "operator@example.com")
-        assertNotNull(enabled)
-        assertTrue(enabled.enabled)
-        assertTrue(toggleAuditRows().any { it.statement.endsWith("enabled false->true") })
-    }
-
-    @Test
-    fun `audit failure rolls back the system toggle in the same transaction`() {
-        ds.connection.use { c ->
-            c.createStatement().use { st ->
-                st.execute(
-                    """CREATE FUNCTION reject_system_policy_toggle() RETURNS trigger
-                       LANGUAGE plpgsql AS $$
-                       BEGIN
-                           IF NEW.detail = 'SYSTEM_POLICY_TOGGLE' THEN
-                               RAISE EXCEPTION 'reject test system-policy audit';
-                           END IF;
-                           RETURN NEW;
-                       END
-                       $$""",
-                )
-                st.execute(
-                    """CREATE TRIGGER reject_system_policy_toggle
-                       BEFORE INSERT ON audit_event
-                       FOR EACH ROW EXECUTE FUNCTION reject_system_policy_toggle()""",
-                )
-            }
-        }
-
-        try {
-            store.setEnabled(-2, enabled = true, updatedBy = "setup@example.com")
-            val versionBefore = store.stateVersion()
-            assertFailsWith<SQLException> {
-                store.setEnabled(-2, enabled = false, updatedBy = "operator@example.com")
-            }
-            assertTrue(store.get(-2)!!.enabled, "the policy update must roll back when its audit insert fails")
-            assertEquals(versionBefore, store.stateVersion(), "a rolled-back toggle must not bump the store version")
-        } finally {
-            ds.connection.use { c ->
-                c.createStatement().use { st ->
-                    st.execute("DROP TRIGGER IF EXISTS reject_system_policy_toggle ON audit_event")
-                    st.execute("DROP FUNCTION IF EXISTS reject_system_policy_toggle()")
-                }
-            }
-        }
+        assertTrue(store.setEnabled(-1, enabled = true, updatedBy = "operator@example.com")!!.enabled)
     }
 
     @Test
@@ -217,9 +156,6 @@ class CedarPolicyOriginTest {
             assertEquals(expected, actual, "V20 changed the effective decision for $case")
         }
     }
-
-    private fun toggleAuditRows(): List<AuditEvent> = audit.recent(500)
-        .filter { it.detail == "SYSTEM_POLICY_TOGGLE" }
 
     private fun AuthzDecision.isAllowed(): Boolean = this == AuthzDecision.Allow
 

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/CedarPolicyRoutesTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/CedarPolicyRoutesTest.kt
@@ -8,6 +8,9 @@ import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyStore
 import com.ridi.oss.proxymonster.controlplane.authz.RoleSource
 import com.ridi.oss.proxymonster.controlplane.authz.cedarPolicyRoutes
 import com.ridi.oss.proxymonster.controlplane.authz.CedarSchema
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import com.ridi.oss.proxymonster.controlplane.management.AuditSource
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
 import com.ridi.oss.proxymonster.controlplane.management.PolicyManagementService
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
@@ -130,8 +133,24 @@ class CedarPolicyRoutesTest {
     }
 
     @Test
+    fun `debug HTTP mutation records the unknown console actor exactly once`() = testApplication {
+        store.setEnabled(-1, enabled = true, updatedBy = "setup@example.com")
+        val before = adminToggleCount()
+        val response = policyClient().post("/api/policies/-1/disable")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(before + 1, adminToggleCount())
+        val row = ds.connection.use { c ->
+            c.prepareStatement(
+                """SELECT action, resource, channel, principal FROM audit_event
+                   WHERE kind='admin' AND resource='Policy::"-1"' ORDER BY id DESC LIMIT 1""",
+            ).use { ps -> ps.executeQuery().use { rs -> rs.next(); (1..4).map(rs::getString) } }
+        }
+        assertEquals(listOf("admin.policies", "Policy::\"-1\"", "console", "unknown"), row)
+    }
+
+    @Test
     fun `REST-shaped policy mutation remains bound to its numeric id after name reuse`() {
-        val management = PolicyManagementService(store, PolicyStore(ds))
+        val management = PolicyManagementService(store, PolicyStore(ds), ManagementAuditRecorder(AuditStore(ds)))
         val original = store.create(CedarPolicyInput("id-stable-policy", ADMIN_SOURCE), "operator@example.com")
         store.update(original.id, CedarPolicyInput("id-stable-policy-renamed", ADMIN_SOURCE), "operator@example.com")
         val replacement = store.create(CedarPolicyInput("id-stable-policy", ADMIN_SOURCE), "operator@example.com")
@@ -140,6 +159,7 @@ class CedarPolicyRoutesTest {
             original.id,
             CedarPolicyInput("id-stable-policy-final", ADMIN_SOURCE),
             "operator@example.com",
+            AuditActor("operator@example.com", channel = AuditSource.CONSOLE),
         )
 
         assertEquals(original.id, updated.id)
@@ -158,7 +178,7 @@ class CedarPolicyRoutesTest {
      */
     @Test
     fun `the served policy schema declares the context tag actions stored rules target`() {
-        val management = PolicyManagementService(store, PolicyStore(ds))
+        val management = PolicyManagementService(store, PolicyStore(ds), ManagementAuditRecorder(AuditStore(ds)))
         store.create(
             CedarPolicyInput("tag-rule-live", tagRule("routes-live-tag")),
             "operator@example.com",
@@ -184,7 +204,7 @@ class CedarPolicyRoutesTest {
      */
     @Test
     fun `escape-aliased tag names collapse to one declaration`() {
-        val management = PolicyManagementService(store, PolicyStore(ds))
+        val management = PolicyManagementService(store, PolicyStore(ds), ManagementAuditRecorder(AuditStore(ds)))
         store.create(CedarPolicyInput("tag-alias-plain", tagRule("aliastag")), "operator@example.com")
         store.create(
             CedarPolicyInput("tag-alias-escaped", tagRule("""\u{61}liastag""")),
@@ -199,6 +219,12 @@ class CedarPolicyRoutesTest {
             CedarSchema.schemaTextFor(setOf("aliastag")) != served || declarations == 1,
             "served schema must remain parseable",
         )
+    }
+
+    private fun adminToggleCount(): Int = ds.connection.use { c ->
+        c.prepareStatement("SELECT count(*) FROM audit_event WHERE kind='admin' AND resource='Policy::\"-1\"'").use { ps ->
+            ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) }
+        }
     }
 
     private fun tagRule(tag: String): String =

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ManagementAuditDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ManagementAuditDbTest.kt
@@ -1,0 +1,320 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
+import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import com.ridi.oss.proxymonster.controlplane.management.AuditSource
+import com.ridi.oss.proxymonster.controlplane.management.DatasourceManagementService
+import com.ridi.oss.proxymonster.controlplane.management.IdentityManagementService
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
+import com.ridi.oss.proxymonster.controlplane.management.PolicyManagementService
+import com.ridi.oss.proxymonster.controlplane.management.ManagementException
+import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
+import com.ridi.oss.proxymonster.controlplane.support.auditChainHead
+import com.ridi.oss.proxymonster.controlplane.support.verifyAuditChain
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.sql.SQLException
+import javax.sql.DataSource
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ManagementAuditDbTest {
+    private lateinit var dataSource: DataSource
+    private lateinit var core: ControlPlaneCore
+    private lateinit var datasources: DatasourceManagementService
+    private lateinit var policies: PolicyManagementService
+    private lateinit var identities: IdentityManagementService
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_management_audit"))
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        core = ControlPlaneCore(dataSource)
+        val recorder = ManagementAuditRecorder(core.auditStore)
+        datasources = DatasourceManagementService(core.datasourceStore, core.proxyEventsHub, TableDetailService(core), recorder)
+        policies = PolicyManagementService(core.cedarPolicyStore, core.policyStore, recorder)
+        identities = IdentityManagementService(
+            dataSource, core.userGroupStore, core.policyStore, core.tokenStore, core.accessStore,
+            PrincipalSessionStore(dataSource, null), recorder,
+        )
+    }
+
+    @Test
+    fun `each service records one atomic admin event with its pinned descriptor`() {
+        val principal = "management-audit-${System.nanoTime()}@example.com"
+        val actor = AuditActor(principal, clientAddr = "192.0.2.1", channel = AuditSource.CONSOLE)
+        policies.createRole("audit-role-${System.nanoTime()}", null, actor).also { role ->
+            assertEvent(principal, AuthzAction.ADMIN_POLICIES, "Role::\"${role.name}\"", "create role '${role.name}'")
+        }
+        identities.createUser(AppUserInput(principal, active = true), actor)
+        assertEvent(principal, AuthzAction.ADMIN_IDENTITY, "User::\"$principal\"", "create user '$principal'")
+        val datasource = datasources.createDatasource(DatasourceInput("audit-ds-${System.nanoTime()}", "postgres"), actor)
+        assertEvent(principal, AuthzAction.ADMIN_DATASOURCES, "Datasource::\"${datasource.name}\"", "create datasource '${datasource.name}'")
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `batch classification writes one row naming resolved columns in canonical order`() {
+        val principal = "management-batch-${System.nanoTime()}@example.com"
+        val actor = AuditActor(principal, channel = AuditSource.CONSOLE)
+        val ds = datasources.createDatasource(DatasourceInput("audit-batch-${System.nanoTime()}", "postgres"), actor)
+        defaultSchemaPublic(ds.id)
+        dataSource.inTx { c ->
+            datasources.setColumnClassifications(
+                ds.name,
+                listOf(
+                    ClassificationInput(null, "users", "rrn", listOf("pii")),
+                    ClassificationInput("public", "users", "email", listOf("contact")),
+                    ClassificationInput(null, "users", "phone", listOf("contact")),
+                ),
+                actor,
+                c,
+            )
+        }
+        assertEvent(
+            principal, AuthzAction.ADMIN_DATASOURCES, "Datasource::\"${ds.name}\"",
+            "tag 3 columns of '${ds.name}' [public.users.email, public.users.phone, public.users.rrn]",
+        )
+        // One row for the whole batch, not one per column: the batch is a single atomic change.
+        assertEquals(1, count("SELECT count(*) FROM audit_event WHERE principal=? AND statement LIKE 'tag %columns%'", principal))
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `a rejected audit insert rolls back the mutation it describes`() {
+        val principal = "management-rollback-${System.nanoTime()}@example.com"
+        val actor = AuditActor(principal, channel = AuditSource.CONSOLE)
+        val roleName = "audit-rollback-role"
+        val headBefore = auditChainHead(dataSource)
+        execute(
+            """CREATE OR REPLACE FUNCTION pm_test_reject_admin_audit() RETURNS trigger AS ${'$'}body${'$'}
+               BEGIN RAISE EXCEPTION 'forced admin audit failure'; END
+               ${'$'}body${'$'} LANGUAGE plpgsql""",
+        )
+        execute(
+            """CREATE TRIGGER pm_test_reject_admin_audit BEFORE INSERT ON audit_event
+               FOR EACH ROW WHEN (NEW.kind = 'admin' AND NEW.resource = 'Role::"$roleName"')
+               EXECUTE FUNCTION pm_test_reject_admin_audit()""",
+        )
+        try {
+            assertFailsWith<SQLException> { policies.createRole(roleName, null, actor) }
+            assertEquals(0, count("SELECT count(*) FROM app_role WHERE name=?", roleName))
+            assertEquals(0, count("SELECT count(*) FROM audit_event WHERE principal=?", principal))
+            val headAfter = auditChainHead(dataSource)
+            assertEquals(headBefore.first, headAfter.first)
+            assertContentEquals(headBefore.second, headAfter.second)
+        } finally {
+            execute("DROP TRIGGER IF EXISTS pm_test_reject_admin_audit ON audit_event")
+            execute("DROP FUNCTION IF EXISTS pm_test_reject_admin_audit()")
+        }
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `a rejected mutation and a no-op removal record nothing`() {
+        val principal = "management-noop-${System.nanoTime()}@example.com"
+        val actor = AuditActor(principal, channel = AuditSource.CONSOLE)
+        val taken = "audit-duplicate-${System.nanoTime()}"
+        policies.createRole(taken, null, actor)
+
+        assertFailsWith<ManagementException> { policies.createRole(taken, null, actor) }
+        assertEquals(1, count("SELECT count(*) FROM audit_event WHERE principal=? AND resource=?", principal, """Role::"$taken""""))
+
+        // A group the principal was never in: nothing was removed, so there is no change to record.
+        val group = identities.createGroup(AppGroupInput("audit-noop-${System.nanoTime()}"), actor)
+        val outsider = identities.createUser(AppUserInput("audit-outsider-${System.nanoTime()}@example.com", active = true), actor)
+        assertEquals(false, identities.removeGroupMember(group.id, outsider.id, actor).deleted)
+        assertEquals(
+            0,
+            count(
+                "SELECT count(*) FROM audit_event WHERE resource=? AND statement LIKE 'remove %'",
+                """Group::"${group.name}"""",
+            ),
+        )
+
+        assertFailsWith<ManagementException> { policies.deleteRole("audit-absent-${System.nanoTime()}", actor) }
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `identity and policy edits record their resolved before and after names`() {
+        val principal = "management-edits-${System.nanoTime()}@example.com"
+        val actor = AuditActor(principal, channel = AuditSource.CONSOLE)
+        val role = policies.createRole("audit-rename-${System.nanoTime()}", null, actor)
+        val renamed = policies.updateRole(role.id, RoleInput("${role.name}-v2", null), actor)
+        assertEvent(principal, AuthzAction.ADMIN_POLICIES, """Role::"${renamed.name}"""", "update role '${role.name}' -> '${renamed.name}'")
+
+        val member = identities.createUser(AppUserInput("audit-member-${System.nanoTime()}@example.com", active = true), actor)
+        policies.assignRole(member.principal, renamed.id, actor)
+        assertEvent(principal, AuthzAction.ADMIN_IDENTITY, """Role::"${renamed.name}"""", "assign role '${renamed.name}' to '${member.principal}'")
+        assertEquals(true, policies.unassignRole(member.principal, renamed.name, actor).deleted)
+        assertEvent(principal, AuthzAction.ADMIN_IDENTITY, """Role::"${renamed.name}"""", "unassign role '${renamed.name}' from '${member.principal}'")
+
+        val group = identities.createGroup(AppGroupInput("audit-group-${System.nanoTime()}"), actor)
+        identities.addGroupMember(group.id, member.id, actor)
+        assertEvent(principal, AuthzAction.ADMIN_IDENTITY, """Group::"${group.name}"""", "add '${member.principal}' to group '${group.name}'")
+        identities.setGroupRoles(group.name, setOf(renamed.name), actor)
+        assertEvent(principal, AuthzAction.ADMIN_IDENTITY, """Group::"${group.name}"""", "set group '${group.name}' roles [${renamed.name}]")
+        assertEquals(true, identities.removeGroupMember(group.id, member.id, actor).deleted)
+        assertEvent(principal, AuthzAction.ADMIN_IDENTITY, """Group::"${group.name}"""", "remove '${member.principal}' from group '${group.name}'")
+
+        assertEquals(true, identities.deprovisionUser(member.id, actor).deleted)
+        assertEvent(principal, AuthzAction.ADMIN_IDENTITY, """User::"${member.principal}"""", "deprovision user '${member.principal}'")
+        assertEquals(true, policies.deleteRole(renamed.id, actor).deleted)
+        assertEvent(principal, AuthzAction.ADMIN_POLICIES, """Role::"${renamed.name}"""", "delete role '${renamed.name}'")
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `mask function CRUD and a SYSTEM policy toggle each record once`() {
+        val principal = "management-maskfn-${System.nanoTime()}@example.com"
+        val actor = AuditActor(principal, channel = AuditSource.CONSOLE)
+        val fn = policies.createMaskFn(MaskFnInput("audit-mask-${System.nanoTime()}", "redact"), actor)
+        assertEvent(principal, AuthzAction.ADMIN_POLICIES, """MaskFn::"${fn.name}"""", "create mask function '${fn.name}'")
+        val renamed = policies.updateMaskFn(fn.id, MaskFnInput("${fn.name}-v2", "redact"), actor)
+        assertEvent(
+            principal, AuthzAction.ADMIN_POLICIES, """MaskFn::"${renamed.name}"""",
+            "update mask function '${fn.name}' -> '${renamed.name}'",
+        )
+        assertEquals(true, policies.deleteMaskFn(renamed.id, actor).deleted)
+        assertEvent(principal, AuthzAction.ADMIN_POLICIES, """MaskFn::"${renamed.name}"""", "delete mask function '${renamed.name}'")
+
+        // Toggling a SYSTEM policy is permitted where update and delete are not, so the toggle is the
+        // only config change that reaches a SYSTEM row and it must still be audited.
+        val system = policies.setPolicyEnabled(-1L, enabled = false, principal = principal, actor = actor)
+        assertEvent(principal, AuthzAction.ADMIN_POLICIES, """Policy::"-1"""", "disable policy '${system.name}'")
+        policies.setPolicyEnabled(-1L, enabled = true, principal = principal, actor = actor)
+        assertEvent(principal, AuthzAction.ADMIN_POLICIES, """Policy::"-1"""", "enable policy '${system.name}'")
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `datasource CRUD and single-column tagging record the resolved column path`() {
+        val principal = "management-ds-${System.nanoTime()}@example.com"
+        val actor = AuditActor(principal, channel = AuditSource.CONSOLE)
+        val created = datasources.createDatasource(DatasourceInput("audit-crud-${System.nanoTime()}", "postgres"), actor)
+        defaultSchemaPublic(created.id)
+        val renamed = assertNotNull(
+            datasources.updateDatasource(created.id, DatasourceInput("${created.name}-v2", "postgres"), actor),
+        )
+        assertEvent(
+            principal, AuthzAction.ADMIN_DATASOURCES, """Datasource::"${renamed.name}"""",
+            "update datasource '${created.name}' -> '${renamed.name}'",
+        )
+
+        // Schema omitted on the wire: both the descriptor and the summary must carry the RESOLVED schema,
+        // since that is the column the mask decision reads.
+        datasources.setColumnClassification(renamed.id, null, "users", "rrn", listOf("pii"), null, actor)
+        assertEvent(
+            principal, AuthzAction.ADMIN_DATASOURCES, """Datasource::"${renamed.name}" col public.users.rrn""",
+            "tag ${renamed.name}.public.users.rrn [pii]",
+        )
+        assertEquals(true, datasources.clearColumnClassification(renamed.id, null, "users", "rrn", actor).deleted)
+        assertEvent(
+            principal, AuthzAction.ADMIN_DATASOURCES, """Datasource::"${renamed.name}" col public.users.rrn""",
+            "clear tags on ${renamed.name}.public.users.rrn",
+        )
+
+        assertEquals(true, datasources.deleteDatasource(renamed.id, actor).deleted)
+        assertEvent(principal, AuthzAction.ADMIN_DATASOURCES, """Datasource::"${renamed.name}"""", "delete datasource '${renamed.name}'")
+        assertEquals(false, datasources.deleteDatasource(renamed.id, actor).deleted)
+        assertEquals(1, count("SELECT count(*) FROM audit_event WHERE principal=? AND statement LIKE 'delete datasource %'", principal))
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `ordinary policy CRUD records create, rename, and delete`() {
+        val principal = "management-policy-${System.nanoTime()}@example.com"
+        val actor = AuditActor(principal, channel = AuditSource.CONSOLE)
+        val src = "permit(principal in Role::\"system:admin\", action == Action::\"admin.policies\", resource);"
+        val created = policies.createPolicy("audit-policy-${System.nanoTime()}", src, enabled = true, principal = principal, actor = actor)
+        assertEvent(principal, AuthzAction.ADMIN_POLICIES, """Policy::"${created.id}"""", "create policy '${created.name}'")
+        val renamed = policies.updatePolicy(created.id, CedarPolicyInput("${created.name}-v2", src, enabled = true), principal, actor)
+        assertEvent(
+            principal, AuthzAction.ADMIN_POLICIES, """Policy::"${renamed.id}"""",
+            "update policy '${created.name}' -> '${renamed.name}'",
+        )
+        assertEquals(true, policies.deletePolicy(created.id, actor).deleted)
+        assertEvent(principal, AuthzAction.ADMIN_POLICIES, """Policy::"${created.id}"""", "delete policy '${renamed.name}'")
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `group role grant and revoke each record once`() {
+        val principal = "management-grouprole-${System.nanoTime()}@example.com"
+        val actor = AuditActor(principal, channel = AuditSource.CONSOLE)
+        val role = policies.createRole("audit-grouprole-${System.nanoTime()}", null, actor)
+        val group = identities.createGroup(AppGroupInput("audit-rolegroup-${System.nanoTime()}"), actor)
+        identities.addGroupRole(group.id, role.id, actor)
+        assertEvent(principal, AuthzAction.ADMIN_IDENTITY, """Group::"${group.name}"""", "add role '${role.name}' to group '${group.name}'")
+        assertEquals(true, identities.removeGroupRole(group.id, role.id, actor).deleted)
+        assertEvent(principal, AuthzAction.ADMIN_IDENTITY, """Group::"${group.name}"""", "remove role '${role.name}' from group '${group.name}'")
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `repeating an add or assignment records nothing the second time`() {
+        val principal = "management-idempotent-${System.nanoTime()}@example.com"
+        val actor = AuditActor(principal, channel = AuditSource.CONSOLE)
+        val role = policies.createRole("audit-idem-role-${System.nanoTime()}", null, actor)
+        val group = identities.createGroup(AppGroupInput("audit-idem-group-${System.nanoTime()}"), actor)
+        val user = identities.createUser(AppUserInput("audit-idem-user-${System.nanoTime()}@example.com", active = true), actor)
+
+        // The store upserts, so a repeated add/assign changes nothing — and a change that did not happen
+        // must not produce an audit row. assertEvent demands exactly one row for the exact statement, so a
+        // second write here fails it.
+        identities.addGroupMember(group.id, user.id, actor)
+        identities.addGroupMember(group.id, user.id, actor)
+        assertEvent(principal, AuthzAction.ADMIN_IDENTITY, """Group::"${group.name}"""", "add '${user.principal}' to group '${group.name}'")
+
+        identities.addGroupRole(group.id, role.id, actor)
+        identities.addGroupRole(group.id, role.id, actor)
+        assertEvent(principal, AuthzAction.ADMIN_IDENTITY, """Group::"${group.name}"""", "add role '${role.name}' to group '${group.name}'")
+
+        policies.assignRole(user.principal, role.id, actor)
+        policies.assignRole(user.principal, role.id, actor)
+        assertEvent(principal, AuthzAction.ADMIN_IDENTITY, """Role::"${role.name}"""", "assign role '${role.name}' to '${user.principal}'")
+        verifyAuditChain(dataSource)
+    }
+
+    private fun defaultSchemaPublic(datasourceId: Long) = dataSource.connection.use { c ->
+        c.prepareStatement("UPDATE datasource SET default_schemas='[\"public\"]'::jsonb WHERE id=?").use { ps ->
+            ps.setLong(1, datasourceId)
+            ps.executeUpdate()
+        }
+    }
+
+    private fun count(sql: String, vararg values: String): Int = dataSource.connection.use { c ->
+        c.prepareStatement(sql).use { ps ->
+            values.forEachIndexed { index, value -> ps.setString(index + 1, value) }
+            ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) }
+        }
+    }
+
+    private fun execute(sql: String) =
+        dataSource.connection.use { c -> c.createStatement().use { it.execute(sql) } }
+
+    private fun assertEvent(principal: String, action: AuthzAction, resource: String, statement: String) {
+        val rows = dataSource.connection.use { c ->
+            c.prepareStatement(
+                """SELECT action, resource, statement, outcome, kind, channel, decision, datasource
+                   FROM audit_event WHERE principal=? AND resource=? AND statement=? ORDER BY id""",
+            ).use { ps ->
+                ps.setString(1, principal); ps.setString(2, resource); ps.setString(3, statement)
+                ps.executeQuery().use { rs ->
+                    buildList { while (rs.next()) add((1..8).map(rs::getString)) }
+                }
+            }
+        }
+        assertEquals(1, rows.size)
+        assertEquals(listOf(action.cedarId, resource, statement, "ALLOW", "admin", "console", "ALLOW", "control-plane"), rows.single())
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/McpServerDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/McpServerDbTest.kt
@@ -7,6 +7,7 @@ import com.ridi.oss.proxymonster.auth.pkceS256
 import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
 import com.ridi.oss.proxymonster.controlplane.management.DatasourceManagementService
 import com.ridi.oss.proxymonster.controlplane.management.IdentityManagementService
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
 import com.ridi.oss.proxymonster.controlplane.management.McpCapabilityRegistry
 import com.ridi.oss.proxymonster.controlplane.management.PolicyManagementService
 import com.ridi.oss.proxymonster.controlplane.mcp.installMcp
@@ -241,7 +242,7 @@ class McpServerDbTest {
         assertEquals(first.structuredContent, replay.structuredContent)
         assertEquals(1L, scalar("SELECT count(*) FROM app_role WHERE name=?", roleName))
         assertEquals(
-            listOf("ALLOW", "IDEMPOTENT_REPLAY"),
+            listOf("IDEMPOTENT_REPLAY"),
             strings(
                 """SELECT outcome FROM audit_event
                    WHERE principal=? AND statement='[MCP create_role]' ORDER BY id""",
@@ -254,6 +255,17 @@ class McpServerDbTest {
                 """SELECT DISTINCT channel FROM audit_event
                    WHERE principal=? AND statement='[MCP create_role]'""",
                 principal,
+            ),
+        )
+        // The config change itself is audited once, by the service, carrying the roles `authorize`
+        // resolved — the HTTP actor has no resolved set to carry, so this is what pins the difference.
+        assertEquals(
+            listOf("admin.policies|ALLOW|mcp|system:admin"),
+            strings(
+                """SELECT action || '|' || outcome || '|' || channel || '|' ||
+                          (SELECT string_agg(r, ',' ORDER BY r) FROM jsonb_array_elements_text(roles) r)
+                   FROM audit_event WHERE kind='admin' AND resource=? ORDER BY id""",
+                """Role::"$roleName"""",
             ),
         )
 
@@ -414,7 +426,8 @@ class McpServerDbTest {
             sdk.callTool("list_column_tags", mapOf("datasource" to "mcp-family-datasource")).structuredContent,
         ).getValue("result").jsonArray
         assertEquals("rrn", tags.single().jsonObject.getValue("column").jsonPrimitive.content)
-        assertEquals(8L, scalar("SELECT count(*) FROM audit_event WHERE principal=?", principal))
+        assertEquals(8L, scalar("SELECT count(*) FROM audit_event WHERE principal=? AND kind='admin'", principal))
+        assertEquals(0L, scalar("SELECT count(*) FROM audit_event WHERE principal=? AND statement LIKE '[MCP %'", principal))
     }
 
     @Test
@@ -511,16 +524,20 @@ class McpServerDbTest {
                WHERE principal=? AND statement='[MCP set_column_classifications]' ORDER BY id""",
             principal,
         )
-        assertEquals(5, details.size)
-        // The audit row names the columns; a bare count would leave an auditor unable to tell WHICH
-        // columns a batch tagged. It records each entry AS SUBMITTED — the same detail captions the
-        // failure rows, which have no resolved schema to report — so an unqualified entry stays
-        // unqualified, exactly as the single-column tool's `table=`/`column=` detail does.
-        assertContains(details.first(), "columns=3")
-        assertContains(details.first(), "users.rrn")
-        assertContains(details.first(), "public.users.email")
+        assertEquals(4, details.size)
+        // Failure rows retain the submitted detail because no resolved write exists.
+        assertContains(details.first(), "orders.buyer")
+        assertContains(details.first(), "orders.card")
+        val adminStatement = strings(
+            """SELECT statement FROM audit_event WHERE principal=? AND kind='admin'
+               AND resource='Datasource::"mcp-batch-datasource"' AND statement LIKE 'tag 3 columns%'""",
+            principal,
+        ).single()
+        assertContains(adminStatement, "public.users.email")
+        assertContains(adminStatement, "public.users.phone")
+        assertContains(adminStatement, "public.users.rrn")
         assertEquals(
-            listOf("ALLOW", "datasource.reserved_tag", "common.not_found", "datasource.duplicate_column", "mcp.invalid_request"),
+            listOf("datasource.reserved_tag", "common.not_found", "datasource.duplicate_column", "mcp.invalid_request"),
             strings(
                 """SELECT outcome FROM audit_event
                    WHERE principal=? AND statement='[MCP set_column_classifications]' ORDER BY id""",
@@ -776,11 +793,20 @@ class McpServerDbTest {
         )
         // The scope refusal above is audited too — a denied batch leaves a trail, it does not vanish.
         assertEquals(
-            listOf("mcp.insufficient_scope", "ALLOW", "IDEMPOTENT_REPLAY", "IDEMPOTENCY_CONFLICT"),
+            listOf("mcp.insufficient_scope", "IDEMPOTENT_REPLAY", "IDEMPOTENCY_CONFLICT"),
             strings(
                 """SELECT outcome FROM audit_event
                    WHERE principal=? AND statement='[MCP set_column_classifications]' ORDER BY id""",
                 principal,
+            ),
+        )
+        // One admin row across all four calls: only the first applied anything, and the replay and the
+        // conflict must not each look like another config change.
+        assertEquals(
+            1L,
+            scalar(
+                "SELECT count(*) FROM audit_event WHERE principal=? AND kind='admin' AND resource=?",
+                principal, """Datasource::"mcp-batch-scope-datasource"""",
             ),
         )
     }
@@ -799,7 +825,7 @@ class McpServerDbTest {
         )
         execute(
             """CREATE TRIGGER pm_test_fail_mcp_audit BEFORE INSERT ON audit_event
-               FOR EACH ROW WHEN (NEW.statement = '[MCP create_group]')
+               FOR EACH ROW WHEN (NEW.kind = 'admin' AND NEW.resource = 'Group::"must-roll-back-with-audit"')
                EXECUTE FUNCTION pm_test_fail_mcp_audit()""",
         )
         try {
@@ -817,11 +843,12 @@ class McpServerDbTest {
         trustedProxies: Set<String> = emptySet(),
     ) {
         install(ContentNegotiation) { json(TEST_JSON) }
-        val datasourceService = DatasourceManagementService(core.datasourceStore, core.proxyEventsHub, TableDetailService(core))
-        val policyService = PolicyManagementService(core.cedarPolicyStore, core.policyStore)
+        val recorder = ManagementAuditRecorder(core.auditStore)
+        val datasourceService = DatasourceManagementService(core.datasourceStore, core.proxyEventsHub, TableDetailService(core), recorder)
+        val policyService = PolicyManagementService(core.cedarPolicyStore, core.policyStore, recorder)
         val identityService = IdentityManagementService(
             dataSource, core.userGroupStore, core.policyStore, core.tokenStore, core.accessStore,
-            PrincipalSessionStore(dataSource, null),
+            PrincipalSessionStore(dataSource, null), recorder,
         )
         installMcp(config(mcpResource, trustedProxies), core, datasourceService, policyService, identityService)
     }
@@ -885,16 +912,16 @@ class McpServerDbTest {
         }
     }
 
-    private fun scalar(sql: String, value: String): Long = dataSource.connection.use { connection ->
+    private fun scalar(sql: String, vararg values: String): Long = dataSource.connection.use { connection ->
         connection.prepareStatement(sql).use { statement ->
-            statement.setString(1, value)
+            values.forEachIndexed { index, value -> statement.setString(index + 1, value) }
             statement.executeQuery().use { result -> result.next(); result.getLong(1) }
         }
     }
 
-    private fun strings(sql: String, value: String): List<String> = dataSource.connection.use { connection ->
+    private fun strings(sql: String, vararg values: String): List<String> = dataSource.connection.use { connection ->
         connection.prepareStatement(sql).use { statement ->
-            statement.setString(1, value)
+            values.forEachIndexed { index, value -> statement.setString(index + 1, value) }
             statement.executeQuery().use { result ->
                 buildList { while (result.next()) add(result.getString(1)) }
             }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/UserAdminDeprovisionDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/UserAdminDeprovisionDbTest.kt
@@ -1,6 +1,9 @@
 package com.ridi.oss.proxymonster.controlplane
 
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import com.ridi.oss.proxymonster.controlplane.management.AuditSource
 import com.ridi.oss.proxymonster.controlplane.management.IdentityManagementService
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
 import org.flywaydb.core.Flyway
@@ -35,6 +38,7 @@ class UserAdminDeprovisionDbTest {
     private lateinit var daemonSessionStore: PrincipalSessionStore
     private lateinit var policyStore: PolicyStore
     private lateinit var management: IdentityManagementService
+    private val actor = AuditActor("admin@example.com", channel = AuditSource.CONSOLE)
 
     @BeforeAll
     fun setup() {
@@ -48,7 +52,7 @@ class UserAdminDeprovisionDbTest {
         daemonSessionStore = PrincipalSessionStore(ds, null)
         policyStore = PolicyStore(ds)
         management = IdentityManagementService(
-            ds, userGroupStore, policyStore, tokenStore, accessStore, daemonSessionStore,
+            ds, userGroupStore, policyStore, tokenStore, accessStore, daemonSessionStore, ManagementAuditRecorder(AuditStore(ds)),
         )
     }
 
@@ -242,7 +246,7 @@ class UserAdminDeprovisionDbTest {
             tokenStore, accessStore, daemonSessionStore,
         )
 
-        assertTrue(management.deprovisionUser(original.id).deleted)
+        assertTrue(management.deprovisionUser(original.id, actor).deleted)
         val addressed = assertNotNull(userGroupStore.getUser(original.id))
         assertEquals("id-stable-after@example.com", addressed.principal)
         assertFalse(addressed.active)
@@ -257,7 +261,7 @@ class UserAdminDeprovisionDbTest {
         val executor = Executors.newFixedThreadPool(2)
         try {
             val futures = listOf(first, second).map { role ->
-                executor.submit<Unit> { start.await(); management.addGroupRole(group.id, role.id) }
+                executor.submit<Unit> { start.await(); management.addGroupRole(group.id, role.id, actor) }
             }
             start.countDown()
             futures.forEach { it.get() }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/AuditChain.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/AuditChain.kt
@@ -1,0 +1,109 @@
+package com.ridi.oss.proxymonster.controlplane.support
+
+import com.ridi.oss.proxymonster.controlplane.AuditCanonical
+import com.ridi.oss.proxymonster.controlplane.AuditEvent
+import com.ridi.oss.proxymonster.controlplane.Decision
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import javax.sql.DataSource
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+private val json = Json
+private val stringList = ListSerializer(String.serializer())
+
+/** The `prev_hash` the first chained row links to, seeded by the audit migration. */
+private val genesis = "88d4f4719f26cf7f32839ac30b1d6a94edf3f9133fb75667d1415fff81bbcd08".hexBytes()
+
+/**
+ * Recompute the whole audit hash chain from the stored rows and assert it still reproduces itself, then
+ * assert the head row points at the last one. Any test that writes audit rows can call this to prove the
+ * rows it added are genuinely chained rather than merely present — a broken link, an altered field, or a
+ * head left behind all surface as a failure here.
+ */
+internal fun verifyAuditChain(dataSource: DataSource) {
+    val rows = readRows(dataSource)
+    val chainStartId = dataSource.connection.use { connection ->
+        connection.prepareStatement("SELECT COALESCE(MIN(id), 1) FROM audit_event WHERE row_hash IS NOT NULL").use { statement ->
+            statement.executeQuery().use { result -> result.next(); result.getLong(1) }
+        }
+    }
+    val baseLastId = chainStartId - 1
+    rows.forEachIndexed { index, row ->
+        val expectedPrev = if (index == 0) genesis else rows[index - 1].rowHash
+        assertContentEquals(expectedPrev, row.prevHash, "chain link at ${row.id}")
+        assertEquals(AuditCanonical.CHAIN_VERSION, row.chainVersion, "chain version at ${row.id}")
+        assertContentEquals(
+            AuditCanonical.rowHash(row.id, row.event, row.tsMicros, row.prevHash),
+            row.rowHash,
+            "row hash at ${row.id}",
+        )
+    }
+    val head = auditChainHead(dataSource)
+    assertEquals(rows.lastOrNull()?.id ?: baseLastId, head.first)
+    if (rows.isEmpty()) assertContentEquals(genesis, head.second) else assertContentEquals(rows.last().rowHash, head.second)
+}
+
+private fun readRows(dataSource: DataSource): List<PersistedRow> = dataSource.connection.use { connection ->
+    connection.prepareStatement(
+        """SELECT id, ts, principal, roles, datasource, client_addr, statement, decision, failed_stage,
+                  effective_namespace, masked_columns, pii_touched, latency_ms, detail, channel, context_tags,
+                  action, resource, outcome, kind, rows_returned, bytes_returned, decision_id,
+                  chain_version, prev_hash, row_hash
+           FROM audit_event WHERE row_hash IS NOT NULL ORDER BY id""",
+    ).use { statement ->
+        statement.executeQuery().use { result ->
+            buildList {
+                while (result.next()) {
+                    val instant = result.getTimestamp("ts").toInstant()
+                    val event = AuditEvent(
+                        id = result.getLong("id"), ts = instant.toString(), principal = result.getString("principal"),
+                        roles = decodeArray(result.getString("roles")), datasource = result.getString("datasource"),
+                        clientAddr = result.getString("client_addr"), statement = result.getString("statement"),
+                        decision = Decision.valueOf(result.getString("decision")), failedStage = result.getString("failed_stage"),
+                        effectiveNamespace = decodeArray(result.getString("effective_namespace")),
+                        maskedColumns = decodeArray(result.getString("masked_columns")),
+                        piiTouched = decodeArray(result.getString("pii_touched")),
+                        latencyMs = result.getLong("latency_ms"), detail = result.getString("detail"),
+                        channel = result.getString("channel"), contextTags = decodeArray(result.getString("context_tags")),
+                        authzAction = result.getString("action"), authzResource = result.getString("resource"),
+                        outcome = result.getString("outcome"), kind = result.getString("kind"),
+                        rowsReturned = result.longOrNull("rows_returned"),
+                        bytesReturned = result.longOrNull("bytes_returned"),
+                        decisionId = result.longOrNull("decision_id"),
+                    )
+                    add(
+                        PersistedRow(
+                            event.id!!, AuditCanonical.epochMicros(instant), event,
+                            result.getInt("chain_version"), result.getBytes("prev_hash"), result.getBytes("row_hash"),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}
+
+internal fun auditChainHead(dataSource: DataSource): Pair<Long, ByteArray> = dataSource.connection.use { connection ->
+    connection.prepareStatement("SELECT last_id, head_hash FROM audit_chain_head WHERE id = 1").use { statement ->
+        statement.executeQuery().use { result -> result.next(); result.getLong(1) to result.getBytes(2) }
+    }
+}
+
+private fun decodeArray(value: String?): List<String> = json.decodeFromString(stringList, value ?: "[]")
+
+private fun java.sql.ResultSet.longOrNull(column: String): Long? =
+    getLong(column).let { if (wasNull()) null else it }
+
+private fun String.hexBytes(): ByteArray =
+    ByteArray(length / 2) { index -> substring(index * 2, index * 2 + 2).toInt(16).toByte() }
+
+private data class PersistedRow(
+    val id: Long,
+    val tsMicros: Long,
+    val event: AuditEvent,
+    val chainVersion: Int,
+    val prevHash: ByteArray,
+    val rowHash: ByteArray,
+)


### PR DESCRIPTION
## What

Config changes made through the HTTP admin API / console were unaudited, while
their MCP-tool twins were logged. This emits a `kind="admin"` audit event for
every config mutation — policy, role, role-assignment, mask-fn, user, group,
group-member, group-role, datasource, and column-classification CRUD — at the
shared `ManagementServices` connection overloads where the HTTP and MCP paths
converge. A change is recorded **once**, the same way, whichever transport made it.

## Why it's safe

- **Atomic**: the audit row is written on the mutation's own transaction, so it
  commits and rolls back with the change. A recorded row is a change that
  happened; an idempotent no-op (re-add / re-assign an existing mapping) writes
  nothing.
- **No double-log**: MCP's own success-audit write is removed — MCP now records
  through the same service chokepoint, and its rows carry the real target entity
  instead of `System::"system"`. Failure / denial / idempotency-replay MCP rows
  are retained.
- **No schema or hash-chain change**: new events reuse the existing `AuditEvent`
  fields; the tamper-evident chain and its canonical encoder are untouched.

## Scope / non-obvious

- The narrow SYSTEM-policy-toggle audit in `CedarPolicyStore` is folded into the
  service, so it is no longer a special case.
- HTTP admin rows carry the actor's principal but leave `roles` empty (MCP rows
  carry the resolved set) — deliberate, to keep a role resolver out of the routes.
- **Authentication/session events (logins, token mint/revoke, SCIM) are a
  separate change** — this is config changes only.

## Tests

DB-backed (`ManagementAuditDbTest`): every op audits exactly once via both the
service (HTTP) and MCP paths, rolls back atomically when the audit insert fails,
records nothing on a no-op, and the audit hash chain re-verifies after each case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qwri6K4wyMaD1vKYbzQTqz
