### PR TITLE
fix(auth): authenticate before device confirmation

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Config.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Config.kt
@@ -118,6 +118,9 @@ data class Config(
     val webBaseUrl: String
         get() = webOrigin.trim().trimEnd('/').ifBlank { mcpIssuer }
 
+    fun webRedirectTarget(path: String): String =
+        if (webOrigin.isBlank()) path else "$webBaseUrl$path"
+
     // The outer per-statement exchange budget the run paths wait on, in milliseconds. Overflow-safe:
     // queryTimeoutSeconds is bounded by MAX_QUERY_TIMEOUT_SECONDS. Kept a grace above the proxy watchdog
     // (see QUERY_EXCHANGE_GRACE_MS) so the watchdog cancels the statement gracefully before this fires.

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/DeviceAuth.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/DeviceAuth.kt
@@ -265,9 +265,10 @@ private const val DEVICE_LOGIN_TTL_SEC = 600L // 10 min to complete the device-a
  * itself is the web app's `/device` (Next.js); the CP owns the API + the approval:
  *  - POST /auth/device/start   — pmon begins a login; the CP mints a PENDING handle + a short user_code and
  *    returns the verification page URL ({origin}/device?user_code=…). No IdP round-trip happens here.
- *  - POST /auth/device/confirm — the web /device page confirms the human-seen code; sets the verify cookie.
- *  - GET  /auth/device/authorize — the browser lands here after confirm; approves with the existing console
- *    session if any, else sends the user through /login (SSO or debug) and back. Requires the verify cookie.
+ *  - POST /auth/device/confirm — the authenticated web /device page confirms the human-seen code and binds
+ *    the verify cookie to that code and web session.
+ *  - GET  /auth/device/authorize — the browser lands here after confirm and approves with that same live web
+ *    session. A missing or replaced session returns to /device for authentication and confirmation again.
  *  - POST /auth/device/poll    — pmon polls by handle; 202 while PENDING, 200 + a one-time SESSION token once
  *    the page approved it.
  *  - /auth/session/renew (delegated to [sessionRenewRoutes]).
@@ -304,29 +305,34 @@ fun Route.deviceSessionRoutes(
         )
     }
 
-    // The web /device page POSTs here when the human confirms the code it shows: validate it's a real pending
-    // login and set the signed verify cookie binding THIS browser to the code. /auth/device/authorize below
-    // requires that cookie, so an attacker's direct authorize link (no /device confirm) cannot approve.
+    // The web /device page POSTs here when the signed-in human confirms the code it shows. The verify cookie
+    // binds THIS browser to the code, so an attacker's direct authorize link cannot approve.
     post("/auth/device/confirm") {
+        val session = call.webSession()
+        if (session == null) {
+            call.unauthenticated()
+            return@post
+        }
         val userCode = runCatching { call.receive<DeviceConfirmInput>().userCode }.getOrNull()?.trim()
         val row = userCode?.let { deviceLoginStore.getByUserCode(it) }
         if (row?.userCode == null || row.expiresAt.isBefore(Instant.now()) || row.status != "PENDING") {
             call.respond(HttpStatusCode.BadRequest, ApiError("device.unknown_or_expired_login"))
             return@post
         }
-        call.sessions.set(DeviceVerifySession(row.userCode))
+        call.sessions.set(DeviceVerifySession(row.userCode, session.id))
         call.respond(HttpStatusCode.OK, DeviceConfirmAck())
     }
 
