### PR TITLE
feat(control-plane): audit SCIM provisioning events

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -635,7 +635,7 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
         // SCIM 2.0 provisioning (docs/auth-model.md "SCIM 2.0 provisioning") — bearer+TLS gated,
         // not a user session. principalSessionStore is passed so a SCIM deprovision durably closes the
         // principal's daemon session windows (renewal secrets), not just its wire tokens + grants.
-        scimRoutes(config, userGroupStore, tokenStore, accessStore, principalSessionStore, this@module.environment.log)
+        scimRoutes(config, userGroupStore, tokenStore, accessStore, principalSessionStore, managementAudit, this@module.environment.log)
 
         // Datasource + catalog + classification config API. Admin-gated: admin.datasources.
         // The events hub backs the admin "refresh now" push + the "which datasources have a proxy attached"

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Scim.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Scim.kt
@@ -1,5 +1,10 @@
 package com.ridi.oss.proxymonster.controlplane
 
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import com.ridi.oss.proxymonster.controlplane.management.AuditSource
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
+import com.ridi.oss.proxymonster.controlplane.management.auditEntity
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
@@ -230,6 +235,14 @@ private suspend fun ApplicationCall.respondScimError(status: HttpStatusCode, sci
     respond(status, ScimError(status = status.value.toString(), scimType = scimType, detail = detail))
 }
 
