### PR TITLE
fix(control-plane): soft-delete roles and mask functions

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Access.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Access.kt
@@ -162,7 +162,7 @@ class AccessStore(private val dataSource: DataSource) {
             .joinToString("") { "%02x".format(it) }
         val id = dataSource.inTx { c ->
             val executeAs = roleId?.let { id ->
-                c.prepareStatement("SELECT name FROM app_role WHERE id = ?").use { ps ->
+                c.prepareStatement("SELECT name FROM app_role WHERE id = ? AND deleted_at IS NULL").use { ps ->
                     ps.setLong(1, id)
                     ps.executeQuery().use { rs -> if (rs.next()) listOf(rs.getString(1)) else emptyList() }
                 }
@@ -702,10 +702,13 @@ class AccessStore(private val dataSource: DataSource) {
                       ar.approved_at, ar.executing_at, ar.executed_at, ar.execute_as, ar.creator_kind
                FROM access_request ar LEFT JOIN app_role r ON r.id = ar.role_id
                LEFT JOIN datasource d ON d.id = ar.datasource_id"""
+        // The app_role join is filtered to LIVE roles: a grant of a soft-deleted role must resolve to no
+        // role (fail-closed in RoleResolver.resolve), so it drops out of listGrants here rather than
+        // silently granting a role the operator deleted.
         const val GRANT_SELECT =
             """SELECT ag.id, ag.principal, ag.role_id, r.name AS role_name,
                       ag.granted_by, ag.granted_at, ag.expires_at, ag.revoked_at
-               FROM access_grant ag JOIN app_role r ON r.id = ag.role_id"""
+               FROM access_grant ag JOIN app_role r ON r.id = ag.role_id AND r.deleted_at IS NULL"""
     }
 }
 

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
@@ -211,8 +211,10 @@ internal fun decideResultView(
     channel: Channel = Channel.WORKFLOW_VIEWER,
 ): ResultViewDecision {
     val sql = childSql ?: return ResultViewDecision.Denied("saved result child has no SQL")
-    val roles = req.executeAs.toSet()
-    if (roles.isEmpty()) return ResultViewDecision.Denied("approval request has no execute-as roles")
+    // Drop any execute-as role soft-deleted since the snapshot was frozen: it must grant nothing, so a
+    // stored result never re-decides under a role that no longer exists (an empty result denies below).
+    val roles = policyStore.liveRoleNames(req.executeAs)
+    if (roles.isEmpty()) return ResultViewDecision.Denied("approval request has no live execute-as roles")
     val ctx = decideQuery(
         principal = viewer,
         ds = ds,
@@ -738,7 +740,9 @@ fun Route.approvalRoutes(
             ?: return@post call.respond(HttpStatusCode.Conflict, ApiError("common.not_found", mapOf("resource" to "datasource")))
         val sql = req.sql ?: return@post call.respond(HttpStatusCode.Conflict, ApiError("approval.no_sql"))
         val requesterIp = call.httpRequesterIp(config)
-        val executeAs = req.executeAs.toSet()
+        // Only LIVE execute-as roles: a role soft-deleted since approval grants nothing, so it drops out of
+        // the run's ceiling here (and an all-deleted snapshot fails closed at the empty check below).
+        val executeAs = policyStore.liveRoleNames(req.executeAs)
         // Fail closed on a task with no execute-as role set — there is no R to enforce the run under. Only
         // a row with no elevation role can be empty (every new request carries R), so this never rejects a
         // current request; without it the run would fall through to the proxy Decide under the requester's

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Datasources.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Datasources.kt
@@ -605,7 +605,7 @@ class DatasourceStore(internal val dataSource: DataSource) {
            LEFT JOIN column_classification cl
              ON cl.datasource_id = c.datasource_id AND cl.schema_name = c.schema_name
             AND cl.table_name = c.table_name AND cl.column_name = c.column_name
-           LEFT JOIN mask_fn m ON m.id = cl.mask_fn_id
+           LEFT JOIN mask_fn m ON m.id = cl.mask_fn_id AND m.deleted_at IS NULL
            WHERE c.datasource_id = ?
            ORDER BY c.schema_name, c.table_name, c.ordinal""",
     ).use { ps ->
@@ -644,7 +644,7 @@ class DatasourceStore(internal val dataSource: DataSource) {
                 """SELECT cl.schema_name, cl.table_name, cl.column_name, cl.tags, cl.mask_fn_id,
                           m.name AS mask_fn_name
                    FROM column_classification cl
-                   LEFT JOIN mask_fn m ON m.id = cl.mask_fn_id
+                   LEFT JOIN mask_fn m ON m.id = cl.mask_fn_id AND m.deleted_at IS NULL
                    WHERE cl.datasource_id = ?""",
             ).use { ps ->
                 ps.setLong(1, id)
@@ -707,7 +707,7 @@ class DatasourceStore(internal val dataSource: DataSource) {
 
     private fun maskFnName(id: Long?, c: java.sql.Connection): String? {
         if (id == null) return null
-        return c.prepareStatement("SELECT name FROM mask_fn WHERE id = ?").use { ps ->
+        return c.prepareStatement("SELECT name FROM mask_fn WHERE id = ? AND deleted_at IS NULL").use { ps ->
             ps.setLong(1, id)
             ps.executeQuery().use { rs -> if (rs.next()) rs.getString(1) else null }
         }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Policies.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Policies.kt
@@ -30,13 +30,28 @@ import javax.sql.DataSource
 class PolicyStore(internal val dataSource: DataSource) {
 
     fun listRoles(): List<Role> = dataSource.connection.use(::listRoles)
-    fun listRoles(c: Connection): List<Role> = c.query("SELECT id, name, description FROM app_role ORDER BY name") { it.toRole() }
+    fun listRoles(c: Connection): List<Role> = c.query("SELECT id, name, description FROM app_role WHERE deleted_at IS NULL ORDER BY name") { it.toRole() }
     fun getRole(id: Long): Role? = dataSource.connection.use { getRole(id, it) }
-    fun getRole(id: Long, c: Connection): Role? = c.queryOne("SELECT id, name, description FROM app_role WHERE id=?", id) { it.toRole() }
+    fun getRole(id: Long, c: Connection): Role? = c.queryOne("SELECT id, name, description FROM app_role WHERE id=? AND deleted_at IS NULL", id) { it.toRole() }
     fun getRoleByName(name: String): Role? = dataSource.connection.use { getRoleByName(name, it) }
     fun getRoleByName(name: String, c: Connection): Role? = c.prepareStatement(
-        "SELECT id, name, description FROM app_role WHERE name=?",
+        "SELECT id, name, description FROM app_role WHERE name=? AND deleted_at IS NULL",
     ).use { ps -> ps.setString(1, name); ps.executeQuery().use { rs -> if (rs.next()) rs.toRole() else null } }
+
+    /**
+     * Of [names], the subset that names a LIVE role — for validating a task's frozen `execute_as` role
+     * snapshot at execution/view time. A role soft-deleted after the snapshot was taken drops out here, so
+     * the caller can fail closed rather than authorize a stored result under a role that no longer exists;
+     * a name freed by a delete and reused resolves to its new live role, matching Cedar name semantics.
+     */
+    fun liveRoleNames(names: Collection<String>): Set<String> = dataSource.connection.use { liveRoleNames(names, it) }
+    fun liveRoleNames(names: Collection<String>, c: Connection): Set<String> {
+        if (names.isEmpty()) return emptySet()
+        return c.prepareStatement("SELECT name FROM app_role WHERE name = ANY(?) AND deleted_at IS NULL").use { ps ->
+            ps.setArray(1, c.createArrayOf("text", names.toTypedArray()))
+            ps.executeQuery().use { rs -> buildSet { while (rs.next()) add(rs.getString(1)) } }
+        }
+    }
     fun createRole(input: RoleInput): Role = dataSource.connection.use { createRole(input, it) }
     fun createRole(input: RoleInput, c: Connection): Role {
         val id = c.insertReturningId("INSERT INTO app_role (name, description) VALUES (?, ?) RETURNING id") {
@@ -47,13 +62,16 @@ class PolicyStore(internal val dataSource: DataSource) {
     fun updateRole(id: Long, input: RoleInput): Role? = dataSource.connection.use { updateRole(id, input, it) }
     fun updateRole(id: Long, input: RoleInput, c: Connection): Role? {
         if (getRole(id, c) == null) return null
-        c.exec("UPDATE app_role SET name=?, description=? WHERE id=?") {
+        c.exec("UPDATE app_role SET name=?, description=? WHERE id=? AND deleted_at IS NULL") {
             it.setString(1, input.name); it.setString(2, input.description); it.setLong(3, id)
         }
         return getRole(id, c)
     }
     fun deleteRole(id: Long): Boolean = dataSource.connection.use { deleteRole(id, it) }
-    fun deleteRole(id: Long, c: Connection): Boolean = c.execUpdate("DELETE FROM app_role WHERE id=?") { it.setLong(1, id) } > 0
+    /** Soft delete: the row (and the access_request / access_grant history that references it) survives,
+     *  while resolution and every live read exclude it and its name is freed for reuse. */
+    fun deleteRole(id: Long, c: Connection): Boolean =
+        c.execUpdate("UPDATE app_role SET deleted_at = now() WHERE id=? AND deleted_at IS NULL") { it.setLong(1, id) } > 0
     fun isSystemRole(id: Long): Boolean = dataSource.connection.use { isSystemRole(id, it) }
     fun isSystemRole(id: Long, c: Connection): Boolean = c.prepareStatement(
         """SELECT EXISTS(SELECT 1 FROM group_role gr JOIN app_group g ON g.id = gr.group_id
@@ -65,7 +83,7 @@ class PolicyStore(internal val dataSource: DataSource) {
     fun listAssignments(principal: String?, roleId: Long?, c: Connection): List<RoleAssignment> {
         val sql = StringBuilder(
             """SELECT pr.id, pr.principal, pr.role_id, r.name AS role_name
-               FROM principal_role pr JOIN app_role r ON r.id = pr.role_id WHERE 1=1""",
+               FROM principal_role pr JOIN app_role r ON r.id = pr.role_id AND r.deleted_at IS NULL WHERE 1=1""",
         )
         if (principal != null) sql.append(" AND pr.principal = ?")
         if (roleId != null) sql.append(" AND pr.role_id = ?")
@@ -84,7 +102,7 @@ class PolicyStore(internal val dataSource: DataSource) {
     fun getAssignment(id: Long): RoleAssignment? = dataSource.connection.use { getAssignment(id, it) }
     fun getAssignment(id: Long, c: Connection): RoleAssignment? = c.prepareStatement(
         """SELECT pr.id, pr.principal, pr.role_id, r.name AS role_name
-           FROM principal_role pr JOIN app_role r ON r.id = pr.role_id WHERE pr.id = ?""",
+           FROM principal_role pr JOIN app_role r ON r.id = pr.role_id AND r.deleted_at IS NULL WHERE pr.id = ?""",
     ).use { ps ->
         ps.setLong(1, id)
         ps.executeQuery().use { rs ->
@@ -105,12 +123,12 @@ class PolicyStore(internal val dataSource: DataSource) {
     ) { it.setString(1, principal); it.setLong(2, roleId) } > 0
 
     fun listMaskFns(): List<MaskFn> = dataSource.connection.use(::listMaskFns)
-    fun listMaskFns(c: Connection): List<MaskFn> = c.query("SELECT id, name, kind FROM mask_fn ORDER BY name") { it.toMaskFn() }
+    fun listMaskFns(c: Connection): List<MaskFn> = c.query("SELECT id, name, kind FROM mask_fn WHERE deleted_at IS NULL ORDER BY name") { it.toMaskFn() }
     fun getMaskFn(id: Long): MaskFn? = dataSource.connection.use { getMaskFn(id, it) }
-    fun getMaskFn(id: Long, c: Connection): MaskFn? = c.queryOne("SELECT id, name, kind FROM mask_fn WHERE id=?", id) { it.toMaskFn() }
+    fun getMaskFn(id: Long, c: Connection): MaskFn? = c.queryOne("SELECT id, name, kind FROM mask_fn WHERE id=? AND deleted_at IS NULL", id) { it.toMaskFn() }
     fun getMaskFnByName(name: String): MaskFn? = dataSource.connection.use { getMaskFnByName(name, it) }
     fun getMaskFnByName(name: String, c: Connection): MaskFn? = c.prepareStatement(
-        "SELECT id, name, kind FROM mask_fn WHERE name=?",
+        "SELECT id, name, kind FROM mask_fn WHERE name=? AND deleted_at IS NULL",
     ).use { ps -> ps.setString(1, name); ps.executeQuery().use { rs -> if (rs.next()) rs.toMaskFn() else null } }
     fun createMaskFn(input: MaskFnInput): MaskFn = dataSource.connection.use { createMaskFn(input, it) }
     fun createMaskFn(input: MaskFnInput, c: Connection): MaskFn {
@@ -122,13 +140,16 @@ class PolicyStore(internal val dataSource: DataSource) {
     fun updateMaskFn(id: Long, input: MaskFnInput): MaskFn? = dataSource.connection.use { updateMaskFn(id, input, it) }
     fun updateMaskFn(id: Long, input: MaskFnInput, c: Connection): MaskFn? {
         if (getMaskFn(id, c) == null) return null
-        c.exec("UPDATE mask_fn SET name=?, kind=? WHERE id=?") {
+        c.exec("UPDATE mask_fn SET name=?, kind=? WHERE id=? AND deleted_at IS NULL") {
             it.setString(1, input.name); it.setString(2, input.kind); it.setLong(3, id)
         }
         return getMaskFn(id, c)
     }
     fun deleteMaskFn(id: Long): Boolean = dataSource.connection.use { deleteMaskFn(id, it) }
-    fun deleteMaskFn(id: Long, c: Connection): Boolean = c.execUpdate("DELETE FROM mask_fn WHERE id=?") { it.setLong(1, id) } > 0
+    /** Soft delete: a column classification still referencing this mask function falls back to FIXED
+     *  masking (the column stays masked), and the name is freed for reuse. */
+    fun deleteMaskFn(id: Long, c: Connection): Boolean =
+        c.execUpdate("UPDATE mask_fn SET deleted_at = now() WHERE id=? AND deleted_at IS NULL") { it.setLong(1, id) } > 0
 
     private fun ResultSet.toRole() = Role(getLong("id"), getString("name"), getString("description"))
     private fun ResultSet.toMaskFn() = MaskFn(getLong("id"), getString("name"), getString("kind"))

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -364,7 +364,12 @@ fun decideQuery(
         return structuralDeny(DEACTIVATED_PRINCIPAL_DENY, emptyList(), failedStage = "deprovisioned")
     }
 
-    val roles = providedRoles ?: roleResolver.resolve(principal)
+    // providedRoles is a task's frozen execute_as snapshot (approval execute + stored-result view). Re-filter
+    // it to LIVE roles at this final authorization point so a role soft-deleted AFTER the route-level liveness
+    // check — including between the route and the async proxy Decide — cannot still authorize the run. An
+    // all-deleted snapshot collapses to the empty set and denies here (never falls back to the principal's
+    // own roles). Ordinary resolution is already deleted-role-filtered in RoleResolver.
+    val roles = providedRoles?.let { policyStore.liveRoleNames(it) } ?: roleResolver.resolve(principal)
     val roleList = roles.toList()
     @Suppress("NAME_SHADOWING")
     val context = effectiveAuthzContext(context, channel, authz, principal, roles, ds.name, ds.tags)

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RoleResolver.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RoleResolver.kt
@@ -20,7 +20,7 @@ class RoleResolver(
         c.prepareStatement(
             """SELECT r.name
                FROM principal_role pr
-               JOIN app_role r ON r.id = pr.role_id
+               JOIN app_role r ON r.id = pr.role_id AND r.deleted_at IS NULL
                WHERE pr.principal = ?""",
         ).use { ps ->
             ps.setString(1, principal)
@@ -66,21 +66,21 @@ class RoleResolver(
                    EXISTS (
                        SELECT 1
                        FROM principal_role pr
-                       JOIN app_role r ON r.id = pr.role_id AND r.name = ?
+                       JOIN app_role r ON r.id = pr.role_id AND r.name = ? AND r.deleted_at IS NULL
                        LEFT JOIN app_user u ON u.principal = pr.principal
                        WHERE u.id IS NULL OR u.active
                    )
                    OR EXISTS (
                        SELECT 1
                        FROM group_role gr
-                       JOIN app_role r ON r.id = gr.role_id AND r.name = ?
+                       JOIN app_role r ON r.id = gr.role_id AND r.name = ? AND r.deleted_at IS NULL
                        JOIN group_member gm ON gm.group_id = gr.group_id
                        JOIN app_user u ON u.id = gm.user_id AND u.active
                    )
                    OR EXISTS (
                        SELECT 1
                        FROM access_grant ag
-                       JOIN app_role r ON r.id = ag.role_id AND r.name = ?
+                       JOIN app_role r ON r.id = ag.role_id AND r.name = ? AND r.deleted_at IS NULL
                        LEFT JOIN app_user u ON u.principal = ag.principal
                        WHERE ag.revoked_at IS NULL
                          AND (ag.expires_at IS NULL OR ag.expires_at > now())

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Users.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Users.kt
@@ -626,7 +626,7 @@ class UserGroupStore(internal val dataSource: DataSource) {
     fun listGroupRoles(groupId: Long): List<GroupRoleEntry> = dataSource.connection.use { listGroupRoles(groupId, it) }
     fun listGroupRoles(groupId: Long, c: Connection): List<GroupRoleEntry> = c.prepareStatement(
         """SELECT r.id AS role_id, r.name AS role_name
-           FROM group_role gr JOIN app_role r ON r.id = gr.role_id
+           FROM group_role gr JOIN app_role r ON r.id = gr.role_id AND r.deleted_at IS NULL
            WHERE gr.group_id = ? ORDER BY r.name""",
     ).use { ps ->
         ps.setLong(1, groupId)
@@ -654,7 +654,7 @@ class UserGroupStore(internal val dataSource: DataSource) {
                    FROM app_user u
                    JOIN group_member gm ON gm.user_id = u.id
                    JOIN group_role gr ON gr.group_id = gm.group_id
-                   JOIN app_role r ON r.id = gr.role_id
+                   JOIN app_role r ON r.id = gr.role_id AND r.deleted_at IS NULL
                    WHERE u.principal = ? AND u.active""",
             ).use { ps ->
                 ps.setString(1, principal)
@@ -693,7 +693,7 @@ class UserGroupStore(internal val dataSource: DataSource) {
             ps.executeQuery().use { rs -> rs.next(); rs.getBoolean(1) }
         }
 
-    fun role(id: Long): GroupRoleEntry? = queryOne("SELECT id, name FROM app_role WHERE id=?", id) {
+    fun role(id: Long): GroupRoleEntry? = queryOne("SELECT id, name FROM app_role WHERE id=? AND deleted_at IS NULL", id) {
         GroupRoleEntry(it.getLong("id"), it.getString("name"))
     }
     fun roleExists(id: Long): Boolean = role(id) != null
@@ -754,7 +754,7 @@ class UserGroupStore(internal val dataSource: DataSource) {
     private fun groupRoles(groupId: Long?): Map<Long, List<GroupRef>> = dataSource.connection.use { c ->
         val sql = StringBuilder(
             """SELECT gr.group_id, r.id, r.name
-               FROM group_role gr JOIN app_role r ON r.id = gr.role_id""",
+               FROM group_role gr JOIN app_role r ON r.id = gr.role_id AND r.deleted_at IS NULL""",
         )
         if (groupId != null) sql.append(" WHERE gr.group_id = ?")
         sql.append(" ORDER BY r.name")

--- a/control-plane/src/main/resources/db/migration/V14__role_maskfn_soft_delete.sql
+++ b/control-plane/src/main/resources/db/migration/V14__role_maskfn_soft_delete.sql
@@ -1,0 +1,14 @@
+-- Soft delete for roles and mask functions, mirroring datasource (V13). A delete stamps `deleted_at`
+-- instead of removing the row, so the access_request / access_grant / column_classification history that
+-- references it survives (and the referencing foreign keys a hard delete could not satisfy are never
+-- touched). A soft-deleted row is excluded from every live read and, critically, from role resolution and
+-- mask selection, so a deleted role grants nothing and a deleted mask function falls back to FIXED masking.
+-- The name is freed for reuse via a partial unique index scoped to live rows.
+
+ALTER TABLE app_role ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE app_role DROP CONSTRAINT app_role_name_key;
+CREATE UNIQUE INDEX app_role_name_live_key ON app_role (name) WHERE deleted_at IS NULL;
+
+ALTER TABLE mask_fn ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE mask_fn DROP CONSTRAINT mask_fn_name_key;
+CREATE UNIQUE INDEX mask_fn_name_live_key ON mask_fn (name) WHERE deleted_at IS NULL;

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/RoleMaskFnSoftDeleteDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/RoleMaskFnSoftDeleteDbTest.kt
@@ -1,0 +1,138 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import javax.sql.DataSource
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Soft delete for roles and mask functions (V14). The security-critical property: a soft-deleted role
+ * must drop out of EVERY role-resolution source (direct assignment, group membership, JIT grant) and out
+ * of the frozen `execute_as` snapshot, so it grants nothing — while the referencing rows survive and the
+ * name is freed for reuse. A soft-deleted mask function falls back to FIXED masking (the column stays
+ * masked). Mirrors the make-inert approach: a delete just stops the entity working everywhere.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RoleMaskFnSoftDeleteDbTest {
+    private lateinit var ds: DataSource
+    private lateinit var policyStore: PolicyStore
+    private lateinit var userGroupStore: UserGroupStore
+    private lateinit var accessStore: AccessStore
+    private lateinit var tokenStore: TokenStore
+    private lateinit var daemonSessionStore: PrincipalSessionStore
+    private lateinit var roleResolver: RoleResolver
+    private lateinit var datasourceStore: DatasourceStore
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        ds = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_role_maskfn_soft_delete"))
+        Flyway.configure().dataSource(ds).load().migrate()
+        policyStore = PolicyStore(ds)
+        userGroupStore = UserGroupStore(ds)
+        accessStore = AccessStore(ds)
+        tokenStore = TokenStore(ds)
+        daemonSessionStore = PrincipalSessionStore(ds, null)
+        roleResolver = RoleResolver(ds, userGroupStore, accessStore)
+        datasourceStore = DatasourceStore(ds)
+    }
+
+    @AfterAll
+    fun close() {
+        (ds as? AutoCloseable)?.close()
+    }
+
+    @Test
+    fun `a soft-deleted role drops out of every resolution source`() {
+        val principal = "role-softdel-${System.nanoTime()}@example.com"
+        val direct = policyStore.createRole(RoleInput("direct-${System.nanoTime()}"))
+        val viaGroup = policyStore.createRole(RoleInput("group-${System.nanoTime()}"))
+        val viaGrant = policyStore.createRole(RoleInput("grant-${System.nanoTime()}"))
+
+        policyStore.createAssignment(RoleAssignmentInput(principal, direct.id))
+        val user = userGroupStore.createUser(AppUserInput(principal = principal), tokenStore, accessStore, daemonSessionStore)
+        val group = userGroupStore.createGroup(AppGroupInput(name = "grp-${System.nanoTime()}"))
+        userGroupStore.addMember(group.id, user.id)
+        userGroupStore.addGroupRole(group.id, viaGroup.id)
+        val request = accessStore.createRequest(principal, AccessRequestInput(roleId = viaGrant.id))
+        accessStore.approve(request.id, durationSec = 3600, decidedBy = "approver@example.com")
+
+        assertEquals(setOf(direct.name, viaGroup.name, viaGrant.name), roleResolver.resolve(principal), "sanity")
+
+        // Soft-delete each role: it must vanish from resolve() while its referencing rows survive.
+        assertTrue(policyStore.deleteRole(direct.id))
+        assertTrue(policyStore.deleteRole(viaGroup.id))
+        assertTrue(policyStore.deleteRole(viaGrant.id))
+
+        assertEquals(emptySet(), roleResolver.resolve(principal), "a soft-deleted role grants nothing")
+        assertNull(policyStore.getRole(direct.id), "and is invisible to live reads")
+        assertEquals(0, policyStore.listRoles().count { it.id == direct.id })
+        // History survives: the assignment / grant rows still reference the tombstoned role.
+        assertEquals(1, rawCount("SELECT count(*) FROM principal_role WHERE role_id = ${direct.id}"))
+        assertEquals(1, rawCount("SELECT count(*) FROM access_grant WHERE role_id = ${viaGrant.id}"))
+        assertEquals(1, rawCount("SELECT count(*) FROM app_role WHERE id = ${direct.id} AND deleted_at IS NOT NULL"))
+    }
+
+    @Test
+    fun `a soft-deleted role name is free for a new role, and the new role resolves`() {
+        val principal = "role-reuse-${System.nanoTime()}@example.com"
+        val name = "reused-role-${System.nanoTime()}"
+        val first = policyStore.createRole(RoleInput(name))
+        assertTrue(policyStore.deleteRole(first.id))
+
+        val second = policyStore.createRole(RoleInput(name))
+        assertNotEquals(first.id, second.id)
+        assertEquals(second.id, policyStore.getRoleByName(name)?.id, "the live name resolves to the new role")
+
+        policyStore.createAssignment(RoleAssignmentInput(principal, second.id))
+        assertEquals(setOf(name), roleResolver.resolve(principal), "the reused name grants via the new role")
+    }
+
+    @Test
+    fun `liveRoleNames drops a role soft-deleted after an execute-as snapshot`() {
+        val live = policyStore.createRole(RoleInput("exec-live-${System.nanoTime()}"))
+        val gone = policyStore.createRole(RoleInput("exec-gone-${System.nanoTime()}"))
+        assertTrue(policyStore.deleteRole(gone.id))
+
+        assertEquals(
+            setOf(live.name),
+            policyStore.liveRoleNames(listOf(live.name, gone.name)),
+            "a stored execute_as re-authorizes only under roles that still exist",
+        )
+    }
+
+    @Test
+    fun `a soft-deleted mask function falls back and its name is reusable`() {
+        val datasource = datasourceStore.create(DatasourceInput("maskfn-ds-${System.nanoTime()}", "mysql"))
+        val name = "email-mask-${System.nanoTime()}"
+        val fn = policyStore.createMaskFn(MaskFnInput(name, "LAST_N"))
+        datasourceStore.upsertClassification(
+            datasource.id,
+            ClassificationInput("app", "users", "email", listOf("pii"), fn.id),
+        )
+        assertEquals(name, datasourceStore.classificationsFor(datasource.id).values.single().maskFnName, "sanity")
+
+        assertTrue(policyStore.deleteMaskFn(fn.id))
+
+        assertNull(
+            datasourceStore.classificationsFor(datasource.id).values.single().maskFnName,
+            "a column keeps its classification but the deleted fn resolves to null -> FIXED masking (still masked)",
+        )
+        assertEquals(0, policyStore.listMaskFns().count { it.id == fn.id }, "and is gone from the live list")
+
+        val reused = policyStore.createMaskFn(MaskFnInput(name, "FIXED"))
+        assertNotEquals(fn.id, reused.id, "the freed name is reusable")
+    }
+
+    private fun rawCount(sql: String): Int = ds.connection.use { c ->
+        c.prepareStatement(sql).use { ps -> ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) } }
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SoftDeleteEnforcementDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SoftDeleteEnforcementDbTest.kt
@@ -1,0 +1,78 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.grpc.EnfAction
+import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * End-to-end: soft-deleting the mask function a column is classified with must never un-mask it — the
+ * column falls back to FIXED masking and the value stays hidden (fail-safe).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MaskFnSoftDeleteEnforcementDbTest {
+    private lateinit var fx: EnforcementFixture
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        fx = EnforcementFixture.postgres()
+    }
+
+    @Test
+    fun `soft-deleting a column's mask function keeps it masked (FIXED fallback), never cleartext`() {
+        val cleartext = fx.execOnTarget("select rrn from users order by id").rows.map { it.single() }
+
+        val before = fx.run("select id, rrn from users order by id")
+        assertEquals(EnfAction.MASK, before.decision, "sanity: rrn masks under the analyst role + last4 fn")
+        val rrn = before.columns.indexOf("rrn")
+        val maskedBefore = before.rows.map { it[rrn] }
+        assertEquals(emptyList(), maskedBefore.filter { it in cleartext }, "sanity: nothing cleartext while masked")
+
+        // Delete the mask function the classification points at.
+        fx.policyStore.deleteMaskFn(fx.policyStore.listMaskFns().first { it.name == "last4" }.id)
+
+        val after = fx.run("select id, rrn from users order by id")
+        assertEquals(EnfAction.MASK, after.decision, "the column stays MASK — a deleted mask fn must not un-mask it")
+        val maskedAfter = after.rows.map { it[rrn] }
+        assertEquals(emptyList(), maskedAfter.filter { it in cleartext }, "and no rrn is cleartext after the delete")
+        assertNotEquals(maskedBefore, maskedAfter, "the mask fell back from last4 to FIXED, so the masked output changed")
+    }
+}
+
+/**
+ * End-to-end: a task's frozen execute_as role snapshot re-authorizes at the decision. A role soft-deleted
+ * after the snapshot (or after the route-level liveness check, before the async proxy Decide) is re-filtered
+ * to live roles at decideQuery, so the run denies rather than authorizing under a role that no longer exists.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RoleExecuteAsSoftDeleteEnforcementDbTest {
+    private lateinit var fx: EnforcementFixture
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        fx = EnforcementFixture.postgres()
+    }
+
+    @Test
+    fun `a soft-deleted execute-as role is re-filtered at the decision so the stored run denies`() {
+        val executeAs = setOf(fx.role) // the seeded analyst role, which masks rrn
+
+        val live = fx.decide("select id, rrn from users", providedRoles = executeAs)
+        assertEquals(EnfAction.MASK, live.action, "sanity: the run authorizes and masks under its execute_as role")
+
+        fx.policyStore.deleteRole(fx.policyStore.listRoles().first { it.name == fx.role }.id)
+
+        val gone = fx.decide("select id, rrn from users", providedRoles = executeAs)
+        assertEquals(
+            EnfAction.DENY,
+            gone.action,
+            "a soft-deleted execute_as role must not still authorize the run (TOCTOU re-check at decideQuery)",
+        )
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/EnforcementFixture.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/EnforcementFixture.kt
@@ -163,10 +163,18 @@ class EnforcementFixture(
      * DecisionContext itself — e.g. the analyzer-emitted `rewrittenSql` — through the production seam rather
      * than injecting synthetic facts.
      */
-    fun decide(sql: String, principal: String = "analyst@example.com", channel: Channel = Channel.WIRE): DecisionContext =
+    fun decide(
+        sql: String,
+        principal: String = "analyst@example.com",
+        channel: Channel = Channel.WIRE,
+        // A task's frozen execute_as snapshot: when set it REPLACES server role resolution (the approval
+        // execute + stored-result view path), exercising the decision's own live-role re-filter.
+        providedRoles: Set<String>? = null,
+    ): DecisionContext =
         decideQuery(
             principal, datasource, sql, channel, datasourceStore.catalog(datasource.id),
             policyStore, accessStore, userGroupStore, roleResolver, authz,
+            providedRoles = providedRoles,
         )
 
     /** Run raw SQL directly against the target (test setup/teardown; no enforcement gate). */


### PR DESCRIPTION
## What

Deleting a role or mask function ran a hard `DELETE`, which threw a foreign-key
violation whenever it was in use — a role referenced by any `access_request` or
`access_grant`, a mask function assigned to any column — the same generic 500 as
the datasource delete. Both now soft-delete (**V14**: `deleted_at` + a partial
unique index scoped to live rows, so the referencing history survives and the
name is free to reuse).

## Fail-closed / fail-safe

- A soft-deleted **role** grants nothing: filtered from every resolution source
  (direct `principal_role`, `group_role`, active `access_grant`) and from the
  frozen `execute_as` snapshot — which is re-filtered to live roles at the final
  authorization point (`decideQuery`), so a role deleted between the route check
  and the async proxy `Decide` can't still authorize the run.
- A soft-deleted **mask function** resolves to null and the column falls back to
  `FIXED` masking — it stays masked, never cleartext.

Unlike datasource, neither needs a delete guard (no runtime state to tear down);
deleting just makes it inert everywhere. The access-request history join stays
unfiltered so a deleted role's name still shows in history.

## Verify

`mise run verify` green. New tests: fail-closed resolution across all three
sources, `execute_as` liveness incl. the decision-time re-filter, and end-to-end
enforcement (a mask stays masked after its fn is deleted; a deleted `execute_as`
role denies the run). Live HTTP e2e: deleting an in-use role and mask function
both return 204 (were 500), history retained, names reusable, classification
falls back to FIXED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVPxL5eCFrvrKQNshZqx3a