-    // After confirm, the web page navigates the browser here. If the user already has a console session, we
-    // approve this pmon login with that identity and land on success — no re-login, no session churn. Else we
-    // send them through the normal /login (SSO or debug), which returns here once a session exists. Requires
-    // the verify cookie (set at confirm) matching the code — the device-phishing gate.
+    // After confirm, the web page navigates the browser here. The same live session that confirmed the code
+    // approves this pmon login. If it is gone, return to /device so authentication and confirmation repeat.
     get("/auth/device/authorize") {
         val userCode = call.request.queryParameters["user_code"]?.trim()
-        fun backToDevice() = "/device${if (userCode.isNullOrBlank()) "" else "?user_code=${userCode.encodeURLParameter()}"}"
-        if (userCode.isNullOrBlank() || call.sessions.get<DeviceVerifySession>()?.userCode != userCode) {
-            call.respondRedirect(backToDevice()) // not confirmed on /device in this browser
+        fun backToDevice() = config.webRedirectTarget(
+            "/device${if (userCode.isNullOrBlank()) "" else "?user_code=${userCode.encodeURLParameter()}"}",
+        )
+        val verified = call.sessions.get<DeviceVerifySession>()
+        if (userCode.isNullOrBlank() || verified?.userCode != userCode) {
+            call.respondRedirect(backToDevice())
             return@get
         }
         val row = deviceLoginStore.getByUserCode(userCode)
@@ -336,10 +342,9 @@ fun Route.deviceSessionRoutes(
             return@get
         }
         val session = call.webSession()
-        if (session == null) {
-            // No console session yet — log in first, then return here (the SSO return_to + the /login debug
-            // redirect both land back on this URL, which now finds a session).
-            call.respondRedirect("/login?return_to=${"/auth/device/authorize?user_code=$userCode".encodeURLParameter()}")
+        if (session == null || session.id != verified.webSessionId) {
+            call.sessions.clear(DEVICE_VERIFY_COOKIE)
+            call.respondRedirect(backToDevice())
             return@get
         }
         // Approve for the logged-in principal (SSO or debug — /login's PM_AUTH_DEBUG gate governs debug), and
@@ -352,7 +357,7 @@ fun Route.deviceSessionRoutes(
         val refreshToken = daemonSessionStore.webRefreshToken(session.id)
         if (!daemonSessionStore.webSessionIsLive(session.id)) {
             call.sessions.clear(DEVICE_VERIFY_COOKIE)
-            call.respondRedirect("/login?return_to=${"/auth/device/authorize?user_code=$userCode".encodeURLParameter()}")
+            call.respondRedirect(backToDevice())
             return@get
         }
         val approver = AuditActor(session.principal, clientAddr = call.httpRequesterIp(config), channel = CHANNEL_DEVICE)
@@ -372,7 +377,7 @@ fun Route.deviceSessionRoutes(
             }
         }
         call.sessions.clear(DEVICE_VERIFY_COOKIE)
-        call.respondRedirect(if (approved) "/device/success" else backToDevice())
+        call.respondRedirect(if (approved) config.webRedirectTarget("/device/success") else backToDevice())
     }
 
     // pmon polls by handle: 202 while the browser page has not approved yet, 200 + a one-time SESSION token

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Oidc.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Oidc.kt
@@ -39,7 +39,7 @@ data class OAuthStateSession(val state: String, val returnTo: String? = null)
 const val DEVICE_VERIFY_COOKIE = "pm_device_verify"
 
 @Serializable
-data class DeviceVerifySession(val userCode: String)
+data class DeviceVerifySession(val userCode: String, val webSessionId: Long)
 
 /** Short-lived signed cookie carrying the OIDC `nonce` between /login and /callback. */
 const val OAUTH_NONCE_COOKIE = "pm_oauth_nonce"
@@ -206,7 +206,7 @@ fun Route.oidcRoutes(
             } else {
                 "/login?error=state"
             }
-            call.respondRedirect(target)
+            call.respondRedirect(config.oidcRedirectTarget(target))
             return@get
         }
         if (params["error"] != null) {
@@ -214,19 +214,31 @@ fun Route.oidcRoutes(
             // The error is whatever the caller put in the query string — /auth/oidc/login is open, so a
             // self-minted state reaches this branch and chooses this value. Bounded before it is recorded.
             auditFailure("idp_error=${auditedValue(params["error"].orEmpty())}")
-            call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "access_denied", consoleError = "oidc"))
+            call.respondRedirect(
+                config.oidcRedirectTarget(
+                    oidcFailureTarget(stateSession, oauthError = "access_denied", consoleError = "oidc"),
+                ),
+            )
             return@get
         }
         if (code == null) {
             log.warn("OIDC callback omitted both code and error")
             auditFailure("missing_code")
-            call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "server_error", consoleError = "state"))
+            call.respondRedirect(
+                config.oidcRedirectTarget(
+                    oidcFailureTarget(stateSession, oauthError = "server_error", consoleError = "state"),
+                ),
+            )
             return@get
         }
         if (expectedNonce == null) {
             log.warn("OIDC callback nonce state is absent")
             auditFailure("missing_nonce")
-            call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "access_denied", consoleError = "nonce"))
+            call.respondRedirect(
+                config.oidcRedirectTarget(
+                    oidcFailureTarget(stateSession, oauthError = "access_denied", consoleError = "nonce"),
+                ),
+            )
             return@get
         }
 
@@ -251,7 +263,11 @@ fun Route.oidcRoutes(
         } catch (e: Exception) {
             log.error("OIDC token exchange failed", e)
             auditFailure("token_exchange_failed")
-            call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "server_error", consoleError = "oidc"))
+            call.respondRedirect(
+                config.oidcRedirectTarget(
+                    oidcFailureTarget(stateSession, oauthError = "server_error", consoleError = "oidc"),
+                ),
+            )
             return@get
         }
 
@@ -262,7 +278,11 @@ fun Route.oidcRoutes(
         if (claims == null) {
             log.warn("OIDC callback id_token validation failed")
             auditFailure("invalid_id_token")
-            call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "access_denied", consoleError = "nonce"))
+            call.respondRedirect(
+                config.oidcRedirectTarget(
+                    oidcFailureTarget(stateSession, oauthError = "access_denied", consoleError = "nonce"),
+                ),
+            )
             return@get
         }
 
@@ -280,13 +300,21 @@ fun Route.oidcRoutes(
             if (roleResolver.resolve(principal).isEmpty()) {
                 log.warn("OIDC callback principal has no effective roles: {}", principal)
                 auditFailure("no_effective_roles", principal)
-                call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "access_denied", consoleError = "no_access"))
+                call.respondRedirect(
+                    config.oidcRedirectTarget(
+                        oidcFailureTarget(stateSession, oauthError = "access_denied", consoleError = "no_access"),
+                    ),
+                )
                 return@get
             }
         } catch (e: Exception) {
             log.error("OIDC provisioning or role resolution failed", e)
             auditFailure("provisioning_failed", principal)
-            call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "server_error", consoleError = "oidc"))
+            call.respondRedirect(
+                config.oidcRedirectTarget(
+                    oidcFailureTarget(stateSession, oauthError = "server_error", consoleError = "oidc"),
+                ),
+            )
             return@get
         }
 
