### PR TITLE
fix(web): return to the intended page after login

### DIFF
--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -12,6 +12,7 @@ import { API_BASE, ApiError } from '@/lib/api/client'
 import { useAuth } from '@/lib/auth'
 import { useAuthConfig } from '@/lib/hooks'
 import { REAUTH_CALLBACK_PATH } from '@/lib/reauth'
+import { NEXT_STORAGE_KEY, safeInternalPath } from '@/lib/next-path'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -66,7 +67,9 @@ function LoginInner() {
     setSubmitting(true)
     try {
       await loginDebug(principal.trim(), roles, requesterIp.trim())
-      router.replace(callbackUrl === REAUTH_CALLBACK_PATH ? callbackUrl : (returnTo ?? next ?? '/query'))
+      const dest =
+        callbackUrl === REAUTH_CALLBACK_PATH ? callbackUrl : (returnTo ?? safeInternalPath(next) ?? '/query')
+      router.replace(dest)
     } catch (err) {
       // A 404 means one of two different things, so branch on the code rather than the status: the route
       // itself is absent (PM_AUTH_DEBUG off), or a claimed role does not exist — which answers with
@@ -85,6 +88,12 @@ function LoginInner() {
 
   // Full-page navigation into the OIDC flow (NOT fetch — the browser must follow the IdP's 302s).
   const handleSso = () => {
+    // A general app path (a deep link) is not on the control plane's return_to allowlist and would be
+    // dropped there, so it rides same-origin sessionStorage across the round-trip instead — the callback
+    // lands on the web origin, where the root page consumes it. The device/reauth `return_to`, which IS
+    // allowlisted, keeps threading through the control plane as before.
+    const deepLink = safeInternalPath(next)
+    if (deepLink) sessionStorage.setItem(NEXT_STORAGE_KEY, deepLink)
     const returnToQs = returnTo
       ? `?return_to=${encodeURIComponent(returnTo)}`
       : callbackUrl === REAUTH_CALLBACK_PATH

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,5 +1,26 @@
-import { redirect } from 'next/navigation'
+'use client'
 
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { Loader2 } from 'lucide-react'
+import { NEXT_STORAGE_KEY, safeInternalPath } from '@/lib/next-path'
+
+/**
+ * The root landing. Normally bounces to the query editor, but first honors a deep link stashed before an
+ * OIDC round-trip (auth-guard → login → IdP → callback lands here). The stash is same-origin sessionStorage
+ * because the intended app path is not on the control plane's return_to allowlist and cannot ride the OIDC
+ * state; it is consumed once and re-validated here, so a tampered value falls back to the default.
+ */
 export default function Home() {
-  redirect('/query')
+  const router = useRouter()
+  useEffect(() => {
+    const stashed = safeInternalPath(sessionStorage.getItem(NEXT_STORAGE_KEY))
+    sessionStorage.removeItem(NEXT_STORAGE_KEY)
+    router.replace(stashed && stashed !== '/' ? stashed : '/query')
+  }, [router])
+  return (
+    <div className="flex h-svh items-center justify-center">
+      <Loader2 className="text-muted-foreground size-5 animate-spin" />
+    </div>
+  )
 }

--- a/web/src/components/auth-guard.tsx
+++ b/web/src/components/auth-guard.tsx
@@ -1,20 +1,32 @@
 'use client'
 
 import { useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { Loader2 } from 'lucide-react'
 import { useAuth } from '@/lib/auth'
+import { safeInternalPath } from '@/lib/next-path'
 
 /** Gates the authenticated shell: redirects to /login when unauthenticated, shows a spinner while resolving. */
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const { status, unauthReason } = useAuth()
   const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
 
   useEffect(() => {
     if (status === 'unauthenticated') {
-      router.replace(unauthReason === 'displaced' ? '/displaced' : '/login')
+      if (unauthReason === 'displaced') {
+        router.replace('/displaced')
+        return
+      }
+      // Carry where the user was headed through login, so a deep link (a Slack "open request" link to
+      // /workflows/N) lands there after auth instead of the default page. Query string included, since a
+      // from-denied compose link carries `?from=`.
+      const qs = searchParams.toString()
+      const here = safeInternalPath(qs ? `${pathname}?${qs}` : pathname)
+      router.replace(here && here !== '/' ? `/login?next=${encodeURIComponent(here)}` : '/login')
     }
-  }, [status, unauthReason, router])
+  }, [status, unauthReason, router, pathname, searchParams])
 
   if (status !== 'authenticated') {
     return (

--- a/web/src/lib/next-path.ts
+++ b/web/src/lib/next-path.ts
@@ -1,0 +1,20 @@
+/**
+ * Post-login return-path safety.
+ *
+ * A `next` destination is attacker-influenceable (it rides a URL), so it must be an internal path and nothing
+ * else — never an absolute URL, a protocol-relative `//host`, or a backslash trick a browser normalizes to
+ * one. Anything that is not a single-slash-rooted path is dropped, and the caller falls back to the default
+ * landing. This is the one gate every producer and consumer of `next` shares, so the rule cannot drift
+ * between them.
+ */
+export function safeInternalPath(candidate: string | null | undefined): string | null {
+  if (!candidate) return null
+  // Must start with exactly one '/', and not '//' or '/\' (both resolve to an off-site host in a browser).
+  if (!candidate.startsWith('/') || candidate.startsWith('//') || candidate.startsWith('/\\')) return null
+  // A control character or whitespace has no place in a path and is a common normalization-bypass vector.
+  if (/[\x00-\x1f\x7f\s]/.test(candidate)) return null
+  return candidate
+}
+
+/** Session-storage key carrying the intended path across the OIDC full-page round-trip. */
+export const NEXT_STORAGE_KEY = 'pm.login.next'


### PR DESCRIPTION
A deep link (a Slack "open request" link to `/workflows/N`) opened while logged
out sent the user to login and then dropped them on the default page — they had
to click the link a second time. This carries the intended path through login so
they land where they were headed.

`safeInternalPath` is the single guard every producer and consumer of `next`
shares: it admits only a single-slash-rooted internal path and drops absolute
URLs, `//host`, `/\host`, and control/whitespace tricks, so `next` can't be
turned into an open redirect.

Trap: a general app path is **not** on the control plane's `return_to`
allowlist, so the OIDC round-trip can't thread it through `state`. It rides
same-origin `sessionStorage` instead and is re-validated on the way out at the
root page. The device/reauth `return_to`, which is allowlisted, is unchanged.

Verified: `mise run lint` clean; deep-link → login → land-on-target confirmed in
the live console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYbzZ3Zv74ns6D6s2pVaeg