+/**
+ * The audit actor for a SCIM mutation. SCIM authenticates with one standing bearer token
+ * ([requireScimAuth]), so there is no per-client identity — the acting principal is the fixed
+ * synthetic [AuditSource.SCIM], on the SCIM channel.
+ */
+private fun ApplicationCall.scimAuditActor(config: Config): AuditActor =
+    AuditActor(principal = AuditSource.SCIM, clientAddr = httpRequesterIp(config), channel = AuditSource.SCIM)
+
 // ---- static discovery documents ------------------------------------------------------------------
 
 private val SERVICE_PROVIDER_CONFIG: JsonObject = buildJsonObject {
@@ -323,6 +336,7 @@ fun Route.scimRoutes(
     tokenStore: TokenStore,
     accessStore: AccessStore,
     daemonSessionStore: PrincipalSessionStore,
+    recorder: ManagementAuditRecorder,
     log: Logger,
 ) {
     get("/api/scim/v2/ServiceProviderConfig") {
@@ -362,17 +376,23 @@ fun Route.scimRoutes(
         // in ONE transaction under the per-principal lock. A POST can legitimately hit either case: Okta
         // may reconcile an existing user (matched by external_id/email) via a full-resource POST, incl.
         // deprovisioning it down to active=false — so no separate, non-atomic follow-up revoke is needed.
+        val actor = call.scimAuditActor(config)
         val user = try {
-            userGroupStore.upsertScimUser(
-                externalId = externalId,
-                principal = principal,
-                email = body.primaryEmail(),
-                displayName = body.name?.formatted,
-                active = body.active,
-                tokenStore = tokenStore,
-                accessStore = accessStore,
-                daemonSessionStore = daemonSessionStore,
-            )
+            userGroupStore.dataSource.inTx { c ->
+                userGroupStore.upsertScimUser(
+                    externalId = externalId,
+                    principal = principal,
+                    email = body.primaryEmail(),
+                    displayName = body.name?.formatted,
+                    active = body.active,
+                    tokenStore = tokenStore,
+                    accessStore = accessStore,
+                    daemonSessionStore = daemonSessionStore,
+                    c = c,
+                ).also {
+                    recorder.record(c, actor, AuthzAction.ADMIN_IDENTITY, auditEntity("User", it.principal), "scim provision user '${it.principal}'")
+                }
+            }
         } catch (e: SQLException) {
             // externalId is a partial UNIQUE index (V14) — a POST whose externalId
             // is new but whose email/principal match resolves to a row already owning a DIFFERENT
@@ -410,18 +430,24 @@ fun Route.scimRoutes(
         // the OLD principal and the active=false revoke of the CURRENT principal
         // still happen atomically inside it — one committed transaction under the
         // per-principal lock, no separate follow-up revoke that a crash could skip.
+        val actor = call.scimAuditActor(config)
         val user = try {
-            userGroupStore.replaceScimUserById(
-                id = id,
-                principal = principal,
-                email = body.primaryEmail() ?: existing.email,
-                displayName = body.name?.formatted ?: existing.displayName,
-                externalId = externalId,
-                active = body.active,
-                tokenStore = tokenStore,
-                accessStore = accessStore,
-                daemonSessionStore = daemonSessionStore,
-            ) ?: return@put call.respondScimError(HttpStatusCode.NotFound, null, "no such user")
+            userGroupStore.dataSource.inTx { c ->
+                userGroupStore.replaceScimUserById(
+                    id = id,
+                    principal = principal,
+                    email = body.primaryEmail() ?: existing.email,
+                    displayName = body.name?.formatted ?: existing.displayName,
+                    externalId = externalId,
+                    active = body.active,
+                    tokenStore = tokenStore,
+                    accessStore = accessStore,
+                    daemonSessionStore = daemonSessionStore,
+                    c = c,
+                )?.also {
+                    recorder.record(c, actor, AuthzAction.ADMIN_IDENTITY, auditEntity("User", it.principal), "scim replace user '${it.principal}'")
+                }
+            } ?: return@put call.respondScimError(HttpStatusCode.NotFound, null, "no such user")
         } catch (e: SQLException) {
             // externalId is a partial UNIQUE index (V14) — an externalId already
             // owned by a DIFFERENT row collides here instead of producing a split-brain external_id.
@@ -451,8 +477,15 @@ fun Route.scimRoutes(
                 // make this act on a stale pre-lock snapshot — and, on active=false, revokes that
                 // principal's credentials in the SAME committed transaction, not a
                 // mutate-then-revoke pair a crash could leave half-applied.
-                val updated = userGroupStore.setActiveById(id, action.active, tokenStore, accessStore, daemonSessionStore)
-                    ?: return@patch call.respondScimError(HttpStatusCode.NotFound, null, "no such user")
+                val actor = call.scimAuditActor(config)
+                val updated = userGroupStore.dataSource.inTx { c ->
+                    userGroupStore.setActiveById(id, action.active, tokenStore, accessStore, daemonSessionStore, c)?.also {
+                        recorder.record(
+                            c, actor, AuthzAction.ADMIN_IDENTITY, auditEntity("User", it.principal),
+                            "scim ${if (action.active) "activate" else "deactivate"} user '${it.principal}'",
+                        )
+                    }
+                } ?: return@patch call.respondScimError(HttpStatusCode.NotFound, null, "no such user")
                 if (!action.active) log.info("SCIM: deactivated user principal={}", updated.principal)
                 call.respond(updated.toScim())
             }
@@ -468,8 +501,14 @@ fun Route.scimRoutes(
         // re-reads the current principal under the per-principal advisory lock and revokes
         // its credentials in the SAME committed transaction, so a concurrent rename can't
         // leave the row's real identity credentialed while we tombstone a stale one.
-        val deprovisioned = id?.let { userGroupStore.setActiveById(it, false, tokenStore, accessStore, daemonSessionStore) }
-            ?: return@delete call.respondScimError(HttpStatusCode.NotFound, null, "no such user")
+        val actor = call.scimAuditActor(config)
+        val deprovisioned = id?.let {
+            userGroupStore.dataSource.inTx { c ->
+                userGroupStore.setActiveById(it, false, tokenStore, accessStore, daemonSessionStore, c)?.also { u ->
+                    recorder.record(c, actor, AuthzAction.ADMIN_IDENTITY, auditEntity("User", u.principal), "scim deprovision user '${u.principal}'")
+                }
+            }
+        } ?: return@delete call.respondScimError(HttpStatusCode.NotFound, null, "no such user")
         log.info("SCIM: deprovisioned user principal={}", deprovisioned.principal)
         call.respond(HttpStatusCode.NoContent)
     }
@@ -495,8 +534,16 @@ fun Route.scimRoutes(
         // FOR UPDATE-checks, and writes the one resolved row in a single transaction). A route-level
         // pre-check on a separate connection was defeatable by a concurrent PUT that re-pointed an
         // external_id between the check and the write — so the store throws instead.
+        // POST is one provisioning action: the group upsert and its member reconciliation commit together
+        // and record ONE group-level event, not a per-member membership event.
+        val actor = call.scimAuditActor(config)
         val group = try {
-            userGroupStore.upsertScimGroup(externalId = externalId, displayName = body.displayName)
+            userGroupStore.dataSource.inTx { c ->
+                userGroupStore.upsertScimGroup(externalId = externalId, displayName = body.displayName, c = c).also { g ->
+                    body.members.forEach { m -> m.value.toLongOrNull()?.let { userGroupStore.addMember(g.id, it, c) } }
+                    recorder.record(c, actor, AuthzAction.ADMIN_IDENTITY, auditEntity("Group", g.name), "scim provision group '${g.name}'")
+                }
+            }
         } catch (e: SystemGroupImmutableException) {
             return@post call.respondScimError(HttpStatusCode.Conflict, "mutability", "system-managed group is immutable")
         } catch (e: SQLException) {
@@ -505,7 +552,6 @@ fun Route.scimRoutes(
             }
             throw e
         }
-        body.members.forEach { m -> m.value.toLongOrNull()?.let { userGroupStore.addMember(group.id, it) } }
         log.info("SCIM: provisioned group name={} externalId={}", group.name, externalId)
         call.respond(HttpStatusCode.Created, group.toScim(userGroupStore.listMembers(group.id)))
     }
@@ -533,20 +579,26 @@ fun Route.scimRoutes(
         // PUT replaces the resource AT THIS id (same class of bug fixed for
         // Users' PUT): replaceScimGroupById mutates the row at [id] directly, never re-discovering a
         // different row by externalId/displayName the way upsertScimGroup (POST) does.
+        // PUT is one full-replace action: the group replace and the membership reconciliation to exactly
+        // the submitted set commit together and record ONE group-level event, not a per-member event.
+        val actor = call.scimAuditActor(config)
         val group = try {
-            userGroupStore.replaceScimGroupById(id, externalId = externalId, displayName = displayName)
-                ?: return@put call.respondScimError(HttpStatusCode.NotFound, null, "no such group")
+            userGroupStore.dataSource.inTx { c ->
+                val replaced = userGroupStore.replaceScimGroupById(id, externalId = externalId, displayName = displayName, c = c)
+                    ?: return@inTx null
+                val desired = body.members.mapNotNull { it.value.toLongOrNull() }.toSet()
+                val current = userGroupStore.listMembers(replaced.id, c).map { it.userId }.toSet()
+                (desired - current).forEach { userGroupStore.addMember(replaced.id, it, c) }
+                (current - desired).forEach { userGroupStore.removeMember(replaced.id, it, c) }
+                recorder.record(c, actor, AuthzAction.ADMIN_IDENTITY, auditEntity("Group", replaced.name), "scim replace group '${replaced.name}'")
+                replaced
+            } ?: return@put call.respondScimError(HttpStatusCode.NotFound, null, "no such group")
         } catch (e: SQLException) {
             if (e.isUniqueViolation()) {
                 return@put call.respondScimError(HttpStatusCode.Conflict, "uniqueness", "externalId already belongs to a different group")
             }
             throw e
         }
-        // PUT is a full replace: reconcile membership to exactly the submitted set.
-        val desired = body.members.mapNotNull { it.value.toLongOrNull() }.toSet()
-        val current = userGroupStore.listMembers(group.id).map { it.userId }.toSet()
-        (desired - current).forEach { userGroupStore.addMember(group.id, it) }
-        (current - desired).forEach { userGroupStore.removeMember(group.id, it) }
         call.respond(group.toScim(userGroupStore.listMembers(group.id)))
     }
     patch("/api/scim/v2/Groups/{id}") {
@@ -565,11 +617,24 @@ fun Route.scimRoutes(
         }
         when (action) {
             is ScimPatchAction.MemberOp -> {
+                // One event per member op ACTUALLY applied — gate on the store boolean so a no-op
+                // (adding a member already present, removing a non-member) records nothing.
+                val actor = call.scimAuditActor(config)
                 val userIds = action.values.mapNotNull { it.toLongOrNull() }
-                if (action.op == "add") {
-                    userIds.forEach { userGroupStore.addMember(existing.id, it) }
-                } else {
-                    userIds.forEach { userGroupStore.removeMember(existing.id, it) }
+                userGroupStore.dataSource.inTx { c ->
+                    userIds.forEach { userId ->
+                        val added = action.op == "add"
+                        val changed = if (added) userGroupStore.addMember(existing.id, userId, c)
+                        else userGroupStore.removeMember(existing.id, userId, c)
+                        if (changed) {
+                            val member = userGroupStore.getUser(userId, c)?.principal ?: userId.toString()
+                            recorder.record(
+                                c, actor, AuthzAction.ADMIN_IDENTITY, auditEntity("Group", existing.name),
+                                if (added) "scim add '$member' to group '${existing.name}'"
+                                else "scim remove '$member' from group '${existing.name}'",
+                            )
+                        }
+                    }
                 }
                 call.respond(existing.toScim(userGroupStore.listMembers(existing.id)))
             }
@@ -585,7 +650,17 @@ fun Route.scimRoutes(
         if (userGroupStore.isSystemGroup(id)) {
             return@delete call.respondScimError(HttpStatusCode.Conflict, null, "system-managed group is immutable")
         }
-        if (userGroupStore.deleteGroup(id)) {
+        val actor = call.scimAuditActor(config)
+        val deleted = userGroupStore.dataSource.inTx { c ->
+            val group = userGroupStore.getGroup(id, c)
+            if (group != null && userGroupStore.deleteGroup(id, c)) {
+                recorder.record(c, actor, AuthzAction.ADMIN_IDENTITY, auditEntity("Group", group.name), "scim delete group '${group.name}'")
+                true
+            } else {
+                false
+            }
+        }
+        if (deleted) {
             call.respond(HttpStatusCode.NoContent)
         } else {
             call.respondScimError(HttpStatusCode.NotFound, null, "no such group")

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Users.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Users.kt
@@ -224,16 +224,23 @@ class UserGroupStore(internal val dataSource: DataSource) {
         tokenStore: TokenStore,
         accessStore: AccessStore,
         daemonSessionStore: PrincipalSessionStore,
+    ): AppUser? = dataSource.inTx { c -> setActiveById(id, active, tokenStore, accessStore, daemonSessionStore, c) }
+
+    fun setActiveById(
+        id: Long,
+        active: Boolean,
+        tokenStore: TokenStore,
+        accessStore: AccessStore,
+        daemonSessionStore: PrincipalSessionStore,
+        c: Connection,
     ): AppUser? {
-        if (getUser(id) == null) return null
-        dataSource.inTx { c ->
-            val current = lockCurrentPrincipal(c, id)
-            c.prepareStatement("UPDATE app_user SET active = ? WHERE id = ?").use { ps ->
-                ps.setBoolean(1, active); ps.setLong(2, id); ps.executeUpdate()
-            }
-            if (!active && current != null) revokeActiveCredentialsTx(current, c, tokenStore, accessStore, daemonSessionStore)
+        if (getUser(id, c) == null) return null
+        val current = lockCurrentPrincipal(c, id)
+        c.prepareStatement("UPDATE app_user SET active = ? WHERE id = ?").use { ps ->
+            ps.setBoolean(1, active); ps.setLong(2, id); ps.executeUpdate()
         }
-        return getUser(id)
+        if (!active && current != null) revokeActiveCredentialsTx(current, c, tokenStore, accessStore, daemonSessionStore)
+        return getUser(id, c)
     }
 
     private fun updateAppUserRow(c: Connection, id: Long, principal: String, displayName: String?, email: String?, active: Boolean) {
@@ -402,31 +409,42 @@ class UserGroupStore(internal val dataSource: DataSource) {
         tokenStore: TokenStore,
         accessStore: AccessStore,
         daemonSessionStore: PrincipalSessionStore,
-    ): AppUser {
-        val existingId = findUserIdByExternalId(externalId)
-            ?: email?.let { findUserIdByEmail(it) }
-            ?: userIdForPrincipal(principal)
+    ): AppUser = dataSource.inTx { c ->
+        upsertScimUser(externalId, principal, email, displayName, active, tokenStore, accessStore, daemonSessionStore, c)
+    }
 
-        val id = dataSource.inTx { c ->
-            // Lock + RE-READ the row's current principal before mutating it.
-            val current = existingId?.let { lockCurrentPrincipal(c, it) }
-            releaseTombstone(c, principal, existingId)
-            val rowId = if (existingId != null) {
-                updateScimAppUserRow(c, existingId, principal, displayName, email, externalId, active)
-                existingId
-            } else {
-                insertScimAppUserRow(c, principal, displayName, email, externalId, active)
-            }
-            if (current != null && current != principal) {
-                // Rename: retire the orphaned old string — tombstone + revoke its credentials.
-                deactivatePrincipalTombstone(current, c)
-                revokeActiveCredentialsTx(current, c, tokenStore, accessStore, daemonSessionStore)
-            }
-            // Deactivate: revoke the current principal atomically with the app_user write.
-            if (!active) revokeActiveCredentialsTx(principal, c, tokenStore, accessStore, daemonSessionStore)
-            rowId
+    fun upsertScimUser(
+        externalId: String,
+        principal: String,
+        email: String?,
+        displayName: String?,
+        active: Boolean,
+        tokenStore: TokenStore,
+        accessStore: AccessStore,
+        daemonSessionStore: PrincipalSessionStore,
+        c: Connection,
+    ): AppUser {
+        val existingId = findUserIdByExternalId(externalId, c)
+            ?: email?.let { findUserIdByEmail(it, c) }
+            ?: userIdForPrincipal(principal, c)
+
+        // Lock + RE-READ the row's current principal before mutating it.
+        val current = existingId?.let { lockCurrentPrincipal(c, it) }
+        releaseTombstone(c, principal, existingId)
+        val rowId = if (existingId != null) {
+            updateScimAppUserRow(c, existingId, principal, displayName, email, externalId, active)
+            existingId
+        } else {
+            insertScimAppUserRow(c, principal, displayName, email, externalId, active)
         }
-        return getUser(id)!!
+        if (current != null && current != principal) {
+            // Rename: retire the orphaned old string — tombstone + revoke its credentials.
+            deactivatePrincipalTombstone(current, c)
+            revokeActiveCredentialsTx(current, c, tokenStore, accessStore, daemonSessionStore)
+        }
+        // Deactivate: revoke the current principal atomically with the app_user write.
+        if (!active) revokeActiveCredentialsTx(principal, c, tokenStore, accessStore, daemonSessionStore)
+        return getUser(rowId, c)!!
     }
 
     /**
@@ -449,19 +467,32 @@ class UserGroupStore(internal val dataSource: DataSource) {
         tokenStore: TokenStore,
         accessStore: AccessStore,
         daemonSessionStore: PrincipalSessionStore,
+    ): AppUser? = dataSource.inTx { c ->
+        replaceScimUserById(id, principal, email, displayName, externalId, active, tokenStore, accessStore, daemonSessionStore, c)
+    }
+
+    fun replaceScimUserById(
+        id: Long,
+        principal: String,
+        email: String?,
+        displayName: String?,
+        externalId: String,
+        active: Boolean,
+        tokenStore: TokenStore,
+        accessStore: AccessStore,
+        daemonSessionStore: PrincipalSessionStore,
+        c: Connection,
     ): AppUser? {
-        if (getUser(id) == null) return null
-        dataSource.inTx { c ->
-            val current = lockCurrentPrincipal(c, id)
-            releaseTombstone(c, principal, id)
-            updateScimAppUserRow(c, id, principal, displayName, email, externalId, active)
-            if (current != null && current != principal) {
-                deactivatePrincipalTombstone(current, c)
-                revokeActiveCredentialsTx(current, c, tokenStore, accessStore, daemonSessionStore)
-            }
-            if (!active) revokeActiveCredentialsTx(principal, c, tokenStore, accessStore, daemonSessionStore)
+        if (getUser(id, c) == null) return null
+        val current = lockCurrentPrincipal(c, id)
+        releaseTombstone(c, principal, id)
+        updateScimAppUserRow(c, id, principal, displayName, email, externalId, active)
+        if (current != null && current != principal) {
+            deactivatePrincipalTombstone(current, c)
+            revokeActiveCredentialsTx(current, c, tokenStore, accessStore, daemonSessionStore)
         }
-        return getUser(id)
+        if (!active) revokeActiveCredentialsTx(principal, c, tokenStore, accessStore, daemonSessionStore)
+        return getUser(id, c)
     }
 
     private fun updateScimAppUserRow(
@@ -510,25 +541,26 @@ class UserGroupStore(internal val dataSource: DataSource) {
      * under a row lock, closes it. Throws [SystemGroupImmutableException] (→ SCIM 409) if the resolved row
      * is SYSTEM; the seeded system:admin always matches by name, so it can never be created or hijacked here.
      */
-    fun upsertScimGroup(externalId: String, displayName: String): AppGroup {
-        val id = dataSource.inTx { c ->
-            val existingId = groupIdByExternalId(c, externalId) ?: groupIdByName(c, displayName)
-            if (existingId != null) {
-                // Re-read the resolved row's source UNDER a row lock, then mutate that SAME id — check and
-                // write target the one resolved row atomically, with no window for a concurrent re-point.
-                if (lockGroupSource(c, existingId) == "SYSTEM") throw SystemGroupImmutableException()
-                c.prepareStatement("UPDATE app_group SET name=?, source='SCIM', external_id=? WHERE id=?").use { ps ->
-                    ps.setString(1, displayName); ps.setString(2, externalId); ps.setLong(3, existingId); ps.executeUpdate()
-                }
-                existingId
-            } else {
-                c.prepareStatement("INSERT INTO app_group (name, source, external_id) VALUES (?, 'SCIM', ?) RETURNING id").use { ps ->
-                    ps.setString(1, displayName); ps.setString(2, externalId)
-                    ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) }
-                }
+    fun upsertScimGroup(externalId: String, displayName: String): AppGroup =
+        dataSource.inTx { c -> upsertScimGroup(externalId, displayName, c) }
+
+    fun upsertScimGroup(externalId: String, displayName: String, c: Connection): AppGroup {
+        val existingId = groupIdByExternalId(c, externalId) ?: groupIdByName(c, displayName)
+        val id = if (existingId != null) {
+            // Re-read the resolved row's source UNDER a row lock, then mutate that SAME id — check and
+            // write target the one resolved row atomically, with no window for a concurrent re-point.
+            if (lockGroupSource(c, existingId) == "SYSTEM") throw SystemGroupImmutableException()
+            c.prepareStatement("UPDATE app_group SET name=?, source='SCIM', external_id=? WHERE id=?").use { ps ->
+                ps.setString(1, displayName); ps.setString(2, externalId); ps.setLong(3, existingId); ps.executeUpdate()
+            }
+            existingId
+        } else {
+            c.prepareStatement("INSERT INTO app_group (name, source, external_id) VALUES (?, 'SCIM', ?) RETURNING id").use { ps ->
+                ps.setString(1, displayName); ps.setString(2, externalId)
+                ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) }
             }
         }
-        return getGroup(id)!!
+        return getGroup(id, c)!!
     }
 
     // Connection-scoped group resolders + a FOR UPDATE source read — used by [upsertScimGroup] so its
@@ -555,12 +587,15 @@ class UserGroupStore(internal val dataSource: DataSource) {
      * group's membership-backing `group_role` instead of the one at this URI). Null (404 at the
      * route) if no such row.
      */
-    fun replaceScimGroupById(id: Long, externalId: String, displayName: String): AppGroup? {
-        if (getGroup(id) == null) return null
-        exec("UPDATE app_group SET name=?, source='SCIM', external_id=? WHERE id=?") {
-            it.setString(1, displayName); it.setString(2, externalId); it.setLong(3, id)
+    fun replaceScimGroupById(id: Long, externalId: String, displayName: String): AppGroup? =
+        dataSource.inTx { c -> replaceScimGroupById(id, externalId, displayName, c) }
+
+    fun replaceScimGroupById(id: Long, externalId: String, displayName: String, c: Connection): AppGroup? {
+        if (getGroup(id, c) == null) return null
+        c.prepareStatement("UPDATE app_group SET name=?, source='SCIM', external_id=? WHERE id=?").use { ps ->
+            ps.setString(1, displayName); ps.setString(2, externalId); ps.setLong(3, id); ps.executeUpdate()
         }
-        return getGroup(id)
+        return getGroup(id, c)
     }
 
     fun findUserByExternalId(id: String): AppUser? = findUserIdByExternalId(id)?.let { getUser(it) }
@@ -733,12 +768,12 @@ class UserGroupStore(internal val dataSource: DataSource) {
         }
     }
 
-    private fun userIdForPrincipal(principal: String): Long? = dataSource.connection.use { c ->
+    private fun userIdForPrincipal(principal: String): Long? = dataSource.connection.use { userIdForPrincipal(principal, it) }
+    private fun userIdForPrincipal(principal: String, c: Connection): Long? =
         c.prepareStatement("SELECT id FROM app_user WHERE principal=?").use { ps ->
             ps.setString(1, principal)
             ps.executeQuery().use { rs -> if (rs.next()) rs.getLong(1) else null }
         }
-    }
 
     /** The principal string currently on this app_user row, read on the caller-supplied connection [c] (locked re-read). */
     private fun principalForUserId(id: Long, c: Connection): String? =
@@ -830,19 +865,21 @@ class UserGroupStore(internal val dataSource: DataSource) {
         }
     }
 
-    private fun findUserIdByExternalId(externalId: String): Long? = dataSource.connection.use { c ->
+    private fun findUserIdByExternalId(externalId: String): Long? =
+        dataSource.connection.use { findUserIdByExternalId(externalId, it) }
+    private fun findUserIdByExternalId(externalId: String, c: Connection): Long? =
         c.prepareStatement("SELECT id FROM app_user WHERE external_id=?").use { ps ->
             ps.setString(1, externalId)
             ps.executeQuery().use { rs -> if (rs.next()) rs.getLong(1) else null }
         }
-    }
 
-    private fun findUserIdByEmail(email: String): Long? = dataSource.connection.use { c ->
+    private fun findUserIdByEmail(email: String): Long? =
+        dataSource.connection.use { findUserIdByEmail(email, it) }
+    private fun findUserIdByEmail(email: String, c: Connection): Long? =
         c.prepareStatement("SELECT id FROM app_user WHERE email=?").use { ps ->
             ps.setString(1, email)
             ps.executeQuery().use { rs -> if (rs.next()) rs.getLong(1) else null }
         }
-    }
 
     private fun findGroupIdByExternalId(externalId: String): Long? = dataSource.connection.use { c ->
         c.prepareStatement("SELECT id FROM app_group WHERE external_id=?").use { ps ->
@@ -878,9 +915,6 @@ class UserGroupStore(internal val dataSource: DataSource) {
     }
     private fun insertReturningId(sql: String, bind: (PreparedStatement) -> Unit): Long = dataSource.connection.use { c ->
         c.prepareStatement(sql).use { ps -> bind(ps); ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) } }
-    }
-    private fun exec(sql: String, bind: (PreparedStatement) -> Unit) {
-        dataSource.connection.use { c -> c.prepareStatement(sql).use { ps -> bind(ps); ps.executeUpdate() } }
     }
     private fun execUpdate(sql: String, bind: (PreparedStatement) -> Unit): Int =
         dataSource.connection.use { c -> c.prepareStatement(sql).use { ps -> bind(ps); ps.executeUpdate() } }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementAudit.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementAudit.kt
@@ -27,6 +27,7 @@ data class AuditActor(
 object AuditSource {
     const val CONSOLE = "console"
     const val MCP = "mcp"
+    const val SCIM = "scim"
 }
 
 /** A display label of the changed entity for the audit row (`Type::"id"`); never re-parsed as a Cedar UID. */

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ScimAuditDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ScimAuditDbTest.kt
@@ -1,0 +1,229 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
+import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
+import com.ridi.oss.proxymonster.controlplane.support.auditChainHead
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.verifyAuditChain
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.delete
+import io.ktor.client.request.header
+import io.ktor.client.request.patch
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.slf4j.LoggerFactory
+import javax.sql.DataSource
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+/**
+ * Every SCIM mutation ([scimRoutes]) records ONE `kind="admin"` audit event, atomic with the store
+ * change, on the SCIM channel under the fixed synthetic `scim` principal (SCIM authenticates with one
+ * standing bearer token — there is no per-client identity). Driven through the real routes over a Ktor
+ * test host, the same seam App.kt wires, so the handler's inTx + recorder plumbing is proven end to end
+ * (mirrors ManagementAuditDbTest for the console path).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ScimAuditDbTest {
+    private lateinit var dataSource: DataSource
+    private lateinit var userGroupStore: UserGroupStore
+    private lateinit var tokenStore: TokenStore
+    private lateinit var accessStore: AccessStore
+    private lateinit var daemonSessionStore: PrincipalSessionStore
+    private lateinit var recorder: ManagementAuditRecorder
+    private val log = LoggerFactory.getLogger("scim-audit-test")
+    private val scimToken = "s3cret-scim-token"
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_scim_audit"))
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        userGroupStore = UserGroupStore(dataSource)
+        tokenStore = TokenStore(dataSource)
+        accessStore = AccessStore(dataSource)
+        daemonSessionStore = PrincipalSessionStore(dataSource, null)
+        recorder = ManagementAuditRecorder(AuditStore(dataSource))
+    }
+
+    @Test
+    fun `user provision, replace, deactivate, activate, and deprovision each record one admin event`() = testApplication {
+        scimApp()
+        val ext = "okta-audit-user-${System.nanoTime()}"
+        val principal = "scim-audit-user-${System.nanoTime()}@example.com"
+
+        assertEquals(
+            HttpStatusCode.Created,
+            client.post("/api/scim/v2/Users") {
+                scimHeaders(); setBody("""{"externalId":"$ext","userName":"$principal","active":true}""")
+            }.status,
+        )
+        assertScimEvent(userResource(principal), "scim provision user '$principal'")
+
+        val id = userGroupStore.findUserByExternalId(ext)!!.id
+
+        assertEquals(HttpStatusCode.OK, client.patch("/api/scim/v2/Users/$id") { scimHeaders(); setBody(setActiveBody(false)) }.status)
+        assertScimEvent(userResource(principal), "scim deactivate user '$principal'")
+
+        assertEquals(HttpStatusCode.OK, client.patch("/api/scim/v2/Users/$id") { scimHeaders(); setBody(setActiveBody(true)) }.status)
+        assertScimEvent(userResource(principal), "scim activate user '$principal'")
+
+        assertEquals(
+            HttpStatusCode.OK,
+            client.put("/api/scim/v2/Users/$id") {
+                scimHeaders(); setBody("""{"externalId":"$ext","userName":"$principal","active":true}""")
+            }.status,
+        )
+        assertScimEvent(userResource(principal), "scim replace user '$principal'")
+
+        assertEquals(HttpStatusCode.NoContent, client.delete("/api/scim/v2/Users/$id") { scimHeaders() }.status)
+        assertScimEvent(userResource(principal), "scim deprovision user '$principal'")
+
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `group provision, membership add and remove, and delete record one event each while a no-op records none`() = testApplication {
+        scimApp()
+        val gExt = "okta-audit-group-${System.nanoTime()}"
+        val gName = "scim-audit-group-${System.nanoTime()}"
+        // The member's own provisioning is not under test — create it directly through the store.
+        val member = userGroupStore.upsertScimUser(
+            externalId = "okta-audit-member-${System.nanoTime()}",
+            principal = "scim-audit-member-${System.nanoTime()}@example.com",
+            email = null, displayName = null, active = true,
+        )
+
+        assertEquals(
+            HttpStatusCode.Created,
+            client.post("/api/scim/v2/Groups") {
+                scimHeaders(); setBody("""{"externalId":"$gExt","displayName":"$gName","members":[]}""")
+            }.status,
+        )
+        assertScimEvent(groupResource(gName), "scim provision group '$gName'")
+
+        val gid = userGroupStore.findGroupByExternalId(gExt)!!.id
+
+        assertEquals(HttpStatusCode.OK, client.patch("/api/scim/v2/Groups/$gid") { scimHeaders(); setBody(membersBody("add", member.id)) }.status)
+        assertScimEvent(groupResource(gName), "scim add '${member.principal}' to group '$gName'")
+
+        assertEquals(HttpStatusCode.OK, client.patch("/api/scim/v2/Groups/$gid") { scimHeaders(); setBody(membersBody("remove", member.id)) }.status)
+        assertScimEvent(groupResource(gName), "scim remove '${member.principal}' from group '$gName'")
+
+        // Removing a member who is no longer present changes nothing, so it must record nothing — the
+        // remove row count stays at the single event the first removal wrote.
+        assertEquals(HttpStatusCode.OK, client.patch("/api/scim/v2/Groups/$gid") { scimHeaders(); setBody(membersBody("remove", member.id)) }.status)
+        assertEquals(
+            1,
+            count(
+                "SELECT count(*) FROM audit_event WHERE resource=? AND statement=?",
+                groupResource(gName), "scim remove '${member.principal}' from group '$gName'",
+            ),
+        )
+
+        assertEquals(HttpStatusCode.NoContent, client.delete("/api/scim/v2/Groups/$gid") { scimHeaders() }.status)
+        assertScimEvent(groupResource(gName), "scim delete group '$gName'")
+
+        verifyAuditChain(dataSource)
+    }
+
+    @Test
+    fun `a rejected audit insert rolls back the SCIM mutation`() = testApplication {
+        scimApp()
+        val ext = "okta-audit-rollback-${System.nanoTime()}"
+        val principal = "scim-audit-rollback-${System.nanoTime()}@example.com"
+        val headBefore = auditChainHead(dataSource)
+        execute(
+            """CREATE OR REPLACE FUNCTION pm_test_reject_scim_audit() RETURNS trigger AS ${'$'}body${'$'}
+               BEGIN RAISE EXCEPTION 'forced scim audit failure'; END
+               ${'$'}body${'$'} LANGUAGE plpgsql""",
+        )
+        execute(
+            """CREATE TRIGGER pm_test_reject_scim_audit BEFORE INSERT ON audit_event
+               FOR EACH ROW WHEN (NEW.kind = 'admin' AND NEW.resource = 'User::"$principal"')
+               EXECUTE FUNCTION pm_test_reject_scim_audit()""",
+        )
+        try {
+            client.post("/api/scim/v2/Users") {
+                scimHeaders(); setBody("""{"externalId":"$ext","userName":"$principal","active":true}""")
+            }
+            assertEquals(0, count("SELECT count(*) FROM app_user WHERE external_id=?", ext))
+            assertEquals(0, count("SELECT count(*) FROM audit_event WHERE resource=?", userResource(principal)))
+            val headAfter = auditChainHead(dataSource)
+            assertEquals(headBefore.first, headAfter.first)
+            assertContentEquals(headBefore.second, headAfter.second)
+        } finally {
+            execute("DROP TRIGGER IF EXISTS pm_test_reject_scim_audit ON audit_event")
+            execute("DROP FUNCTION IF EXISTS pm_test_reject_scim_audit()")
+        }
+        verifyAuditChain(dataSource)
+    }
+
+    private fun ApplicationTestBuilder.scimApp() = application {
+        install(ContentNegotiation) { json() }
+        routing {
+            scimRoutes(
+                testScimConfig(scimToken = scimToken, trustedProxies = setOf("localhost")),
+                userGroupStore, tokenStore, accessStore, daemonSessionStore, recorder, log,
+            )
+        }
+    }
+
+    // The gate is bearer + TLS; a trusted-edge X-Forwarded-Proto stands in for direct HTTPS on the test host.
+    private fun HttpRequestBuilder.scimHeaders() {
+        header("X-Forwarded-Proto", "https")
+        header(HttpHeaders.Authorization, "Bearer $scimToken")
+        contentType(ContentType.Application.Json)
+    }
+
+    private fun setActiveBody(active: Boolean) =
+        """{"Operations":[{"op":"replace","path":"active","value":$active}]}"""
+
+    private fun membersBody(op: String, userId: Long) =
+        """{"Operations":[{"op":"$op","path":"members","value":[{"value":"$userId"}]}]}"""
+
+    private fun userResource(principal: String) = """User::"$principal""""
+    private fun groupResource(name: String) = """Group::"$name""""
+
+    private fun assertScimEvent(resource: String, statement: String) {
+        val rows = dataSource.connection.use { c ->
+            c.prepareStatement(
+                """SELECT action, resource, statement, outcome, kind, channel, decision, datasource, principal
+                   FROM audit_event WHERE resource=? AND statement=? ORDER BY id""",
+            ).use { ps ->
+                ps.setString(1, resource); ps.setString(2, statement)
+                ps.executeQuery().use { rs -> buildList { while (rs.next()) add((1..9).map(rs::getString)) } }
+            }
+        }
+        assertEquals(1, rows.size, "expected exactly one audit row for $resource / $statement")
+        assertEquals(
+            listOf("admin.identity", resource, statement, "ALLOW", "admin", "scim", "ALLOW", "control-plane", "scim"),
+            rows.single(),
+        )
+    }
+
+    private fun count(sql: String, vararg values: String): Int = dataSource.connection.use { c ->
+        c.prepareStatement(sql).use { ps ->
+            values.forEachIndexed { index, value -> ps.setString(index + 1, value) }
+            ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) }
+        }
+    }
+
+    private fun execute(sql: String) =
+        dataSource.connection.use { c -> c.createStatement().use { it.execute(sql) } }
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -131,6 +131,15 @@ forward work. MySQL leads PostgreSQL in priority.
 
 ## Audit trail
 
+- Decide whether machine-driven SCIM re-syncs should suppress no-op audit
+  events. The console admin paths record only when a mutation actually changed a
+  row; the SCIM handlers instead record one `kind="admin"` event per
+  provisioning directive, so an idempotent IdP re-`POST`/`PUT` or an
+  activate-already-active still writes an event. Matching the console would need
+  field-diff detection in the SCIM upsert/replace path (the store returns the
+  row, not a changed/unchanged verdict). Audit-every-directive is kept for now —
+  an IdP-sourced directive is itself an auditable action — but at high re-sync
+  volume it inflates the trail.
 - Decide where an acceptance record belongs. Recovery honors signed acceptance
   records under the write-once bucket, which is what lets a separate operator
   process resume a running monitor — but it also makes an object in the bucket


### PR DESCRIPTION
> Stacked on #121 (base branch `sjcho/audit/jit-approval-events`). Review/merge #121 first.

## What

SCIM user/group provisioning (`Scim.kt`) previously wrote **no** audit rows. Every SCIM mutation — user provision/replace/activate/deactivate/deprovision, group provision/replace/delete, and membership add/remove — now writes one `kind="admin"` audit event on the **same transaction** as the store change, via the existing `ManagementAuditRecorder` (the taxonomy the console and MCP identity paths already use).

## Non-obvious

- The acting principal is the fixed synthetic **`scim`** on channel **`scim`** — SCIM auth is a shared bearer token (`PM_SCIM_TOKEN`) with no per-client identity. Reintroduces the `AuditSource.SCIM` label.
- Group provision/replace records **one** group-level event (membership reconciliation folds into the same transaction, not one event per member); membership PATCH records one event per member op that actually applies; no-ops record nothing.
- Adds `(…, c: Connection)` overloads to the five SCIM* store mutators (they previously self-managed their own tx). Reads inside those overloads use `getUser(id, c)`/`getGroup(id, c)` on the held connection — no nested pool checkout.
- OIDC JIT provisioning is a separate path and is **not** in scope.

No schema or hash-chain change.

## Tests

DB-backed (`ScimAuditDbTest`) drives the real `scimRoutes` over `testApplication`: each mutation writes one `kind="admin"`, `channel="scim"`, `principal="scim"` row with its exact descriptor; a repeated membership op records nothing; a forced audit-insert failure rolls the SCIM mutation back; hash chain re-verifies. Full `:control-plane:test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qwri6K4wyMaD1vKYbzQTqz
