### PR TITLE
feat(auditmon): detect off-hours admin changes and auth-failure bursts

### DIFF
--- a/auditmon/config/config.go
+++ b/auditmon/config/config.go
@@ -33,11 +33,13 @@ type Config struct {
 // Canonical anomaly-rule names. Detection fires alerts tagged with these, alert sinks route on them, and a
 // sink's rules list matches against them, so they are defined once here as the shared vocabulary.
 const (
-	RuleMassExport   = "mass_export"
-	RuleBulkPII      = "bulk_pii"
-	RuleOffHours     = "off_hours"
-	RuleRepeatedDeny = "repeated_deny"
-	RuleIntegrity    = "integrity"
+	RuleMassExport       = "mass_export"
+	RuleBulkPII          = "bulk_pii"
+	RuleOffHours         = "off_hours"
+	RuleRepeatedDeny     = "repeated_deny"
+	RuleAuthFailureBurst = "auth_failure_burst"
+	RuleOffHoursAdmin    = "off_hours_admin"
+	RuleIntegrity        = "integrity"
 )
 
 // Alert severities, least to most urgent. A sink routes an alert only when its severity is at least the
@@ -61,13 +63,15 @@ func SeverityRank(s string) int {
 	}
 }
 
-// RulesConfig holds the thresholds/windows for the four anomaly rules. A rule with a zero window (or, for
+// RulesConfig holds the thresholds/windows for the anomaly rules. A rule with a zero window (or, for
 // off_hours, an empty business_hours) is disabled; the detector skips it and Validate leaves it alone.
 type RulesConfig struct {
-	MassExport   MassExportRule   `koanf:"mass_export"`
-	BulkPII      BulkPIIRule      `koanf:"bulk_pii"`
-	OffHours     OffHoursRule     `koanf:"off_hours"`
-	RepeatedDeny RepeatedDenyRule `koanf:"repeated_deny"`
+	MassExport       MassExportRule       `koanf:"mass_export"`
+	BulkPII          BulkPIIRule          `koanf:"bulk_pii"`
+	OffHours         OffHoursRule         `koanf:"off_hours"`
+	RepeatedDeny     RepeatedDenyRule     `koanf:"repeated_deny"`
+	AuthFailureBurst AuthFailureBurstRule `koanf:"auth_failure_burst"`
+	OffHoursAdmin    OffHoursAdminRule    `koanf:"off_hours_admin"`
 }
 
 // VolumeThreshold is a per-datasource rows/bytes ceiling for mass_export. A zero field means "no ceiling on
