### PR TITLE
fix(control-plane): release saved EXPLAIN plans

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
@@ -8,6 +8,7 @@ import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
 import com.ridi.oss.proxymonster.controlplane.authz.authorizeDatasourceAction
 import com.ridi.oss.proxymonster.controlplane.authz.authorizeWithContext
 import com.ridi.oss.proxymonster.controlplane.authz.resolveContextTags
+import com.ridi.oss.proxymonster.analyzer.pb.StatementKind
 import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
 import com.ridi.oss.proxymonster.controlplane.notify.NotificationEvent
 import com.ridi.oss.proxymonster.controlplane.notify.NotificationService
@@ -179,7 +180,8 @@ internal sealed class ResultViewDecision {
  * Re-evaluate a stored execute-under-R result for the actual viewer in their live HTTP context. The store
  * holds R's execution-enforced output; this function re-applies R's masks for the viewer's current context,
  * narrowing further where it requires. Every uncertainty is a deny: no role/SQL, policy DENY, passthrough,
- * output-column drift, or an unbound mask.
+ * ordinary-result output-column drift, or an unbound mask. An analyzer-verified, fully unmasked EXPLAIN
+ * plan releases its backend-generated columns after those other checks pass.
  *
  * [childSql] is the statement of the SAME result child whose bytes are in [decrypted] (from
  * [ResultAccess.sql]) — NOT the task's first-child `req.sql`, which can diverge once a task holds plural
@@ -246,9 +248,16 @@ internal fun decideResultView(
         }
         return ResultViewDecision.Allowed(decrypted.columns, decrypted.rows)
     }
