### PR TITLE
feat(control-plane): audit JIT elevation and approval decisions

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Access.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Access.kt
@@ -8,6 +8,9 @@ import com.ridi.oss.proxymonster.controlplane.authz.authorizeDatasourceAction
 import com.ridi.oss.proxymonster.controlplane.authz.authorizeWithContext
 import com.ridi.oss.proxymonster.controlplane.authz.requireAuthz
 import com.ridi.oss.proxymonster.controlplane.authz.resolveContextTags
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
+import com.ridi.oss.proxymonster.controlplane.management.auditEntity
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
@@ -72,12 +75,14 @@ class AccessStore(private val dataSource: DataSource) {
 
     private fun ResultSet.longOrNull(col: String): Long? = getLong(col).let { if (wasNull()) null else it }
 
-    fun getRequest(id: Long): AccessRequest? = dataSource.connection.use { c ->
+    fun getRequest(id: Long): AccessRequest? = dataSource.connection.use { getRequest(id, it) }
+
+    /** Read on the caller's connection so an in-transaction read never borrows a second pooled connection. */
+    fun getRequest(id: Long, c: Connection): AccessRequest? =
         c.prepareStatement("$REQ_SELECT WHERE ar.id = ?").use { ps ->
             ps.setLong(1, id)
             ps.executeQuery().use { rs -> if (rs.next()) rs.toRequest() else null }
         }
-    }
 
     fun listRequests(status: String?): List<AccessRequest> = dataSource.connection.use { c ->
         val sql = if (status != null) {
@@ -92,18 +97,42 @@ class AccessStore(private val dataSource: DataSource) {
     }
 
     fun createRequest(principal: String, input: AccessRequestInput): AccessRequest {
-        val id = dataSource.connection.use { c ->
-            c.prepareStatement(
-                """INSERT INTO access_request (principal, role_id, datasource_id, reason, requested_duration_sec)
-                   VALUES (?, ?, ?, ?, ?) RETURNING id""",
-            ).use { ps ->
-                ps.setString(1, principal)
-                ps.setLong(2, input.roleId)
-                if (input.datasourceId == null) ps.setNull(3, java.sql.Types.BIGINT) else ps.setLong(3, input.datasourceId)
-                ps.setString(4, input.reason)
-                ps.setLong(5, input.requestedDurationSec)
-                ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) }
+        val id = dataSource.inTx { c -> createRequest(principal, input, c) }
+        return getRequest(id)!!
+    }
+
+    /** Insert a ROLE access request on the caller's transaction, returning its id. */
+    fun createRequest(principal: String, input: AccessRequestInput, c: Connection): Long =
+        c.prepareStatement(
+            """INSERT INTO access_request (principal, role_id, datasource_id, reason, requested_duration_sec)
+               VALUES (?, ?, ?, ?, ?) RETURNING id""",
+        ).use { ps ->
+            ps.setString(1, principal)
+            ps.setLong(2, input.roleId)
+            if (input.datasourceId == null) ps.setNull(3, java.sql.Types.BIGINT) else ps.setLong(3, input.datasourceId)
+            ps.setString(4, input.reason)
+            ps.setLong(5, input.requestedDurationSec)
+            ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) }
+        }
+
+    /** Open a ROLE access request, recording the [TASK_REQUEST][AuthzAction.TASK_REQUEST] event atomically. */
+    fun createRequest(
+        principal: String,
+        input: AccessRequestInput,
+        actor: AuditActor,
+        recorder: ManagementAuditRecorder,
+    ): AccessRequest {
+        val id = dataSource.inTx { c ->
+            val newId = createRequest(principal, input, c)
+            val roleName = c.prepareStatement("SELECT name FROM app_role WHERE id = ?").use { ps ->
+                ps.setLong(1, input.roleId)
+                ps.executeQuery().use { rs -> if (rs.next()) rs.getString(1) else null }
             }
+            recorder.record(
+                c, actor, AuthzAction.TASK_REQUEST, auditEntity("AccessRequest", newId.toString()),
+                "open access request #$newId for role '$roleName'",
+            )
+            newId
         }
         return getRequest(id)!!
     }
@@ -123,6 +152,10 @@ class AccessStore(private val dataSource: DataSource) {
         // Carried on the shared access_request row; not consumed by the query-approval flow (see
         // CreateApprovalInput.requestedDurationSec). Kept for the column the ROLE-elevation path needs.
         requestedDurationSec: Long = 3600,
+        // Set on the audited create path (the /api/approvals routes); null on internal/test seeds. When both
+        // are present the created request is recorded as a TASK_REQUEST on the insert's transaction.
+        actor: AuditActor? = null,
+        recorder: ManagementAuditRecorder? = null,
     ): AccessRequest {
         val sqlHash = MessageDigest.getInstance("SHA-256")
             .digest(sql.toByteArray(Charsets.UTF_8))
@@ -164,6 +197,12 @@ class AccessStore(private val dataSource: DataSource) {
                 ps.setString(2, sql)
                 ps.setString(3, sqlHash)
                 ps.executeUpdate()
+            }
+            if (actor != null && recorder != null) {
+                recorder.record(
+                    c, actor, AuthzAction.TASK_REQUEST, auditEntity("AccessRequest", taskId.toString()),
+                    "open query request #$taskId under role '${executeAs.firstOrNull()}'",
+                )
             }
             taskId
         }
@@ -309,20 +348,55 @@ class AccessStore(private val dataSource: DataSource) {
         rejectionReason: String?,
         decidedBy: String,
     ): AccessRequest? {
+        val won = dataSource.inTx { c -> decideQueryRequest(id, approved, rejectionReason, decidedBy, c) }
+        return if (won) getRequest(id) else null
+    }
+
+    /** Same as [decideQueryRequest], composed on the caller's transaction. Returns whether a row transitioned. */
+    fun decideQueryRequest(
+        id: Long,
+        approved: Boolean,
+        rejectionReason: String?,
+        decidedBy: String,
+        c: Connection,
+    ): Boolean {
         val decidedAt = Timestamp.from(Instant.now())
-        val won = dataSource.connection.use { c ->
-            c.prepareStatement(
-                """UPDATE access_request
-                   SET status = ?, decided_by = ?, decided_at = ?, approved_at = ?, rejection_reason = ?
-                   WHERE id = ? AND kind = 'QUERY' AND status = 'PENDING'""",
-            ).use { ps ->
-                ps.setString(1, if (approved) "APPROVED" else "REJECTED")
-                ps.setString(2, decidedBy)
-                ps.setTimestamp(3, decidedAt)
-                if (approved) ps.setTimestamp(4, decidedAt) else ps.setNull(4, java.sql.Types.TIMESTAMP)
-                ps.setString(5, rejectionReason)
-                ps.setLong(6, id)
-                ps.executeUpdate() > 0
+        return c.prepareStatement(
+            """UPDATE access_request
+               SET status = ?, decided_by = ?, decided_at = ?, approved_at = ?, rejection_reason = ?
+               WHERE id = ? AND kind = 'QUERY' AND status = 'PENDING'""",
+        ).use { ps ->
+            ps.setString(1, if (approved) "APPROVED" else "REJECTED")
+            ps.setString(2, decidedBy)
+            ps.setTimestamp(3, decidedAt)
+            if (approved) ps.setTimestamp(4, decidedAt) else ps.setNull(4, java.sql.Types.TIMESTAMP)
+            ps.setString(5, rejectionReason)
+            ps.setLong(6, id)
+            ps.executeUpdate() > 0
+        }
+    }
+
+    /**
+     * Decide a pending QUERY task, recording the [TASK_APPROVE][AuthzAction.TASK_APPROVE] decision atomically.
+     * A task no longer PENDING transitions no row, so nothing is recorded.
+     */
+    fun decideQueryRequest(
+        id: Long,
+        approved: Boolean,
+        rejectionReason: String?,
+        decidedBy: String,
+        actor: AuditActor,
+        recorder: ManagementAuditRecorder,
+    ): AccessRequest? {
+        val roleName = getRequest(id)?.roleName
+        val won = dataSource.inTx { c ->
+            decideQueryRequest(id, approved, rejectionReason, decidedBy, c).also { transitioned ->
+                if (transitioned) {
+                    recorder.record(
+                        c, actor, AuthzAction.TASK_APPROVE, auditEntity("AccessRequest", id.toString()),
+                        if (approved) "approve query request #$id under role '$roleName'" else "reject query request #$id",
+                    )
+                }
             }
         }
         return if (won) getRequest(id) else null
@@ -442,32 +516,58 @@ class AccessStore(private val dataSource: DataSource) {
 
     /** Approve: mark the request APPROVED and insert a time-boxed grant. */
     fun approve(id: Long, durationSec: Long?, decidedBy: String): AccessRequest? {
-        val req = getRequest(id) ?: return null
+        dataSource.inTx { c -> approve(id, durationSec, decidedBy, c) }
+        return getRequest(id)
+    }
+
+    /**
+     * Same as [approve], composed on the caller's transaction. Flips a PENDING request to APPROVED and inserts
+     * its time-boxed grant, returning the new grant's id — or null when the request no longer exists, carries
+     * no role, or is no longer PENDING (nothing inserted).
+     */
+    fun approve(id: Long, durationSec: Long?, decidedBy: String, c: Connection): Long? {
+        val req = getRequest(id, c) ?: return null
         val roleId = req.roleId ?: return null
         val dur = durationSec ?: req.requestedDurationSec
         val expires = Timestamp.from(Instant.now().plusSeconds(dur))
-        dataSource.connection.use { c ->
-            c.autoCommit = false
-            try {
-                c.prepareStatement("UPDATE access_request SET status='APPROVED', decided_by=?, decided_at=now() WHERE id=?").use { ps ->
-                    ps.setString(1, decidedBy); ps.setLong(2, id); ps.executeUpdate()
-                }
-                c.prepareStatement(
-                    """INSERT INTO access_grant (request_id, principal, role_id, granted_by, granted_at, expires_at)
-                       VALUES (?, ?, ?, ?, now(), ?)""",
-                ).use { ps ->
-                    ps.setLong(1, id)
-                    ps.setString(2, req.principal)
-                    ps.setLong(3, roleId)
-                    ps.setString(4, decidedBy)
-                    ps.setTimestamp(5, expires)
-                    ps.executeUpdate()
-                }
-                c.commit()
-            } catch (e: Exception) {
-                c.rollback(); throw e
-            } finally {
-                c.autoCommit = true
+        val won = c.prepareStatement(
+            "UPDATE access_request SET status='APPROVED', decided_by=?, decided_at=now() WHERE id=? AND status='PENDING'",
+        ).use { ps ->
+            ps.setString(1, decidedBy); ps.setLong(2, id); ps.executeUpdate() > 0
+        }
+        if (!won) return null
+        return c.prepareStatement(
+            """INSERT INTO access_grant (request_id, principal, role_id, granted_by, granted_at, expires_at)
+               VALUES (?, ?, ?, ?, now(), ?) RETURNING id""",
+        ).use { ps ->
+            ps.setLong(1, id)
+            ps.setString(2, req.principal)
+            ps.setLong(3, roleId)
+            ps.setString(4, decidedBy)
+            ps.setTimestamp(5, expires)
+            ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) }
+        }
+    }
+
+    /**
+     * Approve a ROLE request, recording the granted elevation ([TASK_APPROVE][AuthzAction.TASK_APPROVE]) atomically.
+     * A request no longer PENDING inserts no grant, so nothing is recorded.
+     */
+    fun approve(
+        id: Long,
+        durationSec: Long?,
+        decidedBy: String,
+        actor: AuditActor,
+        recorder: ManagementAuditRecorder,
+    ): AccessRequest? {
+        val req = getRequest(id) ?: return null
+        val dur = durationSec ?: req.requestedDurationSec
+        dataSource.inTx { c ->
+            approve(id, durationSec, decidedBy, c)?.let { grantId ->
+                recorder.record(
+                    c, actor, AuthzAction.TASK_APPROVE, auditEntity("AccessGrant", grantId.toString()),
+                    "approve access request #$id: grant role '${req.roleName}' to '${req.principal}' for ${dur}s",
+                )
             }
         }
         return getRequest(id)
@@ -475,9 +575,36 @@ class AccessStore(private val dataSource: DataSource) {
 
     fun reject(id: Long, reason: String, decidedBy: String): AccessRequest? {
         if (getRequest(id) == null) return null
-        dataSource.connection.use { c ->
-            c.prepareStatement("UPDATE access_request SET status='REJECTED', rejection_reason=?, decided_by=?, decided_at=now() WHERE id=?").use { ps ->
-                ps.setString(1, reason); ps.setString(2, decidedBy); ps.setLong(3, id); ps.executeUpdate()
+        dataSource.inTx { c -> reject(id, reason, decidedBy, c) }
+        return getRequest(id)
+    }
+
+    /** Same as [reject], composed on the caller's transaction. Returns whether a PENDING request transitioned. */
+    fun reject(id: Long, reason: String, decidedBy: String, c: Connection): Boolean =
+        c.prepareStatement(
+            "UPDATE access_request SET status='REJECTED', rejection_reason=?, decided_by=?, decided_at=now() WHERE id=? AND status='PENDING'",
+        ).use { ps ->
+            ps.setString(1, reason); ps.setString(2, decidedBy); ps.setLong(3, id); ps.executeUpdate() > 0
+        }
+
+    /**
+     * Reject a ROLE request, recording the [TASK_APPROVE][AuthzAction.TASK_APPROVE] decision atomically.
+     * A request no longer PENDING transitions no row, so nothing is recorded.
+     */
+    fun reject(
+        id: Long,
+        reason: String,
+        decidedBy: String,
+        actor: AuditActor,
+        recorder: ManagementAuditRecorder,
+    ): AccessRequest? {
+        val req = getRequest(id) ?: return null
+        dataSource.inTx { c ->
+            if (reject(id, reason, decidedBy, c)) {
+                recorder.record(
+                    c, actor, AuthzAction.TASK_APPROVE, auditEntity("AccessRequest", id.toString()),
+                    "reject access request #$id from '${req.principal}'",
+                )
             }
         }
         return getRequest(id)
@@ -501,9 +628,29 @@ class AccessStore(private val dataSource: DataSource) {
         }
     }
 
-    fun revoke(id: Long): Boolean = dataSource.connection.use { c ->
+    fun revoke(id: Long): Boolean = dataSource.inTx { c -> revoke(id, c) }
+
+    /** Same as [revoke], composed on the caller's transaction. */
+    fun revoke(id: Long, c: Connection): Boolean =
         c.prepareStatement("UPDATE access_grant SET revoked_at = now() WHERE id = ? AND revoked_at IS NULL").use { ps ->
             ps.setLong(1, id); ps.executeUpdate() > 0
+        }
+
+    /**
+     * Revoke a JIT grant, recording the [GRANT_REVOKE][AuthzAction.GRANT_REVOKE] event atomically. An
+     * already-revoked grant matches no row, so nothing is recorded.
+     */
+    fun revoke(id: Long, actor: AuditActor, recorder: ManagementAuditRecorder): Boolean {
+        val grant = getGrant(id)
+        return dataSource.inTx { c ->
+            revoke(id, c).also { won ->
+                if (won && grant != null) {
+                    recorder.record(
+                        c, actor, AuthzAction.GRANT_REVOKE, auditEntity("AccessGrant", id.toString()),
+                        "revoke access grant #$id (role '${grant.roleName}' from '${grant.principal}')",
+                    )
+                }
+            }
         }
     }
 
@@ -564,7 +711,14 @@ class AccessStore(private val dataSource: DataSource) {
 
 // ---- Routes ------------------------------------------------------------------------------
 
-fun Route.accessRoutes(config: Config, store: AccessStore, authz: Authz, datasourceStore: DatasourceStore, roleResolver: RoleResolver) {
+fun Route.accessRoutes(
+    config: Config,
+    store: AccessStore,
+    authz: Authz,
+    datasourceStore: DatasourceStore,
+    roleResolver: RoleResolver,
+    recorder: ManagementAuditRecorder,
+) {
     get("/api/access-requests") {
         if (!call.requireApi(config)) return@get
         // Forward-filter by task.read (self seed shows own; admin/oversight shows all),
@@ -613,7 +767,7 @@ fun Route.accessRoutes(config: Config, store: AccessStore, authz: Authz, datasou
                 return@post call.respondError(HttpStatusCode.Forbidden, "approval.request_not_permitted")
             }
         }
-        call.respond(HttpStatusCode.Created, store.createRequest(principal, input))
+        call.respond(HttpStatusCode.Created, store.createRequest(principal, input, call.auditActor(config), recorder))
     }
     post("/api/access-requests/{id}/approve") {
         if (!call.requireApi(config)) return@post
@@ -647,7 +801,7 @@ fun Route.accessRoutes(config: Config, store: AccessStore, authz: Authz, datasou
             }
         }
         val body = runCatching { call.receive<ApproveInput>() }.getOrDefault(ApproveInput())
-        store.approve(id, body.durationSec, approver)?.let { call.respond(it) }
+        store.approve(id, body.durationSec, approver, call.auditActor(config), recorder)?.let { call.respond(it) }
             ?: call.notFound("access request")
     }
     post("/api/access-requests/{id}/reject") {
@@ -678,7 +832,7 @@ fun Route.accessRoutes(config: Config, store: AccessStore, authz: Authz, datasou
             }
         }
         val body = call.receive<RejectInput>()
-        store.reject(id, body.reason, approver)?.let { call.respond(it) }
+        store.reject(id, body.reason, approver, call.auditActor(config), recorder)?.let { call.respond(it) }
             ?: call.notFound("access request")
     }
     get("/api/access-grants") {
@@ -714,6 +868,6 @@ fun Route.accessRoutes(config: Config, store: AccessStore, authz: Authz, datasou
         ) {
             return@post
         }
-        if (store.revoke(id)) call.respond(HttpStatusCode.NoContent) else call.notFound("access grant")
+        if (store.revoke(id, call.auditActor(config), recorder)) call.respond(HttpStatusCode.NoContent) else call.notFound("access grant")
     }
 }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -655,7 +655,7 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
         )
 
         // JIT access elevation: requests, approve/reject, grants, revoke (DESIGN.md).
-        accessRoutes(config, accessStore, authz, datasourceStore, roleResolver)
+        accessRoutes(config, accessStore, authz, datasourceStore, roleResolver, managementAudit)
 
         // Query-approval workflow: from-denied + proactive compose, approver decide, then async
         // execute-under-R with encrypted short-retention result storage.

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
@@ -8,6 +8,7 @@ import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
 import com.ridi.oss.proxymonster.controlplane.authz.authorizeDatasourceAction
 import com.ridi.oss.proxymonster.controlplane.authz.authorizeWithContext
 import com.ridi.oss.proxymonster.controlplane.authz.resolveContextTags
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
 import com.ridi.oss.proxymonster.grpc.EnfAction
 import com.ridi.oss.proxymonster.probe.Masking
 import com.ridi.oss.proxymonster.probe.bindMasks
@@ -343,6 +344,10 @@ fun Route.approvalRoutes(
     // approval tab updates without waiting for its next poll (null in Config-free tests → publish no-ops).
     taskCompletionHub: TaskCompletionHub? = null,
 ) {
+    // Query-approval DECISIONS (approve/reject) record a kind="admin" management event; the result
+    // lifecycle (execute/cancel/view) uses e3Record's separate approval_lifecycle path.
+    val recorder = ManagementAuditRecorder(auditStore)
+
     // Whether the caller may open a query-approval request against this datasource (task.request on the
     // Datasource). The shipped global permit keeps this open by default; an operator can forbid it per
     // datasource. authDebug bypasses.
@@ -473,6 +478,8 @@ fun Route.approvalRoutes(
                     evaluatedDecision = "DENY",
                     roleId = input.roleId,
                     requestedDurationSec = input.requestedDurationSec,
+                    actor = call.auditActor(config),
+                    recorder = recorder,
                 )
             } catch (_: DuplicatePendingQueryRequestException) {
                 return@post call.respond(HttpStatusCode.Conflict, ApiError("approval.pending_request_exists"))
@@ -524,6 +531,8 @@ fun Route.approvalRoutes(
             evaluatedDecision = decision.action.name,
             roleId = input.roleId,
             requestedDurationSec = input.requestedDurationSec,
+            actor = call.auditActor(config),
+            recorder = recorder,
         )
         call.respond(HttpStatusCode.Created, CreateApprovalResponse(request, wouldAllow = decision.action == EnfAction.ALLOW))
     }
@@ -614,8 +623,10 @@ fun Route.approvalRoutes(
         }
         // An approved QUERY request is executed under role R by an approver (execute-under-R); there is no
         // requester-side re-run mode. The proxy masks the result exactly as role R would see it.
-        val updated = accessStore.decideQueryRequest(id, approved = true, rejectionReason = null, decidedBy = principal)
-            ?: return@post call.respond(HttpStatusCode.Conflict, ApiError("approval.already_decided"))
+        val updated = accessStore.decideQueryRequest(
+            id, approved = true, rejectionReason = null, decidedBy = principal,
+            actor = call.auditActor(config), recorder = recorder,
+        ) ?: return@post call.respond(HttpStatusCode.Conflict, ApiError("approval.already_decided"))
         call.application.environment.log.info(
             "query approval approved request={} requester={} decider={} sourceDecisionId={}",
             id,
@@ -640,8 +651,10 @@ fun Route.approvalRoutes(
         if (!mayDecide(call, AuthzAction.TASK_APPROVE, req)) {
             return@post call.respond(HttpStatusCode.Forbidden, ApiError("approval.not_approver"))
         }
-        val updated = accessStore.decideQueryRequest(id, approved = false, rejectionReason = body.reason.trim(), decidedBy = principal)
-            ?: return@post call.respond(HttpStatusCode.Conflict, ApiError("approval.already_decided"))
+        val updated = accessStore.decideQueryRequest(
+            id, approved = false, rejectionReason = body.reason.trim(), decidedBy = principal,
+            actor = call.auditActor(config), recorder = recorder,
+        ) ?: return@post call.respond(HttpStatusCode.Conflict, ApiError("approval.already_decided"))
         call.application.environment.log.info(
             "query approval rejected request={} requester={} decider={} sourceDecisionId={}",
             id,

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ElevationContextRouteAuthzDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ElevationContextRouteAuthzDbTest.kt
@@ -1,6 +1,7 @@
 package com.ridi.oss.proxymonster.controlplane
 
 import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
 import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
@@ -155,7 +156,7 @@ class ElevationContextRouteAuthzDbTest {
                 )
                 call.respond(HttpStatusCode.NoContent)
             }
-            accessRoutes(config, core.accessStore, core.authz, core.datasourceStore, core.roleResolver)
+            accessRoutes(config, core.accessStore, core.authz, core.datasourceStore, core.roleResolver, ManagementAuditRecorder(core.auditStore))
             datasourceRoutes(config, core.authz, core.roleResolver, core.datasourceStore, core.proxyEventsHub, TableDetailService(core), core.tokenStore, core.userGroupStore)
             approvalRoutes(
                 config, core.accessStore, core.auditStore, core.datasourceStore, core.policyStore,
@@ -246,6 +247,40 @@ class ElevationContextRouteAuthzDbTest {
             HttpStatusCode.OK, ok.status,
             "trusted-edge requester_ip -> derived tag -> approve succeeds; FAILS if the route drops httpAuthzContext or the datasource tag-scoping",
         )
+    }
+
+    @Test
+    fun `approve routes write a kind=admin audit event through the wiring`() = testApplication {
+        val client = wire()
+        client.post("/test/session/$approver")
+
+        // ROLE approve through the real route writes one kind="admin" event; count is scoped to this
+        // request's id so the per-class DB's other approvals don't pollute it. Drop call.auditActor/recorder
+        // from the route and this count is 0.
+        val roleReq = seedRoleRequest()
+        assertEquals(
+            HttpStatusCode.OK,
+            client.post("/api/access-requests/$roleReq/approve") { header("X-Forwarded-For", "100.100.5.5") }.status,
+        )
+        assertEquals(1, adminAuditCount("approve access request #$roleReq:%"), "ROLE approve route must audit")
+
+        val queryReq = seedQueryRequest()
+        assertEquals(
+            HttpStatusCode.OK,
+            client.post("/api/approvals/$queryReq/approve") {
+                header("X-Forwarded-For", "100.100.5.5")
+                contentType(ContentType.Application.Json)
+                setBody("""{"mode":"APPROVER_EXEC"}""")
+            }.status,
+        )
+        assertEquals(1, adminAuditCount("approve query request #$queryReq%"), "QUERY approve route must audit")
+    }
+
+    private fun adminAuditCount(statementLike: String): Int = dataSource.connection.use { c ->
+        c.prepareStatement("SELECT count(*) FROM audit_event WHERE kind='admin' AND statement LIKE ?").use { ps ->
+            ps.setString(1, statementLike)
+            ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) }
+        }
     }
 
     @Test

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/JitApprovalAuditDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/JitApprovalAuditDbTest.kt
@@ -1,0 +1,204 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import com.ridi.oss.proxymonster.controlplane.management.AuditSource
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
+import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
+import com.ridi.oss.proxymonster.controlplane.support.auditChainHead
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.verifyAuditChain
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.sql.SQLException
+import javax.sql.DataSource
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * The JIT-elevation and approval-DECISION events (ROLE request create/approve/reject/grant-revoke and QUERY
+ * request create/approve/reject) each write one `kind="admin"` management event on the SAME transaction as
+ * the mutation. Mirrors [ManagementAuditDbTest]: exact descriptor per event, atomic rollback, no-op silence,
+ * and a re-verified hash chain.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JitApprovalAuditDbTest {
+    private lateinit var dataSource: DataSource
+    private lateinit var core: ControlPlaneCore
+    private lateinit var recorder: ManagementAuditRecorder
+    private lateinit var role: Role
+    private lateinit var datasource: Datasource
+
+    private val requester = "jit-audit-requester@example.com"
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_jit_approval_audit"))
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        core = ControlPlaneCore(dataSource)
+        recorder = ManagementAuditRecorder(core.auditStore)
+        role = core.policyStore.createRole(RoleInput("jit-audit-role"))
+        datasource = core.datasourceStore.create(
+            DatasourceInput(name = "jit-audit-ds", engine = "postgres", host = "localhost", port = 5432, dbName = "app"),
+        )
+    }
+
+    private fun actor() = AuditActor("jit-audit-${System.nanoTime()}@example.com", clientAddr = "192.0.2.1", channel = AuditSource.CONSOLE)
+
+    private fun seedRoleRequest() = core.accessStore.createRequest(
+        requester, AccessRequestInput(roleId = role.id, datasourceId = datasource.id, reason = "need it"),
+    )
+
+    private fun seedQueryRequest() = core.accessStore.createQueryRequest(
+        principal = requester, datasourceId = datasource.id, sql = "select 1", denyReason = "denied",
+        sourceDecisionId = null, reason = "need it", title = null, evaluatedDecision = "DENY", roleId = role.id,
+    )
+
+    private fun grantIdFor(requestId: Long): Long = dataSource.connection.use { c ->
+        c.prepareStatement("SELECT id FROM access_grant WHERE request_id = ? ORDER BY id DESC LIMIT 1").use { ps ->
+            ps.setLong(1, requestId)
+            ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) }
+        }
+    }
+
+    @Test
+    fun `ROLE create, approve, reject, and grant revoke each record one admin event`() {
+        val actor = actor()
+
+        val request = core.accessStore.createRequest(
+            requester, AccessRequestInput(roleId = role.id, datasourceId = datasource.id, reason = "need it"), actor, recorder,
+        )
+        assertEvent(actor.principal, AuthzAction.TASK_REQUEST, "AccessRequest::\"${request.id}\"", "open access request #${request.id} for role '${role.name}'")
+
+        val approved = core.accessStore.approve(request.id, durationSec = 3600, decidedBy = "approver@example.com", actor = actor, recorder = recorder)
+        assertEquals("APPROVED", approved?.status)
+        val grantId = grantIdFor(request.id)
+        // The grant exists (written on the same transaction as its audit row).
+        assertEquals(1, count("SELECT count(*) FROM access_grant WHERE request_id = ?", request.id))
+        assertEvent(
+            actor.principal, AuthzAction.TASK_APPROVE, "AccessGrant::\"$grantId\"",
+            "approve access request #${request.id}: grant role '${role.name}' to '$requester' for 3600s",
+        )
+
+        val toReject = seedRoleRequest()
+        core.accessStore.reject(toReject.id, reason = "no", decidedBy = "approver@example.com", actor = actor, recorder = recorder)
+        assertEvent(actor.principal, AuthzAction.TASK_APPROVE, "AccessRequest::\"${toReject.id}\"", "reject access request #${toReject.id} from '$requester'")
+
+        assertEquals(true, core.accessStore.revoke(grantId, actor, recorder))
+        assertEvent(
+            actor.principal, AuthzAction.GRANT_REVOKE, "AccessGrant::\"$grantId\"",
+            "revoke access grant #$grantId (role '${role.name}' from '$requester')",
+        )
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `QUERY create, approve, and reject each record one admin event`() {
+        val actor = actor()
+
+        val request = core.accessStore.createQueryRequest(
+            principal = requester, datasourceId = datasource.id, sql = "select 1", denyReason = "denied",
+            sourceDecisionId = null, reason = "need it", title = null, evaluatedDecision = "DENY", roleId = role.id,
+            actor = actor, recorder = recorder,
+        )
+        assertEvent(actor.principal, AuthzAction.TASK_REQUEST, "AccessRequest::\"${request.id}\"", "open query request #${request.id} under role '${role.name}'")
+
+        val approved = core.accessStore.decideQueryRequest(request.id, approved = true, rejectionReason = null, decidedBy = "approver@example.com", actor = actor, recorder = recorder)
+        assertEquals("APPROVED", approved?.status)
+        assertEvent(actor.principal, AuthzAction.TASK_APPROVE, "AccessRequest::\"${request.id}\"", "approve query request #${request.id} under role '${role.name}'")
+
+        val toReject = seedQueryRequest()
+        core.accessStore.decideQueryRequest(toReject.id, approved = false, rejectionReason = "no", decidedBy = "approver@example.com", actor = actor, recorder = recorder)
+        assertEvent(actor.principal, AuthzAction.TASK_APPROVE, "AccessRequest::\"${toReject.id}\"", "reject query request #${toReject.id}")
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `a rejected audit insert rolls back the approval it describes`() {
+        val actor = actor()
+        val request = seedRoleRequest()
+        val headBefore = auditChainHead(dataSource)
+        execute(
+            """CREATE OR REPLACE FUNCTION pm_test_reject_approval_audit() RETURNS trigger AS ${'$'}body${'$'}
+               BEGIN RAISE EXCEPTION 'forced approval audit failure'; END
+               ${'$'}body${'$'} LANGUAGE plpgsql""",
+        )
+        execute(
+            """CREATE TRIGGER pm_test_reject_approval_audit BEFORE INSERT ON audit_event
+               FOR EACH ROW WHEN (NEW.kind = 'admin' AND NEW.statement LIKE 'approve access request #${request.id}:%')
+               EXECUTE FUNCTION pm_test_reject_approval_audit()""",
+        )
+        try {
+            assertFailsWith<SQLException> {
+                core.accessStore.approve(request.id, durationSec = 3600, decidedBy = "approver@example.com", actor = actor, recorder = recorder)
+            }
+            // The mutation the failed audit described rolled back: no approval, no grant, no audit row.
+            assertEquals("PENDING", core.accessStore.getRequest(request.id)?.status)
+            assertEquals(0, count("SELECT count(*) FROM access_grant WHERE request_id = ?", request.id))
+            assertEquals(0, count("SELECT count(*) FROM audit_event WHERE principal = ?", actor.principal))
+            val headAfter = auditChainHead(dataSource)
+            assertEquals(headBefore.first, headAfter.first)
+            assertContentEquals(headBefore.second, headAfter.second)
+        } finally {
+            execute("DROP TRIGGER IF EXISTS pm_test_reject_approval_audit ON audit_event")
+            execute("DROP FUNCTION IF EXISTS pm_test_reject_approval_audit()")
+        }
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `re-approving and re-revoking record nothing the second time`() {
+        val actor = actor()
+        val request = seedRoleRequest()
+
+        core.accessStore.approve(request.id, durationSec = 3600, decidedBy = "approver@example.com", actor = actor, recorder = recorder)
+        val grantId = grantIdFor(request.id)
+        // A second approve finds no PENDING row: no new grant, and no second audit row.
+        core.accessStore.approve(request.id, durationSec = 3600, decidedBy = "approver@example.com", actor = actor, recorder = recorder)
+        assertEquals(1, count("SELECT count(*) FROM access_grant WHERE request_id = ?", request.id))
+        assertEquals(1, count("SELECT count(*) FROM audit_event WHERE principal = ? AND action = 'task.approve'", actor.principal))
+
+        core.accessStore.revoke(grantId, actor, recorder)
+        // A second revoke matches no still-open grant: no second audit row.
+        assertEquals(false, core.accessStore.revoke(grantId, actor, recorder))
+        assertEquals(1, count("SELECT count(*) FROM audit_event WHERE principal = ? AND action = 'grant.revoke'", actor.principal))
+        verifyAuditChain(dataSource)
+    }
+
+    private fun count(sql: String, id: Long): Int = dataSource.connection.use { c ->
+        c.prepareStatement(sql).use { ps ->
+            ps.setLong(1, id)
+            ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) }
+        }
+    }
+
+    private fun count(sql: String, value: String): Int = dataSource.connection.use { c ->
+        c.prepareStatement(sql).use { ps ->
+            ps.setString(1, value)
+            ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) }
+        }
+    }
+
+    private fun execute(sql: String) =
+        dataSource.connection.use { c -> c.createStatement().use { it.execute(sql) } }
+
+    private fun assertEvent(principal: String, action: AuthzAction, resource: String, statement: String) {
+        val rows = dataSource.connection.use { c ->
+            c.prepareStatement(
+                """SELECT action, resource, statement, outcome, kind, channel, decision, datasource
+                   FROM audit_event WHERE principal=? AND resource=? AND statement=? ORDER BY id""",
+            ).use { ps ->
+                ps.setString(1, principal); ps.setString(2, resource); ps.setString(3, statement)
+                ps.executeQuery().use { rs ->
+                    buildList { while (rs.next()) add((1..8).map(rs::getString)) }
+                }
+            }
+        }
+        assertEquals(1, rows.size)
+        assertEquals(listOf(action.cedarId, resource, statement, "ALLOW", "admin", "console", "ALLOW", "control-plane"), rows.single())
+    }
+}


### PR DESCRIPTION
## What

Audits the JIT-elevation and approval-**decision** events that were unaudited: ROLE access-request create / approve / reject and grant revoke (`Access.kt`), and QUERY approval-request create / approve / reject (`Approvals.kt` — approve/reject were previously only `log.info`). Each is a `kind="admin"` management event via the existing `ManagementAuditRecorder`, written on the **same transaction** as the mutation (atomic — rolls back with it) and recorded **only when the mutation actually changes a row**.

The already-audited result lifecycle (execute / cancel / view via `e3Record`, `kind="approval_lifecycle"`) is untouched. No schema or hash-chain change.

## Non-obvious

- **Idempotency fix:** the ROLE approve/reject mutations now gate on `status='PENDING'`. A decision on an already-decided request is a no-op (HTTP **200**, current state returned) instead of re-approving — closing a latent **double-grant** path (approve was previously an unconditional UPDATE + INSERT). Missing request → 404; QUERY re-decide → 409, both unchanged.
- Audit summaries read `roleName` outside the mutation tx (label text only; the state transition itself is a CAS on `status='PENDING'`).

## Tests

DB-backed (`JitApprovalAuditDbTest`): each event writes exactly one row with its exact descriptor; a forced audit-insert failure rolls the approval + grant back atomically; re-approve/re-revoke record nothing **and** create no duplicate grant; hash chain re-verifies. Full `:control-plane:test` green.

## Stack

Base of a 4-PR stack for the remaining audit backlog: **C (this)** → D (SCIM) → E (ValidateToken client addr) → F (auditmon admin/auth anomaly rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qwri6K4wyMaD1vKYbzQTqz
