### PR TITLE
fix(control-plane): soft-delete groups

### DIFF
--- a/auth/src/main/kotlin/com/ridi/oss/proxymonster/auth/OidcDirectoryProvisioner.kt
+++ b/auth/src/main/kotlin/com/ridi/oss/proxymonster/auth/OidcDirectoryProvisioner.kt
@@ -68,7 +68,7 @@ class OidcDirectoryProvisioner(private val dataSource: DataSource) {
     private fun Connection.ensureGroup(name: String): Long =
         prepareStatement(
             """INSERT INTO app_group (name, source) VALUES (?, 'OIDC')
-               ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+               ON CONFLICT (name) WHERE deleted_at IS NULL DO UPDATE SET name = EXCLUDED.name
                RETURNING id""",
         ).use { statement ->
             statement.setString(1, name)

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RoleResolver.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RoleResolver.kt
@@ -74,6 +74,7 @@ class RoleResolver(
                        SELECT 1
                        FROM group_role gr
                        JOIN app_role r ON r.id = gr.role_id AND r.name = ? AND r.deleted_at IS NULL
+                       JOIN app_group g ON g.id = gr.group_id AND g.deleted_at IS NULL
                        JOIN group_member gm ON gm.group_id = gr.group_id
                        JOIN app_user u ON u.id = gm.user_id AND u.active
                    )

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Users.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Users.kt
@@ -253,7 +253,7 @@ class UserGroupStore(internal val dataSource: DataSource) {
     fun listGroups(): List<AppGroup> {
         val counts = memberCounts(null)
         val rolesByGroup = groupRoles(null)
-        return query("SELECT id, name, description, source, external_id FROM app_group ORDER BY name") {
+        return query("SELECT id, name, description, source, external_id FROM app_group WHERE deleted_at IS NULL ORDER BY name") {
             it.toGroup(counts[it.getLong("id")] ?: 0, rolesByGroup[it.getLong("id")].orEmpty())
         }
     }
@@ -265,7 +265,7 @@ class UserGroupStore(internal val dataSource: DataSource) {
             ps.setLong(1, id); ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) }
         }
         val roles = listGroupRoles(id, c).map { GroupRef(it.roleId, it.roleName) }
-        return c.prepareStatement("SELECT id, name, description, source, external_id FROM app_group WHERE id=?").use { ps ->
+        return c.prepareStatement("SELECT id, name, description, source, external_id FROM app_group WHERE id=? AND deleted_at IS NULL").use { ps ->
             ps.setLong(1, id)
             ps.executeQuery().use { rs -> if (rs.next()) rs.toGroup(count, roles) else null }
         }
@@ -274,7 +274,7 @@ class UserGroupStore(internal val dataSource: DataSource) {
     fun getGroupByName(name: String): AppGroup? = dataSource.connection.use { getGroupByName(name, it) }
 
     fun getGroupByName(name: String, c: Connection): AppGroup? {
-        val id = c.prepareStatement("SELECT id FROM app_group WHERE name=?").use { ps ->
+        val id = c.prepareStatement("SELECT id FROM app_group WHERE name=? AND deleted_at IS NULL").use { ps ->
             ps.setString(1, name); ps.executeQuery().use { rs -> if (rs.next()) rs.getLong(1) else null }
         } ?: return null
         return getGroup(id, c)
@@ -294,16 +294,19 @@ class UserGroupStore(internal val dataSource: DataSource) {
 
     fun updateGroup(id: Long, input: AppGroupInput, c: Connection): AppGroup? {
         if (getGroup(id, c) == null) return null
-        c.prepareStatement("UPDATE app_group SET name=?, description=? WHERE id=?").use { ps ->
+        c.prepareStatement("UPDATE app_group SET name=?, description=? WHERE id=? AND deleted_at IS NULL").use { ps ->
             ps.setString(1, input.name); ps.setString(2, input.description); ps.setLong(3, id); ps.executeUpdate()
         }
         return getGroup(id, c)
     }
 
     fun deleteGroup(id: Long): Boolean = dataSource.connection.use { deleteGroup(id, it) }
-    fun deleteGroup(id: Long, c: Connection): Boolean = c.prepareStatement("DELETE FROM app_group WHERE id=?").use { ps ->
-        ps.setLong(1, id); ps.executeUpdate() > 0
-    }
+    /** Soft delete: the group_member / group_role rows survive but the group is excluded from role
+     *  resolution and every live read, and its name + SCIM external_id are freed for reuse. */
+    fun deleteGroup(id: Long, c: Connection): Boolean =
+        c.prepareStatement("UPDATE app_group SET deleted_at = now() WHERE id=? AND deleted_at IS NULL").use { ps ->
+            ps.setLong(1, id); ps.executeUpdate() > 0
+        }
 
     /**
      * True if the group is SYSTEM-owned (e.g. the seeded `system:admin`). Such groups are immutable
@@ -325,7 +328,7 @@ class UserGroupStore(internal val dataSource: DataSource) {
      * SYSTEM group to source=SCIM and defeat every other immutability guard.
      */
     fun isSystemGroupByName(name: String): Boolean = dataSource.connection.use { c ->
-        c.prepareStatement("SELECT source = 'SYSTEM' FROM app_group WHERE name = ?").use { ps ->
+        c.prepareStatement("SELECT source = 'SYSTEM' FROM app_group WHERE name = ? AND deleted_at IS NULL").use { ps ->
             ps.setString(1, name)
             ps.executeQuery().use { rs -> rs.next() && rs.getBoolean(1) }
         }
@@ -550,7 +553,7 @@ class UserGroupStore(internal val dataSource: DataSource) {
             // Re-read the resolved row's source UNDER a row lock, then mutate that SAME id — check and
             // write target the one resolved row atomically, with no window for a concurrent re-point.
             if (lockGroupSource(c, existingId) == "SYSTEM") throw SystemGroupImmutableException()
-            c.prepareStatement("UPDATE app_group SET name=?, source='SCIM', external_id=? WHERE id=?").use { ps ->
+            c.prepareStatement("UPDATE app_group SET name=?, source='SCIM', external_id=? WHERE id=? AND deleted_at IS NULL").use { ps ->
                 ps.setString(1, displayName); ps.setString(2, externalId); ps.setLong(3, existingId); ps.executeUpdate()
             }
             existingId
@@ -567,15 +570,15 @@ class UserGroupStore(internal val dataSource: DataSource) {
     // resolve/check/mutate share one transaction (the standalone [findGroupIdByExternalId]/[findGroupIdByName]
     // each open their own connection and must NOT be mixed into the atomic path).
     private fun groupIdByExternalId(c: Connection, externalId: String): Long? =
-        c.prepareStatement("SELECT id FROM app_group WHERE external_id=?").use { ps ->
+        c.prepareStatement("SELECT id FROM app_group WHERE external_id=? AND deleted_at IS NULL").use { ps ->
             ps.setString(1, externalId); ps.executeQuery().use { rs -> if (rs.next()) rs.getLong(1) else null }
         }
     private fun groupIdByName(c: Connection, name: String): Long? =
-        c.prepareStatement("SELECT id FROM app_group WHERE name=?").use { ps ->
+        c.prepareStatement("SELECT id FROM app_group WHERE name=? AND deleted_at IS NULL").use { ps ->
             ps.setString(1, name); ps.executeQuery().use { rs -> if (rs.next()) rs.getLong(1) else null }
         }
     private fun lockGroupSource(c: Connection, id: Long): String? =
-        c.prepareStatement("SELECT source FROM app_group WHERE id=? FOR UPDATE").use { ps ->
+        c.prepareStatement("SELECT source FROM app_group WHERE id=? AND deleted_at IS NULL FOR UPDATE").use { ps ->
             ps.setLong(1, id); ps.executeQuery().use { rs -> if (rs.next()) rs.getString(1) else null }
         }
 
@@ -592,7 +595,7 @@ class UserGroupStore(internal val dataSource: DataSource) {
 
     fun replaceScimGroupById(id: Long, externalId: String, displayName: String, c: Connection): AppGroup? {
         if (getGroup(id, c) == null) return null
-        c.prepareStatement("UPDATE app_group SET name=?, source='SCIM', external_id=? WHERE id=?").use { ps ->
+        c.prepareStatement("UPDATE app_group SET name=?, source='SCIM', external_id=? WHERE id=? AND deleted_at IS NULL").use { ps ->
             ps.setString(1, displayName); ps.setString(2, externalId); ps.setLong(3, id); ps.executeUpdate()
         }
         return getGroup(id, c)
@@ -653,6 +656,7 @@ class UserGroupStore(internal val dataSource: DataSource) {
                 """SELECT DISTINCT r.name
                    FROM app_user u
                    JOIN group_member gm ON gm.user_id = u.id
+                   JOIN app_group g ON g.id = gm.group_id AND g.deleted_at IS NULL
                    JOIN group_role gr ON gr.group_id = gm.group_id
                    JOIN app_role r ON r.id = gr.role_id AND r.deleted_at IS NULL
                    WHERE u.principal = ? AND u.active""",
@@ -724,7 +728,7 @@ class UserGroupStore(internal val dataSource: DataSource) {
     private fun userGroups(userId: Long?): Map<Long, List<GroupRef>> = dataSource.connection.use { userGroups(userId, it) }
 
     private fun userGroups(userId: Long?, c: Connection): Map<Long, List<GroupRef>> {
-        val sql = StringBuilder("SELECT gm.user_id, g.id, g.name FROM group_member gm JOIN app_group g ON g.id = gm.group_id")
+        val sql = StringBuilder("SELECT gm.user_id, g.id, g.name FROM group_member gm JOIN app_group g ON g.id = gm.group_id AND g.deleted_at IS NULL")
         if (userId != null) sql.append(" WHERE gm.user_id = ?")
         sql.append(" ORDER BY g.name")
         return c.prepareStatement(sql.toString()).use { ps ->
@@ -882,14 +886,14 @@ class UserGroupStore(internal val dataSource: DataSource) {
         }
 
     private fun findGroupIdByExternalId(externalId: String): Long? = dataSource.connection.use { c ->
-        c.prepareStatement("SELECT id FROM app_group WHERE external_id=?").use { ps ->
+        c.prepareStatement("SELECT id FROM app_group WHERE external_id=? AND deleted_at IS NULL").use { ps ->
             ps.setString(1, externalId)
             ps.executeQuery().use { rs -> if (rs.next()) rs.getLong(1) else null }
         }
     }
 
     private fun findGroupIdByName(name: String): Long? = dataSource.connection.use { c ->
-        c.prepareStatement("SELECT id FROM app_group WHERE name=?").use { ps ->
+        c.prepareStatement("SELECT id FROM app_group WHERE name=? AND deleted_at IS NULL").use { ps ->
             ps.setString(1, name)
             ps.executeQuery().use { rs -> if (rs.next()) rs.getLong(1) else null }
         }
@@ -903,7 +907,7 @@ class UserGroupStore(internal val dataSource: DataSource) {
      */
     private fun ensureGroupByName(name: String): Long = insertReturningId(
         """INSERT INTO app_group (name, source) VALUES (?, 'OIDC')
-           ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+           ON CONFLICT (name) WHERE deleted_at IS NULL DO UPDATE SET name = EXCLUDED.name
            RETURNING id""",
     ) { it.setString(1, name) }
 

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementServices.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementServices.kt
@@ -1010,7 +1010,7 @@ class IdentityManagementService(
     ): GroupRolesResult {
         required("groupName", groupName)
         roleNames.forEach { required("roleNames", it) }
-        val group = c.prepareStatement("SELECT id, source FROM app_group WHERE name = ? FOR UPDATE").use { statement ->
+        val group = c.prepareStatement("SELECT id, source FROM app_group WHERE name = ? AND deleted_at IS NULL FOR UPDATE").use { statement ->
             statement.setString(1, groupName)
             statement.executeQuery().use { result ->
                 if (!result.next()) notFound("group")
@@ -1036,7 +1036,7 @@ class IdentityManagementService(
      */
     /** Row-lock a mutable (non-SYSTEM) group, returning its name for the audit summary. */
     private fun lockMutableGroup(id: Long, c: Connection): String {
-        val (source, name) = c.prepareStatement("SELECT source, name FROM app_group WHERE id = ? FOR UPDATE").use { statement ->
+        val (source, name) = c.prepareStatement("SELECT source, name FROM app_group WHERE id = ? AND deleted_at IS NULL FOR UPDATE").use { statement ->
             statement.setLong(1, id)
             statement.executeQuery().use { result ->
                 if (result.next()) result.getString("source") to result.getString("name") else notFound("group")

--- a/control-plane/src/main/resources/db/migration/V15__group_soft_delete.sql
+++ b/control-plane/src/main/resources/db/migration/V15__group_soft_delete.sql
@@ -1,0 +1,13 @@
+-- Soft delete for groups, mirroring datasource (V13) and role/mask_fn (V14). A delete stamps `deleted_at`
+-- instead of removing the row, so the group_member / group_role history survives and the referencing
+-- foreign keys a hard delete could not need to cascade are left intact. A soft-deleted group is excluded
+-- from every live read AND from role resolution — its group_role links grant nothing. Its name and SCIM
+-- external_id are freed for reuse by scoping both uniqueness indexes to live rows.
+ALTER TABLE app_group ADD COLUMN deleted_at TIMESTAMPTZ;
+
+ALTER TABLE app_group DROP CONSTRAINT app_group_name_key;
+CREATE UNIQUE INDEX app_group_name_live_key ON app_group (name) WHERE deleted_at IS NULL;
+
+DROP INDEX idx_app_group_external_id_unique;
+CREATE UNIQUE INDEX idx_app_group_external_id_unique
+    ON app_group (external_id) WHERE external_id IS NOT NULL AND deleted_at IS NULL;

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/GroupSoftDeleteDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/GroupSoftDeleteDbTest.kt
@@ -1,0 +1,108 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import javax.sql.DataSource
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Soft delete for groups (V15). Security-critical: a soft-deleted group must grant NO roles — its
+ * lingering group_member / group_role rows must stop resolving — and be invisible to every live read.
+ * Its name and SCIM external_id are freed for reuse.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GroupSoftDeleteDbTest {
+    private lateinit var ds: DataSource
+    private lateinit var policyStore: PolicyStore
+    private lateinit var userGroupStore: UserGroupStore
+    private lateinit var accessStore: AccessStore
+    private lateinit var tokenStore: TokenStore
+    private lateinit var daemonSessionStore: PrincipalSessionStore
+    private lateinit var roleResolver: RoleResolver
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        ds = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_group_soft_delete"))
+        Flyway.configure().dataSource(ds).load().migrate()
+        policyStore = PolicyStore(ds)
+        userGroupStore = UserGroupStore(ds)
+        accessStore = AccessStore(ds)
+        tokenStore = TokenStore(ds)
+        daemonSessionStore = PrincipalSessionStore(ds, null)
+        roleResolver = RoleResolver(ds, userGroupStore, accessStore)
+    }
+
+    @AfterAll
+    fun close() {
+        (ds as? AutoCloseable)?.close()
+    }
+
+    /** Put [principal] in a fresh group that grants a fresh role; returns (group, roleName). */
+    private fun groupGrantingRole(principal: String): Pair<AppGroup, String> {
+        val role = policyStore.createRole(RoleInput("grp-role-${System.nanoTime()}"))
+        val user = userGroupStore.createUser(AppUserInput(principal = principal), tokenStore, accessStore, daemonSessionStore)
+        val group = userGroupStore.createGroup(AppGroupInput(name = "grp-${System.nanoTime()}"))
+        userGroupStore.addMember(group.id, user.id)
+        userGroupStore.addGroupRole(group.id, role.id)
+        return group to role.name
+    }
+
+    @Test
+    fun `a soft-deleted group grants no roles and keeps its membership rows`() {
+        val principal = "grp-softdel-${System.nanoTime()}@example.com"
+        val (group, roleName) = groupGrantingRole(principal)
+        assertEquals(setOf(roleName), roleResolver.resolve(principal), "sanity: the group grants its role")
+
+        assertTrue(userGroupStore.deleteGroup(group.id))
+
+        assertEquals(emptySet(), roleResolver.resolve(principal), "a soft-deleted group grants nothing")
+        assertNull(userGroupStore.getGroup(group.id), "and is invisible to reads")
+        assertEquals(0, userGroupStore.listGroups().count { it.id == group.id })
+        assertEquals(emptyList(), userGroupStore.getUserByPrincipal(principal)!!.groups, "not embedded on the user")
+        // History survives: the membership + group-role rows still reference the tombstoned group.
+        assertEquals(1, rawCount("SELECT count(*) FROM group_member WHERE group_id = ${group.id}"))
+        assertEquals(1, rawCount("SELECT count(*) FROM group_role WHERE group_id = ${group.id}"))
+    }
+
+    @Test
+    fun `hasActiveAssignee stops counting a role granted only through a soft-deleted group`() {
+        val principal = "grp-assignee-${System.nanoTime()}@example.com"
+        val (group, roleName) = groupGrantingRole(principal)
+        assertTrue(roleResolver.hasActiveAssignee(roleName), "sanity: a live group with an active member is an assignee")
+
+        assertTrue(userGroupStore.deleteGroup(group.id))
+
+        assertEquals(false, roleResolver.hasActiveAssignee(roleName), "a soft-deleted group is no longer an active assignee")
+    }
+
+    @Test
+    fun `a soft-deleted group's name is free for a new group that resolves`() {
+        val principal = "grp-reuse-${System.nanoTime()}@example.com"
+        val name = "reused-grp-${System.nanoTime()}"
+        val first = userGroupStore.createGroup(AppGroupInput(name = name))
+        assertTrue(userGroupStore.deleteGroup(first.id))
+
+        val second = userGroupStore.createGroup(AppGroupInput(name = name))
+        assertNotEquals(first.id, second.id)
+        assertEquals(second.id, userGroupStore.getGroupByName(name)?.id, "the live name resolves to the new group")
+
+        val role = policyStore.createRole(RoleInput("reuse-role-${System.nanoTime()}"))
+        val user = userGroupStore.createUser(AppUserInput(principal = principal), tokenStore, accessStore, daemonSessionStore)
+        userGroupStore.addMember(second.id, user.id)
+        userGroupStore.addGroupRole(second.id, role.id)
+        assertEquals(setOf(role.name), roleResolver.resolve(principal), "the reused-name group grants via the new group")
+    }
+
+    private fun rawCount(sql: String): Int = ds.connection.use { c ->
+        c.prepareStatement(sql).use { ps -> ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) } }
+    }
+}

--- a/docs/mcp-access-control.md
+++ b/docs/mcp-access-control.md
@@ -294,8 +294,8 @@ All under `admin.policies` (write tools also require `mcp:policies:write`):
   (writes need `mcp:identity:write`).
 - `list_users` / `create_user` / `update_user` / `deprovision_user` (soft
   delete) → `admin.identity`.
-- `list_groups` / `create_group` / `update_group` / `delete_group` (hard),
-  `add_group_member` / `remove_group_member`, `set_group_roles` →
+- `list_groups` / `create_group` / `update_group` / `delete_group` (soft
+  delete), `add_group_member` / `remove_group_member`, `set_group_roles` →
   `admin.identity`; SYSTEM group → 409 `group.system_immutable`.
 - `list_mask_fns` / `create_mask_fn` / `update_mask_fn` / `delete_mask_fn` →
   `admin.policies` (writes need `mcp:policies:write`).


### PR DESCRIPTION
## What

Deleting a group ran a hard `DELETE FROM app_group`, cascading its `group_member`
/ `group_role` rows away. It now soft-deletes (**V15**: `deleted_at` + partial
unique indexes on `name` AND the SCIM `external_id`, so both are freed for reuse),
keeping the membership / role-link history.

## Fail-closed

A soft-deleted group grants nothing: role resolution filters it out. The
group->role join in `rolesForPrincipal` and `RoleResolver.hasActiveAssignee` now
filters `app_group.deleted_at IS NULL`, so the lingering `group_role` links grant
no roles. Every live read and the SCIM/OIDC external_id + name lookups exclude
soft-deleted groups, and the JIT-login upsert uses `ON CONFLICT (name) WHERE
deleted_at IS NULL` (a bare `ON CONFLICT (name)` would fault against the partial
index). The `AppUser.groups` embedding drops a lingering membership's deleted
group. Make-inert like role/mask_fn — no delete guard; system groups stay
immutable.

## Verify

`mise run verify` green. Tests cover fail-closed resolution across direct + group
+ grant, the `hasActiveAssignee` group arm, and name reuse. Live HTTP e2e:
deleting an in-use group returns 204, soft-deletes, retains membership / role-link
history, drops the group from the member's embedding, and the name is reusable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVPxL5eCFrvrKQNshZqx3a