@@ -158,6 +162,21 @@ func (r OffHoursRule) AppliesToWrite() bool { return containsFold(r.AppliesTo, "
 type RepeatedDenyRule struct {
 	Window  time.Duration `koanf:"window"`
 	MaxDeny int           `koanf:"max_deny"`
+}
+
+// AuthFailureBurstRule flags a principal accumulating more than MaxFailures failed authentication events
+// (kind "auth", outcome FAILURE) in a window — a brute-force / credential-stuffing signal from failed
+// logins and rejected wire tokens. Unattributed failures carry the principal "unknown"; a burst on
+// "unknown" is a valid signal, so it is keyed like any other principal.
+type AuthFailureBurstRule struct {
+	Window      time.Duration `koanf:"window"`
+	MaxFailures int           `koanf:"max_failures"`
+}
+
+// OffHoursAdminRule flags a privileged config/authorization change (kind "admin") made outside business
+// hours. It reuses the off_hours business window rather than defining a second one; Enabled turns it on.
+type OffHoursAdminRule struct {
+	Enabled bool `koanf:"enabled"`
 }
 
 // AlertsConfig is the alert delivery configuration: how long to suppress duplicate subjects and where to
@@ -424,6 +443,14 @@ func (r RulesConfig) validate() error {
 	}
 	if r.RepeatedDeny.Window > 0 && r.RepeatedDeny.MaxDeny <= 0 {
 		return fmt.Errorf("config: rules.repeated_deny has a window but max_deny <= 0")
+	}
+	if r.AuthFailureBurst.Window > 0 && r.AuthFailureBurst.MaxFailures <= 0 {
+		return fmt.Errorf("config: rules.auth_failure_burst has a window but max_failures <= 0")
+	}
+	// off_hours_admin borrows the off_hours window; enabling it without one leaves a rule that can never
+	// fire, so reject that at load rather than silently monitor nothing.
+	if r.OffHoursAdmin.Enabled && r.OffHours.BusinessHours == "" {
+		return fmt.Errorf("config: rules.off_hours_admin.enabled requires rules.off_hours.business_hours")
 	}
 	return nil
 }

--- a/auditmon/config/rules_test.go
+++ b/auditmon/config/rules_test.go
@@ -32,6 +32,12 @@ func TestLoadParsesRulesAndAlerts(t *testing.T) {
 	if cfg.Rules.RepeatedDeny.Window != 5*time.Minute || cfg.Rules.RepeatedDeny.MaxDeny != 20 {
 		t.Errorf("repeated_deny = %+v", cfg.Rules.RepeatedDeny)
 	}
+	if cfg.Rules.AuthFailureBurst.Window != 5*time.Minute || cfg.Rules.AuthFailureBurst.MaxFailures != 10 {
+		t.Errorf("auth_failure_burst = %+v", cfg.Rules.AuthFailureBurst)
+	}
+	if !cfg.Rules.OffHoursAdmin.Enabled {
+		t.Errorf("off_hours_admin.enabled = %v, want true", cfg.Rules.OffHoursAdmin.Enabled)
+	}
 
 	oh := cfg.Rules.OffHours
 	if !oh.AppliesToPIIRead() || !oh.AppliesToWrite() {
@@ -94,6 +100,12 @@ func TestValidateRejectsBadRules(t *testing.T) {
 		},
 		"repeated_deny window without max": func(c *Config) {
 			c.Rules.RepeatedDeny = RepeatedDenyRule{Window: time.Minute}
+		},
+		"auth_failure_burst window without max": func(c *Config) {
+			c.Rules.AuthFailureBurst = AuthFailureBurstRule{Window: time.Minute}
+		},
+		"off_hours_admin enabled without a window": func(c *Config) {
+			c.Rules.OffHoursAdmin = OffHoursAdminRule{Enabled: true}
 		},
 		"off_hours bad business_hours": func(c *Config) {
 			c.Rules.OffHours = OffHoursRule{BusinessHours: "nope", AppliesTo: []string{"write"}}

--- a/auditmon/config/testdata/monitor.yaml
+++ b/auditmon/config/testdata/monitor.yaml
@@ -26,6 +26,11 @@ rules:
   repeated_deny:
     window: 5m
     max_deny: 20
+  auth_failure_burst:
+    window: 5m
+    max_failures: 10
+  off_hours_admin:
+    enabled: true
 alerts:
   dedup_window: 15m
   sinks:

--- a/auditmon/detect/detect.go
+++ b/auditmon/detect/detect.go
@@ -1,9 +1,10 @@
 // Package detect evaluates the config-driven anomaly rules over the committed audit trail and fires alerts
 // through an AlertSink. It plugs into the monitor as the Detector: Inspect is called each poll with the
-// freshly verified, past-watermark rows. The rate rules (mass_export, bulk_pii, repeated_deny) need more than
-// that one batch, so the detector also reads a window of the durable trail on each poll and recomputes the
-// windows from it — a restart loses no state and nothing is double-counted. off_hours is a per-event rule and
-// needs only the fresh batch. Every rule is fail-safe: a bad row is skipped, never fatal.
+// freshly verified, past-watermark rows. The rate rules (mass_export, bulk_pii, repeated_deny,
+// auth_failure_burst) need more than that one batch, so the detector also reads a window of the durable trail
+// on each poll and recomputes the windows from it — a restart loses no state and nothing is double-counted.
+// off_hours and off_hours_admin are per-event rules and need only the fresh batch. Every rule is fail-safe: a
+// bad row is skipped, never fatal.
 package detect
 
 import (
@@ -65,7 +66,12 @@ func New(reader WindowReader, sink AlertSink, rules config.RulesConfig) (*Detect
 		d.business = bw
 		d.offHoursOK = true
 	}
-	for _, w := range []time.Duration{rules.MassExport.Window, rules.BulkPII.Window, rules.RepeatedDeny.Window} {
+	// Fail closed at construction, not just in Config.Validate: an enabled off-hours-admin rule with no
+	// window would silently never fire — a monitoring gap in a security tool.
+	if rules.OffHoursAdmin.Enabled && rules.OffHours.BusinessHours == "" {
+		return nil, fmt.Errorf("config: rules.off_hours_admin.enabled requires rules.off_hours.business_hours")
+	}
+	for _, w := range []time.Duration{rules.MassExport.Window, rules.BulkPII.Window, rules.RepeatedDeny.Window, rules.AuthFailureBurst.Window} {
 		if w > d.maxWindow {
 			d.maxWindow = w
 		}
@@ -81,6 +87,7 @@ func (d *Detector) needsWindow() bool { return d.maxWindow > 0 }
 // read failure is returned for the monitor to log and retry; it never blocks the loop.
 func (d *Detector) Inspect(fresh []store.StoredEvent) error {
 	d.evalOffHours(fresh)
+	d.evalOffHoursAdmin(fresh)
 
 	if !d.needsWindow() {
 		return nil
@@ -93,6 +100,7 @@ func (d *Detector) Inspect(fresh []store.StoredEvent) error {
 	d.evalMassExport(fresh, window)
 	d.evalBulkPII(fresh, window)
 	d.evalRepeatedDeny(fresh, window)
+	d.evalAuthFailureBurst(fresh, window)
 	return nil
 }
 
@@ -124,6 +132,31 @@ func (d *Detector) evalOffHours(fresh []store.StoredEvent) {
 		d.sink.Deliver(alert.Alert{
 			Severity:    config.SeverityWarn,
 			Rule:        config.RuleOffHours,
+			Principal:   ev.Event.Principal,
+			Datasource:  ev.Event.Datasource,
+			DecisionIDs: []int64{ev.ID},
+			TS:          ts,
+		})
+	}
+}
+
+// evalOffHoursAdmin fires on each fresh admin event — a privileged config/authorization change — whose
+// timestamp falls outside business hours, reusing the same business window off_hours parses.
+func (d *Detector) evalOffHoursAdmin(fresh []store.StoredEvent) {
+	if !d.offHoursOK || !d.rules.OffHoursAdmin.Enabled {
+		return
+	}
+	for _, ev := range fresh {
+		if !isAdmin(ev) {
+			continue
+		}
+		ts := time.UnixMicro(ev.Event.TSMicros).In(d.business.Location)
+		if !d.isOffHours(ts) {
+			continue
+		}
+		d.sink.Deliver(alert.Alert{
+			Severity:    config.SeverityWarn,
+			Rule:        config.RuleOffHoursAdmin,
 			Principal:   ev.Event.Principal,
 			Datasource:  ev.Event.Datasource,
 			DecisionIDs: []int64{ev.ID},
@@ -177,6 +210,52 @@ func (d *Detector) evalRepeatedDeny(fresh, window []store.StoredEvent) {
 			d.sink.Deliver(alert.Alert{
 				Severity:    config.SeverityWarn,
 				Rule:        config.RuleRepeatedDeny,
+				Principal:   p,
+				DecisionIDs: ids[p],
+				TS:          d.now(),
+			})
+		}
+	}
+}
+
+// evalAuthFailureBurst fires when a principal accumulates more than max_failures failed authentication events
+// in the window (a brute-force / credential-stuffing signal). Unattributed failures carry the principal
+// "unknown"; a burst on "unknown" is itself worth surfacing, so it is keyed like any other principal.
+func (d *Detector) evalAuthFailureBurst(fresh, window []store.StoredEvent) {
+	rule := d.rules.AuthFailureBurst
+	if rule.Window <= 0 {
+		return
+	}
+	cutoff := d.now().Add(-rule.Window)
+
+	touched := map[string]struct{}{}
+	for _, ev := range fresh {
+		if isAuthFailure(ev) {
+			touched[ev.Event.Principal] = struct{}{}
+		}
+	}
+	if len(touched) == 0 {
+		return
+	}
+
+	counts := map[string]int{}
+	ids := map[string][]int64{}
+	for _, ev := range window {
+		if !withinWindow(ev, cutoff) || !isAuthFailure(ev) {
+			continue
+		}
+		p := ev.Event.Principal
+		if _, ok := touched[p]; !ok {
+			continue
+		}
+		counts[p]++
+		ids[p] = appendCapped(ids[p], ev.ID)
+	}
+	for p := range touched {
+		if counts[p] > rule.MaxFailures {
+			d.sink.Deliver(alert.Alert{
+				Severity:    config.SeverityWarn,
+				Rule:        config.RuleAuthFailureBurst,
 				Principal:   p,
 				DecisionIDs: ids[p],
 				TS:          d.now(),
@@ -381,6 +460,14 @@ func (d *Detector) evalMassExport(fresh, window []store.StoredEvent) {
 
 func isDecision(ev store.StoredEvent) bool   { return ev.Event.Kind == "decision" }
 func isCompletion(ev store.StoredEvent) bool { return ev.Event.Kind == "completion" }
+func isAuth(ev store.StoredEvent) bool       { return ev.Event.Kind == "auth" }
+func isAdmin(ev store.StoredEvent) bool      { return ev.Event.Kind == "admin" }
+
+// isAuthFailure reports whether an event is a failed authentication (kind "auth" with outcome FAILURE). The
+// outcome is a nullable column, so a missing outcome is treated as not-a-failure rather than dereferenced.
+func isAuthFailure(ev store.StoredEvent) bool {
+	return isAuth(ev) && ev.Event.Outcome != nil && *ev.Event.Outcome == "FAILURE"
+}
 
 // isDenyOrError reports whether a decision was denied or errored.
 func isDenyOrError(ev store.StoredEvent) bool {

--- a/auditmon/detect/detect_test.go
+++ b/auditmon/detect/detect_test.go
@@ -98,6 +98,29 @@ func completion(principal, datasource string, decisionID, rows, bytes int64, ts 
 	}
 }
 
+func authEvent(principal, outcome, channel, action string, ts time.Time) canon.AuditEvent {
+	return canon.AuditEvent{
+		Kind:        "auth",
+		TSMicros:    canon.EpochMicros(ts),
+		Principal:   principal,
+		Channel:     &channel,
+		AuthzAction: &action,
+		Outcome:     &outcome,
+	}
+}
+
+func adminEvent(principal, action string, ts time.Time) canon.AuditEvent {
+	outcome, channel := "ALLOW", "console"
+	return canon.AuditEvent{
+		Kind:        "admin",
+		TSMicros:    canon.EpochMicros(ts),
+		Principal:   principal,
+		Channel:     &channel,
+		AuthzAction: &action,
+		Outcome:     &outcome,
+	}
+}
+
 func repeat(n int, mk func(i int) canon.AuditEvent) []canon.AuditEvent {
 	out := make([]canon.AuditEvent, 0, n)
 	for i := 0; i < n; i++ {
@@ -126,6 +149,120 @@ func TestRepeatedDeny(t *testing.T) {
 	got := sink.byRule(config.RuleRepeatedDeny)
 	if len(got) != 1 || got[0].Principal != "mallory" {
 		t.Fatalf("4 denies (> max 3) = %+v, want one alert for mallory", got)
+	}
+}
+
+// --- auth_failure_burst ---
+
+func TestAuthFailureBurst(t *testing.T) {
+	rules := config.RulesConfig{AuthFailureBurst: config.AuthFailureBurstRule{Window: 10 * time.Minute, MaxFailures: 3}}
+	now := time.Now()
+	fail := func(int) canon.AuditEvent {
+		return authEvent("mallory", "FAILURE", "wire", "login", now)
+	}
+
+	// At the threshold (== max) it must NOT fire.
+	sink := seedAndInspect(t, rules, repeat(3, fail))
+	if got := sink.byRule(config.RuleAuthFailureBurst); len(got) != 0 {
+		t.Fatalf("3 auth failures (== max 3) fired %d auth_failure_burst alerts, want 0", len(got))
+	}
+
+	// One over the threshold fires, at warn, for the right principal.
+	sink = seedAndInspect(t, rules, repeat(4, fail))
+	got := sink.byRule(config.RuleAuthFailureBurst)
+	if len(got) != 1 || got[0].Principal != "mallory" || got[0].Severity != config.SeverityWarn {
+		t.Fatalf("4 auth failures (> max 3) = %+v, want one warn alert for mallory", got)
+	}
+
+	// Successful auth events never count toward the burst, even well past the threshold.
+	success := func(int) canon.AuditEvent {
+		return authEvent("mallory", "SUCCESS", "wire", "login", now)
+	}
+	sink = seedAndInspect(t, rules, repeat(10, success))
+	if got := sink.byRule(config.RuleAuthFailureBurst); len(got) != 0 {
+		t.Fatalf("10 auth successes fired %d auth_failure_burst alerts, want 0", len(got))
+	}
+}
+
+// TestAuthFailureBurstUnknownPrincipal confirms that unattributed failures — rejected wire tokens that carry
+// the principal "unknown" — still burst: "unknown" is keyed like any other principal.
+func TestAuthFailureBurstUnknownPrincipal(t *testing.T) {
+	rules := config.RulesConfig{AuthFailureBurst: config.AuthFailureBurstRule{Window: 10 * time.Minute, MaxFailures: 3}}
+	now := time.Now()
+	fail := func(int) canon.AuditEvent {
+		return authEvent("unknown", "FAILURE", "wire", "token_validate", now)
+	}
+	sink := seedAndInspect(t, rules, repeat(4, fail))
+	got := sink.byRule(config.RuleAuthFailureBurst)
+	if len(got) != 1 || got[0].Principal != "unknown" {
+		t.Fatalf("4 unknown-principal auth failures = %+v, want one alert for unknown", got)
+	}
+}
+
+// --- off_hours_admin ---
+
+func TestOffHoursAdmin(t *testing.T) {
+	rules := config.RulesConfig{
+		OffHours:      config.OffHoursRule{BusinessHours: "09:00-19:00 Asia/Seoul", AppliesTo: []string{"pii_read", "write"}},
+		OffHoursAdmin: config.OffHoursAdminRule{Enabled: true},
+	}
+	seoul, err := time.LoadLocation("Asia/Seoul")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	mon0300 := time.Date(2026, 1, 5, 3, 0, 0, 0, seoul)  // Monday, before business hours
+	mon1200 := time.Date(2026, 1, 5, 12, 0, 0, 0, seoul) // Monday, business hours
+
+	// An admin change inside business hours does NOT fire.
+	sink := seedAndInspect(t, rules, []canon.AuditEvent{adminEvent("root", "policy.update", mon1200)})
+	if got := sink.byRule(config.RuleOffHoursAdmin); len(got) != 0 {
+		t.Fatalf("business-hours admin change fired %d off_hours_admin alerts, want 0", len(got))
+	}
+
+	// The same change outside business hours fires, at warn, for the right principal.
+	sink = seedAndInspect(t, rules, []canon.AuditEvent{adminEvent("root", "policy.update", mon0300)})
+	got := sink.byRule(config.RuleOffHoursAdmin)
+	if len(got) != 1 || got[0].Principal != "root" || got[0].Severity != config.SeverityWarn {
+		t.Fatalf("off-hours admin change = %+v, want one warn alert for root", got)
+	}
+}
+
+// TestOffHoursAdminNoCrossKind confirms the admin rule keys strictly on kind "admin": an off-hours decision
+// or auth event does not trigger it, and an off-hours admin change does not leak into the pii off_hours rule.
+func TestOffHoursAdminNoCrossKind(t *testing.T) {
+	rules := config.RulesConfig{
+		OffHours:      config.OffHoursRule{BusinessHours: "09:00-19:00 Asia/Seoul", AppliesTo: []string{"pii_read", "write"}},
+		OffHoursAdmin: config.OffHoursAdminRule{Enabled: true},
+	}
+	seoul, _ := time.LoadLocation("Asia/Seoul")
+	mon0300 := time.Date(2026, 1, 5, 3, 0, 0, 0, seoul) // off-hours
+
+	events := []canon.AuditEvent{
+		decision("alice", "example-mysql", "SELECT email FROM users", "ALLOW", []string{"pii:email"}, mon0300),
+		authEvent("mallory", "FAILURE", "wire", "login", mon0300),
+		adminEvent("root", "policy.update", mon0300),
+	}
+	sink := seedAndInspect(t, rules, events)
+
+	// Exactly the admin change triggers off_hours_admin — not the decision, not the auth event.
+	if got := sink.byRule(config.RuleOffHoursAdmin); len(got) != 1 || got[0].Principal != "root" {
+		t.Fatalf("off_hours_admin = %+v, want exactly the admin change (root)", got)
+	}
+	// The admin change is neither a PII read nor a write, so it must not appear under the pii off_hours rule.
+	for _, a := range sink.byRule(config.RuleOffHours) {
+		if a.Principal == "root" {
+			t.Fatalf("admin change leaked into the pii off_hours rule: %+v", a)
+		}
+	}
+}
+
+// New fails closed when off_hours_admin is enabled without a business-hours window, rather than
+// constructing a detector whose enabled rule can never fire (Config.Validate rejects it too).
+func TestNewRejectsEnabledOffHoursAdminWithoutBusinessHours(t *testing.T) {
+	if _, err := detect.New(nil, nil, config.RulesConfig{
+		OffHoursAdmin: config.OffHoursAdminRule{Enabled: true},
+	}); err == nil {
+		t.Fatal("New should reject off_hours_admin enabled with no business_hours window")
 	}
 }
 


### PR DESCRIPTION
> Stacked on #125 → #123 → #121 (base branch `sjcho/audit/wire-validate-client-addr`). Top of the audit-backlog stack; review/merge bottom-up.

## What

auditmon's anomaly detector only reacted to query `decision`/`completion` events. The `kind="admin"` (config/authorization changes, #115 + this stack's C/D) and `kind="auth"` (auth/session, #116) events flowed to SIEM but triggered **no anomaly detection**. Adds exactly **two** rules, each mirroring an existing one:

- **`off_hours_admin`** (SeverityWarn) — a privileged config/authorization change (`kind="admin"`) outside business hours. Per-event, reuses the existing off-hours window.
- **`auth_failure_burst`** (SeverityWarn) — a rate rule: `kind="auth"` + `outcome="FAILURE"` per principal over a window, firing above a threshold (brute-force / credential-stuffing; the unattributed `"unknown"` principal counts). Mirrors `repeated_deny`.

SIEM export is unchanged — admin/auth events (and any anomaly they trigger) already flow through it.

## Non-obvious

- Both rules are disabled by default (zero window / `enabled: false`). `Config.Validate` **and** `detect.New` fail closed if `off_hours_admin` is enabled without a business-hours window (an enabled rule that can never fire is a monitoring gap in a security tool).
- Nullable `outcome`/`channel` columns are nil-checked; the admin and existing decision off-hours rules filter strictly by kind (no cross-kind false positives).

## Tests

`detect_test`: threshold boundary (`>` not `>=`), successful-auth excluded, `"unknown"` principal, business vs off-hours, cross-kind isolation, and the fail-closed constructor. `config` tests: parse + both new reject cases. `go test -race ./...` green across the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qwri6K4wyMaD1vKYbzQTqz