-    if (
-        ctx.outputColumns.size != decrypted.columns.size ||
-        ctx.outputColumns.zip(decrypted.columns).any { (decided, stored) -> !decided.equals(stored, ignoreCase = true) }
+    val planOnlyExplain =
+        ctx.statementKind == StatementKind.STATEMENT_KIND_EXPLAIN &&
+            ctx.action == EnfAction.ALLOW &&
+            ctx.masks.isEmpty() &&
+            ctx.outputColumns.isEmpty()
+    if (!planOnlyExplain &&
+        (
+            ctx.outputColumns.size != decrypted.columns.size ||
+                ctx.outputColumns.zip(decrypted.columns).any { (decided, stored) -> !decided.equals(stored, ignoreCase = true) }
+            )
     ) {
         return ResultViewDecision.Denied("stored result columns no longer match the live query decision")
     }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -147,10 +147,12 @@ data class DecisionContext(
      * so target-DB column order matches the mask ordinals. Null = send verbatim. */
     val rewrittenSql: String? = null,
     /** The analyzer's ordered output column names for this decision (an empty list for a passthrough /
-     * unanalyzed statement). APPROVAL live result viewing compares this against the stored execute-enforced
-     * result to detect catalog drift between execute and view (a `SELECT *` re-expansion that would slide a
-     * mask onto the wrong stored column and leak a value) — a mismatch is DENY. */
+     * unanalyzed statement). Live result viewing compares this against the stored execute-enforced result to
+     * detect catalog drift between execute and view (a `SELECT *` re-expansion that would slide a mask onto
+     * the wrong stored column and leak a value) — a mismatch is DENY. */
     val outputColumns: List<String> = emptyList(),
+    /** The analyzer-attested statement kind for this decision, or STMT_UNKNOWN when absent. */
+    val statementKind: StatementKind = StatementKind.STATEMENT_KIND_STMT_UNKNOWN,
     /** The derived `context.tags` this decision was evaluated under, surfaced so [decisionRecord]
      * logs which tags the request earned. Stamped on EVERY decision that runs after context derivation —
      * ALLOW, MASK, DENY (structural + policy), and passthrough alike — so an audit row carries the attested
@@ -798,6 +800,7 @@ fun decideQuery(
         detail = facts.detail,
         passthrough = false,
         outputColumns = facts.outputColumnsList,
+        statementKind = statementKind,
         contextTags = derivedTags,
         unmaskablePermitted = unmaskablePermitted,
         sanitizeDiagnostics = sanitizeDiagnostics,
@@ -880,9 +883,8 @@ internal fun wireTaskForbiddenDeny(
 // Relay the analyzer's optional rewritten SQL on a decision we allow. rewrittenSql is Go-analyzer output
 // (the `SELECT *` expansion, the MySQL charset pin) independent of statement class, so every
 // understood-and-allowed decision — analyzed, metadata, session — routes it through this one point rather
-// than each building its own. An EXPLAIN/DESCRIBE keeps its original text — the analyzer emits no
-// rewritten_sql for it (the rewrite is for the inner query it plans). The exception.unanalyzable escape
-// hatches deliberately relay the original whole statement, so they do not call this.
+// than each building its own. The sql.unanalyzable escape hatches deliberately relay the original whole
+// statement, so they do not call this.
 private fun DecisionContext.withAnalyzerRewrite(facts: StatementFacts): DecisionContext =
     if (facts.hasRewrittenSql()) copy(rewrittenSql = facts.rewrittenSql) else this
 

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultAssumeMysqlDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultAssumeMysqlDbTest.kt
@@ -27,6 +27,7 @@ class ApprovalResultAssumeMysqlDbTest {
     private val roleName = "system:production-pii-accessor"
     private val rawSsn = "987-65-4320"
     private val maskedSsn = "*******4320"
+    private var explainPolicyEnabled = false
 
     @BeforeAll
     fun setup() {
@@ -72,7 +73,7 @@ class ApprovalResultAssumeMysqlDbTest {
         context = AuthzContext(requesterIp = ip),
     )
 
-    private fun request() = AccessRequest(
+    private fun request(sql: String = "SELECT ssn FROM users") = AccessRequest(
         id = 1,
         principal = requester,
         roleId = roleId,
@@ -85,9 +86,61 @@ class ApprovalResultAssumeMysqlDbTest {
         executedBy = approver,
         createdAt = "2026-07-23T00:00:00Z",
         kind = "QUERY",
-        sql = "SELECT ssn FROM users",
+        sql = sql,
         executeAs = listOf(roleName),
         creatorKind = "WORKFLOW",
+    )
+
+    private fun ensureExplainPolicy() {
+        if (!explainPolicyEnabled) {
+            checkNotNull(fx.cedarPolicyStore.setEnabled(-262L, true, "test-enable-explain"))
+            explainPolicyEnabled = true
+        }
+    }
+
+    private fun viewExplain(
+        sql: String,
+        decrypted: DecryptedResult,
+        requesterIp: String = "100.100.1.10",
+    ): ResultViewDecision {
+        ensureExplainPolicy()
+        return decideResultView(
+            viewer = requester,
+            req = request(sql),
+            childSql = sql,
+            ds = datasource,
+            decrypted = decrypted,
+            callerContext = AuthzContext(requesterIp = requesterIp),
+            datasourceStore = fx.datasourceStore,
+            policyStore = fx.policyStore,
+            accessStore = fx.accessStore,
+            userGroupStore = fx.userGroupStore,
+            roleResolver = fx.roleResolver,
+            authz = fx.authz,
+            systemClassification = null,
+            channel = Channel.EDITOR,
+        )
+    }
+
+    private fun viewEditor(
+        sql: String,
+        decrypted: DecryptedResult,
+        requesterIp: String = "100.100.1.10",
+    ): ResultViewDecision = decideResultView(
+        viewer = requester,
+        req = request(),
+        childSql = sql,
+        ds = datasource,
+        decrypted = decrypted,
+        callerContext = AuthzContext(requesterIp = requesterIp),
+        datasourceStore = fx.datasourceStore,
+        policyStore = fx.policyStore,
+        accessStore = fx.accessStore,
+        userGroupStore = fx.userGroupStore,
+        roleResolver = fx.roleResolver,
+        authz = fx.authz,
+        systemClassification = null,
+        channel = Channel.EDITOR,
     )
 
     @Test
@@ -254,5 +307,38 @@ class ApprovalResultAssumeMysqlDbTest {
             channel = Channel.EDITOR,
         )
         assertIs<ResultViewDecision.Denied>(view)
+    }
+
+    @Test
+    fun `editor view returns an allowed explain plan with its backend-generated columns`() {
+        val stored = fx.execOnTarget("EXPLAIN SELECT id FROM users")
+        val allowed = assertIs<ResultViewDecision.Allowed>(
+            viewExplain("EXPLAIN SELECT id FROM users", DecryptedResult(stored.columns, stored.rows)),
+        )
+        assertEquals(stored.columns, allowed.columns)
+        assertEquals(stored.rows, allowed.rows)
+    }
+
+    @Test
+    fun `editor view denies an explain plan whose inner query would mask a protected column`() {
+        val stored = fx.execOnTarget("EXPLAIN SELECT ssn FROM users")
+        assertIs<ResultViewDecision.Denied>(
+            viewExplain("EXPLAIN SELECT ssn FROM users", DecryptedResult(stored.columns, stored.rows)),
+        )
+    }
+
+    @Test
+    fun `editor view returns an allowed explain analyze plan and denies the masked one`() {
+        val allowedStored = fx.execOnTarget("EXPLAIN ANALYZE SELECT id FROM users")
+        val allowed = assertIs<ResultViewDecision.Allowed>(
+            viewExplain("EXPLAIN ANALYZE SELECT id FROM users", DecryptedResult(allowedStored.columns, allowedStored.rows)),
+        )
+        assertEquals(allowedStored.columns, allowed.columns)
+        assertEquals(allowedStored.rows, allowed.rows)
+
+        val deniedStored = fx.execOnTarget("EXPLAIN ANALYZE SELECT ssn FROM users")
+        assertIs<ResultViewDecision.Denied>(
+            viewExplain("EXPLAIN ANALYZE SELECT ssn FROM users", DecryptedResult(deniedStored.columns, deniedStored.rows)),
+        )
     }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultAssumeMysqlDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultAssumeMysqlDbTest.kt
@@ -21,10 +21,12 @@ class ApprovalResultAssumeMysqlDbTest {
     private lateinit var fx: EnforcementFixture
     private lateinit var datasource: Datasource
     private var roleId = 0L
+    private var viewerRoleId = 0L
 
     private val requester = "requester@example.com"
     private val approver = "approver@example.com"
     private val roleName = "system:production-pii-accessor"
+    private val viewerRoleName = "system:development-viewer"
     private val rawSsn = "987-65-4320"
     private val maskedSsn = "*******4320"
     private var explainPolicyEnabled = false
@@ -47,6 +49,7 @@ class ApprovalResultAssumeMysqlDbTest {
         listOf(-250L, -251L, -256L, -257L, -258L, -260L).forEach {
             checkNotNull(fx.cedarPolicyStore.setEnabled(it, true, "test-enable-production"))
         }
+        viewerRoleId = fx.policyStore.listRoles().first { it.name == viewerRoleName }.id
         fx.cedarPolicyStore.create(
             CedarPolicyInput(
                 name = "trusted-network-test",
@@ -73,7 +76,11 @@ class ApprovalResultAssumeMysqlDbTest {
         context = AuthzContext(requesterIp = ip),
     )
 
-    private fun request(sql: String = "SELECT ssn FROM users") = AccessRequest(
+    private fun request(
+        sql: String = "SELECT ssn FROM users",
+        roleName: String = this.roleName,
+        roleId: Long = this.roleId,
+    ) = AccessRequest(
         id = 1,
         principal = requester,
         roleId = roleId,
@@ -101,12 +108,14 @@ class ApprovalResultAssumeMysqlDbTest {
     private fun viewExplain(
         sql: String,
         decrypted: DecryptedResult,
+        roleName: String = this.roleName,
+        roleId: Long = this.roleId,
         requesterIp: String = "100.100.1.10",
     ): ResultViewDecision {
         ensureExplainPolicy()
         return decideResultView(
             viewer = requester,
-            req = request(sql),
+            req = request(sql, roleName, roleId),
             childSql = sql,
             ds = datasource,
             decrypted = decrypted,
@@ -320,10 +329,27 @@ class ApprovalResultAssumeMysqlDbTest {
     }
 
     @Test
+    fun `editor view denies a malformed-width explain plan`() {
+        val stored = fx.execOnTarget("EXPLAIN SELECT id FROM users")
+        check(stored.columns.size > 1)
+        val malformed = DecryptedResult(stored.columns.dropLast(1), stored.rows)
+
+        assertIs<ResultViewDecision.Denied>(
+            viewExplain("EXPLAIN SELECT id FROM users", malformed),
+        )
+    }
+
+    @Test
     fun `editor view denies an explain plan whose inner query would mask a protected column`() {
         val stored = fx.execOnTarget("EXPLAIN SELECT ssn FROM users")
         assertIs<ResultViewDecision.Denied>(
-            viewExplain("EXPLAIN SELECT ssn FROM users", DecryptedResult(stored.columns, stored.rows)),
+            viewExplain(
+                "EXPLAIN SELECT ssn FROM users",
+                DecryptedResult(stored.columns, stored.rows),
+                roleName = viewerRoleName,
+                roleId = viewerRoleId,
+                requesterIp = "100.99.1.10",
+            ),
         )
     }
 
@@ -338,7 +364,13 @@ class ApprovalResultAssumeMysqlDbTest {
 
         val deniedStored = fx.execOnTarget("EXPLAIN ANALYZE SELECT ssn FROM users")
         assertIs<ResultViewDecision.Denied>(
-            viewExplain("EXPLAIN ANALYZE SELECT ssn FROM users", DecryptedResult(deniedStored.columns, deniedStored.rows)),
+            viewExplain(
+                "EXPLAIN ANALYZE SELECT ssn FROM users",
+                DecryptedResult(deniedStored.columns, deniedStored.rows),
+                roleName = viewerRoleName,
+                roleId = viewerRoleId,
+                requesterIp = "100.99.1.10",
+            ),
         )
     }
 }


### PR DESCRIPTION
## Problem

The web console saves a result view and re-evaluates it before displaying rows. For an allowed `EXPLAIN` or `EXPLAIN ANALYZE` query, the analyzer reports the inner query's output columns, while the database returns engine-specific plan columns. The saved-result check treated that expected shape difference as unsafe and rejected the result.

This made the web console reject plans that the proxy and `pmon` correctly allow and return, creating divergent behavior between console and native-client access.

## Change

- Mark final resolved decision contexts for `EXPLAIN` statements.
- Allow backend-generated plan column shapes only when the analyzed statement is `EXPLAIN`, the decision is `ALLOW`, and no result masks apply.
- Preserve exact output-column matching for all ordinary result views.
- Preserve fail-closed behavior for denied, masked, passthrough, malformed, and width-mismatched results.
- Document that `output_columns` for `explain_of_query` describes the inner query rather than the backend plan output.

## Validation

- `go test ./analyzer/probe`
- `./gradlew --no-daemon :control-plane:test --tests '*ApprovalResultAssumeMysqlDbTest' --tests '*ApprovalResultViewContextDbTest'`
- `mise run verify`

The focused MySQL coverage verifies that an allowed saved `EXPLAIN SELECT id FROM users` can display plan columns, while a masked inner query remains denied.