@@ -323,13 +351,17 @@ fun Route.oidcRoutes(
         } catch (e: Exception) {
             log.error("OIDC session mint failed", e)
             auditFailure("session_mint_failed", principal)
-            call.respondRedirect(oidcFailureTarget(stateSession, oauthError = "server_error", consoleError = "oidc"))
+            call.respondRedirect(
+                config.oidcRedirectTarget(
+                    oidcFailureTarget(stateSession, oauthError = "server_error", consoleError = "oidc"),
+                ),
+            )
             return@get
         }
         // Post-commit: the SUCCESS row is durable. A disconnect on either line propagates uncaught rather
         // than writing a contradicting FAILURE row.
         call.sessions.set(WebSessionRef(sessionId))
-        call.respondRedirect(stateSession?.returnTo ?: "/")
+        call.respondRedirect(config.oidcRedirectTarget(stateSession?.returnTo ?: "/"))
     }
 }
 
@@ -340,13 +372,15 @@ fun Route.oidcRoutes(
 internal fun OidcDiscoveryDocument.supportsPkceS256(): Boolean =
     code_challenge_methods_supported?.any { it.equals("S256", ignoreCase = true) } == true
 
+// Keep continuations on fixed local routes; arbitrary paths or origins would turn OIDC into an open redirect.
 internal fun oidcReturnTarget(raw: String?): String? =
     raw?.takeIf {
-        // Fixed co-hosted continuations, plus the pmon device-authorize landing (a fixed path with only a
-        // constrained user_code query) — never an arbitrary value, so this can't become an open redirect.
-        it == "/oauth/resume" || it == "/auth/reauth-complete" ||
-            it.matches(Regex("/auth/device/authorize\\?user_code=[A-Za-z0-9-]{1,16}"))
+        it == "/oauth/resume" || it == "/auth/reauth-complete" || it == "/device" ||
+            it.matches(Regex("/device\\?user_code=[A-Za-z0-9-]{1,16}"))
     }
+
+private fun Config.oidcRedirectTarget(path: String): String =
+    if (path.startsWith("/oauth/")) path else webRedirectTarget(path)
 
 internal fun oidcFailureTarget(state: OAuthStateSession?, oauthError: String, consoleError: String): String {
     val returnTo = state?.returnTo

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DeviceLoginStoreDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DeviceLoginStoreDbTest.kt
@@ -180,6 +180,10 @@ class DeviceLoginStoreDbTest {
                 call.sessions.set(WebSessionRef(sessionId))
                 call.respond(HttpStatusCode.OK, "ok")
             }
+            get("/test/end-session") {
+                lastPrincipalSessionStore.endWeb(call.webSession()!!.id, ENDED_SIGNED_OUT)
+                call.respond(HttpStatusCode.OK, "ok")
+            }
         }
         return createClient {
             install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
@@ -253,8 +257,8 @@ class DeviceLoginStoreDbTest {
     fun `a failed device mint rolls the consume back so the poll can retry`() = testApplication {
         val client = installDeviceRoutes()
         val started = client.startLogin()
-        client.confirm(started.userCode)
         client.get("/test/login-as/retry@example.com")
+        client.confirm(started.userCode)
         client.authorize(started.userCode)
 
         rejectAction(AuthAuditRecorder.ACTION_DEVICE_MINT)
@@ -291,13 +295,26 @@ class DeviceLoginStoreDbTest {
             mcpResource = "https://console.example/mcp",
         )
         assertEquals("https://console.example", sameOrigin.webBaseUrl)
-        assertEquals("http://127.0.0.1:41300", sameOrigin.copy(webOrigin = "http://127.0.0.1:41300/").webBaseUrl)
+        assertEquals("/device", sameOrigin.webRedirectTarget("/device"))
+        val splitOrigin = sameOrigin.copy(webOrigin = "http://127.0.0.1:41300/")
+        assertEquals("http://127.0.0.1:41300", splitOrigin.webBaseUrl)
+        assertEquals("http://127.0.0.1:41300/device", splitOrigin.webRedirectTarget("/device"))
     }
 
     @Test
-    fun `confirm accepts a real pending code and rejects an unknown one`() = testApplication {
+    fun `confirm requires a live web session`() = testApplication {
         val client = installDeviceRoutes()
         val started = client.startLogin()
+
+        assertEquals(HttpStatusCode.Unauthorized, client.confirm(started.userCode).status)
+        assertEquals("PENDING", store.get(started.handle)!!.status)
+    }
+
+    @Test
+    fun `an authenticated confirm accepts a pending code and rejects an unknown one`() = testApplication {
+        val client = installDeviceRoutes()
+        val started = client.startLogin()
+        client.get("/test/login-as/alice@example.com")
 
         assertEquals(HttpStatusCode.OK, client.confirm(started.userCode).status)
         assertEquals(HttpStatusCode.BadRequest, client.confirm("NOPE-NOPE").status, "an unknown code must not be confirmable")
@@ -341,25 +358,46 @@ class DeviceLoginStoreDbTest {
     }
 
     @Test
-    fun `authorize with no session sends the user to login and approves nothing yet`() = testApplication {
+    fun `session loss after confirm returns to the device page and approves nothing`() = testApplication {
         val client = installDeviceRoutes()
         val started = client.startLogin()
-        client.confirm(started.userCode)
+        client.get("/test/login-as/alice@example.com")
+        assertEquals(HttpStatusCode.OK, client.confirm(started.userCode).status)
+        client.get("/test/end-session")
 
         val res = client.authorize(started.userCode)
         assertEquals(HttpStatusCode.Found, res.status)
-        val location = res.headers[HttpHeaders.Location]!!
-        assertTrue(location.startsWith("/login?return_to="), "no console session → go log in first, got $location")
-        assertTrue(location.contains("device"), "login must return to the device authorize URL, got $location")
-        assertEquals("PENDING", store.get(started.handle)!!.status, "still pending until a session exists")
+        assertEquals("/device?user_code=${started.userCode}", res.headers[HttpHeaders.Location])
+        assertEquals("PENDING", store.get(started.handle)!!.status)
+
+        client.get("/test/login-as/alice@example.com")
+        assertEquals(
+            "/device?user_code=${started.userCode}",
+            client.authorize(started.userCode).headers[HttpHeaders.Location],
+            "a new session must confirm the code again",
+        )
+    }
+
+    @Test
+    fun `a replacement session cannot inherit an earlier confirmation`() = testApplication {
+        val client = installDeviceRoutes()
+        val started = client.startLogin()
+        client.get("/test/login-as/alice@example.com")
+        assertEquals(HttpStatusCode.OK, client.confirm(started.userCode).status)
+        client.get("/test/login-as/bob@example.com")
+
+        val res = client.authorize(started.userCode)
+        assertEquals(HttpStatusCode.Found, res.status)
+        assertEquals("/device?user_code=${started.userCode}", res.headers[HttpHeaders.Location])
+        assertEquals("PENDING", store.get(started.handle)!!.status)
     }
 
     @Test
     fun `an existing console session approves the login without re-authenticating`() = testApplication {
         val client = installDeviceRoutes()
         val started = client.startLogin()
-        client.confirm(started.userCode)
         client.get("/test/login-as/alice@example.com")
+        assertEquals(HttpStatusCode.OK, client.confirm(started.userCode).status)
 
         val res = client.authorize(started.userCode)
         assertEquals(HttpStatusCode.Found, res.status)
@@ -395,8 +433,8 @@ class DeviceLoginStoreDbTest {
         // Until the browser approves, pmon's poll is pending — start never auto-approves.
         assertEquals(HttpStatusCode.Accepted, client.poll(started.handle).status, "poll is pending until the browser approves")
 
-        client.confirm(started.userCode)
         client.get("/test/login-as/alice@example.com")
+        client.confirm(started.userCode)
         assertEquals(HttpStatusCode.Found, client.authorize(started.userCode).status)
 
         val poll = client.poll(started.handle)
@@ -425,8 +463,8 @@ class DeviceLoginStoreDbTest {
     fun `a device handle mints exactly once — a replayed poll is refused and mints no second session`() = testApplication {
         val client = installDeviceRoutes()
         val started = client.startLogin()
-        client.confirm(started.userCode)
         client.get("/test/login-as/alice@example.com")
+        client.confirm(started.userCode)
         client.authorize(started.userCode)
 
         // First poll completes the login and mints the one session + renewal secret.

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/OidcCallbackTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/OidcCallbackTest.kt
@@ -205,11 +205,18 @@ class OidcCallbackTest {
     }
 
     @Test
-    fun `OIDC continuation accepts only the co-hosted resume and reauth routes`() {
+    fun `OIDC continuation accepts only fixed auth and device routes`() {
         assertEquals("/oauth/resume", oidcReturnTarget("/oauth/resume"))
         assertEquals("/auth/reauth-complete", oidcReturnTarget("/auth/reauth-complete"))
-        assertNull(oidcReturnTarget("https://evil.example/callback"))
-        assertNull(oidcReturnTarget("//evil.example/callback"))
+        assertEquals("/device", oidcReturnTarget("/device"))
+        assertEquals("/device?user_code=ABCD-EFGH", oidcReturnTarget("/device?user_code=ABCD-EFGH"))
+        assertNull(oidcReturnTarget("/auth/device/authorize?user_code=ABCD-EFGH"))
+        assertNull(oidcReturnTarget("https://evil.example/device"))
+        assertNull(oidcReturnTarget("//evil.example/device"))
+        assertNull(oidcReturnTarget("/device/other"))
+        assertNull(oidcReturnTarget("/device?foo=bar"))
+        assertNull(oidcReturnTarget("/device?user_code=ABCD-EFGH&next=https://evil.example"))
+        assertNull(oidcReturnTarget("/auth/device/authorize?user_code=ABCD-EFGH&extra=x"))
         assertNull(oidcReturnTarget("/other"))
         assertNull(oidcReturnTarget("/"))
     }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/OidcWebSessionDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/OidcWebSessionDbTest.kt
@@ -216,7 +216,7 @@ class OidcWebSessionDbTest {
     }
 
     @Test
-    fun `a device login with no session logs in via SSO and comes back to approve the handle`() = testApplication {
+    fun `a device login authenticates via SSO before confirming and approving the handle`() = testApplication {
         requireDockerOrSkip()
         val dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_oidc_web"))
         Flyway.configure().dataSource(dataSource).load().migrate()
@@ -231,21 +231,17 @@ class OidcWebSessionDbTest {
         val started = deviceStore.createPending(intervalSec = 2, ttlSeconds = 3600, expiresAt = Instant.now().plusSeconds(600))
         val userCode = started.userCode!!
 
-        application { installOidcWebApp(config("openid email offline_access", resultKey = ByteArray(32) { it.toByte() }), dataSource) }
+        application {
+            installOidcWebApp(
+                config("openid email offline_access", resultKey = ByteArray(32) { it.toByte() })
+                    .copy(webOrigin = "https://console.example"),
+                dataSource,
+            )
+        }
         val client = createClient { expectSuccess = false; followRedirects = false; install(HttpCookies) }
 
-        // 1) The web /device page confirms the code the human read off their terminal.
-        client.post("/auth/device/confirm") {
-            contentType(ContentType.Application.Json)
-            setBody("""{"userCode":"$userCode"}""")
-        }
-        // 2) The page sends the browser to authorize; with no console session it routes through /login.
-        val authorize = client.get("/auth/device/authorize?user_code=$userCode")
-        val loginTarget = assertNotNull(authorize.headers[HttpHeaders.Location])
-        assertTrue(loginTarget.startsWith("/login?return_to="), "no session → /login first, got $loginTarget")
-        val returnTo = parseQueryString(loginTarget.substringAfter('?'))["return_to"]!!
-
-        // 3) /login's SSO button carries that return_to into the auth-code flow.
+        // The unauthenticated /device page sends this exact continuation through the login page.
+        val returnTo = "/device?user_code=${userCode.encodeURLParameter()}"
         val login = client.get("/auth/oidc/login?return_to=${returnTo.encodeURLParameter()}")
         val query = parseQueryString(assertNotNull(login.headers[HttpHeaders.Location]).substringAfter('?'))
         nonce.set(assertNotNull(query["nonce"]))
@@ -255,16 +251,25 @@ class OidcWebSessionDbTest {
         // advertises S256, so the challenge on /authorize must be the hash of what /token received.
         assertEquals(query["code_challenge"], pkceS256(assertNotNull(tokenCodeVerifier.get())))
         assertEquals(HttpStatusCode.Found, callback.status)
-        assertEquals(returnTo, callback.headers[HttpHeaders.Location], "SSO returns to the device authorize URL")
+        assertEquals(
+            "https://console.example$returnTo",
+            callback.headers[HttpHeaders.Location],
+            "SSO returns to the web console's device confirmation page",
+        )
         assertTrue(
             callback.headers.getAll(HttpHeaders.SetCookie).orEmpty().any { it.startsWith("$SESSION_COOKIE=") },
-            "the login itself mints the console session that authorize then reuses",
+            "the login itself mints the console session that device confirmation then reuses",
         )
 
-        // 4) Back on authorize — now a session exists, so the handle is approved for that principal.
-        val approve = client.get(returnTo)
+        val confirm = client.post("/auth/device/confirm") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"userCode":"$userCode"}""")
+        }
+        assertEquals(HttpStatusCode.OK, confirm.status)
+
+        val approve = client.get("/auth/device/authorize?user_code=${userCode.encodeURLParameter()}")
         assertEquals(HttpStatusCode.Found, approve.status)
-        assertEquals("/device/success", approve.headers[HttpHeaders.Location])
+        assertEquals("https://console.example/device/success", approve.headers[HttpHeaders.Location])
 
         val approved = deviceStore.get(started.handle)!!
         assertEquals("APPROVED", approved.status)

--- a/docs/auth-model.md
+++ b/docs/auth-model.md
@@ -68,12 +68,12 @@ discovery (`OidcDiscovery.kt`), so the flow is provider-agnostic:
 
 ## CLI / daemon login — web verification page
 
-`pmon login` follows the familiar device-code flow: the user confirms a short
-code on the **web console's `/device` page**, and the login completes with
-whatever identity the console already has — or, if they aren't signed in,
-through the **same `/login` page** the console uses. `pmon` is a thin client
-that only starts the flow and polls; the IdP is reached in the browser via the
-ordinary auth-code flow, never a device grant.
+`pmon login` follows the familiar device-code flow: the browser authenticates
+through the **same `/login` page** the console uses, then the user confirms the
+short code on the **web console's `/device` page**. An existing console session
+skips the login step. `pmon` is a thin client that only starts the flow and
+polls; the IdP is reached in the browser via the ordinary auth-code flow, never
+a device grant.
 
 ```
 pmon:  POST /auth/device/start
@@ -81,13 +81,15 @@ cp:    → mint a PENDING login: an opaque handle (pmon polls it) + a short user
        → return { verificationUri={origin}/device, verificationUriComplete={origin}/device?user_code=…, userCode, handle, interval }
 pmon:  print the plain URL + the code (best-effort auto-open uses the complete URL, which prefills it),
        then POST /auth/device/poll { handle } every interval
-user:  open /device (web) → the code field is prefilled when auto-opened, typed by hand when the link was
-       clicked → Continue
+user:  open /device (web)
+web:   signed in already? → show the code field
+       not signed in?     → /login?return_to=/device… → SSO or debug → back to /device
+user:  confirm the prefilled code, or type the code from the terminal → Continue
 web:   POST /auth/device/confirm { userCode }   → CP validates it's a live pending login, sets the verify cookie
        → GET /auth/device/authorize?user_code=…
-cp:    signed in already? → approve the handle with that session's principal   → 302 /device/success
-       not signed in?     → 302 /login?return_to=… → SSO or debug → back to authorize → approve → /device/success
-cp:    → /auth/device/poll: 202 while PENDING; once approved, mint a wire SESSION token (one-time claim per handle)
+cp:    approve the handle with the same live session that confirmed the code → 302 /device/success
+       session missing or replaced? → back to /device to authenticate and confirm again
+       → /auth/device/poll: 202 while PENDING; once approved, mint a wire SESSION token (one-time claim per handle)
 pmon:  store the wire token; open the loopback brokers (one per datasource) immediately
 ```
 
@@ -99,8 +101,8 @@ pmon:  store the wire token; open the loopback brokers (one per datasource) imme
   support is irrelevant).
 - **One login page.** The device flow does not carry its own sign-in UI: it
   reuses `/login` (SSO, plus the debug affordance where `PM_AUTH_DEBUG` allows
-  it) with a `return_to` back to the device authorization, so there is exactly
-  one place login can happen and `pmon` carries no dev-only code.
+  it) with a `return_to` back to `/device`, so there is exactly one place login
+  can happen and `pmon` carries no dev-only code.
 - **An existing console session is reused, not disturbed.** If the browser
   already has a console session, the approval uses it directly — no re-prompt,
   and nothing displaces or ends that session.
@@ -111,11 +113,12 @@ pmon:  store the wire token; open the loopback brokers (one per datasource) imme
   printed URL is the plain one, so a hand-opened link makes the user type the
   code — the step that ties the code they approve to the terminal in front of
   them.
-- **Confirm-before-approve.** Approval requires a signed cookie that
-  `POST /auth/device/confirm` sets, so a direct `/auth/device/authorize` link
-  can't approve a code the victim never confirmed on `/device` (device-phishing
-  defense). The residual (a victim who confirms someone else's code anyway) is
-  tracked in `docs/backlog.md`.
+- **Confirm-before-approve.** Confirmation requires a live web session and sets
+  a signed cookie bound to both that session and the code. A direct
+  `/auth/device/authorize` link cannot approve a code the victim never
+  confirmed, and a replaced session must authenticate and confirm again. The
+  residual (a victim who confirms someone else's code anyway) is tracked in
+  `docs/backlog.md`.
 - **Session renewal (decided).** A login opens a **session window**
   (`PM_SESSION_WINDOW`, default 2h). _Within_ it the daemon **silently
   re-mints** its wire SESSION token — **no re-prompt**. _After_ it, renewal is

--- a/web/src/app/device/page.tsx
+++ b/web/src/app/device/page.tsx
@@ -1,24 +1,21 @@
 'use client'
 
-// /device — the browser-facing verification step of the pmon device-login flow.
-// `pmon login` prints a URL + short code and polls the control-plane; the user
-// lands here (auto-opened as /device?user_code=WDJB-MJHT, or bare /device when
-// the link was clicked manually), confirms the code, and continues into the
-// control-plane authorize endpoint, which approves or bounces through /login.
-// Styled to match /login (same header, card, and UI components).
-
-import { Suspense, useState, type FormEvent } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { Suspense, useEffect, useState, type FormEvent } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useTranslations } from 'next-intl'
-import { ShieldHalf } from 'lucide-react'
+import { Loader2, ShieldHalf } from 'lucide-react'
 import { API_BASE } from '@/lib/api/client'
+import { useAuth } from '@/lib/auth'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 
 /** Uppercase, strip non-alphanumerics, cap at the 8 significant characters. */
 function normalizeCode(raw: string): string {
-  return raw.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 8)
+  return raw
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, '')
+    .slice(0, 8)
 }
 
 /** Render the 8-char code as the familiar XXXX-XXXX (hyphen appears after 4 chars). */
@@ -28,15 +25,36 @@ function formatCode(clean: string): string {
 
 function DeviceInner() {
   const t = useTranslations('Device')
+  const router = useRouter()
   const params = useSearchParams()
+  const { status, unauthReason } = useAuth()
   const initialCode = normalizeCode(params.get('user_code') ?? '')
   const prefilled = initialCode.length > 0
+  const deviceTarget = prefilled ? `/device?user_code=${encodeURIComponent(formatCode(initialCode))}` : '/device'
 
   const [code, setCode] = useState(initialCode)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const complete = code.length === 8
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.replace(
+        unauthReason === 'displaced'
+          ? '/displaced'
+          : `/login?return_to=${encodeURIComponent(deviceTarget)}`,
+      )
+    }
+  }, [deviceTarget, router, status, unauthReason])
+
+  if (status !== 'authenticated') {
+    return (
+      <div className="flex h-svh items-center justify-center">
+        <Loader2 className="text-muted-foreground size-5 animate-spin" />
+      </div>
+    )
+  }
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
@@ -52,13 +70,15 @@ function DeviceInner() {
         credentials: 'include',
         body: JSON.stringify({ userCode }),
       })
+      if (res.status === 401) {
+        router.replace(`/login?return_to=${encodeURIComponent(deviceTarget)}`)
+        return
+      }
       if (!res.ok) {
         setError(t('error'))
         setSubmitting(false)
         return
       }
-      // Full-page navigation (NOT fetch): the authorize endpoint issues browser
-      // redirects — it either approves (already logged in) or bounces through /login.
       window.location.href = `${API_BASE}/auth/device/authorize?user_code=${encodeURIComponent(userCode)}`
     } catch {
       setError(t('error'))
@@ -78,9 +98,7 @@ function DeviceInner() {
 
       <div className="bg-card w-full max-w-sm rounded-xl border p-6 shadow-sm">
         <h1 className="mb-1 text-base font-semibold">{t('title')}</h1>
-        <p className="text-muted-foreground mb-4 text-sm">
-          {prefilled ? t('confirm') : t('instruction')}
-        </p>
+        <p className="text-muted-foreground mb-4 text-sm">{prefilled ? t('confirm') : t('instruction')}</p>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-1.5">

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -17,11 +17,9 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { TagsInput } from '@/components/tags-input'
 
-// The only continuation the device-login flow needs: the control-plane's own authorize endpoint for one
-// short code. Anything else — an absolute URL, a protocol-relative host, extra params — is treated as absent,
-// so this page can never be turned into an open redirect via ?return_to=.
+// Device login returns only to its fixed local page; rejecting every other shape prevents an open redirect.
 function deviceReturnTarget(raw: string | null): string | null {
-  return raw && /^\/auth\/device\/authorize\?user_code=[A-Za-z0-9-]{1,16}$/.test(raw) ? raw : null
+  return raw && (raw === '/device' || /^\/device\?user_code=[A-Za-z0-9-]{1,16}$/.test(raw)) ? raw : null
 }
 
 function LoginInner() {
@@ -37,9 +35,6 @@ function LoginInner() {
   const params = useSearchParams()
   const next = params.get('next')
   const callbackUrl = params.get('callbackUrl')
-  // Set by the device-login flow: where the control-plane authorize endpoint wants the browser to return
-  // after a fresh sign-in. Narrowed to the exact device-authorize shape so a crafted ?return_to= can never
-  // send a signed-in user off-site (the control plane applies the same allowlist on the SSO leg).
   const returnTo = deviceReturnTarget(params.get('return_to'))
   const reason = params.get('reason')
   const errorCode = params.get('error')
@@ -71,9 +66,7 @@ function LoginInner() {
     setSubmitting(true)
     try {
       await loginDebug(principal.trim(), roles, requesterIp.trim())
-      router.replace(
-        callbackUrl === REAUTH_CALLBACK_PATH ? callbackUrl : (returnTo ?? next ?? '/query'),
-      )
+      router.replace(callbackUrl === REAUTH_CALLBACK_PATH ? callbackUrl : (returnTo ?? next ?? '/query'))
     } catch (err) {
       // A 404 means one of two different things, so branch on the code rather than the status: the route
       // itself is absent (PM_AUTH_DEBUG off), or a claimed role does not exist — which answers with
@@ -143,14 +136,14 @@ function LoginInner() {
           <>
             <div className="my-5 flex items-center gap-3">
               <div className="h-px flex-1 bg-border" />
-              <span className="text-muted-foreground text-[11px] tracking-wider uppercase">
-                {t('devOnly')}
-              </span>
+              <span className="text-muted-foreground text-[11px] tracking-wider uppercase">{t('devOnly')}</span>
               <div className="h-px flex-1 bg-border" />
             </div>
 
             <div className="mb-4 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-500">
-              {t.rich('debugWarning', { debug: (chunks) => <span className="font-semibold">{chunks}</span> })}
+              {t.rich('debugWarning', {
+                debug: (chunks) => <span className="font-semibold">{chunks}</span>,
+              })}
             </div>
 
             <form onSubmit={handleSubmit} className="space-y-3">

--- a/web/tests/session-routing.spec.ts
+++ b/web/tests/session-routing.spec.ts
@@ -9,15 +9,23 @@ const SESSION_CONFIG = {
 }
 
 async function mockAppBootstrap(page: Page, meResponse: { status: number; body: object }) {
-  await page.route('**/auth/config', (route) => route.fulfill({
-    contentType: 'application/json',
-    body: JSON.stringify({ oidcEnabled: false, authDebug: true, session: SESSION_CONFIG }),
-  }))
-  await page.route('**/auth/me', (route) => route.fulfill({
-    status: meResponse.status,
-    contentType: 'application/json',
-    body: JSON.stringify(meResponse.body),
-  }))
+  await page.route('**/auth/config', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        oidcEnabled: false,
+        authDebug: true,
+        session: SESSION_CONFIG,
+      }),
+    }),
+  )
+  await page.route('**/auth/me', (route) =>
+    route.fulfill({
+      status: meResponse.status,
+      contentType: 'application/json',
+      body: JSON.stringify(meResponse.body),
+    }),
+  )
 }
 
 test('a displaced session lands on the displacement interstitial', async ({ page }) => {
@@ -39,11 +47,120 @@ for (const reason of ['expired', 'none']) {
   })
 }
 
+test('a displaced device login lands on the displacement interstitial', async ({ page }) => {
+  await mockAppBootstrap(page, { status: 401, body: { reason: 'displaced' } })
+
+  await page.goto('/device?user_code=ABCD-EFGH')
+
+  await expect(page).toHaveURL(/\/displaced$/)
+  await expect(page.getByRole('heading', { name: 'You were signed in on another device' })).toBeVisible()
+})
+
+test('device login authenticates before showing the verification code', async ({ page }) => {
+  await mockAppBootstrap(page, { status: 401, body: { reason: 'none' } })
+  await page.route('**/auth/debug', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ principal: 'sam@example.com', roles: [] }),
+    }),
+  )
+
+  await page.goto('/device?user_code=abcd-efgh')
+
+  await expect(page).toHaveURL(/\/login\?return_to=/)
+  expect(new URL(page.url()).searchParams.get('return_to')).toBe('/device?user_code=ABCD-EFGH')
+  await expect(page.getByRole('heading', { name: 'Device login' })).toHaveCount(0)
+
+  await page.getByRole('button', { name: 'Sign in as debug user' }).click()
+
+  await expect(page).toHaveURL(/\/device\?user_code=ABCD-EFGH$/)
+  await expect(page.getByRole('heading', { name: 'Device login' })).toBeVisible()
+  await expect(page.getByLabel('Verification code')).toHaveValue('ABCD-EFGH')
+})
+
+test('an authenticated device login shows the verification code directly', async ({ page }) => {
+  await mockAppBootstrap(page, {
+    status: 200,
+    body: { principal: 'sam@example.com', roles: [] },
+  })
+
+  await page.goto('/device?user_code=ABCD-EFGH')
+
+  await expect(page).toHaveURL(/\/device\?user_code=ABCD-EFGH$/)
+  await expect(page.getByRole('heading', { name: 'Device login' })).toBeVisible()
+  await expect(page.getByLabel('Verification code')).toHaveValue('ABCD-EFGH')
+})
+
+test('device confirmation returns to login when the session expires before submit', async ({ page }) => {
+  await mockAppBootstrap(page, {
+    status: 200,
+    body: { principal: 'sam@example.com', roles: [] },
+  })
+  await page.route('**/auth/device/confirm', (route) =>
+    route.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({ code: 'common.unauthenticated' }),
+    }),
+  )
+
+  await page.goto('/device?user_code=ABCD-EFGH')
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page).toHaveURL(/\/login\?return_to=/)
+  expect(new URL(page.url()).searchParams.get('return_to')).toBe('/device?user_code=ABCD-EFGH')
+})
+
+test('a bare device URL authenticates before allowing manual code entry', async ({ page }) => {
+  await mockAppBootstrap(page, { status: 401, body: { reason: 'none' } })
+  await page.route('**/auth/debug', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ principal: 'sam@example.com', roles: [] }),
+    }),
+  )
+
+  await page.goto('/device')
+
+  await expect(page).toHaveURL(/\/login\?return_to=/)
+  expect(new URL(page.url()).searchParams.get('return_to')).toBe('/device')
+  await page.getByRole('button', { name: 'Sign in as debug user' }).click()
+  await expect(page).toHaveURL(/\/device$/)
+  await expect(page.getByLabel('Verification code')).toHaveValue('')
+})
+
+test('device verification stays hidden while authentication resolves', async ({ page }) => {
+  let releaseMe = () => {}
+  const meReleased = new Promise<void>((resolve) => {
+    releaseMe = resolve
+  })
+  await page.route('**/auth/me', async (route) => {
+    await meReleased
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ principal: 'sam@example.com', roles: [] }),
+    })
+  })
+
+  await page.goto('/device?user_code=ABCD-EFGH')
+  await expect(page.getByRole('heading', { name: 'Device login' })).toHaveCount(0)
+
+  releaseMe()
+
+  await expect(page.getByRole('heading', { name: 'Device login' })).toBeVisible()
+})
+
 test('debug login stays hidden when auth config disables it', async ({ page }) => {
-  await page.route('**/auth/config', (route) => route.fulfill({
-    contentType: 'application/json',
-    body: JSON.stringify({ oidcEnabled: true, authDebug: false, session: SESSION_CONFIG }),
-  }))
+  await page.route('**/auth/config', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        oidcEnabled: true,
+        authDebug: false,
+        session: SESSION_CONFIG,
+      }),
+    }),
+  )
 
   await page.goto('/login')
 
@@ -66,14 +183,20 @@ test('debug login stays hidden until auth config explicitly enables it', async (
     await configReleased
     await route.fulfill({
       contentType: 'application/json',
-      body: JSON.stringify({ oidcEnabled: false, authDebug: true, session: SESSION_CONFIG }),
+      body: JSON.stringify({
+        oidcEnabled: false,
+        authDebug: true,
+        session: SESSION_CONFIG,
+      }),
     })
   })
-  await page.route('**/auth/me', (route) => route.fulfill({
-    status: 401,
-    contentType: 'application/json',
-    body: JSON.stringify({ reason: 'none' }),
-  }))
+  await page.route('**/auth/me', (route) =>
+    route.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({ reason: 'none' }),
+    }),
+  )
 
   await page.goto('/login')
   await configRequested
@@ -88,18 +211,21 @@ test('debug login stays hidden until auth config explicitly enables it', async (
 
 for (const locale of ['en', 'ko'] as const) {
   test(`session-expired login banner renders in ${locale}`, async ({ context, page }) => {
-    await context.addCookies([{
-      name: 'NEXT_LOCALE',
-      value: locale,
-      url: 'http://localhost:41310',
-    }])
+    await context.addCookies([
+      {
+        name: 'NEXT_LOCALE',
+        value: locale,
+        url: 'http://localhost:41310',
+      },
+    ])
     await mockAppBootstrap(page, { status: 401, body: { reason: 'none' } })
 
     await page.goto('/login?reason=session_expired')
 
-    const copy = locale === 'en'
-      ? 'Your session has ended — please sign in again.'
-      : '세션이 종료되었습니다 — 다시 로그인해 주세요.'
+    const copy =
+      locale === 'en'
+        ? 'Your session has ended — please sign in again.'
+        : '세션이 종료되었습니다 — 다시 로그인해 주세요.'
     await expect(page.getByText(copy)).toBeVisible()
   })
 }


### PR DESCRIPTION
## Summary
- require a live web session before a pmon device code can be confirmed
- bind confirmation to the exact session that authorizes the device login
- preserve direct code confirmation for browsers that are already signed in
- route device continuations to the configured web origin without widening redirect allowlists

## Verification
- `mise run verify`
- live pmon/browser E2E: unauthenticated login → confirm → success → token
- live pmon/browser E2E: existing session → direct confirm → success → token

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcYk54oexm41CtkmCqq6H9