### PR TITLE
feat(control-plane): audit authentication and session events

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -79,6 +79,27 @@ control-plane store, which is PostgreSQL only and carries no portability caveat
   `revokeActiveCredentialsTx` revokes the wire tokens outright. Detail:
   [`docs/auth-model.md`](./docs/auth-model.md#security-invariants).
 
+## Audit trail
+
+- 🟡 A rejected wire-token validation is recorded without a source address. The
+  `kind="auth"` event for an invalid, expired, revoked, or deprovisioned wire
+  credential is written from the gRPC `ValidateToken` handler, and that request
+  carries only the token and the datasource name — the end client's address
+  never reaches the control plane, because the proxy holds the socket. The event
+  still names the datasource and, where the token resolved, the principal, so a
+  repeated-failure signal is available per principal but not per source address.
+  Closing this needs a client-address field on `ValidateTokenRequest`, tracked
+  in [`docs/backlog.md`](./docs/backlog.md).
+
+- 🟡 OIDC group reconciliation is not part of the login-audit transaction. On a
+  successful login the session mint and its `auth.oidc.login` event commit
+  together, but the preceding `provisionFromOidc` — adding and removing local
+  group memberships to match the IdP claim — commits on its own connection
+  first. It is directory reconciliation, not the login event, so a session mint
+  that then fails leaves the reconciled membership in place; the next login
+  re-reconciles it. Membership changes are covered by the `admin` config-change
+  trail, not the `auth` login event.
+
 ## Identifier handling (schema-aware enforcement)
 
 - 🟡 Identifiers containing `.` or `/` cannot be authorized normally. Both are

--- a/auth/src/main/kotlin/com/ridi/oss/proxymonster/auth/McpOAuth.kt
+++ b/auth/src/main/kotlin/com/ridi/oss/proxymonster/auth/McpOAuth.kt
@@ -164,7 +164,15 @@ class OAuthAuthorizationStore(private val dataSource: DataSource) {
         return code
     }
 
-    fun consumeAuthorizationCode(input: ConsumeAuthorizationCodeInput): OAuthTokenPair? = inTransaction { connection ->
+    /**
+     * [onCommit] runs inside this transaction after the grant succeeds and before commit, so a caller can
+     * write an audit row that commits or rolls back WITH the grant — a rejected audit leaves the code
+     * unconsumed and the client retries cleanly.
+     */
+    fun consumeAuthorizationCode(
+        input: ConsumeAuthorizationCodeInput,
+        onCommit: ((Connection) -> Unit)? = null,
+    ): OAuthTokenPair? = inTransaction { connection ->
         val row = connection.prepareStatement(
             """SELECT id, principal, client_id, redirect_uri, resource, scope, code_challenge, consent_id
                FROM oauth_authorization_code
@@ -202,7 +210,7 @@ class OAuthAuthorizationStore(private val dataSource: DataSource) {
         if (!consentActive(connection, row.consentId, row.principal, row.clientId, row.resource, row.scope)) {
             return@inTransaction null
         }
-        issuePair(
+        val pair = issuePair(
             connection = connection,
             principal = row.principal,
             clientId = row.clientId,
@@ -214,9 +222,21 @@ class OAuthAuthorizationStore(private val dataSource: DataSource) {
             refreshTtlSeconds = input.refreshTtlSeconds,
             rotatedFrom = null,
         )
+        onCommit?.invoke(connection)
+        pair
     }
 
-    fun rotateRefresh(input: RefreshTokenInput): OAuthTokenPair? = inTransaction { connection ->
+    /**
+     * [onCommit] runs inside this transaction on the SUCCESS (rotation) path; [onReplayRevoke] runs when a
+     * replayed (already-rotated) refresh token forces its family to be revoked — a real revocation that
+     * commits, so its audit row must commit with it. Both are invoked before commit, keyed by the presented
+     * token's id.
+     */
+    fun rotateRefresh(
+        input: RefreshTokenInput,
+        onCommit: ((Connection) -> Unit)? = null,
+        onReplayRevoke: ((Connection, Long) -> Unit)? = null,
+    ): OAuthTokenPair? = inTransaction { connection ->
         val row = connection.prepareStatement(
             """SELECT id, kind, principal, client_id, resource, scope, refresh_family, consent_id,
                       revoked_at, expires_at, rotated_at
@@ -241,7 +261,7 @@ class OAuthAuthorizationStore(private val dataSource: DataSource) {
         }
         if (row.clientId != input.clientId || row.resource != input.resource) return@inTransaction null
         if (row.rotated) {
-            revokeFamily(connection, row.family)
+            if (revokeFamily(connection, row.family) > 0) onReplayRevoke?.invoke(connection, row.id)
             return@inTransaction null
         }
         if (row.revoked || row.expired ||
@@ -251,7 +271,7 @@ class OAuthAuthorizationStore(private val dataSource: DataSource) {
             statement.setLong(1, row.id)
             if (statement.executeUpdate() != 1) return@inTransaction null
         }
-        issuePair(
+        val pair = issuePair(
             connection = connection,
             principal = row.principal,
             clientId = row.clientId,
@@ -263,9 +283,19 @@ class OAuthAuthorizationStore(private val dataSource: DataSource) {
             refreshTtlSeconds = input.refreshTtlSeconds,
             rotatedFrom = row.id,
         )
+        onCommit?.invoke(connection)
+        pair
     }
 
-    fun rememberConsent(principal: String, clientId: String, resource: String, scopes: Collection<String>): OAuthConsent =
+    /** [onCommit] runs inside this transaction with the consent id, so a caller's consent-grant audit commits
+     *  or rolls back with the consent. */
+    fun rememberConsent(
+        principal: String,
+        clientId: String,
+        resource: String,
+        scopes: Collection<String>,
+        onCommit: ((Connection, Long) -> Unit)? = null,
+    ): OAuthConsent =
         inTransaction { connection ->
             val canonical = canonicalScopes(scopes)
             val id = connection.prepareStatement(
@@ -281,7 +311,7 @@ class OAuthAuthorizationStore(private val dataSource: DataSource) {
                 statement.setString(4, canonical)
                 statement.executeQuery().use { result -> result.next(); result.getLong(1) }
             }
-            consent(connection, id)!!
+            consent(connection, id)!!.also { onCommit?.invoke(connection, id) }
         }
 
     fun findActiveConsent(principal: String, clientId: String, resource: String, scopes: Collection<String>): OAuthConsent? =
@@ -309,7 +339,9 @@ class OAuthAuthorizationStore(private val dataSource: DataSource) {
         }
     }
 
-    fun revokeConsent(id: Long, principal: String): Boolean = inTransaction { connection ->
+    /** [onCommit] runs inside this transaction with the consent id when the revocation actually transitions a
+     *  row, so a caller's revoke audit commits with the consent + token revocation. */
+    fun revokeConsent(id: Long, principal: String, onCommit: ((Connection, Long) -> Unit)? = null): Boolean = inTransaction { connection ->
         val updated = connection.prepareStatement(
             "UPDATE oauth_consent SET revoked_at = now(), updated_at = now() WHERE id = ? AND principal = ? AND revoked_at IS NULL",
         ).use { statement ->
@@ -321,23 +353,36 @@ class OAuthAuthorizationStore(private val dataSource: DataSource) {
         connection.prepareStatement(
             "UPDATE proxy_token SET revoked_at = COALESCE(revoked_at, now()) WHERE consent_id = ? AND kind IN ('MCP_ACCESS', 'MCP_REFRESH')",
         ).use { statement -> statement.setLong(1, id); statement.executeUpdate() }
+        onCommit?.invoke(connection, id)
         true
     }
 
-    /** RFC 7009: access closes only itself; refresh closes its entire rotation family. */
-    fun revoke(token: String) = inTransaction { connection ->
-        val row = connection.prepareStatement(
+    /**
+     * RFC 7009: access closes only itself; refresh closes its entire rotation family. Returns the presented
+     * token's id when this call actually closed something, null when it resolved to nothing or to a token
+     * already revoked. The caller answers 200 either way (RFC 7009 §2.2 forbids distinguishing the cases to
+     * the client), but the endpoint is unauthenticated, so a caller replaying one once-valid token must not
+     * be able to append a revocation record per call.
+     */
+    fun revoke(token: String, onCommit: ((Connection, Long) -> Unit)? = null): Long? = inTransaction { connection ->
+        val (id, kind, family) = connection.prepareStatement(
             "SELECT id, kind, refresh_family FROM proxy_token WHERE token_hash = ? FOR UPDATE",
         ).use { statement ->
             statement.setString(1, sha256Hex(token))
             statement.executeQuery().use { result ->
                 if (result.next()) Triple(result.getLong(1), result.getString(2), result.getString(3)) else null
             }
-        } ?: return@inTransaction Unit
-        if (row.second == MCP_REFRESH_KIND) revokeFamily(connection, row.third)
-        else if (row.second == MCP_ACCESS_KIND) connection.prepareStatement(
-            "UPDATE proxy_token SET revoked_at = COALESCE(revoked_at, now()) WHERE id = ?",
-        ).use { statement -> statement.setLong(1, row.first); statement.executeUpdate() }
+        } ?: return@inTransaction null
+        val closed = when (kind) {
+            MCP_REFRESH_KIND -> revokeFamily(connection, family)
+            MCP_ACCESS_KIND -> connection.prepareStatement(
+                "UPDATE proxy_token SET revoked_at = now() WHERE id = ? AND revoked_at IS NULL",
+            ).use { statement -> statement.setLong(1, id); statement.executeUpdate() }
+            else -> 0
+        }
+        // [onCommit] runs inside this transaction only when a token actually closed, so the revoke audit
+        // commits with the revocation (RFC 7009 still answers 200 regardless — the caller absorbs a throw).
+        id.takeIf { closed > 0 }?.also { onCommit?.invoke(connection, it) }
     }
 
     private fun issuePair(
@@ -391,10 +436,13 @@ class OAuthAuthorizationStore(private val dataSource: DataSource) {
         }
     }
 
-    private fun revokeFamily(connection: Connection, family: String?) {
-        if (family == null) return
-        connection.prepareStatement(
-            "UPDATE proxy_token SET revoked_at = COALESCE(revoked_at, now()) WHERE refresh_family = ? AND kind IN ('MCP_ACCESS', 'MCP_REFRESH')",
+    /** Closes every still-open token in [family] and returns how many that was — an already-closed family
+     *  keeps its original timestamps and reports 0, which is how a caller tells a real revocation from a replay. */
+    private fun revokeFamily(connection: Connection, family: String?): Int {
+        if (family == null) return 0
+        return connection.prepareStatement(
+            """UPDATE proxy_token SET revoked_at = now()
+               WHERE refresh_family = ? AND kind IN ('MCP_ACCESS', 'MCP_REFRESH') AND revoked_at IS NULL""",
         ).use { statement -> statement.setString(1, family); statement.executeUpdate() }
     }
 

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -16,6 +16,7 @@ import com.ridi.oss.proxymonster.controlplane.management.IdentityManagementServi
 import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
 import com.ridi.oss.proxymonster.controlplane.management.ManagementException
 import com.ridi.oss.proxymonster.controlplane.management.PolicyManagementService
+import com.ridi.oss.proxymonster.controlplane.management.auditEntity
 import com.ridi.oss.proxymonster.controlplane.mcp.installMcp
 import com.ridi.oss.proxymonster.controlplane.oauth.MCP_OAUTH_PENDING_COOKIE
 import com.ridi.oss.proxymonster.controlplane.oauth.McpPendingAuthorization
@@ -440,7 +441,7 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
             runCatching {
                 sweepSessionLiveness(
                     config, discovery, validator, oidcHttp, principalSessionStore, userGroupStore,
-                    roleResolver, environment.log,
+                    roleResolver, core.authAudit, environment.log,
                 )
             }.onFailure { environment.log.warn("session liveness sweep failed", it) }
         }
@@ -617,18 +618,18 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
         // OIDC authorization-code routes (/auth/oidc/login, /auth/oidc/callback).
         oidcRoutes(
             config, discovery, validator, oidcHttp, userGroupStore, roleResolver, principalSessionStore,
-            this@module.environment.log,
+            core.authAudit, this@module.environment.log,
         )
 
         // OAuth 2.1/CIMD authorization-server routes share this process, origin, DB pool, OIDC login,
         // and signed user session with the control plane. There is no service-to-service auth hop.
-        mcpOAuthRoutes(config, dataSource, principalSessionStore)
+        mcpOAuthRoutes(config, dataSource, principalSessionStore, core.authAudit)
 
         // CLI/daemon login surface: /auth/device/start + /poll (pmon), the /device verification page + its
         // SSO/debug choices, and /auth/session/renew (docs/auth-model.md "CLI / daemon login").
         deviceSessionRoutes(
             config, deviceLoginStore, principalSessionStore,
-            tokenStore, userGroupStore, this@module.environment.log,
+            tokenStore, userGroupStore, core.authAudit, this@module.environment.log,
         )
 
         // SCIM 2.0 provisioning (docs/auth-model.md "SCIM 2.0 provisioning") — bearer+TLS gated,
@@ -678,7 +679,7 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
         queryHistoryRoutes(config, queryHistoryStore)
 
         // Wire-auth: SESSION/PAT token issuance + revocation.
-        tokenRoutes(config, tokenStore, userGroupStore, authz)
+        tokenRoutes(config, tokenStore, userGroupStore, authz, core.authAudit)
 
         // Cedar policy admin: put/enable/disable + validate-on-write. Admin-gated: admin.policies.
         cedarPolicyRoutes(config, authz, cedarPolicyStore, policyManagement)
@@ -804,6 +805,28 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
             if (request?.sessionId != null && currentRef != null && currentRef.sessionId != request.sessionId) {
                 call.respond(HttpStatusCode.OK, LogoutResponse(ended = false))
                 return@post
+            }
+            // Ends the row here rather than leaving it to the cookie-storage invalidate below, so the end and
+            // its audit record share one transaction. Keyed off the session REF, not the resolved row: a
+            // session past its idle deadline no longer resolves yet is still ended by a logout, and that
+            // termination has to appear in the trail like any other. The invalidate then no-ops on the
+            // already-ended row, so exactly one event is written.
+            if (currentRef != null) {
+                // Resolved BEFORE the transaction: under the debug bypass this reads the web session, and
+                // that read can itself write (the device-binding mismatch end) on a second connection —
+                // which would then block on the row this transaction has already locked.
+                val clientAddr = call.httpRequesterIp(config)
+                principalSessionStore.dataSource.inTx { c ->
+                    principalSessionStore.endWebOwner(currentRef.sessionId, ENDED_SIGNED_OUT, c)?.let { owner ->
+                        core.authAudit.success(
+                            c,
+                            AuditActor(owner, clientAddr = clientAddr, channel = AuthAuditRecorder.CHANNEL_SESSION),
+                            AuthAuditRecorder.ACTION_LOGOUT,
+                            auditEntity("Session", currentRef.sessionId.toString()),
+                            "Web session signed out",
+                        )
+                    }
+                }
             }
             call.sessions.clear(SESSION_COOKIE)
             call.respond(HttpStatusCode.OK, LogoutResponse(ended = true))

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/AuthAudit.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/AuthAudit.kt
@@ -1,0 +1,131 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import java.sql.Connection
+
+private const val MAX_AUDITED_VALUE_CHARS = 200
+
+/**
+ * Bound a caller-supplied value before it reaches an audit row. Rejection paths run before any validation,
+ * and several of them (the OIDC callback, wire-token validation) are reachable unauthenticated — without a
+ * bound the caller chooses how much of a tamper-evident, SIEM-exported chain each attempt consumes.
+ */
+internal fun auditedValue(raw: String): String = raw.take(MAX_AUDITED_VALUE_CHARS)
+
+/**
+ * Writes a `kind="auth"` authentication/session-lifecycle event through the one [AuditStore] chain
+ * chokepoint, alongside [com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder]'s
+ * `kind="admin"` config-change events.
+ *
+ * Pass the caller's transaction as `c` whenever the event accompanies a state change (a session minted,
+ * a token revoked) so the two commit or roll back together. `c = null` writes standalone, which is for
+ * the stateless rejections — a bad `state` parameter, an invalid wire token — that change nothing and so
+ * have no transaction to join.
+ *
+ * Successful wire-token validation is deliberately NOT recorded here: it runs on every connection and
+ * query, the per-query decision is already audited by the data plane, and the volume would bury the
+ * rejected attempts this trail exists to surface.
+ */
+class AuthAuditRecorder(private val auditStore: AuditStore) {
+    private val log = org.slf4j.LoggerFactory.getLogger(AuthAuditRecorder::class.java)
+
+    fun success(
+        c: Connection?,
+        actor: AuditActor,
+        action: String,
+        resource: String,
+        summary: String,
+        detail: String? = null,
+    ) {
+        record(c, actor, action, resource, summary, detail, Decision.ALLOW, OUTCOME_SUCCESS)
+    }
+
+    fun failure(
+        c: Connection?,
+        actor: AuditActor,
+        action: String,
+        resource: String,
+        summary: String,
+        detail: String? = null,
+    ) {
+        record(c, actor, action, resource, summary, detail, Decision.DENY, OUTCOME_FAILURE)
+    }
+
+    /**
+     * Record a standalone rejection/failure event best-effort. A rejection accompanies no state change, so a
+     * failed audit insert must never change the caller's outcome — turn an UNAUTHENTICATED into an INTERNAL,
+     * or a redirect into a 500. Logs and swallows an insert failure. For `c == null` events only; an event
+     * that accompanies a committed mutation MUST use [success]/[failure] on the caller's transaction so the
+     * two commit or roll back together.
+     */
+    fun failureBestEffort(
+        actor: AuditActor,
+        action: String,
+        resource: String,
+        summary: String,
+        detail: String? = null,
+    ) {
+        runCatching { record(null, actor, action, resource, summary, detail, Decision.DENY, OUTCOME_FAILURE) }
+            .onFailure { log.warn("best-effort auth failure audit insert failed (action={})", action, it) }
+    }
+
+    private fun record(
+        c: Connection?,
+        actor: AuditActor,
+        action: String,
+        resource: String,
+        summary: String,
+        detail: String?,
+        decision: Decision,
+        outcome: String,
+    ) {
+        val event = AuditEvent(
+            principal = actor.principal,
+            roles = actor.roles,
+            datasource = DATASOURCE,
+            clientAddr = actor.clientAddr,
+            statement = summary,
+            decision = decision,
+            detail = detail,
+            channel = actor.channel,
+            authzAction = action,
+            authzResource = resource,
+            outcome = outcome,
+            kind = KIND_AUTH,
+        )
+        if (c == null) auditStore.insert(event) else auditStore.insert(c, event)
+    }
+
+    companion object {
+        const val KIND_AUTH = "auth"
+        const val OUTCOME_SUCCESS = "SUCCESS"
+        const val OUTCOME_FAILURE = "FAILURE"
+
+        /** The `principal` of an event no identity can be attributed to — a credential that did not resolve,
+         *  or a grant redeemed by a client rather than a user. `principal` is NOT NULL, so absence needs a
+         *  value; one shared literal keeps "unattributed" a queryable state instead of a per-site spelling. */
+        const val PRINCIPAL_UNATTRIBUTED = "unknown"
+
+        const val CHANNEL_OIDC = "oidc"
+        const val CHANNEL_WIRE = "wire"
+        const val CHANNEL_DEVICE = "device"
+        const val CHANNEL_PMON = "pmon"
+        const val CHANNEL_OAUTH = "oauth"
+        const val CHANNEL_SESSION = "session"
+
+        const val ACTION_OIDC_LOGIN = "auth.oidc.login"
+        const val ACTION_LOGOUT = "auth.logout"
+        const val ACTION_DEVICE_APPROVE = "auth.device.approve"
+        const val ACTION_DEVICE_MINT = "auth.device.mint"
+        const val ACTION_SESSION_RENEW = "auth.session.renew"
+        const val ACTION_SESSION_EXPIRE = "auth.session.expire"
+        const val ACTION_WIRE_VALIDATE = "auth.wire.validate"
+        const val ACTION_TOKEN_MINT = "auth.token.mint"
+        const val ACTION_TOKEN_REVOKE = "auth.token.revoke"
+        const val ACTION_OAUTH_CONSENT = "auth.oauth.consent"
+        const val ACTION_OAUTH_TOKEN = "auth.oauth.token"
+        const val ACTION_OAUTH_REVOKE = "auth.oauth.revoke"
+
+        private const val DATASOURCE = "control-plane"
+    }
+}

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ControlPlaneCore.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ControlPlaneCore.kt
@@ -22,6 +22,7 @@ import javax.sql.DataSource
  */
 class ControlPlaneCore(val dataSource: DataSource) {
     val auditStore = AuditStore(dataSource)
+    val authAudit = AuthAuditRecorder(auditStore)
     val datasourceStore = DatasourceStore(dataSource)
     val policyStore = PolicyStore(dataSource)
     val accessStore = AccessStore(dataSource)

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/DaemonSession.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/DaemonSession.kt
@@ -1,5 +1,11 @@
 package com.ridi.oss.proxymonster.controlplane
 
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.ACTION_SESSION_EXPIRE
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.ACTION_SESSION_RENEW
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.CHANNEL_PMON
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.CHANNEL_SESSION
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import com.ridi.oss.proxymonster.controlplane.management.auditEntity
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.ClientRequestException
@@ -279,11 +285,18 @@ class PrincipalSessionStore(
         }
     }
 
-    fun endWeb(id: Long, reason: String, c: Connection? = null): Boolean {
+    fun endWeb(id: Long, reason: String, c: Connection? = null): Boolean = endWebOwner(id, reason, c) != null
+
+    /**
+     * [endWeb], returning the principal whose session this ended (null when nothing transitioned) — the owner
+     * an audit record must name, which the caller may no longer be able to resolve: a row past its idle
+     * deadline still ends here but no longer resolves as a session.
+     */
+    fun endWebOwner(id: Long, reason: String, c: Connection? = null): String? {
         // The cleanup callback runs on the SAME connection as the end-write (see [onWebSessionEnded]), so when
         // [c] is a caller's transaction the delete composes with it; when null it shares this auto-commit
         // connection. Invoked inside the .use block so the connection is still open.
-        val useConnection: (Connection) -> Boolean = { connection ->
+        val useConnection: (Connection) -> String? = { connection ->
             val principal = connection.prepareStatement(
                 """UPDATE principal_session
                    SET ended_at = now(), ended_reason = ?, liveness_status = ?
@@ -296,7 +309,7 @@ class PrincipalSessionStore(
                 ps.executeQuery().use { rs -> if (rs.next()) rs.getString(1) else null }
             }
             if (principal != null) onWebSessionEnded?.invoke(principal, connection)
-            principal != null
+            principal
         }
         return if (c == null) dataSource.connection.use(useConnection) else useConnection(c)
     }
@@ -459,8 +472,9 @@ class PrincipalSessionStore(
             ps.executeUpdate()
         }
 
-    /** Close only the specified daemon session's still-open renewal window. */
-    fun closeDaemonWindow(id: Long) = dataSource.connection.use { c ->
+    /** Close only the specified daemon session's still-open renewal window, on the caller's connection [c].
+     *  Returns the count closed, so a caller can tell a real close from a repeat on an already-closed one. */
+    fun closeDaemonWindow(id: Long, c: Connection): Int =
         c.prepareStatement(
             """UPDATE principal_session
                SET liveness_status = ?, absolute_expires_at = now()
@@ -470,7 +484,6 @@ class PrincipalSessionStore(
             ps.setLong(2, id)
             ps.executeUpdate()
         }
-    }
 
     /** End every active web session for [principal], on a fresh connection. Already-ended rows remain unchanged. */
     fun endAllWebForPrincipal(principal: String, reason: String): Int =
@@ -632,9 +645,11 @@ class PrincipalSessionStore(
  * of someone's principal string must never be enough to mint them a fresh wire token.
  */
 internal fun Route.sessionRenewRoutes(
+    config: Config,
     daemonSessionStore: PrincipalSessionStore,
     tokenStore: TokenStore,
     userGroupStore: UserGroupStore,
+    authAudit: AuthAuditRecorder,
 ) {
     post("/auth/session/renew") {
         val authHeader = call.request.headers["Authorization"]
@@ -648,12 +663,24 @@ internal fun Route.sessionRenewRoutes(
             call.respond(HttpStatusCode.Unauthorized, ApiError("common.unauthenticated"))
             return@post
         }
+        val clientAddr = call.httpRequesterIp(config)
         // Re-check and mint under the per-principal advisory lock, not against [row]'s pre-lock
         // snapshot. Every fail-closed decision is repeated on the locked connection before issuance.
         val issued = daemonSessionStore.renewLocked(
             row,
             isDeactivated = { principal, c -> userGroupStore.isDeactivated(principal, c) },
-            mint = { fresh, c -> tokenStore.issue(TokenKind.SESSION, fresh.principal, emptyList(), name = null, ttlSeconds = fresh.ttlSeconds, c) },
+            mint = { fresh, c ->
+                tokenStore.issue(TokenKind.SESSION, fresh.principal, emptyList(), name = null, ttlSeconds = fresh.ttlSeconds, c)
+                    .also { token ->
+                        authAudit.success(
+                            c,
+                            AuditActor(fresh.principal, clientAddr = clientAddr, channel = CHANNEL_PMON),
+                            ACTION_SESSION_RENEW,
+                            auditEntity("Token", token.id.toString()),
+                            "Daemon session renewed SESSION token",
+                        )
+                    }
+            },
         )
         if (issued == null) {
             call.respond(HttpStatusCode.Unauthorized, ApiError("auth.session_window_expired"))
@@ -680,12 +707,15 @@ suspend fun sweepSessionLiveness(
     sessionStore: PrincipalSessionStore,
     userGroupStore: UserGroupStore,
     roleResolver: RoleResolver,
+    authAudit: AuthAuditRecorder,
     log: Logger,
 ) {
     if (config.oidc == null || discovery == null) return
     for (row in sessionStore.staleSessions(config.idpRecheckIntervalSeconds)) {
         runCatching {
-            revalidateSession(row, config, discovery, validator, http, sessionStore, userGroupStore, roleResolver, log)
+            revalidateSession(
+                row, config, discovery, validator, http, sessionStore, userGroupStore, roleResolver, authAudit, log,
+            )
         }.onFailure { log.warn("IdP liveness sweep failed for {} session {}", row.principal, row.id, it) }
     }
 }
@@ -704,6 +734,7 @@ private suspend fun revalidateSession(
     sessionStore: PrincipalSessionStore,
     userGroupStore: UserGroupStore,
     roleResolver: RoleResolver,
+    authAudit: AuthAuditRecorder,
     log: Logger,
 ) {
     val oidc = config.oidc ?: return
@@ -738,16 +769,48 @@ private suspend fun revalidateSession(
                 // Reconciliation is principal-global, so a zero-role verdict ends every live web
                 // session for the principal regardless of which kind produced this candidate. Daemon
                 // rows stay open; each daemon query re-resolves roles and fail-closes on its own.
-                sessionStore.endAllWebForPrincipal(row.principal, ENDED_GROUP_REVOKED)
+                sessionStore.dataSource.inTx { c ->
+                    val ended = sessionStore.endAllWebForPrincipal(row.principal, ENDED_GROUP_REVOKED, c)
+                    if (ended > 0) {
+                        authAudit.success(
+                            c,
+                            AuditActor(row.principal, clientAddr = null, channel = CHANNEL_SESSION),
+                            ACTION_SESSION_EXPIRE,
+                            auditEntity("User", row.principal),
+                            "IdP liveness ended $ended web session(s)",
+                            detail = "group_revoked",
+                        )
+                    }
+                }
             }
             sessionStore.markCheck(row.id, LIVENESS_ACTIVE)
         }
         is RefreshOutcome.Inactive -> {
             log.warn("IdP rejected refresh token for {} session {} ({})", row.principal, row.id, outcome.reason)
-            when (row.kind) {
-                "WEB" -> sessionStore.endWeb(row.id, ENDED_IDP_REJECTED)
-                "DAEMON" -> sessionStore.closeDaemonWindow(row.id)
-                else -> log.warn("ignoring unknown principal session kind {} for row {}", row.kind, row.id)
+            // Each kind has its own end (a web row is ended; a daemon row's renewal window is closed), but the
+            // record is the same event either way, and it commits with the end so a recorded revocation is one
+            // that took effect. A row already ended by an earlier sweep transitions nothing and records nothing.
+            val end: ((Connection) -> Boolean)? = when (row.kind) {
+                "WEB" -> { c -> sessionStore.endWeb(row.id, ENDED_IDP_REJECTED, c) }
+                "DAEMON" -> { c -> sessionStore.closeDaemonWindow(row.id, c) > 0 }
+                else -> {
+                    log.warn("ignoring unknown principal session kind {} for row {}", row.kind, row.id)
+                    null
+                }
+            }
+            if (end != null) {
+                sessionStore.dataSource.inTx { c ->
+                    if (end(c)) {
+                        authAudit.success(
+                            c,
+                            AuditActor(row.principal, clientAddr = null, channel = CHANNEL_SESSION),
+                            ACTION_SESSION_EXPIRE,
+                            auditEntity("Session", row.id.toString()),
+                            "IdP rejected ${row.kind.lowercase()} session",
+                            detail = "idp_rejected",
+                        )
+                    }
+                }
             }
         }
         is RefreshOutcome.Transient ->

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/DeviceAuth.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/DeviceAuth.kt
@@ -1,5 +1,10 @@
 package com.ridi.oss.proxymonster.controlplane
 
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.ACTION_DEVICE_APPROVE
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.ACTION_DEVICE_MINT
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.CHANNEL_DEVICE
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import com.ridi.oss.proxymonster.controlplane.management.auditEntity
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.encodeURLParameter
 import io.ktor.server.application.ApplicationCall
@@ -16,6 +21,7 @@ import io.ktor.server.sessions.set
 import kotlinx.serialization.Serializable
 import org.slf4j.Logger
 import java.security.SecureRandom
+import java.sql.Connection
 import java.sql.ResultSet
 import java.sql.Timestamp
 import java.time.Instant
@@ -88,7 +94,7 @@ data class DeviceLoginRow(
  * `PM_AUTH_DEBUG` it's simply absent (the dev-bypass short-circuit pre-approves a synthetic row
  * without ever hitting the IdP); `pmon` only ever sees the opaque [DeviceLoginRow.handle].
  */
-class DeviceLoginStore(private val dataSource: DataSource, private val crypto: ResultCrypto? = null) {
+class DeviceLoginStore(internal val dataSource: DataSource, private val crypto: ResultCrypto? = null) {
     private val rng = SecureRandom()
 
     private companion object {
@@ -183,17 +189,25 @@ class DeviceLoginStore(private val dataSource: DataSource, private val crypto: R
      * A CAS on (PENDING, unexpired) — the return value is the truth. [refreshToken], present only on the SSO
      * path with offline_access, is stored encrypted so the minted daemon session keeps its IdP-liveness path.
      */
-    fun markApproved(handle: String, principal: String, refreshToken: String? = null): Boolean = dataSource.connection.use { c ->
+    fun markApproved(
+        handle: String,
+        principal: String,
+        refreshToken: String? = null,
+        c: Connection? = null,
+    ): Boolean {
         val encrypted = refreshToken?.let { crypto?.encrypt(it.toByteArray(Charsets.UTF_8)) }
-        c.prepareStatement(
-            """UPDATE device_login SET status = 'APPROVED', principal = ?, refresh_token_enc = ?
-               WHERE handle = ? AND status = 'PENDING' AND expires_at > now()""",
-        ).use { ps ->
-            ps.setString(1, principal)
-            ps.setBytes(2, encrypted)
-            ps.setString(3, handle)
-            ps.executeUpdate() > 0
+        val update: (Connection) -> Boolean = { connection ->
+            connection.prepareStatement(
+                """UPDATE device_login SET status = 'APPROVED', principal = ?, refresh_token_enc = ?
+                   WHERE handle = ? AND status = 'PENDING' AND expires_at > now()""",
+            ).use { ps ->
+                ps.setString(1, principal)
+                ps.setBytes(2, encrypted)
+                ps.setString(3, handle)
+                ps.executeUpdate() > 0
+            }
         }
+        return if (c == null) dataSource.connection.use(update) else update(c)
     }
 
     /** Decrypt the refresh token captured at SSO approval — null for a debug login, no offline_access, or no key. */
@@ -208,13 +222,16 @@ class DeviceLoginStore(private val dataSource: DataSource, private val crypto: R
      * — without it, re-polling an approved handle re-mints a fresh renewal secret on every call,
      * turning a short-lived login handle into an unbounded credential-minting handle.
      */
-    fun consume(handle: String): Boolean = dataSource.connection.use { c ->
-        c.prepareStatement(
-            "UPDATE device_login SET status = 'CONSUMED' WHERE handle = ? AND status = 'APPROVED' AND expires_at > now()",
-        ).use { ps ->
-            ps.setString(1, handle)
-            ps.executeUpdate() > 0
+    fun consume(handle: String, c: Connection? = null): Boolean {
+        val update: (Connection) -> Boolean = { connection ->
+            connection.prepareStatement(
+                "UPDATE device_login SET status = 'CONSUMED' WHERE handle = ? AND status = 'APPROVED' AND expires_at > now()",
+            ).use { ps ->
+                ps.setString(1, handle)
+                ps.executeUpdate() > 0
+            }
         }
+        return if (c == null) dataSource.connection.use(update) else update(c)
     }
 
     /** Delete every expired row — device-auth attempts are short-lived; nothing to keep past expiry. */
@@ -263,6 +280,7 @@ fun Route.deviceSessionRoutes(
     daemonSessionStore: PrincipalSessionStore,
     tokenStore: TokenStore,
     userGroupStore: UserGroupStore,
+    authAudit: AuthAuditRecorder,
     log: Logger,
 ) {
     // pmon begins a login: mint a PENDING handle (pmon polls it) + a short human user_code, and hand back the
@@ -337,7 +355,22 @@ fun Route.deviceSessionRoutes(
             call.respondRedirect("/login?return_to=${"/auth/device/authorize?user_code=$userCode".encodeURLParameter()}")
             return@get
         }
-        val approved = deviceLoginStore.markApproved(row.handle, session.principal, refreshToken)
+        val approver = AuditActor(session.principal, clientAddr = call.httpRequesterIp(config), channel = CHANNEL_DEVICE)
+        val approved = deviceLoginStore.dataSource.inTx { c ->
+            deviceLoginStore.markApproved(row.handle, session.principal, refreshToken, c).also { changed ->
+                if (changed) {
+                    authAudit.success(
+                        c,
+                        approver,
+                        ACTION_DEVICE_APPROVE,
+                        // The row id, never [DeviceLoginRow.handle]: the handle is the bearer secret
+                        // /auth/device/poll accepts on its own, and the audit trail is readable and exported.
+                        auditEntity("DeviceLogin", row.id.toString()),
+                        "Device login approved",
+                    )
+                }
+            }
+        }
         call.sessions.clear(DEVICE_VERIFY_COOKIE)
         call.respondRedirect(if (approved) "/device/success" else backToDevice())
     }
@@ -356,19 +389,17 @@ fun Route.deviceSessionRoutes(
             call.respond(HttpStatusCode.Accepted, DevicePollPending())
             return@post
         }
-        // Claim the approved handle for a ONE-TIME mint (APPROVED -> CONSUMED); a replay finds it CONSUMED and
-        // is refused, so the handle can't be replayed into a stream of tokens + renewal secrets. A deactivated
-        // principal still fails closed below: respondWithMintedSession mints under mintForActivePrincipalLocked.
-        if (!deviceLoginStore.consume(row.handle)) {
-            call.respond(HttpStatusCode.BadRequest, ApiError("device.login_already_completed"))
-            return@post
-        }
         // Carry the refresh token captured at SSO approval onto the daemon session (null for a debug login or
-        // no offline_access/key), so its timer-driven IdP-liveness revalidation keeps working.
-        respondWithMintedSession(call, principal, row, refreshToken = deviceLoginStore.decryptRefresh(row), config, tokenStore, daemonSessionStore, userGroupStore)
+        // no offline_access/key), so its timer-driven IdP-liveness revalidation keeps working. The one-time
+        // APPROVED -> CONSUMED claim happens INSIDE the mint transaction (respondWithMintedSession), so a
+        // failed mint rolls the claim back and the poll can retry rather than stranding the handle CONSUMED.
+        respondWithMintedSession(
+            call, principal, row, refreshToken = deviceLoginStore.decryptRefresh(row), config, tokenStore,
+            daemonSessionStore, deviceLoginStore, userGroupStore, authAudit,
+        )
     }
 
-    sessionRenewRoutes(daemonSessionStore, tokenStore, userGroupStore)
+    sessionRenewRoutes(config, daemonSessionStore, tokenStore, userGroupStore, authAudit)
 }
 
 /**
@@ -387,11 +418,29 @@ private suspend fun respondWithMintedSession(
     config: Config,
     tokenStore: TokenStore,
     daemonSessionStore: PrincipalSessionStore,
+    deviceLoginStore: DeviceLoginStore,
     userGroupStore: UserGroupStore,
+    authAudit: AuthAuditRecorder,
 ) {
-    val result = tokenStore.dataSource.mintForActivePrincipalLocked(principal, userGroupStore) { c ->
+    val poller = AuditActor(principal, clientAddr = call.httpRequesterIp(config), channel = CHANNEL_DEVICE)
+    // consume + session + token + audit are ONE transaction under the per-principal lock. A replay finds the
+    // handle already CONSUMED and never reaches the mint; a failed mint rolls the consume back so the poll can
+    // retry. A deprovisioned principal is refused before the block runs, leaving the handle claimable again.
+    var alreadyCompleted = false
+    val result: DevicePollResult? = tokenStore.dataSource.mintForActivePrincipalLocked(principal, userGroupStore) { c ->
+        if (!deviceLoginStore.consume(row.handle, c)) {
+            alreadyCompleted = true
+            return@mintForActivePrincipalLocked null
+        }
         val created = daemonSessionStore.create(principal, row.handle, refreshToken, config.sessionWindowSeconds, row.ttlSeconds, c)
         val issued = tokenStore.issue(TokenKind.SESSION, principal, emptyList(), name = null, ttlSeconds = row.ttlSeconds, c)
+        authAudit.success(
+            c,
+            poller,
+            ACTION_DEVICE_MINT,
+            auditEntity("Token", issued.id.toString()),
+            "Device login minted SESSION token",
+        )
         DevicePollResult(
             issued.token,
             issued.expiresAt,
@@ -400,9 +449,9 @@ private suspend fun respondWithMintedSession(
             created.renewalToken,
         )
     }
-    if (result == null) {
-        call.respond(HttpStatusCode.Forbidden, ApiError("auth.principal_deprovisioned"))
-    } else {
-        call.respond(result)
+    when {
+        alreadyCompleted -> call.respond(HttpStatusCode.BadRequest, ApiError("device.login_already_completed"))
+        result == null -> call.respond(HttpStatusCode.Forbidden, ApiError("auth.principal_deprovisioned"))
+        else -> call.respond(result)
     }
 }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Oidc.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Oidc.kt
@@ -1,6 +1,11 @@
 package com.ridi.oss.proxymonster.controlplane
 
 import com.ridi.oss.proxymonster.auth.pkceS256
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.ACTION_OIDC_LOGIN
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.CHANNEL_OIDC
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.PRINCIPAL_UNATTRIBUTED
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import com.ridi.oss.proxymonster.controlplane.management.auditEntity
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.forms.submitForm
@@ -114,6 +119,7 @@ fun Route.oidcRoutes(
     userGroupStore: UserGroupStore,
     roleResolver: RoleResolver,
     store: PrincipalSessionStore,
+    authAudit: AuthAuditRecorder,
     log: Logger,
 ) {
     // Begin the auth-code flow: stash CSRF state + nonce, then 302 to the IdP's authorize endpoint.
@@ -178,8 +184,23 @@ fun Route.oidcRoutes(
         call.sessions.clear(OAUTH_NONCE_COOKIE)
         call.sessions.clear(OAUTH_VERIFIER_COOKIE)
 
+        // Most rejections happen before any id_token is validated, so there is no principal to name and
+        // the row is attributed to the IdP client instead; [principal] is passed only once it is known.
+        // Best-effort: every branch below redirects regardless, so a failed audit insert must not turn a
+        // login rejection into a 500.
+        fun auditFailure(detail: String, principal: String? = null) {
+            authAudit.failureBestEffort(
+                AuditActor(principal ?: PRINCIPAL_UNATTRIBUTED, clientAddr = call.httpRequesterIp(config), channel = CHANNEL_OIDC),
+                ACTION_OIDC_LOGIN,
+                if (principal == null) auditEntity("Client", oidc.clientId) else auditEntity("User", principal),
+                "OIDC login failed",
+                detail,
+            )
+        }
+
         if (state == null || expectedState == null || state != expectedState) {
             log.warn("OIDC callback state validation failed")
+            auditFailure("invalid_state")
             val target = if (stateSession?.returnTo == "/auth/reauth-complete") {
                 oidcFailureTarget(stateSession, oauthError = "access_denied", consoleError = "state")
             } else {
@@ -190,23 +211,31 @@ fun Route.oidcRoutes(
         }
         if (params["error"] != null) {
             log.warn("OIDC callback returned error: {}", params["error"])
+            // The error is whatever the caller put in the query string — /auth/oidc/login is open, so a
+            // self-minted state reaches this branch and chooses this value. Bounded before it is recorded.
+            auditFailure("idp_error=${auditedValue(params["error"].orEmpty())}")
             call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "access_denied", consoleError = "oidc"))
             return@get
         }
         if (code == null) {
             log.warn("OIDC callback omitted both code and error")
+            auditFailure("missing_code")
             call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "server_error", consoleError = "state"))
             return@get
         }
         if (expectedNonce == null) {
             log.warn("OIDC callback nonce state is absent")
+            auditFailure("missing_nonce")
             call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "access_denied", consoleError = "nonce"))
             return@get
         }
 
-        try {
+        // Each fallible step carries its own narrow catch so a failure is attributed to the step that failed
+        // — and so the post-commit session-set + redirect below sit OUTSIDE every failure-audit catch: a
+        // browser disconnect there must not write a FAILURE row contradicting the SUCCESS already committed.
+        val token: TokenResponse = try {
             val document = discovery.document()
-            val token: TokenResponse = http.submitForm(
+            http.submitForm(
                 url = document.token_endpoint,
                 formParameters = Parameters.build {
                     append("grant_type", "authorization_code")
@@ -219,47 +248,88 @@ fun Route.oidcRoutes(
                     if (codeVerifier != null) append("code_verifier", codeVerifier)
                 },
             ).body()
+        } catch (e: Exception) {
+            log.error("OIDC token exchange failed", e)
+            auditFailure("token_exchange_failed")
+            call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "server_error", consoleError = "oidc"))
+            return@get
+        }
 
-            // Signature + iss/aud/exp + nonce all verified inside validate(); null means any of
-            // those failed (incl. a nonce mismatch — the one-time cookie above already guards
-            // replay of the *state*, this guards injection of a *different* authorization result).
-            val claims = validator.validate(token.id_token, expectedNonce = expectedNonce)
-            if (claims == null) {
-                log.warn("OIDC callback id_token validation failed")
-                call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "access_denied", consoleError = "nonce"))
-                return@get
-            }
+        // Signature + iss/aud/exp + nonce all verified inside validate(); null means any of
+        // those failed (incl. a nonce mismatch — the one-time cookie above already guards
+        // replay of the *state*, this guards injection of a *different* authorization result).
+        val claims = validator.validate(token.id_token, expectedNonce = expectedNonce)
+        if (claims == null) {
+            log.warn("OIDC callback id_token validation failed")
+            auditFailure("invalid_id_token")
+            call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "access_denied", consoleError = "nonce"))
+            return@get
+        }
 
-            val principal = claims.email ?: claims.subject
-            // JIT-provision + SYNC group membership to the IdP claim (docs/backlog.md):
+        val principal = claims.email ?: claims.subject
+        // JIT-provision + SYNC group membership, then resolve effective roles — both attributed to the
+        // RESOLVED principal on failure, not the IdP client: the identity is known by this point, and
+        // provisioning/role-resolve is not the token exchange. (provisionFromOidc commits its directory
+        // changes on its own connection — that is directory reconciliation, not the login event; see
+        // KNOWN_LIMITATIONS.md "Audit trail".)
+        try {
             // membership is reconciled to the mapped claim set — added AND removed — so IdP group changes
             // (including admin, via system:admin) take effect on the next login. Deactivation stays SCIM's job.
             userGroupStore.provisionFromOidc(principal, claims.email, claims.groups, oidc.groupMapping)
             // Gate a principal with no effective roles to the no-access screen before minting a session.
             if (roleResolver.resolve(principal).isEmpty()) {
                 log.warn("OIDC callback principal has no effective roles: {}", principal)
+                auditFailure("no_effective_roles", principal)
                 call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "access_denied", consoleError = "no_access"))
                 return@get
             }
-
-            val refreshToken = token.refresh_token?.takeIf {
-                "offline_access" in oidc.scopes.split(Regex("\\s+")).filter(String::isNotBlank)
-            }
-
-            val deviceId = call.ensureDeviceCookie(config.mcpIssuer.startsWith("https://"))
-            val sessionId = store.mintWeb(
-                principal,
-                refreshToken,
-                config.webSessionAbsoluteSeconds,
-                config.webSessionIdleSeconds,
-                deviceId,
-            )
-            call.sessions.set(WebSessionRef(sessionId))
-            call.respondRedirect(stateSession?.returnTo ?: "/")
         } catch (e: Exception) {
-            log.error("OIDC token exchange failed", e)
+            log.error("OIDC provisioning or role resolution failed", e)
+            auditFailure("provisioning_failed", principal)
             call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "server_error", consoleError = "oidc"))
+            return@get
         }
+
+        val refreshToken = token.refresh_token?.takeIf {
+            "offline_access" in oidc.scopes.split(Regex("\\s+")).filter(String::isNotBlank)
+        }
+
+        val deviceId = call.ensureDeviceCookie(config.mcpIssuer.startsWith("https://"))
+        // Resolved before the transaction below opens: under the debug bypass this reads (and can end)
+        // a web session on a second connection, which the mint's principal lock would then block.
+        val actor = AuditActor(principal, clientAddr = call.httpRequesterIp(config), channel = CHANNEL_OIDC)
+        // Mint and record on one transaction: a session that exists is a session the trail names. A store
+        // failure here records the rejection standalone (the mint rolled back, so no other row names this
+        // attempt).
+        val sessionId = try {
+            store.dataSource.inTx { c ->
+                val id = store.mintWeb(
+                    principal,
+                    refreshToken,
+                    config.webSessionAbsoluteSeconds,
+                    config.webSessionIdleSeconds,
+                    deviceId,
+                    c = c,
+                )
+                authAudit.success(
+                    c,
+                    actor,
+                    ACTION_OIDC_LOGIN,
+                    auditEntity("Session", id.toString()),
+                    "OIDC login established session",
+                )
+                id
+            }
+        } catch (e: Exception) {
+            log.error("OIDC session mint failed", e)
+            auditFailure("session_mint_failed", principal)
+            call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "server_error", consoleError = "oidc"))
+            return@get
+        }
+        // Post-commit: the SUCCESS row is durable. A disconnect on either line propagates uncaught rather
+        // than writing a contradicting FAILURE row.
+        call.sessions.set(WebSessionRef(sessionId))
+        call.respondRedirect(stateSession?.returnTo ?: "/")
     }
 }
 

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Tokens.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Tokens.kt
@@ -1,9 +1,14 @@
 package com.ridi.oss.proxymonster.controlplane
 
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.ACTION_TOKEN_MINT
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.ACTION_TOKEN_REVOKE
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.CHANNEL_WIRE
 import com.ridi.oss.proxymonster.controlplane.authz.Authz
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
 import com.ridi.oss.proxymonster.controlplane.authz.requireAuthz
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import com.ridi.oss.proxymonster.controlplane.management.auditEntity
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
@@ -224,14 +229,15 @@ class TokenStore(internal val dataSource: DataSource) {
     }
 
     /** Revoke a token by id, but only if it belongs to [principal] (ownership check). */
-    fun revoke(id: Long, principal: String): Boolean = dataSource.connection.use { c ->
+    fun revoke(id: Long, principal: String): Boolean = dataSource.connection.use { c -> revoke(id, principal, c) }
+
+    fun revoke(id: Long, principal: String, c: Connection): Boolean =
         c.prepareStatement(
             "UPDATE proxy_token SET revoked_at = now() WHERE id = ? AND principal = ? AND revoked_at IS NULL",
         ).use { ps ->
             ps.setLong(1, id); ps.setString(2, principal)
             ps.executeUpdate() > 0
         }
-    }
 
     /**
      * Revoke every currently-active (non-revoked, non-expired) wire token for [principal] — the
@@ -267,7 +273,18 @@ class TokenStore(internal val dataSource: DataSource) {
 private fun principalOf(call: io.ktor.server.application.ApplicationCall) = call.userSession()?.principal ?: "debug-user"
 private fun rolesOf(call: io.ktor.server.application.ApplicationCall) = call.userSession()?.roles ?: emptyList()
 
-fun Route.tokenRoutes(config: Config, store: TokenStore, userGroupStore: UserGroupStore, authz: Authz) {
+/** The audited actor of a token route: whoever made the request, resolved the same way the route's own
+ *  authorization resolves it — never the token's owner, who may be someone else on the revoke path. */
+private fun callerActor(call: io.ktor.server.application.ApplicationCall, config: Config) =
+    AuditActor(principalOf(call), clientAddr = call.httpRequesterIp(config), channel = CHANNEL_WIRE)
+
+fun Route.tokenRoutes(
+    config: Config,
+    store: TokenStore,
+    userGroupStore: UserGroupStore,
+    authz: Authz,
+    authAudit: AuthAuditRecorder,
+) {
     // Mint a short-lived SESSION token for the daemon (`pm login`) — held locally, refreshed.
     // Credential issuance is a Cedar decision (token.mint on Token{owner, kind}); the self seed permits a
     // principal to mint its own, a kind-scoped forbid can bar a role from long-lived PATs.
@@ -280,8 +297,17 @@ fun Route.tokenRoutes(config: Config, store: TokenStore, userGroupStore: UserGro
         // check + the INSERT run on ONE transaction under the per-principal advisory lock,
         // so a concurrent SCIM/liveness teardown can't slip its revoke between them and leave a
         // token that survives the deprovision (resurrectable on a later reactivation).
+        val minter = callerActor(call, config)
         val issued = store.dataSource.mintForActivePrincipalLocked(principal, userGroupStore) { c ->
-            store.issue(TokenKind.SESSION, principal, roles, name = null, ttlSeconds = ttl, c)
+            store.issue(TokenKind.SESSION, principal, roles, name = null, ttlSeconds = ttl, c).also { token ->
+                authAudit.success(
+                    c,
+                    minter,
+                    ACTION_TOKEN_MINT,
+                    auditEntity("Token", token.id.toString()),
+                    "Minted SESSION wire token",
+                )
+            }
         }
         if (issued == null) {
             call.respond(HttpStatusCode.Forbidden, ApiError("auth.principal_deprovisioned")); return@post
@@ -306,8 +332,17 @@ fun Route.tokenRoutes(config: Config, store: TokenStore, userGroupStore: UserGro
         val roles = rolesOf(call)
         // Same locked check-then-mint as /api/wire-tokens above — no fresh credentials
         // for a deactivated principal, and no revoke can race between the check and the INSERT.
+        val minter = callerActor(call, config)
         val issued = store.dataSource.mintForActivePrincipalLocked(principal, userGroupStore) { c ->
-            store.issue(TokenKind.USER, principal, roles, input.name?.ifBlank { null }, ttl, c)
+            store.issue(TokenKind.USER, principal, roles, input.name?.ifBlank { null }, ttl, c).also { token ->
+                authAudit.success(
+                    c,
+                    minter,
+                    ACTION_TOKEN_MINT,
+                    auditEntity("Token", token.id.toString()),
+                    "Minted USER wire token",
+                )
+            }
         }
         if (issued == null) {
             call.respond(HttpStatusCode.Forbidden, ApiError("auth.principal_deprovisioned")); return@post
@@ -322,7 +357,22 @@ fun Route.tokenRoutes(config: Config, store: TokenStore, userGroupStore: UserGro
         val token = store.get(id)
             ?: return@delete call.notFound("token")
         if (!call.requireAuthz(config, authz, AuthzAction.TOKEN_REVOKE, AuthzResource.Token(token.principal, TokenKind.fromWire(token.kind)))) return@delete
-        if (store.revoke(id, token.principal)) call.respond(HttpStatusCode.NoContent)
-        else call.notFound("token")
+        // The actor is the CALLER, not the token's owner: an oversight seed lets an identity admin revoke
+        // someone else's token, and attributing that to the owner would name the victim as the actor.
+        val revoker = callerActor(call, config)
+        val revoked = store.dataSource.inTx { c ->
+            store.revoke(id, token.principal, c).also { changed ->
+                if (changed) {
+                    authAudit.success(
+                        c,
+                        revoker,
+                        ACTION_TOKEN_REVOKE,
+                        auditEntity("Token", id.toString()),
+                        "Revoked ${token.kind} wire token owned by ${token.principal}",
+                    )
+                }
+            }
+        }
+        if (revoked) call.respond(HttpStatusCode.NoContent) else call.notFound("token")
     }
 }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/ControlPlaneGrpcService.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/ControlPlaneGrpcService.kt
@@ -1,6 +1,10 @@
 package com.ridi.oss.proxymonster.controlplane.grpc
 
 import com.ridi.oss.proxymonster.controlplane.Attached
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.ACTION_WIRE_VALIDATE
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.CHANNEL_WIRE
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.PRINCIPAL_UNATTRIBUTED
+import com.ridi.oss.proxymonster.controlplane.auditedValue
 import com.ridi.oss.proxymonster.controlplane.AttachedTableDetail
 import com.ridi.oss.proxymonster.controlplane.AuditEvent
 import com.ridi.oss.proxymonster.controlplane.CatalogColumn
@@ -10,7 +14,9 @@ import com.ridi.oss.proxymonster.controlplane.CatalogMutationResult
 import com.ridi.oss.proxymonster.controlplane.Channel
 import com.ridi.oss.proxymonster.controlplane.ControlPlaneCore
 import com.ridi.oss.proxymonster.controlplane.DatasourceEngineConflictException
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
 import com.ridi.oss.proxymonster.controlplane.management.ManagementException
+import com.ridi.oss.proxymonster.controlplane.management.auditEntity
 import com.ridi.oss.proxymonster.controlplane.catalogIsConnectionIndependent
 import com.ridi.oss.proxymonster.controlplane.catalogName
 import com.ridi.oss.proxymonster.controlplane.EnforcementOutcome
@@ -118,10 +124,34 @@ class ControlPlaneGrpcService(
 
     private val log = org.slf4j.LoggerFactory.getLogger(ControlPlaneGrpcService::class.java)
 
+    /**
+     * Record a rejected wire credential. [ValidateTokenRequest] carries no end-client address, so these rows
+     * have none — see KNOWN_LIMITATIONS.md "Audit trail". The requested datasource is caller-supplied and
+     * unvalidated at this point, so it is bounded and confined to `detail` rather than naming the resource.
+     */
+    private fun auditWireRejection(request: ValidateTokenRequest, principal: String?, reason: String) {
+        // Best-effort: this rejection changes no state, and validateToken is the hot wire path — an audit
+        // insert that throws (the chain-head lock, a broken chain) must not replace UNAUTHENTICATED with
+        // INTERNAL, which every bad token got before this trail existed.
+        core.authAudit.failureBestEffort(
+            AuditActor(principal ?: PRINCIPAL_UNATTRIBUTED, clientAddr = null, channel = CHANNEL_WIRE),
+            ACTION_WIRE_VALIDATE,
+            if (principal == null) auditEntity("Token", "unresolved") else auditEntity("User", principal),
+            "Wire token validation failed",
+            detail = "datasource=${auditedValue(request.datasourceName)};reason=$reason",
+        )
+    }
+
     override suspend fun validateToken(request: ValidateTokenRequest): WireIdentity {
         val id = core.tokenStore.validate(request.token)
-            ?: throw StatusException(Status.UNAUTHENTICATED.withDescription("invalid, expired, or revoked wire token"))
+        if (id == null) {
+            // validate() collapses invalid/expired/revoked into one null, and none of them names a
+            // principal — hence one reason covering the set, and no attribution.
+            auditWireRejection(request, principal = null, reason = "invalid_expired_or_revoked")
+            throw StatusException(Status.UNAUTHENTICATED.withDescription("invalid, expired, or revoked wire token"))
+        }
         if (core.userGroupStore.isDeactivated(id.principal)) {
+            auditWireRejection(request, id.principal, reason = "principal_deprovisioned")
             throw StatusException(Status.UNAUTHENTICATED.withDescription("principal is deprovisioned"))
         }
         if (request.datasourceName.isBlank()) {

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/oauth/OAuthRoutes.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/oauth/OAuthRoutes.kt
@@ -3,15 +3,26 @@ package com.ridi.oss.proxymonster.controlplane.oauth
 import com.ridi.oss.proxymonster.auth.AuthorizationCodeInput
 import com.ridi.oss.proxymonster.auth.ConsumeAuthorizationCodeInput
 import com.ridi.oss.proxymonster.auth.OAuthAuthorizationStore
+import com.ridi.oss.proxymonster.auth.OAuthConsent
 import com.ridi.oss.proxymonster.auth.OAuthTokenPair
 import com.ridi.oss.proxymonster.auth.RefreshTokenInput
 import com.ridi.oss.proxymonster.auth.canonicalScopes
 import com.ridi.oss.proxymonster.auth.isValidPkceChallenge
 import com.ridi.oss.proxymonster.auth.randomSecret
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.ACTION_OAUTH_CONSENT
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.ACTION_OAUTH_REVOKE
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.ACTION_OAUTH_TOKEN
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.CHANNEL_OAUTH
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.PRINCIPAL_UNATTRIBUTED
 import com.ridi.oss.proxymonster.controlplane.Config
+import com.ridi.oss.proxymonster.controlplane.auditedValue
 import com.ridi.oss.proxymonster.controlplane.PrincipalSessionStore
 import com.ridi.oss.proxymonster.controlplane.WebSessionRef
 import com.ridi.oss.proxymonster.controlplane.ensureDeviceCookie
+import com.ridi.oss.proxymonster.controlplane.httpRequesterIp
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import com.ridi.oss.proxymonster.controlplane.management.auditEntity
 import com.ridi.oss.proxymonster.controlplane.userSession
 import com.ridi.oss.proxymonster.controlplane.webSession
 import io.ktor.http.ContentType
@@ -38,6 +49,7 @@ import io.ktor.server.sessions.sessions
 import io.ktor.server.sessions.set
 import kotlinx.serialization.Serializable
 import java.security.MessageDigest
+import java.sql.Connection
 import java.util.Locale
 import java.util.ResourceBundle
 import javax.crypto.Mac
@@ -45,6 +57,8 @@ import javax.crypto.spec.SecretKeySpec
 import javax.sql.DataSource
 
 val MCPA_SCOPES = setOf("mcp:read", "mcp:datasources:write", "mcp:policies:write", "mcp:identity:write")
+
+private val log = org.slf4j.LoggerFactory.getLogger("com.ridi.oss.proxymonster.controlplane.oauth.OAuthRoutes")
 
 internal const val MCP_OAUTH_PENDING_COOKIE = "pm_oauth_pending"
 
@@ -88,7 +102,7 @@ private data class AuthorizationServerMetadata(
 
 @Serializable
 private data class ConsentListResponse(
-    val consents: List<com.ridi.oss.proxymonster.auth.OAuthConsent>,
+    val consents: List<OAuthConsent>,
     val csrfToken: String,
 )
 
@@ -106,6 +120,7 @@ fun Route.mcpOAuthRoutes(
     config: Config,
     dataSource: DataSource,
     principalSessionStore: PrincipalSessionStore,
+    authAudit: AuthAuditRecorder,
     cimdResolver: CimdResolver = HttpCimdResolver(productionChecks = !config.authDebug),
 ) {
     val store = OAuthAuthorizationStore(dataSource)
@@ -182,8 +197,12 @@ fun Route.mcpOAuthRoutes(
                 ),
             )
             if (config.mcpDebugAutoConsent || params["auto_consent"] == "true") {
+                // Only a NEW consent is a grant. Reusing one the user already gave changes nothing, and
+                // recording it per authorization would report a fresh grant on every client reconnect.
                 val consent = store.findActiveConsent(principal, clientId, resource, requestedScopes)
-                    ?: store.rememberConsent(principal, clientId, resource, requestedScopes)
+                    ?: store.rememberConsent(principal, clientId, resource, requestedScopes) { c, id ->
+                        call.auditConsentGrant(c, config, authAudit, principal, clientId, id, canonicalScope)
+                    }
                 issueAuthorizationCode(call, pending, consent.id, store, cimdResolver)
             } else {
                 renderConsent(call, pending, metadata.client_name, metadata.client_id)
@@ -246,43 +265,101 @@ fun Route.mcpOAuthRoutes(
             call.respondRedirect(oauthRedirect(pending.redirectUri, mapOf("error" to "access_denied", "state" to pending.state)))
             return@post
         }
-        val consent = store.rememberConsent(principal, pending.clientId, pending.resource, pending.scope.split(' '))
+        // Only a NEW consent is a grant — a double-submit of the approval form (the pending cookie is still
+        // attached until the first response clears it) must not write a second consent event for one grant.
+        val scopes = pending.scope.split(' ')
+        val consent = store.findActiveConsent(principal, pending.clientId, pending.resource, scopes)
+            ?: store.rememberConsent(principal, pending.clientId, pending.resource, scopes) { c, id ->
+                call.auditConsentGrant(c, config, authAudit, principal, pending.clientId, id, pending.scope)
+            }
         issueAuthorizationCode(call, pending, consent.id, store, cimdResolver)
     }
 
     post("/oauth/token") {
         val form = call.receiveParameters()
+        // client_id is a caller-supplied CIMD URL on an unauthenticated endpoint — bound it before it reaches
+        // the tamper-evident chain, like every other caller field.
+        val clientId = auditedValue(form["client_id"].orEmpty())
+        val grantType = form["grant_type"].orEmpty()
+        val actor = { AuditActor(PRINCIPAL_UNATTRIBUTED, clientAddr = call.httpRequesterIp(config), channel = CHANNEL_OAUTH) }
+        // Attributed to the client, not a user: the grant is redeemed by the client against a code or a
+        // refresh token, and [OAuthTokenPair] carries no principal. Written inside the store's grant
+        // transaction, so a rejected audit rolls the grant back and the code stays unconsumed for a retry.
+        val onGrant: (Connection) -> Unit = { c ->
+            authAudit.success(
+                c, actor(), ACTION_OAUTH_TOKEN, auditEntity("Client", clientId),
+                "OAuth token granted to client $clientId", detail = "grant_type=$grantType",
+            )
+        }
+        // A replayed rotated refresh token forces its whole family revoked — a real revocation that commits,
+        // so record it atomically, keyed by the presented (replayed) token's id.
+        val onReplayRevoke: (Connection, Long) -> Unit = { c, tokenId ->
+            authAudit.success(
+                c, actor(), ACTION_OAUTH_REVOKE, auditEntity("Token", tokenId.toString()),
+                "OAuth refresh family revoked on replay", detail = "grant_type=$grantType",
+            )
+        }
         val pair: OAuthTokenPair? = when (form["grant_type"]) {
             "authorization_code" -> {
                 val code = form["code"] ?: return@post call.oauthError("invalid_request")
-                val clientId = form["client_id"] ?: return@post call.oauthError("invalid_request")
+                val client = form["client_id"] ?: return@post call.oauthError("invalid_request")
                 val redirectUri = form["redirect_uri"] ?: return@post call.oauthError("invalid_request")
                 val resource = form["resource"] ?: return@post call.oauthError("invalid_request")
                 val verifier = form["code_verifier"] ?: return@post call.oauthError("invalid_request")
                 if (resource != config.mcpResource) null else store.consumeAuthorizationCode(
                     ConsumeAuthorizationCodeInput(
-                        code, clientId, redirectUri, resource, verifier,
+                        code, client, redirectUri, resource, verifier,
                         config.mcpAccessTtlSeconds, config.mcpRefreshTtlSeconds,
                     ),
+                    onGrant,
                 )
             }
             "refresh_token" -> {
                 val refresh = form["refresh_token"] ?: return@post call.oauthError("invalid_request")
-                val clientId = form["client_id"] ?: return@post call.oauthError("invalid_request")
+                val client = form["client_id"] ?: return@post call.oauthError("invalid_request")
                 val resource = form["resource"] ?: return@post call.oauthError("invalid_request")
                 if (resource != config.mcpResource) null else store.rotateRefresh(
-                    RefreshTokenInput(refresh, clientId, resource, config.mcpAccessTtlSeconds, config.mcpRefreshTtlSeconds),
+                    RefreshTokenInput(refresh, client, resource, config.mcpAccessTtlSeconds, config.mcpRefreshTtlSeconds),
+                    onGrant,
+                    onReplayRevoke,
                 )
             }
             else -> return@post call.oauthError("unsupported_grant_type")
         }
-        if (pair == null) return@post call.oauthError("invalid_grant")
+        if (pair == null) {
+            // Best-effort, standalone: the denied grant changed nothing (any replay-revoke already recorded
+            // itself atomically above), so a failed audit insert must not turn invalid_grant into a 500.
+            authAudit.failureBestEffort(
+                actor(), ACTION_OAUTH_TOKEN, auditEntity("Client", clientId),
+                "OAuth token grant denied", detail = "grant_type=$grantType",
+            )
+            return@post call.oauthError("invalid_grant")
+        }
         call.respond(pair.toResponse())
     }
 
     post("/oauth/revoke") {
         val token = call.receiveParameters()["token"]
-        if (token != null) store.revoke(token)
+        val clientAddr = call.httpRequesterIp(config)
+        // Only a call that actually closed a token is recorded, and it names the token id [revoke] reports,
+        // written inside the revoke's own transaction so the row commits with the revocation. This endpoint
+        // is unauthenticated by design (RFC 7009 answers 200 for an unknown token), so recording every call
+        // would let anyone replay one once-valid token to append unbounded rows to a tamper-evident chain.
+        // The presented token is never itself recorded. RFC 7009 §2.2 answers 200 regardless — so even when
+        // the atomic audit throws, log and still return 200, never 500.
+        runCatching {
+            token?.let {
+                store.revoke(it) { c, revokedId ->
+                    authAudit.success(
+                        c,
+                        AuditActor(PRINCIPAL_UNATTRIBUTED, clientAddr = clientAddr, channel = CHANNEL_OAUTH),
+                        ACTION_OAUTH_REVOKE,
+                        auditEntity("Token", revokedId.toString()),
+                        "OAuth token revoked",
+                    )
+                }
+            }
+        }.onFailure { log.warn("OAuth token revoke did not record; RFC 7009 answers 200 regardless", it) }
         call.respond(HttpStatusCode.OK, emptyMap<String, String>())
     }
 
@@ -302,9 +379,49 @@ fun Route.mcpOAuthRoutes(
             return@delete call.respond(HttpStatusCode.BadRequest, OAuthError("invalid_request"))
         }
         if (id == null) return@delete call.respond(HttpStatusCode.BadRequest, OAuthError("invalid_request"))
-        if (store.revokeConsent(id, user.principal)) call.respond(HttpStatusCode.NoContent)
-        else call.respond(HttpStatusCode.NotFound, OAuthError("invalid_request"))
+        val clientAddr = call.httpRequesterIp(config)
+        // The revoke + its audit commit or roll back together (revoking a consent cascades to revoking its MCP
+        // tokens, so a committed cascade with no audit row is what atomicity closes). A revoke that transitioned
+        // nothing returns 404; only the rare atomic-audit throw is logged and treated as done rather than a 500.
+        val revoked = runCatching {
+            store.revokeConsent(id, user.principal) { c, consentId ->
+                authAudit.success(
+                    c,
+                    AuditActor(user.principal, clientAddr = clientAddr, channel = CHANNEL_OAUTH),
+                    ACTION_OAUTH_REVOKE,
+                    auditEntity("Consent", consentId.toString()),
+                    "OAuth consent revoked",
+                )
+            }
+        }.getOrElse { log.warn("OAuth consent revoke did not record", it); true }
+        if (revoked) call.respond(HttpStatusCode.NoContent) else call.respond(HttpStatusCode.NotFound, OAuthError("invalid_request"))
     }
+}
+
+/**
+ * Record a user granting an MCP client consent — the one event that names WHO authorized a client, since
+ * the token grant that follows is redeemed by the client and carries no principal.
+ *
+ * Written on the store's own transaction [c] (via [OAuthAuthorizationStore.rememberConsent]'s onCommit
+ * callback) so the audit row commits or rolls back with the consent it names. [clientId] is a caller-supplied
+ * CIMD URL, so it is bounded before it reaches the chain.
+ */
+private fun ApplicationCall.auditConsentGrant(
+    c: Connection,
+    config: Config,
+    authAudit: AuthAuditRecorder,
+    principal: String,
+    clientId: String,
+    consentId: Long,
+    scope: String,
+) {
+    authAudit.success(
+        c,
+        AuditActor(principal, clientAddr = httpRequesterIp(config), channel = CHANNEL_OAUTH),
+        ACTION_OAUTH_CONSENT,
+        auditEntity("Consent", consentId.toString()),
+        "OAuth consent granted to client ${auditedValue(clientId)} for $scope",
+    )
 }
 
 private suspend fun continueAuthorization(

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AuthAuditDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AuthAuditDbTest.kt
@@ -1,0 +1,431 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.ACTION_TOKEN_MINT
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.ACTION_TOKEN_REVOKE
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.ACTION_WIRE_VALIDATE
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.CHANNEL_WIRE
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.PRINCIPAL_UNATTRIBUTED
+import com.ridi.oss.proxymonster.controlplane.authz.Authz
+import com.ridi.oss.proxymonster.controlplane.authz.CedarEngine
+import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyStore
+import com.ridi.oss.proxymonster.controlplane.authz.RoleSource
+import com.ridi.oss.proxymonster.controlplane.grpc.ControlPlaneGrpcService
+import com.ridi.oss.proxymonster.controlplane.management.auditEntity
+import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
+import com.ridi.oss.proxymonster.controlplane.support.auditChainHead
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.verifyAuditChain
+import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
+import com.ridi.oss.proxymonster.grpc.validateTokenRequest
+import io.grpc.Status
+import io.grpc.StatusException
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.delete
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.call
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post as serverPost
+import io.ktor.server.routing.routing
+import io.ktor.server.sessions.Sessions
+import io.ktor.server.sessions.sessions
+import io.ktor.server.sessions.set
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import javax.sql.DataSource
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * DB-backed coverage of the `kind="auth"` trail written by [AuthAuditRecorder], through the routes and
+ * the gRPC service that own each chokepoint rather than a re-composition of their store calls — deleting
+ * an emission in `Tokens.kt` or `ControlPlaneGrpcService.kt` has to fail here.
+ *
+ * The load-bearing assertion is the last one: a SUCCESSFUL wire-token validation writes NO row. That path
+ * runs per connection and per query, and burying the rejected attempts under it would defeat the trail.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AuthAuditDbTest {
+    private lateinit var dataSource: DataSource
+    private lateinit var core: ControlPlaneCore
+    private lateinit var grpc: ControlPlaneGrpcService
+    private lateinit var authz: Authz
+    private lateinit var sessionStore: PrincipalSessionStore
+    private lateinit var datasourceName: String
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_auth_audit"))
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        core = ControlPlaneCore(dataSource)
+        grpc = ControlPlaneGrpcService(core)
+        val policyStore = CedarPolicyStore(dataSource)
+        authz = Authz(CedarEngine(policyStore), policyStore, RoleSource { emptySet() })
+        sessionStore = PrincipalSessionStore(dataSource, null)
+        datasourceName = core.datasourceStore.create(DatasourceInput("auth-audit-ds", "postgres")).name
+    }
+
+    /** authDebug bypasses requireAuthz, so the routes under test decide nothing here — the point is who the
+     *  audit row NAMES, and a signed-in caller is established through the same web-session cookie the app uses.
+     *  The test host's socket peer is trusted as an edge so [CALLER_ADDR] resolves off `X-Forwarded-For`,
+     *  which is how the recorder's client-address wiring is pinned to a known value. */
+    private fun testConfig() = Config(
+        httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = true, secretToken = null,
+        sessionSecret = "auth-audit-test-secret-at-least-32-bytes", oidc = null, resultKey = null,
+        scimToken = null, sessionWindowSeconds = 3600, idpRecheckIntervalSeconds = 600, devMarker = true,
+        trustedProxies = setOf("localhost"),
+    )
+
+    private fun ApplicationTestBuilder.installTokenRoutes() {
+        val config = testConfig()
+        application {
+            attributes.put(PRINCIPAL_SESSION_STORE, sessionStore)
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
+            // Mirrors the application-level fallback module() installs, so a route that throws answers 500
+            // here the way it would in the running server instead of surfacing as a transport failure.
+            install(StatusPages) { exception<Throwable> { call, _ -> call.respond(HttpStatusCode.InternalServerError) } }
+            install(Sessions) { webSessionCookie(sessionStore, config.sessionSecret) }
+            routing {
+                serverPost("/test/login/{principal}") {
+                    val principal = requireNotNull(call.parameters["principal"])
+                    val deviceId = call.ensureDeviceCookie(secure = false)
+                    call.sessions.set(
+                        WebSessionRef(
+                            sessionStore.mintWeb(
+                                principal, null, config.webSessionAbsoluteSeconds, config.webSessionIdleSeconds, deviceId,
+                            ),
+                        ),
+                    )
+                    call.respond(HttpStatusCode.NoContent)
+                }
+                tokenRoutes(config, core.tokenStore, core.userGroupStore, authz, core.authAudit)
+            }
+        }
+    }
+
+    /** A cookie-jar client that presents [CALLER_ADDR] as its forwarded source on every request. */
+    private fun ApplicationTestBuilder.callerClient() = createClient {
+        expectSuccess = false
+        install(HttpCookies)
+        install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        install(DefaultRequest) { header("X-Forwarded-For", CALLER_ADDR) }
+    }
+
+    @Test
+    fun `token mint and revoke are audited through their routes and name the caller`() = testApplication {
+        installTokenRoutes()
+        val client = callerClient()
+
+        val owner = "token-owner@example.com"
+        client.post("/test/login/$owner")
+        val minted: IssuedToken = client.post("/api/tokens") {
+            contentType(ContentType.Application.Json)
+            setBody(CreateTokenInput(name = "audited"))
+        }.body()
+        assertEvent(owner, ACTION_TOKEN_MINT, auditEntity("Token", minted.id.toString()), "SUCCESS", "ALLOW")
+
+        // An identity admin may revoke someone else's token (the token.revoke oversight seed). The row must
+        // name the ADMIN who did it, not the owner it was done to — otherwise the trail frames the victim.
+        val admin = "token-admin@example.com"
+        val adminClient = callerClient()
+        adminClient.post("/test/login/$admin")
+        assertEquals(HttpStatusCode.NoContent, adminClient.delete("/api/tokens/${minted.id}").status)
+        assertNotNull(core.tokenStore.get(minted.id)?.revokedAt)
+        assertEvent(admin, ACTION_TOKEN_REVOKE, auditEntity("Token", minted.id.toString()), "SUCCESS", "ALLOW")
+        assertEquals(
+            0, count("SELECT count(*) FROM audit_event WHERE kind='auth' AND action='$ACTION_TOKEN_REVOKE' AND principal='$owner'"),
+            "the token's owner did not perform this revocation and must not be named as its actor",
+        )
+
+        // A 404 revoke changes nothing, so it records nothing.
+        val before = countAuth()
+        assertEquals(HttpStatusCode.NotFound, adminClient.delete("/api/tokens/${minted.id}").status)
+        assertEquals(before, countAuth(), "a revoke that changed no row must not write an event")
+
+        assertEquals(
+            0, count("SELECT count(*) FROM audit_event WHERE statement LIKE '%${minted.token}%' OR detail LIKE '%${minted.token}%'"),
+            "a minted token's secret must never reach the audit trail",
+        )
+        verifyAuditChain(dataSource)
+    }
+
+    /**
+     * Atomicity proven through the ROUTES, not a re-composition of their store calls: a route that committed
+     * the credential change and then recorded it separately would satisfy every other assertion in this class
+     * while leaving a rejected insert with a committed mutation behind it.
+     */
+    @Test
+    fun `a rejected auth audit insert rolls the token route's own mutation back`() = testApplication {
+        installTokenRoutes()
+        val client = callerClient()
+        val principal = "auth-audit-rollback@example.com"
+        client.post("/test/login/$principal")
+
+        val headBeforeMint = auditChainHead(dataSource)
+        val tokensBefore = count("SELECT count(*) FROM proxy_token WHERE principal = '$principal'")
+        rejectAction(ACTION_TOKEN_MINT)
+        try {
+            assertEquals(
+                HttpStatusCode.InternalServerError,
+                client.post("/api/tokens") {
+                    contentType(ContentType.Application.Json)
+                    setBody(CreateTokenInput(name = "rolled-back"))
+                }.status,
+            )
+            assertEquals(
+                tokensBefore, count("SELECT count(*) FROM proxy_token WHERE principal = '$principal'"),
+                "a mint whose audit insert was rejected must leave no token behind",
+            )
+            assertHeadUnchanged(headBeforeMint)
+        } finally {
+            dropRejectTrigger()
+        }
+
+        val minted: IssuedToken = client.post("/api/tokens") {
+            contentType(ContentType.Application.Json)
+            setBody(CreateTokenInput(name = "revoke-rollback"))
+        }.body()
+        val headBeforeRevoke = auditChainHead(dataSource)
+        rejectAction(ACTION_TOKEN_REVOKE)
+        try {
+            assertEquals(HttpStatusCode.InternalServerError, client.delete("/api/tokens/${minted.id}").status)
+            assertNull(
+                core.tokenStore.get(minted.id)?.revokedAt,
+                "a revoke whose audit insert was rejected must leave the token usable",
+            )
+            assertHeadUnchanged(headBeforeRevoke)
+        } finally {
+            dropRejectTrigger()
+        }
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `session wire-token mint is audited through its route and names the caller`() = testApplication {
+        installTokenRoutes()
+        val client = callerClient()
+
+        val owner = "wire-token-owner@example.com"
+        client.post("/test/login/$owner")
+        val minted: IssuedToken = client.post("/api/wire-tokens") {
+            contentType(ContentType.Application.Json)
+            setBody(MintSessionTokenInput())
+        }.body()
+        assertEquals(TokenKind.SESSION.name, minted.kind)
+        assertEvent(owner, ACTION_TOKEN_MINT, auditEntity("Token", minted.id.toString()), "SUCCESS", "ALLOW")
+
+        assertEquals(
+            0, count("SELECT count(*) FROM audit_event WHERE statement LIKE '%${minted.token}%' OR detail LIKE '%${minted.token}%'"),
+            "a minted token's secret must never reach the audit trail",
+        )
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `a rejected auth audit insert rolls the wire-token route's own mint back`() = testApplication {
+        installTokenRoutes()
+        val client = callerClient()
+        val principal = "wire-audit-rollback@example.com"
+        client.post("/test/login/$principal")
+
+        val headBeforeMint = auditChainHead(dataSource)
+        val tokensBefore = count("SELECT count(*) FROM proxy_token WHERE principal = '$principal'")
+        rejectAction(ACTION_TOKEN_MINT)
+        try {
+            assertEquals(
+                HttpStatusCode.InternalServerError,
+                client.post("/api/wire-tokens") {
+                    contentType(ContentType.Application.Json)
+                    setBody(MintSessionTokenInput())
+                }.status,
+            )
+            assertEquals(
+                tokensBefore, count("SELECT count(*) FROM proxy_token WHERE principal = '$principal'"),
+                "a mint whose audit insert was rejected must leave no token behind",
+            )
+            assertHeadUnchanged(headBeforeMint)
+        } finally {
+            dropRejectTrigger()
+        }
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `validateToken audits failures but not successful validation`() {
+        val before = countAuth()
+        assertEquals(Status.Code.UNAUTHENTICATED, statusOf("not-a-token"))
+        assertEquals(before + 1, countAuth())
+        // No client address: ValidateTokenRequest carries none (KNOWN_LIMITATIONS.md "Audit trail").
+        assertEvent(
+            PRINCIPAL_UNATTRIBUTED, ACTION_WIRE_VALIDATE, auditEntity("Token", "unresolved"), "FAILURE", "DENY",
+            expectedRows = 1, clientAddr = null,
+        )
+
+        val revoked = core.tokenStore.issue(TokenKind.USER, "revoked@example.com", emptyList(), null, 3600)
+        assertTrue(core.tokenStore.revoke(revoked.id, "revoked@example.com"))
+        val afterUnknown = countAuth()
+        assertEquals(Status.Code.UNAUTHENTICATED, statusOf(revoked.token))
+        assertEquals(afterUnknown + 1, countAuth())
+
+        val expired = core.tokenStore.issue(TokenKind.USER, "expired@example.com", emptyList(), null, 3600)
+        execute("UPDATE proxy_token SET expires_at = now() - interval '1 hour' WHERE id = ${expired.id}")
+        val afterRevoked = countAuth()
+        assertEquals(Status.Code.UNAUTHENTICATED, statusOf(expired.token))
+        assertEquals(afterRevoked + 1, countAuth())
+
+        val deprovisionedPrincipal = "deprovisioned@example.com"
+        core.userGroupStore.createUser(
+            AppUserInput(deprovisionedPrincipal), core.tokenStore, core.accessStore, sessionStore,
+        )
+        val deprovisioned = core.tokenStore.issue(TokenKind.USER, deprovisionedPrincipal, emptyList(), null, 3600)
+        core.userGroupStore.setUserActive(deprovisionedPrincipal, false)
+        val afterExpired = countAuth()
+        assertEquals(Status.Code.UNAUTHENTICATED, statusOf(deprovisioned.token))
+        assertEquals(afterExpired + 1, countAuth())
+        assertEvent(
+            deprovisionedPrincipal, ACTION_WIRE_VALIDATE, auditEntity("User", deprovisionedPrincipal), "FAILURE", "DENY",
+            clientAddr = null,
+        )
+
+        // The presented credential is never itself recorded, on any of the failure paths above.
+        assertEquals(
+            0,
+            count(
+                """SELECT count(*) FROM audit_event
+                   WHERE statement LIKE '%${revoked.token}%' OR detail LIKE '%${revoked.token}%'
+                      OR statement LIKE '%${expired.token}%' OR detail LIKE '%${expired.token}%'""",
+            ),
+        )
+
+        val valid = core.tokenStore.issue(TokenKind.USER, "valid@example.com", emptyList(), null, 3600)
+        val beforeSuccess = countAuth()
+        val identity = runBlocking {
+            grpc.validateToken(validateTokenRequest { token = valid.token; datasourceName = this@AuthAuditDbTest.datasourceName })
+        }
+        assertEquals("valid@example.com", identity.principal)
+        assertEquals(beforeSuccess, countAuth(), "successful wire validation must not emit auth audit rows")
+        verifyAuditChain(dataSource)
+    }
+
+    /**
+     * The wire-rejection audit is best-effort: a bad token has no state change to join, so an audit-insert
+     * failure on this hot path must NOT turn UNAUTHENTICATED into INTERNAL — the regression this guards. A
+     * reject-trigger on the wire-validate insert forces the insert to throw; the status must stay
+     * UNAUTHENTICATED and the chain untouched.
+     */
+    @Test
+    fun `a rejected wire-rejection audit still answers UNAUTHENTICATED, not INTERNAL`() {
+        val headBefore = auditChainHead(dataSource)
+        rejectAction(ACTION_WIRE_VALIDATE)
+        try {
+            assertEquals(
+                Status.Code.UNAUTHENTICATED, statusOf("still-not-a-token"),
+                "a failed rejection audit must not change the auth outcome",
+            )
+        } finally {
+            dropRejectTrigger()
+        }
+        assertHeadUnchanged(headBefore)
+        verifyAuditChain(dataSource)
+    }
+
+    private fun statusOf(token: String): Status.Code =
+        assertFailsWith<StatusException> {
+            runBlocking { grpc.validateToken(validateTokenRequest { this.token = token; datasourceName = this@AuthAuditDbTest.datasourceName }) }
+        }.status.code
+
+    /**
+     * Assert the (principal, action, resource) triple identifies exactly [expectedRows] rows that read as
+     * expected, [clientAddr] included: the recorder is the only thing carrying the caller's address onto the
+     * row, so an unasserted address is a wire that can be cut without a test noticing.
+     */
+    private fun assertEvent(
+        principal: String,
+        action: String,
+        resource: String,
+        outcome: String,
+        decision: String,
+        expectedRows: Int = 1,
+        channel: String = CHANNEL_WIRE,
+        clientAddr: String? = CALLER_ADDR,
+    ) {
+        val rows = dataSource.connection.use { c ->
+            c.prepareStatement(
+                """SELECT action, resource, outcome, kind, channel, decision, datasource, client_addr
+                   FROM audit_event WHERE principal=? AND action=? AND resource=? ORDER BY id""",
+            ).use { ps ->
+                ps.setString(1, principal)
+                ps.setString(2, action)
+                ps.setString(3, resource)
+                ps.executeQuery().use { rs -> buildList { while (rs.next()) add((1..8).map(rs::getString)) } }
+            }
+        }
+        assertEquals(
+            List(expectedRows) {
+                listOf(action, resource, outcome, "auth", channel, decision, "control-plane", clientAddr)
+            },
+            rows,
+        )
+    }
+
+    /** Make every `kind="auth"` insert for [action] fail, so a caller's transaction has to roll back with it. */
+    private fun rejectAction(action: String) {
+        execute(
+            """CREATE OR REPLACE FUNCTION pm_test_reject_auth_audit() RETURNS trigger AS ${'$'}body${'$'}
+               BEGIN RAISE EXCEPTION 'forced auth audit failure'; END
+               ${'$'}body${'$'} LANGUAGE plpgsql""",
+        )
+        execute(
+            """CREATE TRIGGER pm_test_reject_auth_audit BEFORE INSERT ON audit_event
+               FOR EACH ROW WHEN (NEW.kind = 'auth' AND NEW.action = '$action')
+               EXECUTE FUNCTION pm_test_reject_auth_audit()""",
+        )
+    }
+
+    private fun dropRejectTrigger() {
+        execute("DROP TRIGGER IF EXISTS pm_test_reject_auth_audit ON audit_event")
+        execute("DROP FUNCTION IF EXISTS pm_test_reject_auth_audit()")
+    }
+
+    private fun assertHeadUnchanged(before: Pair<Long, ByteArray>) {
+        val after = auditChainHead(dataSource)
+        assertEquals(before.first, after.first)
+        assertContentEquals(before.second, after.second)
+    }
+
+    private fun countAuth(): Int = count("SELECT count(*) FROM audit_event WHERE kind = 'auth'")
+
+    private fun count(sql: String): Int = dataSource.connection.use { c ->
+        c.prepareStatement(sql).use { ps -> ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) } }
+    }
+
+    private fun execute(sql: String) = dataSource.connection.use { c -> c.createStatement().use { it.execute(sql) } }
+
+    private companion object {
+        /** The forwarded source address every HTTP request in this class presents — a documentation range,
+         *  never a real host, and the value the audit rows must carry back. */
+        const val CALLER_ADDR = "203.0.113.7"
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DaemonSessionLivenessIdpTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DaemonSessionLivenessIdpTest.kt
@@ -179,6 +179,7 @@ class DaemonSessionLivenessIdpTest {
                 sessionStore,
                 userGroupStore,
                 roleResolver,
+                AuthAuditRecorder(AuditStore(ds)),
                 LoggerFactory.getLogger("DaemonSessionLivenessIdpTest"),
             )
         } finally {
@@ -231,6 +232,18 @@ class DaemonSessionLivenessIdpTest {
         val endedReason: String?,
     )
 
+    /** The (resource, detail, outcome, channel) of every `auth.session.expire` row for [principal]. */
+    private fun expiryEvents(principal: String): List<List<String?>> = ds.connection.use { c ->
+        c.prepareStatement(
+            """SELECT resource, detail, outcome, channel FROM audit_event
+               WHERE kind='auth' AND action=? AND principal=? ORDER BY id""",
+        ).use { ps ->
+            ps.setString(1, AuthAuditRecorder.ACTION_SESSION_EXPIRE)
+            ps.setString(2, principal)
+            ps.executeQuery().use { rs -> buildList { while (rs.next()) add((1..4).map(rs::getString)) } }
+        }
+    }
+
     @Test
     fun `fresh fewer groups end only the zero-role web session and preserve inactive liveness`() {
         val principal = "web-groups-removed@example.com"
@@ -254,6 +267,11 @@ class DaemonSessionLivenessIdpTest {
         assertEquals("WEB", after.kind)
         assertEquals(LIVENESS_INACTIVE, after.livenessStatus)
         assertNotNull(after.lastIdpCheckAt)
+        // Group revocation is principal-global, so the event names the principal, not one session row.
+        assertEquals(
+            listOf(listOf("""User::"$principal"""", "group_revoked", "SUCCESS", AuthAuditRecorder.CHANNEL_SESSION)),
+            expiryEvents(principal),
+        )
     }
 
     @Test
@@ -310,6 +328,10 @@ class DaemonSessionLivenessIdpTest {
         assertNull(sessionStore.resolveWeb(webId, "web-groups-omitted-device"))
         assertEquals(ENDED_GROUP_REVOKED, sessionStore.webEndedReason(webId))
         assertNotNull(snapshot(webId).lastIdpCheckAt)
+        assertEquals(
+            listOf(listOf("""User::"$principal"""", "group_revoked", "SUCCESS", AuthAuditRecorder.CHANNEL_SESSION)),
+            expiryEvents(principal),
+        )
     }
 
     @Test
@@ -331,6 +353,11 @@ class DaemonSessionLivenessIdpTest {
         assertNotNull(validAfter.lastIdpCheckAt)
         assertNull(tokenStore.get(wireToken.id)!!.revokedAt)
         assertEquals(1, accessStore.listGrants(principal, activeOnly = true).size)
+        // Only the row the IdP rejected is recorded — the sibling it left open must not appear.
+        assertEquals(
+            listOf(listOf("""Session::"${rejected.id}"""", "idp_rejected", "SUCCESS", AuthAuditRecorder.CHANNEL_SESSION)),
+            expiryEvents(principal),
+        )
     }
 
     @Test
@@ -354,6 +381,13 @@ class DaemonSessionLivenessIdpTest {
         assertEquals(LIVENESS_INACTIVE, snapshot(webId).livenessStatus)
         assertNull(tokenStore.get(wireToken.id)!!.revokedAt)
         assertEquals(1, accessStore.listGrants(principal, activeOnly = true).size)
+        // One row per session actually closed — both daemon rows and the web row, none doubled.
+        assertEquals(
+            listOf(daemonA.id, daemonB.id, webId).map {
+                listOf("""Session::"$it"""", "idp_rejected", "SUCCESS", AuthAuditRecorder.CHANNEL_SESSION)
+            }.toSet(),
+            expiryEvents(principal).toSet(),
+        )
     }
 
     @Test
@@ -380,6 +414,8 @@ class DaemonSessionLivenessIdpTest {
             assertNull(snapshot(webId).endedReason)
             assertNull(tokenStore.get(wireToken.id)!!.revokedAt)
             assertEquals(1, accessStore.listGrants(principal, activeOnly = true).size)
+            // A transient IdP error revokes nothing, so it must not be recorded as an expiry.
+            assertEquals(emptyList(), expiryEvents(principal))
         }
     }
 
@@ -406,7 +442,9 @@ class DaemonSessionLivenessIdpTest {
     fun `renew route never revalidates and only the timer sweep reaches the token endpoint`() = testApplication {
         application {
             install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
-            routing { sessionRenewRoutes(sessionStore, tokenStore, userGroupStore) }
+            routing {
+                sessionRenewRoutes(testConfig(), sessionStore, tokenStore, userGroupStore, AuthAuditRecorder(AuditStore(ds)))
+            }
         }
         val principal = "sole-revalidator@example.com"
         val created = sessionStore.create(

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DeviceLoginStoreDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DeviceLoginStoreDbTest.kt
@@ -1,5 +1,6 @@
 package com.ridi.oss.proxymonster.controlplane
 
+import com.ridi.oss.proxymonster.controlplane.management.auditEntity
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
 import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
@@ -15,6 +16,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.sessions.SessionTransportTransformerMessageAuthentication
@@ -149,6 +151,9 @@ class DeviceLoginStoreDbTest {
         // reads as unauthenticated and the authorize route would always bounce to /login.
         application { attributes.put(PRINCIPAL_SESSION_STORE, lastPrincipalSessionStore) }
         install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
+        // Mirrors module()'s fallback so a poll whose atomic mint audit throws answers 500, as in the running
+        // server, rather than surfacing as a transport failure.
+        install(StatusPages) { exception<Throwable> { call, _ -> call.respond(HttpStatusCode.InternalServerError) } }
         install(Sessions) {
             webSessionCookie(lastPrincipalSessionStore, config.sessionSecret) {
                 cookie.maxAgeInSeconds = config.webSessionAbsoluteSeconds
@@ -159,7 +164,10 @@ class DeviceLoginStoreDbTest {
             }
         }
         routing {
-            deviceSessionRoutes(config, store, lastPrincipalSessionStore, lastTokenStore, userGroupStore, log)
+            deviceSessionRoutes(
+                config, store, lastPrincipalSessionStore, lastTokenStore, userGroupStore,
+                AuthAuditRecorder(AuditStore(ds)), log,
+            )
             // Stands in for the web console's own login: mints a web session so the "already logged in" path
             // can be exercised without dragging the whole OIDC flow into this test.
             get("/test/login-as/{principal}") {
@@ -199,6 +207,77 @@ class DeviceLoginStoreDbTest {
 
     private suspend fun io.ktor.client.HttpClient.poll(handle: String) =
         post("/auth/device/poll") { contentType(ContentType.Application.Json); setBody("""{"handle":"$handle"}""") }
+
+    /** `kind="auth"` rows matching [where], whose `?` placeholders [args] fill in order. */
+    private fun auditCount(where: String, vararg args: String): Int = ds.connection.use { c ->
+        c.prepareStatement("SELECT count(*) FROM audit_event WHERE kind='auth' AND ($where)").use { ps ->
+            args.forEachIndexed { i, value -> ps.setString(i + 1, value) }
+            ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) }
+        }
+    }
+
+    private fun daemonSessionCount(handle: String): Int = ds.connection.use { c ->
+        c.prepareStatement("SELECT count(*) FROM principal_session WHERE handle = ? AND kind = 'DAEMON'").use { ps ->
+            ps.setString(1, handle)
+            ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) }
+        }
+    }
+
+    /** Make every `kind="auth"` insert for [action] fail, so the poll's mint transaction must roll back with it. */
+    private fun rejectAction(action: String) {
+        execute(
+            """CREATE OR REPLACE FUNCTION pm_test_reject_auth_audit() RETURNS trigger AS ${'$'}body${'$'}
+               BEGIN RAISE EXCEPTION 'forced auth audit failure'; END
+               ${'$'}body${'$'} LANGUAGE plpgsql""",
+        )
+        execute(
+            """CREATE TRIGGER pm_test_reject_auth_audit BEFORE INSERT ON audit_event
+               FOR EACH ROW WHEN (NEW.kind = 'auth' AND NEW.action = '$action')
+               EXECUTE FUNCTION pm_test_reject_auth_audit()""",
+        )
+    }
+
+    private fun dropRejectTrigger() {
+        execute("DROP TRIGGER IF EXISTS pm_test_reject_auth_audit ON audit_event")
+        execute("DROP FUNCTION IF EXISTS pm_test_reject_auth_audit()")
+    }
+
+    private fun execute(sql: String) = ds.connection.use { c -> c.createStatement().use { it.execute(sql) } }
+
+    /**
+     * The APPROVED -> CONSUMED claim now runs INSIDE the mint transaction, so a failed mint rolls it back and
+     * the poll can retry — instead of stranding the handle CONSUMED with no token and no audit (finding 3). A
+     * reject-trigger on the device-mint audit forces the mint to fail after consume would have run.
+     */
+    @Test
+    fun `a failed device mint rolls the consume back so the poll can retry`() = testApplication {
+        val client = installDeviceRoutes()
+        val started = client.startLogin()
+        client.confirm(started.userCode)
+        client.get("/test/login-as/retry@example.com")
+        client.authorize(started.userCode)
+
+        rejectAction(AuthAuditRecorder.ACTION_DEVICE_MINT)
+        try {
+            assertEquals(HttpStatusCode.InternalServerError, client.poll(started.handle).status)
+            assertEquals(
+                "APPROVED", store.get(started.handle)!!.status,
+                "a failed mint must roll the consume back, leaving the handle replayable",
+            )
+            assertEquals(0, daemonSessionCount(started.handle), "a rolled-back mint must leave no session")
+            assertEquals(
+                0, auditCount("action=? AND principal=?", AuthAuditRecorder.ACTION_DEVICE_MINT, "retry@example.com"),
+                "a rolled-back mint must leave no device-mint audit row",
+            )
+        } finally {
+            dropRejectTrigger()
+        }
+
+        // The retry succeeds — proving the handle was never stranded CONSUMED.
+        val poll = client.poll(started.handle)
+        assertEquals(HttpStatusCode.OK, poll.status)
+        assertEquals("retry@example.com", poll.body<DevicePollResult>().principal)
+    }
 
     @Test
     fun `the verification URL points at the web console origin, not the control plane`() {
@@ -289,6 +368,23 @@ class DeviceLoginStoreDbTest {
         val row = store.get(started.handle)!!
         assertEquals("APPROVED", row.status)
         assertEquals("alice@example.com", row.principal, "approved as the logged-in principal, never a debug default")
+        assertEquals(
+            1,
+            auditCount(
+                "action=? AND principal=? AND resource=?",
+                AuthAuditRecorder.ACTION_DEVICE_APPROVE, "alice@example.com", auditEntity("DeviceLogin", row.id.toString()),
+            ),
+        )
+        // The handle is the bearer secret /auth/device/poll accepts on its own, and the audit trail is
+        // readable by every auditor and exported to the SIEM. It must appear in NO column of NO event.
+        assertEquals(
+            0,
+            auditCount(
+                "resource LIKE ? OR statement LIKE ? OR detail LIKE ? OR principal = ?",
+                "%${started.handle}%", "%${started.handle}%", "%${started.handle}%", started.handle,
+            ),
+            "the device-login handle is a credential and must never reach the audit trail",
+        )
     }
 
     @Test
@@ -310,6 +406,19 @@ class DeviceLoginStoreDbTest {
         assertTrue(result.token.isNotBlank())
         assertNotNull(lastTokenStore.validate(result.token))
         assertTrue(result.renewalToken.startsWith("pmr_"), "renewalToken must be the mint-once bearer renewal secret")
+        assertEquals(
+            1,
+            auditCount(
+                "action=? AND principal=? AND resource=?",
+                AuthAuditRecorder.ACTION_DEVICE_MINT, "alice@example.com",
+                auditEntity("Token", lastTokenStore.list("alice@example.com").first().id.toString()),
+            ),
+        )
+        assertEquals(
+            0,
+            auditCount("statement LIKE ? OR detail LIKE ? OR resource LIKE ?", "%${result.token}%", "%${result.renewalToken}%", "%pmr_%"),
+            "a minted token and its renewal secret must never reach the audit trail",
+        )
     }
 
     @Test
@@ -335,5 +444,14 @@ class DeviceLoginStoreDbTest {
             }
         }
         assertEquals(1, count, "a replayed poll must not mint a second session/renewal secret")
+        assertEquals(
+            1,
+            auditCount(
+                "action=? AND principal=? AND resource=?",
+                AuthAuditRecorder.ACTION_DEVICE_MINT, "alice@example.com",
+                auditEntity("Token", lastTokenStore.list("alice@example.com").first().id.toString()),
+            ),
+            "a replayed poll must not emit a second device mint event",
+        )
     }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/McpOAuthStoreDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/McpOAuthStoreDbTest.kt
@@ -111,14 +111,32 @@ class McpOAuthStoreDbTest {
     @Test
     fun `RFC 7009 access revocation is local while refresh revocation closes the family`() {
         val accessOnly = issue("oauth-revoke-access@example.com")
-        store.revoke(accessOnly.accessToken)
+        assertNotNull(store.revoke(accessOnly.accessToken))
         assertNull(tokens.resolveAccess(accessOnly.accessToken, RESOURCE))
         val afterAccessRevoke = assertNotNull(store.rotateRefresh(refresh(accessOnly.refreshToken)))
         assertNotNull(tokens.resolveAccess(afterAccessRevoke.accessToken, RESOURCE))
 
-        store.revoke(afterAccessRevoke.refreshToken)
+        assertNotNull(store.revoke(afterAccessRevoke.refreshToken))
         assertNull(tokens.resolveAccess(afterAccessRevoke.accessToken, RESOURCE))
         assertNull(store.rotateRefresh(refresh(afterAccessRevoke.refreshToken)))
+    }
+
+    /**
+     * Revocation reports the token it CLOSED, not merely one that resolved. The endpoint in front of this is
+     * unauthenticated (RFC 7009 answers 200 for an unknown token), so a caller replaying one once-valid token
+     * must not be able to append a revocation record per call.
+     */
+    @Test
+    fun `revoke reports a transition once and an unknown token never`() {
+        val pair = issue("oauth-revoke-replay@example.com")
+
+        assertNotNull(store.revoke(pair.accessToken), "the first revoke closes the access token")
+        assertNull(store.revoke(pair.accessToken), "replaying the same access token closes nothing")
+
+        assertNotNull(store.revoke(pair.refreshToken), "the refresh token's family is still open")
+        assertNull(store.revoke(pair.refreshToken), "replaying the refresh token closes nothing")
+
+        assertNull(store.revoke("pma_never-issued"))
     }
 
     @Test

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/OidcCallbackTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/OidcCallbackTest.kt
@@ -3,10 +3,15 @@ package com.ridi.oss.proxymonster.controlplane
 import com.ridi.oss.proxymonster.auth.isValidPkceChallenge
 import com.ridi.oss.proxymonster.auth.isValidPkceVerifier
 import com.ridi.oss.proxymonster.auth.pkceS256
+import com.ridi.oss.proxymonster.controlplane.management.auditEntity
+import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
 import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
@@ -27,7 +32,10 @@ import io.ktor.server.sessions.cookie
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import kotlinx.serialization.json.Json
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicReference
@@ -38,6 +46,12 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 private const val TEST_SESSION_SECRET = "oidc-callback-test-secret-not-for-prod"
+
+/** The IdP client every rejection row is attributed to — no principal exists before an id_token validates. */
+private const val CLIENT_ID = "test-client"
+
+/** The forwarded source address this suite's clients present, and the one every rejection row must carry. */
+private const val CALLER_ADDR = "203.0.113.9"
 
 /**
  * Syntactically-invalid `id_token` — [IdTokenValidator.validate] fails to even parse it, so it
@@ -54,12 +68,70 @@ private const val UNPARSEABLE_ID_TOKEN = "not-a-real-jwt"
  * (discovery document + token endpoint) is a tiny double colocated in the same test application so
  * it's reachable via relative URLs through the in-process test client — no real sockets, and no real
  * signing keys needed since every scenario here fails validation/CSRF *before* JIT provisioning
- * would run (so [UserGroupStore] is backed by a [DataSource] that must never actually be touched).
+ * would run.
+ *
+ * The store is nonetheless a real database: a rejected callback records a `kind="auth"` FAILURE event,
+ * and asserting those rows is how each rejection is told apart from a redirect that merely looks alike.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OidcCallbackTest {
     private val log = LoggerFactory.getLogger(OidcCallbackTest::class.java)
-    private val userGroupStore = UserGroupStore(UnusedDataSource)
-    private val roleResolver = RoleResolver(UnusedDataSource, userGroupStore, AccessStore(UnusedDataSource))
+    private lateinit var dataSource: DataSource
+    private lateinit var userGroupStore: UserGroupStore
+    private lateinit var roleResolver: RoleResolver
+
+    /** The newest audit row's id, so an assertion can scope itself to what a single request appended —
+     *  the whole class shares one database and several branches produce the same `detail`. */
+    private fun latestAuditId(): Long = dataSource.connection.use { c ->
+        c.prepareStatement("SELECT COALESCE(MAX(id), 0) FROM audit_event").use { ps ->
+            ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) }
+        }
+    }
+
+    /**
+     * Assert the callback appended exactly one `kind="auth"` row after [sinceId], reading as the full
+     * contract requires: a count alone would still pass with the action, channel, attribution, resource, or
+     * requester address wrong, and those are what make the row usable.
+     *
+     * A rejection happens before any id_token is validated, so there is no principal to name and the row is
+     * attributed to the IdP client instead. [OidcWebSessionDbTest] covers the one branch that DOES name a
+     * principal (a login refused for having no effective roles).
+     */
+    private fun assertOneRejectionRecorded(sinceId: Long, detail: String) {
+        val rows = dataSource.connection.use { c ->
+            c.prepareStatement(
+                """SELECT principal, action, resource, outcome, decision, channel, client_addr, detail
+                   FROM audit_event WHERE kind='auth' AND id > ? ORDER BY id""",
+            ).use { ps ->
+                ps.setLong(1, sinceId)
+                ps.executeQuery().use { rs -> buildList { while (rs.next()) add((1..8).map(rs::getString)) } }
+            }
+        }
+        assertEquals(
+            listOf(
+                listOf(
+                    AuthAuditRecorder.PRINCIPAL_UNATTRIBUTED,
+                    AuthAuditRecorder.ACTION_OIDC_LOGIN,
+                    auditEntity("Client", CLIENT_ID),
+                    "FAILURE",
+                    "DENY",
+                    AuthAuditRecorder.CHANNEL_OIDC,
+                    CALLER_ADDR,
+                    detail,
+                ),
+            ),
+            rows,
+        )
+    }
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_oidc_callback"))
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        userGroupStore = UserGroupStore(dataSource)
+        roleResolver = RoleResolver(dataSource, userGroupStore, AccessStore(dataSource))
+    }
 
     private fun testConfig(oidcConfigured: Boolean = true): Config = Config(
         httpPort = 0,
@@ -72,7 +144,7 @@ class OidcCallbackTest {
         oidc = if (oidcConfigured) {
             OidcConfig(
                 issuer = "",
-                clientId = "test-client",
+                clientId = CLIENT_ID,
                 clientSecret = "test-secret",
                 redirectUri = "https://cp.example.test/auth/oidc/callback",
                 scopes = "openid profile email groups offline_access",
@@ -86,6 +158,9 @@ class OidcCallbackTest {
         sessionWindowSeconds = 12 * 3600,
         idpRecheckIntervalSeconds = 600,
         devMarker = false,
+        // The Ktor test host's socket peer, trusted as an edge so the client's X-Forwarded-For resolves to
+        // [CALLER_ADDR] — the requester address every rejection row is asserted to carry.
+        trustedProxies = setOf("localhost"),
     )
 
     /**
@@ -98,6 +173,7 @@ class OidcCallbackTest {
         config: Config,
         pkceMethods: List<String>? = null,
         tokenForm: AtomicReference<Parameters>? = null,
+        tokenEndpointFails: Boolean = false,
     ): HttpClient {
         // The client oidcRoutes/OidcDiscovery use for their OWN outbound calls (discovery fetch +
         // token exchange) — bound to this test app's in-process engine, so "/.well-known/..." and
@@ -115,7 +191,8 @@ class OidcCallbackTest {
         // Application.module itself is structured, resolves it unambiguously.
         application {
             installOidcTestApp(
-                config, discovery, validator, internalHttp, userGroupStore, roleResolver, log, pkceMethods, tokenForm,
+                config, discovery, validator, internalHttp, dataSource, userGroupStore, roleResolver, log,
+                pkceMethods, tokenForm, tokenEndpointFails,
             )
         }
 
@@ -123,6 +200,7 @@ class OidcCallbackTest {
             expectSuccess = false
             followRedirects = false
             install(HttpCookies)
+            install(DefaultRequest) { header("X-Forwarded-For", CALLER_ADDR) }
         }
     }
 
@@ -150,9 +228,78 @@ class OidcCallbackTest {
 
         val loginResp = client.get("/auth/oidc/login")
         val realState = parseQueryString(loginResp.headers[HttpHeaders.Location]!!.substringAfter('?'))["state"]!!
+        val before = latestAuditId()
         val resp = client.get("/auth/oidc/callback?error=access_denied&state=$realState")
         assertEquals(HttpStatusCode.Found, resp.status)
         assertEquals("/login?error=oidc", resp.headers[HttpHeaders.Location])
+        assertOneRejectionRecorded(before, "idp_error=access_denied")
+    }
+
+    /**
+     * The IdP error is a caller-chosen query parameter — `/auth/oidc/login` is open, so a self-minted state
+     * reaches this branch with any value. It must be bounded before it reaches a hash-chained, SIEM-exported
+     * row, or an unauthenticated caller decides how much of the trail each attempt consumes.
+     */
+    @Test
+    fun `an oversized idp error is truncated before it reaches the trail`() = testApplication {
+        val client = wireOidc(testConfig())
+
+        val loginResp = client.get("/auth/oidc/login")
+        val realState = parseQueryString(loginResp.headers[HttpHeaders.Location]!!.substringAfter('?'))["state"]!!
+        val before = latestAuditId()
+        client.get("/auth/oidc/callback?error=${"a".repeat(5_000)}&state=$realState")
+
+        assertOneRejectionRecorded(before, "idp_error=${"a".repeat(200)}")
+    }
+
+    @Test
+    fun `a callback with neither code nor error is recorded`() = testApplication {
+        val client = wireOidc(testConfig())
+
+        val loginResp = client.get("/auth/oidc/login")
+        val realState = parseQueryString(loginResp.headers[HttpHeaders.Location]!!.substringAfter('?'))["state"]!!
+        val before = latestAuditId()
+        val resp = client.get("/auth/oidc/callback?state=$realState")
+
+        assertEquals("/login?error=state", resp.headers[HttpHeaders.Location])
+        assertOneRejectionRecorded(before, "missing_code")
+    }
+
+    @Test
+    fun `a callback whose nonce cookie is gone is recorded`() = testApplication {
+        val client = wireOidc(testConfig())
+
+        val loginResp = client.get("/auth/oidc/login")
+        val realState = parseQueryString(loginResp.headers[HttpHeaders.Location]!!.substringAfter('?'))["state"]!!
+        // Replay the state cookie alone, without the nonce one: state then validates and the absent nonce is
+        // what rejects the callback, which is the branch under test. A cookie-jar client would carry both.
+        val stateCookie = loginResp.headers.getAll(HttpHeaders.SetCookie)!!
+            .single { it.startsWith("$OAUTH_STATE_COOKIE=") }.substringBefore(';')
+        val jarless = createClient {
+            expectSuccess = false
+            followRedirects = false
+            install(DefaultRequest) { header("X-Forwarded-For", CALLER_ADDR) }
+        }
+        val before = latestAuditId()
+        val resp = jarless.get("/auth/oidc/callback?code=abc&state=$realState") {
+            header(HttpHeaders.Cookie, stateCookie)
+        }
+
+        assertEquals("/login?error=nonce", resp.headers[HttpHeaders.Location])
+        assertOneRejectionRecorded(before, "missing_nonce")
+    }
+
+    @Test
+    fun `a failed token exchange is recorded`() = testApplication {
+        val client = wireOidc(testConfig(), tokenEndpointFails = true)
+
+        val loginResp = client.get("/auth/oidc/login")
+        val realState = parseQueryString(loginResp.headers[HttpHeaders.Location]!!.substringAfter('?'))["state"]!!
+        val before = latestAuditId()
+        val resp = client.get("/auth/oidc/callback?code=abc&state=$realState")
+
+        assertEquals("/login?error=oidc", resp.headers[HttpHeaders.Location])
+        assertOneRejectionRecorded(before, "token_exchange_failed")
     }
 
     @Test
@@ -205,9 +352,11 @@ class OidcCallbackTest {
         val realState = parseQueryString(loginResp.headers[HttpHeaders.Location]!!.substringAfter('?'))["state"]!!
 
         // Wrong state -> rejected; per the clear-regardless idiom, the cookie is burned either way.
+        val before = latestAuditId()
         val wrongResp = client.get("/auth/oidc/callback?code=abc&state=not-the-real-state")
         assertEquals(HttpStatusCode.Found, wrongResp.status)
         assertEquals("/login?error=state", wrongResp.headers[HttpHeaders.Location])
+        assertOneRejectionRecorded(before, "invalid_state")
 
         // Replaying with the ORIGINAL, correct state now also fails — proves one-time-use (the
         // cookie is gone), not just that the string comparison rejects a bad value.
@@ -222,9 +371,11 @@ class OidcCallbackTest {
         val loginResp = client.get("/auth/oidc/login")
         val realState = parseQueryString(loginResp.headers[HttpHeaders.Location]!!.substringAfter('?'))["state"]!!
 
+        val before = latestAuditId()
         val resp = client.get("/auth/oidc/callback?code=abc&state=$realState")
         assertEquals(HttpStatusCode.Found, resp.status)
         assertEquals("/login?error=nonce", resp.headers[HttpHeaders.Location])
+        assertOneRejectionRecorded(before, "invalid_id_token")
 
         // The state (and nonce) cookies were cleared on this first attempt regardless of outcome —
         // a replay of the same, originally-valid state now hits the (now-empty) state guard.
@@ -326,11 +477,13 @@ private fun Application.installOidcTestApp(
     discovery: OidcDiscovery?,
     validator: IdTokenValidator?,
     http: HttpClient,
+    dataSource: DataSource,
     userGroupStore: UserGroupStore,
     roleResolver: RoleResolver,
     log: Logger,
     pkceMethods: List<String>? = null,
     tokenForm: AtomicReference<Parameters>? = null,
+    tokenEndpointFails: Boolean = false,
 ) {
     install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
     install(Sessions) {
@@ -377,27 +530,12 @@ private fun Application.installOidcTestApp(
         }
         post("/token") {
             tokenForm?.set(call.receiveParameters())
-            call.respond(mapOf("id_token" to UNPARSEABLE_ID_TOKEN))
+            if (tokenEndpointFails) call.respond(HttpStatusCode.BadGateway, mapOf("error" to "temporarily_unavailable"))
+            else call.respond(mapOf("id_token" to UNPARSEABLE_ID_TOKEN))
         }
-        oidcRoutes(config, discovery, validator, http, userGroupStore, roleResolver, PrincipalSessionStore(UnusedDataSource, null), log)
+        oidcRoutes(
+            config, discovery, validator, http, userGroupStore, roleResolver, PrincipalSessionStore(dataSource, null),
+            AuthAuditRecorder(AuditStore(dataSource)), log,
+        )
     }
-}
-
-/**
- * A [DataSource] that must never be touched. Every scenario in [OidcCallbackTest] fails CSRF/id_token
- * validation before `UserGroupStore.provisionFromOidc` would ever run — real JIT-provisioning-on-login
- * behavior belongs to [UserGroupStore]'s own (DB-backed) tests, not here.
- */
-private object UnusedDataSource : DataSource {
-    private fun boom(): Nothing = error("OidcCallbackTest: UserGroupStore should not be queried by any scenario here")
-
-    override fun getConnection() = boom()
-    override fun getConnection(username: String?, password: String?) = boom()
-    override fun <T : Any?> unwrap(iface: Class<T>?): T = boom()
-    override fun isWrapperFor(iface: Class<*>?): Boolean = false
-    override fun getLogWriter(): java.io.PrintWriter? = null
-    override fun setLogWriter(out: java.io.PrintWriter?) {}
-    override fun setLoginTimeout(seconds: Int) {}
-    override fun getLoginTimeout(): Int = 0
-    override fun getParentLogger(): java.util.logging.Logger = boom()
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/OidcWebSessionDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/OidcWebSessionDbTest.kt
@@ -9,11 +9,14 @@ import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import com.ridi.oss.proxymonster.auth.pkceS256
+import com.ridi.oss.proxymonster.controlplane.management.auditEntity
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
 import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
+import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -55,6 +58,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+
+/** The forwarded source address the callback client presents, and the one the login's audit row must carry. */
+private const val CALLER_ADDR = "203.0.113.11"
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OidcWebSessionDbTest {
@@ -120,6 +126,82 @@ class OidcWebSessionDbTest {
             seedRole = false,
             expectSession = false,
         )
+    }
+
+    @Test
+    fun `a session mint failure after id_token validation is audited and leaves no session`() = testApplication {
+        requireDockerOrSkip()
+        val dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_oidc_web"))
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        val principal = "oidc-mint-fail@example.com"
+        callbackPrincipal.set(principal)
+        val policyStore = PolicyStore(dataSource)
+        val role = policyStore.createRole(RoleInput("oidc-mint-fail-role"))
+        policyStore.createAssignment(RoleAssignmentInput(principal, role.id))
+
+        // Fail the session mint AFTER the id_token validates: a BEFORE INSERT trigger on principal_session
+        // rolls the mint transaction back, exercising the callback's own mint-failure catch. The standalone
+        // failure row it writes is not on that rolled-back transaction, so it survives.
+        dataSource.connection.use { c ->
+            c.createStatement().use {
+                it.execute(
+                    """CREATE OR REPLACE FUNCTION pm_test_reject_session_insert() RETURNS trigger AS ${'$'}body${'$'}
+                       BEGIN RAISE EXCEPTION 'forced session mint failure'; END
+                       ${'$'}body${'$'} LANGUAGE plpgsql""",
+                )
+                it.execute(
+                    """CREATE TRIGGER pm_test_reject_session_insert BEFORE INSERT ON principal_session
+                       FOR EACH ROW EXECUTE FUNCTION pm_test_reject_session_insert()""",
+                )
+            }
+        }
+
+        application { installOidcWebApp(config("openid email", resultKey = ByteArray(32) { it.toByte() }), dataSource) }
+        val client = createClient {
+            expectSuccess = false
+            followRedirects = false
+            install(HttpCookies)
+            install(DefaultRequest) { header("X-Forwarded-For", CALLER_ADDR) }
+        }
+
+        val login = client.get("/auth/oidc/login")
+        val query = parseQueryString(assertNotNull(login.headers[HttpHeaders.Location]).substringAfter('?'))
+        nonce.set(assertNotNull(query["nonce"]))
+        val callback = client.get("/auth/oidc/callback?code=ok&state=${assertNotNull(query["state"])}")
+
+        assertEquals(HttpStatusCode.Found, callback.status)
+        assertEquals("/login?error=oidc", callback.headers[HttpHeaders.Location])
+        assertTrue(
+            callback.headers.getAll(HttpHeaders.SetCookie).orEmpty().none { it.startsWith("$SESSION_COOKIE=") },
+            "a rolled-back mint must set no console session cookie",
+        )
+
+        dataSource.connection.use { c ->
+            c.prepareStatement("SELECT count(*) FROM principal_session WHERE principal = ?").use { ps ->
+                ps.setString(1, principal)
+                ps.executeQuery().use { rs ->
+                    assertTrue(rs.next())
+                    assertEquals(0, rs.getInt(1), "the rolled-back mint leaves no session row")
+                }
+            }
+            c.prepareStatement(
+                """SELECT outcome, decision, channel, detail, client_addr, resource FROM audit_event
+                   WHERE kind='auth' AND principal=? AND action=?""",
+            ).use { ps ->
+                ps.setString(1, principal)
+                ps.setString(2, AuthAuditRecorder.ACTION_OIDC_LOGIN)
+                ps.executeQuery().use { rs ->
+                    assertTrue(rs.next(), "the mint failure must be audited")
+                    assertEquals("FAILURE", rs.getString("outcome"))
+                    assertEquals("DENY", rs.getString("decision"))
+                    assertEquals(AuthAuditRecorder.CHANNEL_OIDC, rs.getString("channel"))
+                    assertEquals("session_mint_failed", rs.getString("detail"))
+                    assertEquals(CALLER_ADDR, rs.getString("client_addr"))
+                    assertEquals(auditEntity("User", principal), rs.getString("resource"))
+                    assertTrue(!rs.next(), "exactly one FAILURE row for the mint failure")
+                }
+            }
+        }
     }
 
     @Test
@@ -253,6 +335,7 @@ class OidcWebSessionDbTest {
             expectSuccess = false
             followRedirects = false
             install(HttpCookies)
+            install(DefaultRequest) { header("X-Forwarded-For", CALLER_ADDR) }
         }
 
         val login = client.get(
@@ -276,6 +359,21 @@ class OidcWebSessionDbTest {
                         assertEquals(0, rs.getInt(1))
                     }
                 }
+                c.prepareStatement(
+                    """SELECT outcome, decision, channel, detail, client_addr FROM audit_event
+                       WHERE kind='auth' AND principal=? AND action=?""",
+                ).use { ps ->
+                    ps.setString(1, principal)
+                    ps.setString(2, AuthAuditRecorder.ACTION_OIDC_LOGIN)
+                    ps.executeQuery().use { rs ->
+                        assertTrue(rs.next(), "a login refused for having no roles must be audited")
+                        assertEquals("FAILURE", rs.getString("outcome"))
+                        assertEquals("DENY", rs.getString("decision"))
+                        assertEquals(AuthAuditRecorder.CHANNEL_OIDC, rs.getString("channel"))
+                        assertEquals("no_effective_roles", rs.getString("detail"))
+                        assertEquals(CALLER_ADDR, rs.getString("client_addr"))
+                    }
+                }
             }
             return@testApplication
         }
@@ -291,12 +389,30 @@ class OidcWebSessionDbTest {
 
         dataSource.connection.use { c ->
             c.prepareStatement(
-                """SELECT kind, refresh_token_enc, idle_expires_at, absolute_expires_at, created_at, device_id, session_key
+                """SELECT kind, refresh_token_enc, idle_expires_at, absolute_expires_at, created_at, device_id, session_key, id
                    FROM principal_session WHERE principal = ?""",
             ).use { ps ->
                 ps.setString(1, principal)
                 ps.executeQuery().use { rs ->
                     assertTrue(rs.next())
+                    // The audit row names the session this login actually minted, not merely that some
+                    // login happened: a row pointing at a different session would go unnoticed otherwise.
+                    val sessionId = rs.getLong("id")
+                    c.prepareStatement(
+                        """SELECT outcome, decision, channel, resource, client_addr FROM audit_event
+                           WHERE kind='auth' AND principal=? AND action=?""",
+                    ).use { auditPs ->
+                        auditPs.setString(1, principal)
+                        auditPs.setString(2, AuthAuditRecorder.ACTION_OIDC_LOGIN)
+                        auditPs.executeQuery().use { auditRs ->
+                            assertTrue(auditRs.next(), "a login that minted a session must be audited")
+                            assertEquals("SUCCESS", auditRs.getString("outcome"))
+                            assertEquals("ALLOW", auditRs.getString("decision"))
+                            assertEquals(AuthAuditRecorder.CHANNEL_OIDC, auditRs.getString("channel"))
+                            assertEquals(auditEntity("Session", sessionId.toString()), auditRs.getString("resource"))
+                            assertEquals(CALLER_ADDR, auditRs.getString("client_addr"))
+                        }
+                    }
                     assertEquals("WEB", rs.getString("kind"))
                     assertEquals(deviceId, rs.getString("device_id"))
                     assertNotNull(rs.getString("session_key"))
@@ -350,8 +466,11 @@ class OidcWebSessionDbTest {
             }
         }
         routing {
-            oidcRoutes(config, discovery, validator, http, userGroupStore, roleResolver, store, environment.log)
-            deviceSessionRoutes(config, deviceLoginStore, store, TokenStore(dataSource), userGroupStore, environment.log)
+            val authAudit = AuthAuditRecorder(AuditStore(dataSource))
+            oidcRoutes(config, discovery, validator, http, userGroupStore, roleResolver, store, authAudit, environment.log)
+            deviceSessionRoutes(
+                config, deviceLoginStore, store, TokenStore(dataSource), userGroupStore, authAudit, environment.log,
+            )
         }
     }
 
@@ -377,6 +496,9 @@ class OidcWebSessionDbTest {
         webSessionAbsoluteSeconds = 7200,
         idpRecheckIntervalSeconds = 600,
         devMarker = true,
+        // The Ktor test host's socket peer, trusted as an edge so the client's X-Forwarded-For resolves to
+        // [CALLER_ADDR] — the requester address the login's audit row is asserted to carry.
+        trustedProxies = setOf("localhost"),
     )
 
     private fun sign(expectedNonce: String): String {

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/RenewalWindowTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/RenewalWindowTest.kt
@@ -69,7 +69,7 @@ class RenewalWindowTest {
     private fun ApplicationTestBuilder.installRenewRoute() {
         install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
         routing {
-            sessionRenewRoutes(daemonSessionStore, tokenStore, userGroupStore)
+            sessionRenewRoutes(config, daemonSessionStore, tokenStore, userGroupStore, AuthAuditRecorder(AuditStore(ds)))
         }
     }
 
@@ -87,6 +87,14 @@ class RenewalWindowTest {
         val body: RenewSessionResponse = resp.body()
         assertTrue(body.token.isNotBlank())
         assertNotNull(tokenStore.validate(body.token))
+        val audit = ds.connection.use { c ->
+            c.prepareStatement("SELECT outcome, channel FROM audit_event WHERE kind='auth' AND action=? AND principal=?").use { ps ->
+                ps.setString(1, AuthAuditRecorder.ACTION_SESSION_RENEW)
+                ps.setString(2, principal)
+                ps.executeQuery().use { rs -> assertTrue(rs.next()); rs.getString(1) to rs.getString(2) }
+            }
+        }
+        assertEquals("SUCCESS" to AuthAuditRecorder.CHANNEL_PMON, audit)
     }
 
     @Test

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TokenRoutesDeactivationTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TokenRoutesDeactivationTest.kt
@@ -77,7 +77,7 @@ class TokenRoutesDeactivationTest {
     private fun ApplicationTestBuilder.installTokenRoutes() {
         install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
         routing {
-            tokenRoutes(config, tokenStore, userGroupStore, authz)
+            tokenRoutes(config, tokenStore, userGroupStore, authz, AuthAuditRecorder(AuditStore(ds)))
         }
     }
 

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/WebSessionRoutesDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/WebSessionRoutesDbTest.kt
@@ -1,5 +1,6 @@
 package com.ridi.oss.proxymonster.controlplane
 
+import com.ridi.oss.proxymonster.controlplane.management.auditEntity
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
 import io.ktor.client.HttpClient
@@ -245,6 +246,20 @@ class WebSessionRoutesDbTest {
                     assertEquals(ENDED_SIGNED_OUT, rs.getString("ended_reason"))
                 }
             }
+            c.prepareStatement(
+                """SELECT outcome, decision, channel FROM audit_event
+                   WHERE kind='auth' AND principal=? AND action=? AND resource=?""",
+            ).use { ps ->
+                ps.setString(1, "web@example.com")
+                ps.setString(2, AuthAuditRecorder.ACTION_LOGOUT)
+                ps.setString(3, auditEntity("Session", id.toString()))
+                ps.executeQuery().use { rs ->
+                    assertTrue(rs.next())
+                    assertEquals("SUCCESS", rs.getString("outcome"))
+                    assertEquals("ALLOW", rs.getString("decision"))
+                    assertEquals(AuthAuditRecorder.CHANNEL_SESSION, rs.getString("channel"))
+                }
+            }
         }
         assertEquals(HttpStatusCode.Unauthorized, client.get("/auth/me").status)
         val replay = createClient { expectSuccess = false }.get("/auth/me") {
@@ -292,6 +307,16 @@ class WebSessionRoutesDbTest {
         assertEquals(HttpStatusCode.OK, staleLogout.status)
         assertEquals(LogoutResponse(ended = false), staleLogout.body())
         assertNull(staleLogout.headers[HttpHeaders.SetCookie], "a stale conditional logout must not clear the cookie")
+        assertEquals(
+            0,
+            dataSource.connection.use { c ->
+                c.prepareStatement("SELECT count(*) FROM audit_event WHERE kind='auth' AND action=? AND resource=?").use { ps ->
+                    ps.setString(1, AuthAuditRecorder.ACTION_LOGOUT)
+                    ps.setString(2, auditEntity("Session", currentId.toString()))
+                    ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) }
+                }
+            },
+        )
         val stillCurrent = client.get("/auth/session/status")
         assertEquals(HttpStatusCode.OK, stillCurrent.status)
         assertEquals(currentId, stillCurrent.body<SessionStatus>().sessionId)
@@ -304,6 +329,53 @@ class WebSessionRoutesDbTest {
         assertEquals(LogoutResponse(ended = true), matchingLogout.body())
         assertContains(assertNotNull(matchingLogout.headers.getAll(HttpHeaders.SetCookie)?.joinToString()), "Max-Age=0")
         assertReason(client.get("/auth/session/status"), "none")
+    }
+
+    /**
+     * A logout that terminates a session must appear in the trail even when that session no longer resolves.
+     * An idle-expired row is still open (`ended_at IS NULL`), so logout ends it for real — keying the audit
+     * record off the resolved identity instead of the session reference would silently drop this one.
+     */
+    @Test
+    fun `logging out of an idle-expired session still records the termination`() = testApplication {
+        requireDockerOrSkip()
+        val dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_web_idle_logout"))
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        val config = Config.fromEnv { null }.copy(dbUrl = "", dbUser = "", dbPassword = "")
+        application { module(config, ControlPlaneCore(dataSource)) }
+        val client = sessionClient()
+
+        client.post("/auth/debug") {
+            headers.append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            setBody(DebugLogin("idle-logout@example.com"))
+        }
+        val id = webSessionId(dataSource, "idle-logout@example.com")
+        dataSource.connection.use { c ->
+            c.prepareStatement("UPDATE principal_session SET idle_expires_at = now() - interval '1 second' WHERE id = ?").use { ps ->
+                ps.setLong(1, id)
+                ps.executeUpdate()
+            }
+        }
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/auth/me").status, "the row must no longer resolve")
+
+        assertEquals(HttpStatusCode.OK, client.post("/auth/logout").status)
+        dataSource.connection.use { c ->
+            c.prepareStatement("SELECT ended_reason FROM principal_session WHERE id = ?").use { ps ->
+                ps.setLong(1, id)
+                ps.executeQuery().use { rs -> assertTrue(rs.next()); assertEquals(ENDED_SIGNED_OUT, rs.getString(1)) }
+            }
+            c.prepareStatement(
+                "SELECT principal, outcome FROM audit_event WHERE kind='auth' AND action=? AND resource=?",
+            ).use { ps ->
+                ps.setString(1, AuthAuditRecorder.ACTION_LOGOUT)
+                ps.setString(2, auditEntity("Session", id.toString()))
+                ps.executeQuery().use { rs ->
+                    assertTrue(rs.next(), "a logout that ended a session must be audited even when it no longer resolves")
+                    assertEquals("idle-logout@example.com", rs.getString("principal"))
+                    assertEquals("SUCCESS", rs.getString("outcome"))
+                }
+            }
+        }
     }
 
     @Test

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/oauth/OAuthRoutesDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/oauth/OAuthRoutesDbTest.kt
@@ -1,6 +1,9 @@
 package com.ridi.oss.proxymonster.controlplane.oauth
 
 import com.ridi.oss.proxymonster.auth.pkceS256
+import com.ridi.oss.proxymonster.auth.sha256Hex
+import com.ridi.oss.proxymonster.controlplane.AuditStore
+import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder
 import com.ridi.oss.proxymonster.controlplane.Config
 import com.ridi.oss.proxymonster.controlplane.ControlPlaneCore
 import com.ridi.oss.proxymonster.controlplane.PRINCIPAL_SESSION_STORE
@@ -12,11 +15,14 @@ import com.ridi.oss.proxymonster.controlplane.jsonSessionSerializer
 import com.ridi.oss.proxymonster.controlplane.module
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.verifyAuditChain
 import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
 import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.post
@@ -30,6 +36,7 @@ import io.ktor.server.application.Application
 import io.ktor.server.application.call
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.response.respond
 import io.ktor.server.routing.post as serverPost
 import io.ktor.server.routing.routing
@@ -441,6 +448,368 @@ class OAuthRoutesDbTest {
         )
     }
 
+    /**
+     * The OAuth half of the `kind="auth"` trail, driven through the routes: consent grant, token grant,
+     * `/oauth/revoke`, and consent revoke. Each assertion is written so that deleting its emission in
+     * `OAuthRoutes.kt` fails exactly here.
+     */
+    @Test
+    fun `consent, token grant, and both revoke routes each write one auth event`() = testApplication {
+        application { oauthTestModule(config().copy(mcpDebugAutoConsent = false), dataSource, resolver()) }
+        val client = createClient {
+            expectSuccess = false
+            followRedirects = false
+            install(HttpCookies)
+            install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+        val principal = "oauth-audit@example.com"
+        val grantsBefore = authEvents(AUTH_OAUTH_TOKEN, resource = """Client::"$CLIENT_ID"""").size
+        val consentPage = client.get("/oauth/authorize") {
+            parameter("response_type", "code")
+            parameter("client_id", CLIENT_ID)
+            parameter("redirect_uri", REDIRECT_URI)
+            parameter("scope", "mcp:read")
+            parameter("state", "state-audit")
+            parameter("resource", RESOURCE)
+            parameter("code_challenge", CHALLENGE)
+            parameter("code_challenge_method", "S256")
+            parameter("principal", principal)
+        }
+        assertEquals(HttpStatusCode.OK, consentPage.status)
+        val csrf = assertNotNull(
+            Regex("""name="csrf" value="([^"]+)"""").find(consentPage.bodyAsText())?.groupValues?.get(1),
+        )
+
+        assertEquals(0, authEvents(AUTH_OAUTH_CONSENT, principal).size)
+        val approved = client.submitForm(
+            "/oauth/consent",
+            Parameters.build { append("csrf", csrf); append("decision", "approve") },
+        )
+        assertEquals(HttpStatusCode.Found, approved.status)
+        val consentId = consentIdOf(principal)
+        assertEquals(
+            listOf(Triple("SUCCESS", "ALLOW", "oauth")),
+            authEvents(AUTH_OAUTH_CONSENT, principal, resource = """Consent::"$consentId""""),
+        )
+
+        val code = assertNotNull(Url(assertNotNull(approved.headers[HttpHeaders.Location])).parameters["code"])
+        val token = client.submitForm(
+            "/oauth/token",
+            Parameters.build {
+                append("grant_type", "authorization_code")
+                append("code", code)
+                append("client_id", CLIENT_ID)
+                append("redirect_uri", REDIRECT_URI)
+                append("resource", RESOURCE)
+                append("code_verifier", VERIFIER)
+            },
+        )
+        assertEquals(HttpStatusCode.OK, token.status)
+        val accessToken = token.body<JsonObject>().getValue("access_token").jsonPrimitive.content
+        // The grant is attributed to the client, not a user — the code was already redeemed, and the pair
+        // carries no principal. Counted as a delta because every other test in this class grants tokens for
+        // the same client id against this shared database.
+        val grants = authEvents(AUTH_OAUTH_TOKEN, resource = """Client::"$CLIENT_ID"""")
+        assertEquals(Triple("SUCCESS", "ALLOW", "oauth"), grants.last())
+        assertEquals(1, grants.size - grantsBefore, "one token grant must write exactly one event")
+
+        // /oauth/revoke is unauthenticated by design (RFC 7009 answers 200 for an unknown token), so only a
+        // call that actually closed a token may write a row — otherwise anyone could append to a
+        // tamper-evident chain, claiming revocations that never happened, by replaying one token.
+        val revokedResource = """Token::"${accessTokenIdOf(accessToken)}""""
+        assertEquals(HttpStatusCode.OK, client.submitForm("/oauth/revoke", Parameters.build { append("token", "pma_bogus") }).status)
+        assertEquals(
+            emptyList(), authEvents(AUTH_OAUTH_REVOKE, resource = revokedResource),
+            "a revoke of an unknown token must not claim a revocation that never happened",
+        )
+
+        assertEquals(HttpStatusCode.OK, client.submitForm("/oauth/revoke", Parameters.build { append("token", accessToken) }).status)
+        assertEquals(listOf(Triple("SUCCESS", "ALLOW", "oauth")), authEvents(AUTH_OAUTH_REVOKE, resource = revokedResource))
+
+        // Replaying the SAME token revokes nothing the second time, so it adds nothing.
+        assertEquals(HttpStatusCode.OK, client.submitForm("/oauth/revoke", Parameters.build { append("token", accessToken) }).status)
+        assertEquals(
+            1, authEvents(AUTH_OAUTH_REVOKE, resource = revokedResource).size,
+            "replaying an already-revoked token must not append a second revocation event",
+        )
+
+        val csrfHeader = assertNotNull(client.get("/oauth/consents").body<JsonObject>()["csrfToken"]).jsonPrimitive.content
+        assertEquals(
+            HttpStatusCode.NoContent,
+            client.delete("/oauth/consents/$consentId") { header("X-PM-CSRF", csrfHeader) }.status,
+        )
+        assertEquals(
+            listOf(Triple("SUCCESS", "ALLOW", "oauth")),
+            authEvents(AUTH_OAUTH_REVOKE, principal, resource = """Consent::"$consentId""""),
+        )
+        // A repeat revoke transitions nothing, so it adds nothing.
+        assertEquals(
+            HttpStatusCode.NotFound,
+            client.delete("/oauth/consents/$consentId") { header("X-PM-CSRF", csrfHeader) }.status,
+        )
+        assertEquals(
+            1,
+            authEvents(AUTH_OAUTH_REVOKE, principal, resource = """Consent::"$consentId"""").size,
+            "a consent revoke that changed nothing must not write a second event",
+        )
+
+        assertEquals(
+            0,
+            countWhere("statement LIKE '%$accessToken%' OR detail LIKE '%$accessToken%' OR resource LIKE '%$accessToken%'"),
+            "a presented OAuth token must never reach the audit trail",
+        )
+        verifyAuditChain(dataSource)
+    }
+
+    /**
+     * The debug auto-consent chokepoint (PM_AUTH_DEBUG + auto-consent) remembers a NEW consent and issues a
+     * code in one authorize hop, bypassing the manual consent form the test above drives. Deleting its
+     * emission would go unnoticed there.
+     */
+    @Test
+    fun `debug auto-consent writes one consent auth event`() = testApplication {
+        application { oauthTestModule(config(), dataSource, resolver()) }
+        val client = createClient {
+            expectSuccess = false
+            followRedirects = false
+            install(HttpCookies)
+            install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+        val principal = "oauth-auto-consent@example.com"
+        assertEquals(0, authEvents(AUTH_OAUTH_CONSENT, principal).size)
+        val authorization = client.get("/oauth/authorize") {
+            parameter("response_type", "code")
+            parameter("client_id", CLIENT_ID)
+            parameter("redirect_uri", REDIRECT_URI)
+            parameter("scope", "mcp:read")
+            parameter("state", "state-auto-consent")
+            parameter("resource", RESOURCE)
+            parameter("code_challenge", CHALLENGE)
+            parameter("code_challenge_method", "S256")
+            parameter("principal", principal)
+        }
+        assertEquals(HttpStatusCode.Found, authorization.status)
+        assertNotNull(Url(assertNotNull(authorization.headers[HttpHeaders.Location])).parameters["code"])
+
+        assertEquals(
+            listOf(Triple("SUCCESS", "ALLOW", "oauth")),
+            authEvents(AUTH_OAUTH_CONSENT, principal, resource = """Consent::"${consentIdOf(principal)}""""),
+        )
+        verifyAuditChain(dataSource)
+    }
+
+    /**
+     * A rejected token-grant audit must roll the whole grant back: the auth code stays unconsumed and no token
+     * is minted, so the client retries cleanly (finding 2, GRANT path). Proven through the route, not a
+     * re-composition of store calls.
+     */
+    @Test
+    fun `a rejected token-grant audit rolls the OAuth grant back, leaving the code unconsumed for retry`() = testApplication {
+        application { oauthTestModule(config(), dataSource, resolver()) }
+        val client = createClient {
+            expectSuccess = false
+            followRedirects = false
+            install(HttpCookies)
+            install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+        val principal = "oauth-token-rollback@example.com"
+        val authorization = client.get("/oauth/authorize") {
+            parameter("response_type", "code")
+            parameter("client_id", CLIENT_ID)
+            parameter("redirect_uri", REDIRECT_URI)
+            parameter("scope", "mcp:read")
+            parameter("state", "state-token-rollback")
+            parameter("resource", RESOURCE)
+            parameter("code_challenge", CHALLENGE)
+            parameter("code_challenge_method", "S256")
+            parameter("principal", principal)
+        }
+        val code = assertNotNull(Url(assertNotNull(authorization.headers[HttpHeaders.Location])).parameters["code"])
+
+        suspend fun grant() = client.submitForm(
+            "/oauth/token",
+            Parameters.build {
+                append("grant_type", "authorization_code"); append("code", code)
+                append("client_id", CLIENT_ID); append("redirect_uri", REDIRECT_URI)
+                append("resource", RESOURCE); append("code_verifier", VERIFIER)
+            },
+        )
+
+        val proxyTokensBefore = proxyTokenCount()
+        rejectAction(AUTH_OAUTH_TOKEN)
+        try {
+            assertEquals(HttpStatusCode.InternalServerError, grant().status)
+            assertTrue(codeUnused(code), "a rejected token-grant audit must leave the auth code unconsumed")
+            assertEquals(proxyTokensBefore, proxyTokenCount(), "a rejected token-grant audit must mint no token")
+        } finally {
+            dropRejectTrigger()
+        }
+        // The rollback left the code usable — the SAME code now grants cleanly.
+        assertEquals(HttpStatusCode.OK, grant().status)
+        verifyAuditChain(dataSource)
+    }
+
+    /**
+     * client_id is a caller-supplied CIMD URL on an unauthenticated endpoint; it must be bounded before it
+     * reaches the tamper-evident chain (finding 6). Driven on the invalid_grant failure path, which records
+     * the same bounded client_id without needing CIMD resolution.
+     */
+    @Test
+    fun `a caller-supplied client_id is bounded before it reaches the audit chain`() = testApplication {
+        application { oauthTestModule(config(), dataSource, resolver()) }
+        val client = createClient {
+            expectSuccess = false
+            install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+        val longClientId = "https://client.example/" + "a".repeat(300)
+        val bounded = longClientId.take(200)
+        val failed = client.submitForm(
+            "/oauth/token",
+            Parameters.build {
+                append("grant_type", "authorization_code"); append("code", "pmc_never-issued")
+                append("client_id", longClientId); append("redirect_uri", REDIRECT_URI)
+                append("resource", RESOURCE); append("code_verifier", VERIFIER)
+            },
+        )
+        assertEquals(HttpStatusCode.BadRequest, failed.status)
+        assertEquals("invalid_grant", failed.body<JsonObject>().getValue("error").jsonPrimitive.content)
+
+        assertEquals(
+            1, countWhere("""action='$AUTH_OAUTH_TOKEN' AND outcome='FAILURE' AND resource = 'Client::"$bounded"'"""),
+            "the invalid_grant failure must record the client_id truncated to the audited bound",
+        )
+        assertEquals(
+            0, countWhere("resource LIKE '%${"a".repeat(220)}%'"),
+            "the full over-long client_id must never reach the chain",
+        )
+        verifyAuditChain(dataSource)
+    }
+
+    /**
+     * The manual consent form guards on an existing active consent, so a double-submit of the approval (the
+     * pending cookie is still attached until the first response clears it) writes only ONE consent event for
+     * one grant (finding 7).
+     */
+    @Test
+    fun `a repeated manual consent for the same grant writes only one consent event`() = testApplication {
+        application { oauthTestModule(config().copy(mcpDebugAutoConsent = false), dataSource, resolver()) }
+        val client = createClient {
+            expectSuccess = false
+            followRedirects = false
+            install(HttpCookies)
+            install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+        val principal = "oauth-double-consent@example.com"
+
+        suspend fun authorizeThenApprove() {
+            val page = client.get("/oauth/authorize") {
+                parameter("response_type", "code")
+                parameter("client_id", CLIENT_ID)
+                parameter("redirect_uri", REDIRECT_URI)
+                parameter("scope", "mcp:read")
+                parameter("state", "state-double")
+                parameter("resource", RESOURCE)
+                parameter("code_challenge", CHALLENGE)
+                parameter("code_challenge_method", "S256")
+                parameter("principal", principal)
+            }
+            assertEquals(HttpStatusCode.OK, page.status)
+            val csrf = assertNotNull(Regex("""name="csrf" value="([^"]+)"""").find(page.bodyAsText())?.groupValues?.get(1))
+            val approved = client.submitForm("/oauth/consent", Parameters.build { append("csrf", csrf); append("decision", "approve") })
+            assertEquals(HttpStatusCode.Found, approved.status)
+        }
+
+        assertEquals(0, authEvents(AUTH_OAUTH_CONSENT, principal).size)
+        authorizeThenApprove()
+        authorizeThenApprove() // same principal/client/scope → the second is a no-op consent
+        assertEquals(
+            listOf(Triple("SUCCESS", "ALLOW", "oauth")),
+            authEvents(AUTH_OAUTH_CONSENT, principal, resource = """Consent::"${consentIdOf(principal)}""""),
+            "a manual re-consent for an existing active grant must not write a second consent event",
+        )
+        verifyAuditChain(dataSource)
+    }
+
+    /** Count of MCP tokens the test client holds — asserts a rejected grant minted none. */
+    private fun proxyTokenCount(): Int = dataSource.connection.use { c ->
+        c.prepareStatement("SELECT count(*) FROM proxy_token WHERE client_id = ?").use { ps ->
+            ps.setString(1, CLIENT_ID)
+            ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) }
+        }
+    }
+
+    /** Whether the authorization code is still unconsumed (used_at IS NULL) — the rollback left it retryable. */
+    private fun codeUnused(code: String): Boolean = dataSource.connection.use { c ->
+        c.prepareStatement("SELECT used_at IS NULL FROM oauth_authorization_code WHERE code_hash = ?").use { ps ->
+            ps.setString(1, sha256Hex(code))
+            ps.executeQuery().use { rs -> assertTrue(rs.next()); rs.getBoolean(1) }
+        }
+    }
+
+    /** Make every `kind="auth"` insert for [action] fail, so a caller's transaction must roll back with it. */
+    private fun rejectAction(action: String) {
+        execute(
+            """CREATE OR REPLACE FUNCTION pm_test_reject_auth_audit() RETURNS trigger AS ${'$'}body${'$'}
+               BEGIN RAISE EXCEPTION 'forced auth audit failure'; END
+               ${'$'}body${'$'} LANGUAGE plpgsql""",
+        )
+        execute(
+            """CREATE TRIGGER pm_test_reject_auth_audit BEFORE INSERT ON audit_event
+               FOR EACH ROW WHEN (NEW.kind = 'auth' AND NEW.action = '$action')
+               EXECUTE FUNCTION pm_test_reject_auth_audit()""",
+        )
+    }
+
+    private fun dropRejectTrigger() {
+        execute("DROP TRIGGER IF EXISTS pm_test_reject_auth_audit ON audit_event")
+        execute("DROP FUNCTION IF EXISTS pm_test_reject_auth_audit()")
+    }
+
+    private fun execute(sql: String) = dataSource.connection.use { c -> c.createStatement().use { it.execute(sql) } }
+
+    private fun consentIdOf(principal: String): Long = dataSource.connection.use { c ->
+        c.prepareStatement("SELECT id FROM oauth_consent WHERE principal = ? ORDER BY id DESC LIMIT 1").use { ps ->
+            ps.setString(1, principal)
+            ps.executeQuery().use { rs -> assertTrue(rs.next()); rs.getLong(1) }
+        }
+    }
+
+    /** The stored id of an access token, for asserting the revocation event names the token it closed. */
+    private fun accessTokenIdOf(token: String): Long = dataSource.connection.use { c ->
+        c.prepareStatement("SELECT id FROM proxy_token WHERE token_hash = ?").use { ps ->
+            ps.setString(1, sha256Hex(token))
+            ps.executeQuery().use { rs -> assertTrue(rs.next()); rs.getLong(1) }
+        }
+    }
+
+    /** The (outcome, decision, channel) of every `kind="auth"` row matching the given filters. */
+    private fun authEvents(action: String, principal: String? = null, resource: String? = null): List<Triple<String, String, String>> =
+        dataSource.connection.use { c ->
+            val filters = buildList {
+                add("kind='auth'"); add("action=?")
+                if (principal != null) add("principal=?")
+                if (resource != null) add("resource=?")
+            }
+            c.prepareStatement(
+                "SELECT outcome, decision, channel FROM audit_event WHERE ${filters.joinToString(" AND ")} ORDER BY id",
+            ).use { ps ->
+                listOfNotNull(action, principal, resource).forEachIndexed { i, v -> ps.setString(i + 1, v) }
+                ps.executeQuery().use { rs ->
+                    buildList { while (rs.next()) add(Triple(rs.getString(1), rs.getString(2), rs.getString(3))) }
+                }
+            }
+        }
+
+    private fun countWhere(where: String): Int = dataSource.connection.use { c ->
+        c.prepareStatement("SELECT count(*) FROM audit_event WHERE $where").use { ps ->
+            ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) }
+        }
+    }
+
     /** The simulated address on [principal]'s single LIVE web session — the row a decision would resolve. */
     private fun liveDebugIp(principal: String): String? = dataSource.connection.use { c ->
         c.prepareStatement(
@@ -494,6 +863,9 @@ class OAuthRoutesDbTest {
         const val REDIRECT_URI = "http://127.0.0.1:43110/callback"
         val VERIFIER = "v".repeat(43)
         val CHALLENGE = pkceS256(VERIFIER)
+        val AUTH_OAUTH_CONSENT = AuthAuditRecorder.ACTION_OAUTH_CONSENT
+        val AUTH_OAUTH_TOKEN = AuthAuditRecorder.ACTION_OAUTH_TOKEN
+        val AUTH_OAUTH_REVOKE = AuthAuditRecorder.ACTION_OAUTH_REVOKE
     }
 }
 
@@ -501,6 +873,9 @@ private fun Application.oauthTestModule(config: Config, dataSource: DataSource, 
     val principalSessionStore = PrincipalSessionStore(dataSource, null)
     attributes.put(PRINCIPAL_SESSION_STORE, principalSessionStore)
     install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
+    // Mirrors module()'s fallback so a route whose atomic audit throws answers 500 here, as it would in the
+    // running server, instead of surfacing as a transport failure.
+    install(StatusPages) { exception<Throwable> { call, _ -> call.respond(HttpStatusCode.InternalServerError) } }
     install(Sessions) {
         webSessionCookie(principalSessionStore, config.sessionSecret)
         cookie<McpPendingAuthorization>(MCP_OAUTH_PENDING_COOKIE) {
@@ -528,6 +903,8 @@ private fun Application.oauthTestModule(config: Config, dataSource: DataSource, 
                 )))
             call.respond(HttpStatusCode.NoContent)
         }
-        mcpOAuthRoutes(config, dataSource, principalSessionStore, resolver)
+        mcpOAuthRoutes(
+            config, dataSource, principalSessionStore, AuthAuditRecorder(AuditStore(dataSource)), resolver,
+        )
     }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/TestDatabases.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/TestDatabases.kt
@@ -73,6 +73,21 @@ internal fun assertServerSeries(image: String, expected: String?, actual: String
 }
 
 /**
+ * Let a finished test class's pool give its connections back to the shared container.
+ *
+ * Every DB-backed test class opens a pool in `@BeforeAll` and never closes it, so without this a class
+ * keeps [HikariConfig.getMinimumIdle] connections (defaulted to the max) for the rest of the JVM's life
+ * and the suite's peak is the sum over *all* classes, not the ones actually running. Classes execute
+ * sequentially in one JVM, so holding them idle buys nothing while the sum climbs toward the server's
+ * `max_connections` — which surfaces in whichever class happens to start next as
+ * "FATAL: sorry, too many clients already", not in the one that leaked.
+ */
+private fun HikariConfig.applyTestPoolReclaim() {
+    minimumIdle = 0
+    idleTimeout = 10_000
+}
+
+/**
  * Shared Testcontainers-backed databases for DB-backed unit tests.
  *
  * Each engine's container is started **once, lazily, and reused across every test in the module**
@@ -85,10 +100,9 @@ object SharedPostgres {
     private val counter = AtomicInteger()
 
     private val container: PostgreSQLContainer<*> by lazy {
-        // Generous max_connections: every DB-backed test class opens its own pool (maximumPoolSize=4)
-        // against this ONE shared container and holds it for its @BeforeAll lifetime, so the suite's peak
-        // concurrent connections scale with the number of DB test classes — which outgrew Postgres's
-        // default of 100 ("FATAL: sorry, too many clients already"). This is test-infra headroom only.
+        // Generous max_connections: every DB-backed test class opens its own pool against this ONE shared
+        // container, and no pool is ever closed, so the suite's ceiling scales with the number of DB test
+        // classes rather than with how many run at once. This is test-infra headroom only.
         PostgreSQLContainer(IMAGE).apply { withCommand("postgres", "-c", "max_connections=500"); start() }
     }
 
@@ -108,6 +122,7 @@ object SharedPostgres {
             password = container.password
             driverClassName = "org.postgresql.Driver"
             maximumPoolSize = 4
+            applyTestPoolReclaim()
         },
     )
 
@@ -198,6 +213,7 @@ object SharedMySql {
             password = container.password
             driverClassName = "com.mysql.cj.jdbc.Driver"
             maximumPoolSize = 4
+            applyTestPoolReclaim()
         },
     )
 

--- a/docs/audit-trail-hardening.md
+++ b/docs/audit-trail-hardening.md
@@ -319,7 +319,7 @@ still lands in WORM + SIEM.
 ## Data model
 
 - `audit_event` is a heterogeneous event log (decision / completion / lifecycle
-  / management), discriminated by a `kind` column. `id` is app-allocated
+  / management / auth), discriminated by a `kind` column. `id` is app-allocated
   `BIGINT` (gap-free, lock-ordered, no `BIGSERIAL` default), plus
   `prev_hash BYTEA` and `row_hash BYTEA` (or a sidecar `audit_chain` 1:1 by
   `id`). No separate `seq` — `id` is ordinal and cursor.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -181,6 +181,12 @@ forward work. MySQL leads PostgreSQL in priority.
 - Distinguish verify's failure kinds by exit status. An integrity break and a
   database, storage, or configuration failure both exit non-zero, so automation
   has to parse logs to tell "the trail is broken" from "I could not check".
+- Carry the end client's address on `ValidateTokenRequest`. The proxy holds the
+  client socket, so a rejected wire credential is audited without a source
+  address and repeated failures can be correlated only by principal. The proxy
+  already resolves that address for the per-statement decision; adding the field
+  and populating it from the same place gives failed wire logins the source
+  attribution the rest of the auth events have.
 
 ## Enforcement completeness
 


### PR DESCRIPTION
## What

Adds a `kind="auth"` audit trail for the authentication/session lifecycle, previously
unrecorded: OIDC login success/failure, logout, the device-code flow, wire-token
mint/revoke, daemon session renew, IdP-driven session expiry, and the MCP-OAuth
consent/token/revoke grants. Mirrors #115's `kind="admin"` recorder over the same
`AuditStore` chain chokepoint. No schema or hash-chain change.

## Two emission rules (the load-bearing part)

- **Rejections** (bad login, invalid/expired/revoked wire token, invalid OAuth grant)
  change nothing → the audit is **best-effort**: a failed audit insert logs but never
  changes the auth outcome — in particular it can't turn an `UNAUTHENTICATED` wire
  rejection into an internal error.
- **State-change events** (session/token/consent mint or revoke, device consume) are
  written on the mutation's **own transaction**, so they commit or roll back together.
  The OAuth store runs the audit inside its transaction via an `onCommit` callback;
  revoke keeps RFC 7009's 200-on-error.

## Non-obvious

- Successful wire-token validation is **not** recorded — it runs on every
  connection/query and the per-statement decision already audits it.
- Caller-supplied values on unauthenticated paths are length-bounded before the chain.
- The gRPC `ValidateToken` failure carries no client address (proto limitation,
  documented in `KNOWN_LIMITATIONS.md`).

## Tests

DB-backed: each event fires exactly once with the right fields; a **successful** wire
validation writes **zero** rows; mint/revoke/consume roll back atomically under a
forced audit-insert failure; a best-effort wire rejection still answers
`UNAUTHENTICATED`; `client_id` is bounded; a repeated consent is a no-op. Hash chain
re-verifies. 939 tests green; full `mise verify` gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qwri6K4wyMaD1vKYbzQTqz
