### PR TITLE
fix(auditmon): skip an unset alert webhook instead of failing closed

### DIFF
--- a/auditmon/alert/alert.go
+++ b/auditmon/alert/alert.go
@@ -103,8 +103,8 @@ const (
 )
 
 // New builds a Sink from the alerts config. Each sink's URL is resolved from its named env var (secrets never
-// live in the file); a configured sink whose env var is unset is a loud, fail-closed error rather than a
-// silently-dead notification path.
+// live in the file); a configured sink whose env var is unset is logged and skipped, so a missing notification
+// URL disables that one channel rather than aborting the monitor.
 func New(cfg config.AlertsConfig, store worm.ObjectStore, opts ...Option) (*Sink, error) {
 	s := &Sink{
 		store:       store,
@@ -120,7 +120,12 @@ func New(cfg config.AlertsConfig, store worm.ObjectStore, opts ...Option) (*Sink
 	for i, sc := range cfg.Sinks {
 		url := strings.TrimSpace(os.Getenv(sc.URLEnv))
 		if url == "" {
-			return nil, fmt.Errorf("alert: sinks[%d] env var %s (url_env) is empty", i, sc.URLEnv)
+			// A missing notification URL disables just this sink, loudly — its notifications stay off
+			// until the value is set (a redeploy then picks it up). It must not take down the monitor:
+			// every alert still lands durably in WORM regardless of any webhook.
+			s.log.Warn("alert: sink url_env is empty; its notifications are disabled until it is set",
+				"sink", i, "url_env", sc.URLEnv)
+			continue
 		}
 		d := destination{
 			url:        url,

--- a/auditmon/alert/alert_test.go
+++ b/auditmon/alert/alert_test.go
@@ -296,12 +296,16 @@ func TestIntegrityReporterDelivers(t *testing.T) {
 	}
 }
 
-func TestNewRejectsMissingURLEnv(t *testing.T) {
-	// Env var intentionally unset: a configured sink with no URL is a loud, fail-closed error.
-	_, err := New(config.AlertsConfig{
+func TestNewSkipsMissingURLEnv(t *testing.T) {
+	// Env var intentionally unset: the sink is skipped (its notifications disabled), not fatal — a missing
+	// webhook URL must not take down the monitor.
+	s, err := New(config.AlertsConfig{
 		Sinks: []config.SinkConfig{{Type: "webhook", URLEnv: "DEFINITELY_UNSET_WEBHOOK_URL", MinSeverity: "warn"}},
 	}, worm.NewMemory())
-	if err == nil {
-		t.Fatal("expected New to reject a sink whose url_env is unset")
+	if err != nil {
+		t.Fatalf("New should skip a urlless sink, not error: %v", err)
+	}
+	if len(s.dests) != 0 {
+		t.Fatalf("urlless sink should be dropped, got %d destinations", len(s.dests))
 	}
 }


### PR DESCRIPTION
alert.New aborted the whole monitor if a configured sink's `url_env` was empty. Now a missing notification URL logs a warning and disables just that sink — alerts still land in WORM, and setting the URL + redeploying enables the channel. A missing notification channel shouldn't take down audit-chain verification.

This removes the fail-closed-on-empty behavior that was forcing elaborate deploy choreography (fill-before-enable ordering, pre-create+import, deploy circuit breaker) on the terraform side. With this, the Slack sink can be enabled anytime and the webhook secret filled whenever.

Test: `TestNewRejectsMissingURLEnv` → `TestNewSkipsMissingURLEnv` (New succeeds, the urlless sink is dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)