### PR TITLE
fix(control-plane): soft-delete Cedar policies

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/CedarPolicyStore.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/CedarPolicyStore.kt
@@ -81,13 +81,13 @@ class CedarPolicyStore(internal val dataSource: DataSource) {
     fun stateVersion(): Long = version.get()
 
     fun list(): List<CedarPolicy> = query(
-        "SELECT id, origin, system_key, name, cedar_src, enabled, updated_by, updated_at FROM policy ORDER BY id",
+        "SELECT id, origin, system_key, name, cedar_src, enabled, updated_by, updated_at FROM policy WHERE deleted_at IS NULL ORDER BY id",
     ) { it.toPolicy() }
 
     fun get(id: Long): CedarPolicy? = dataSource.connection.use { get(id, it) }
 
     fun get(id: Long, c: java.sql.Connection): CedarPolicy? = c.prepareStatement(
-        "SELECT id, origin, system_key, name, cedar_src, enabled, updated_by, updated_at FROM policy WHERE id=?",
+        "SELECT id, origin, system_key, name, cedar_src, enabled, updated_by, updated_at FROM policy WHERE id=? AND deleted_at IS NULL",
     ).use { ps ->
         ps.setLong(1, id)
         ps.executeQuery().use { rs -> if (rs.next()) rs.toPolicy() else null }
@@ -96,7 +96,7 @@ class CedarPolicyStore(internal val dataSource: DataSource) {
     fun getByName(name: String): CedarPolicy? = dataSource.connection.use { getByName(name, it) }
 
     fun getByName(name: String, c: java.sql.Connection): CedarPolicy? = c.prepareStatement(
-        "SELECT id, origin, system_key, name, cedar_src, enabled, updated_by, updated_at FROM policy WHERE name=?",
+        "SELECT id, origin, system_key, name, cedar_src, enabled, updated_by, updated_at FROM policy WHERE name=? AND deleted_at IS NULL",
     ).use { ps ->
         ps.setString(1, name)
         ps.executeQuery().use { rs -> if (rs.next()) rs.toPolicy() else null }
@@ -136,7 +136,7 @@ class CedarPolicyStore(internal val dataSource: DataSource) {
     }
 
     fun update(id: Long, input: CedarPolicyInput, updatedBy: String?, c: java.sql.Connection): CedarPolicy? {
-        val origin = c.prepareStatement("SELECT origin FROM policy WHERE id=? FOR UPDATE").use { ps ->
+        val origin = c.prepareStatement("SELECT origin FROM policy WHERE id=? AND deleted_at IS NULL FOR UPDATE").use { ps ->
             ps.setLong(1, id)
             ps.executeQuery().use { rs -> if (rs.next()) rs.getString("origin") else null }
         } ?: return null
@@ -145,7 +145,7 @@ class CedarPolicyStore(internal val dataSource: DataSource) {
         val errors = CedarSchema.validate(input.cedarSrc)
         if (errors.isNotEmpty()) throw InvalidCedarPolicyException(errors)
         c.prepareStatement(
-            "UPDATE policy SET name=?, cedar_src=?, enabled=?, updated_by=?, updated_at=now() WHERE id=?",
+            "UPDATE policy SET name=?, cedar_src=?, enabled=?, updated_by=?, updated_at=now() WHERE id=? AND deleted_at IS NULL",
         ).use { ps ->
             ps.setString(1, input.name); ps.setString(2, input.cedarSrc); ps.setBoolean(3, input.enabled)
             ps.setString(4, updatedBy); ps.setLong(5, id); ps.executeUpdate()
@@ -161,7 +161,7 @@ class CedarPolicyStore(internal val dataSource: DataSource) {
 
     fun setEnabled(id: Long, enabled: Boolean, updatedBy: String?, c: java.sql.Connection): CedarPolicy? {
         val existing = c.prepareStatement(
-            "SELECT id, origin, system_key, name, cedar_src, enabled, updated_by, updated_at FROM policy WHERE id=? FOR UPDATE",
+            "SELECT id, origin, system_key, name, cedar_src, enabled, updated_by, updated_at FROM policy WHERE id=? AND deleted_at IS NULL FOR UPDATE",
         ).use { ps ->
             ps.setLong(1, id)
             ps.executeQuery().use { rs -> if (rs.next()) rs.toPolicy() else null }
@@ -170,7 +170,7 @@ class CedarPolicyStore(internal val dataSource: DataSource) {
             val errors = CedarSchema.validate(existing.cedarSrc)
             if (errors.isNotEmpty()) throw InvalidCedarPolicyException(errors)
         }
-        c.prepareStatement("UPDATE policy SET enabled=?, updated_by=?, updated_at=now() WHERE id=?").use { ps ->
+        c.prepareStatement("UPDATE policy SET enabled=?, updated_by=?, updated_at=now() WHERE id=? AND deleted_at IS NULL").use { ps ->
             ps.setBoolean(1, enabled); ps.setString(2, updatedBy); ps.setLong(3, id); ps.executeUpdate()
         }
         return get(id, c)
@@ -184,20 +184,25 @@ class CedarPolicyStore(internal val dataSource: DataSource) {
     }
 
     fun delete(id: Long, c: java.sql.Connection): Boolean {
-        val origin = c.prepareStatement("SELECT origin FROM policy WHERE id=? FOR UPDATE").use { ps ->
+        val origin = c.prepareStatement("SELECT origin FROM policy WHERE id=? AND deleted_at IS NULL FOR UPDATE").use { ps ->
             ps.setLong(1, id)
             ps.executeQuery().use { rs -> if (rs.next()) rs.getString("origin") else null }
         } ?: return false
         if (origin == "SYSTEM") throw SystemPolicyImmutableException()
-        return c.prepareStatement("DELETE FROM policy WHERE id=?").use { ps ->
+        // Soft delete: the row survives (name freed for reuse via the partial unique index), but it leaves
+        // the evaluated policy set — enabledSources() filters it and the caller bumps the version.
+        return c.prepareStatement("UPDATE policy SET deleted_at = now() WHERE id=? AND deleted_at IS NULL").use { ps ->
             ps.setLong(1, id)
             ps.executeUpdate() > 0
         }
     }
 
-    /** `(id, cedar_src)` for every enabled row, in a stable order — what [CedarEngine] loads. */
+    /** `(id, cedar_src)` for every LIVE enabled row, in a stable order — the ONLY policy set [CedarEngine]
+     *  evaluates. Filtering `deleted_at IS NULL` here is what makes a soft-deleted policy (permit OR forbid)
+     *  stop applying: the delete bumps the version, the engine rebuilds its PolicySet, and the tombstone
+     *  is gone from it. */
     fun enabledSources(): List<Pair<Long, String>> = dataSource.connection.use { c ->
-        c.prepareStatement("SELECT id, cedar_src FROM policy WHERE enabled = true ORDER BY id").use { ps ->
+        c.prepareStatement("SELECT id, cedar_src FROM policy WHERE enabled = true AND deleted_at IS NULL ORDER BY id").use { ps ->
             ps.executeQuery().use { rs ->
                 val out = ArrayList<Pair<Long, String>>()
                 while (rs.next()) out += rs.getLong("id") to rs.getString("cedar_src")

--- a/control-plane/src/main/resources/db/migration/V16__policy_soft_delete.sql
+++ b/control-plane/src/main/resources/db/migration/V16__policy_soft_delete.sql
@@ -1,0 +1,11 @@
+-- Soft delete for Cedar policies, mirroring the sibling entities (V13–V15). A delete stamps `deleted_at`
+-- instead of removing the row. The one runtime effect of deleting a policy is that it leaves the evaluated
+-- Cedar policy set: `CedarPolicyStore.enabledSources()` — the engine's only policy load — filters
+-- `deleted_at IS NULL`, and the existing per-mutation version bump rebuilds the cached PolicySet, so a
+-- soft-deleted policy (permit OR forbid) stops applying immediately. The name is freed for reuse via a
+-- partial unique index scoped to live rows. SYSTEM policies (negative id, `origin='SYSTEM'`) are already
+-- undeletable, so soft-delete only ever applies to USER policies.
+ALTER TABLE policy ADD COLUMN deleted_at TIMESTAMPTZ;
+
+ALTER TABLE policy DROP CONSTRAINT policy_name_key;
+CREATE UNIQUE INDEX policy_name_live_key ON policy (name) WHERE deleted_at IS NULL;

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PolicySoftDeleteDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PolicySoftDeleteDbTest.kt
@@ -1,0 +1,106 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.controlplane.authz.Authz
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzDecision
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
+import com.ridi.oss.proxymonster.controlplane.authz.CedarEngine
+import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
+import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyStore
+import com.ridi.oss.proxymonster.controlplane.authz.RoleSource
+import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import javax.sql.DataSource
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Soft delete for Cedar policies (V16). The inverted-risk case: deleting a policy — permit OR forbid — must
+ * remove it from the evaluated policy set. For a forbid that means it stops denying (deleting a deny is
+ * intentional and matches the old hard delete); the concern is only that the engine's cached PolicySet
+ * actually rebuilds without it. The name is freed for reuse.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PolicySoftDeleteDbTest {
+    private lateinit var ds: DataSource
+    private lateinit var store: CedarPolicyStore
+    private lateinit var engine: CedarEngine
+    private lateinit var authz: Authz
+    private val roles = mutableMapOf<String, Set<String>>()
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        ds = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_policy_soft_delete"))
+        Flyway.configure().dataSource(ds).load().migrate()
+        store = CedarPolicyStore(ds)
+        engine = CedarEngine(store)
+        authz = Authz(engine, store, RoleSource { principal -> roles[principal] ?: emptySet() })
+    }
+
+    @AfterAll
+    fun close() {
+        (ds as? AutoCloseable)?.close()
+    }
+
+    @Test
+    fun `soft-deleting a forbid removes it from the evaluated policy set`() {
+        val principal = "policy-softdel-${System.nanoTime()}"
+        val role = "policy-role-${System.nanoTime()}"
+        roles[principal] = setOf(role)
+        val n = System.nanoTime()
+        store.create(
+            CedarPolicyInput(
+                name = "permit-$n",
+                cedarSrc = """permit(principal in Role::"$role", action == Action::"admin.datasources", resource);""",
+            ),
+            updatedBy = null,
+        )
+        val forbid = store.create(
+            CedarPolicyInput(
+                name = "forbid-$n",
+                cedarSrc = """forbid(principal in Role::"$role", action == Action::"admin.datasources", resource);""",
+            ),
+            updatedBy = null,
+        )
+        assertIs<AuthzDecision.Deny>(
+            authz.authorize(principal, AuthzAction.ADMIN_DATASOURCES, AuthzResource.System),
+            "sanity: the forbid overrides the permit",
+        )
+
+        assertTrue(store.delete(forbid.id))
+
+        assertEquals(
+            AuthzDecision.Allow,
+            authz.authorize(principal, AuthzAction.ADMIN_DATASOURCES, AuthzResource.System),
+            "a soft-deleted forbid must leave the engine — the surviving permit now decides",
+        )
+        assertNull(store.get(forbid.id), "and is invisible to live reads")
+        assertEquals(0, store.list().count { it.id == forbid.id })
+        assertEquals(1, rawCount("SELECT count(*) FROM policy WHERE id = ${forbid.id} AND deleted_at IS NOT NULL"), "row survives")
+    }
+
+    @Test
+    fun `a soft-deleted policy name is free for a new policy`() {
+        val name = "reused-policy-${System.nanoTime()}"
+        val src = """permit(principal in Role::"reuse-nobody-$name", action == Action::"admin.datasources", resource);"""
+        val first = store.create(CedarPolicyInput(name = name, cedarSrc = src), updatedBy = null)
+        assertTrue(store.delete(first.id))
+
+        val second = store.create(CedarPolicyInput(name = name, cedarSrc = src), updatedBy = null)
+        assertNotEquals(first.id, second.id)
+        assertEquals(second.id, store.getByName(name)?.id, "the live name resolves to the new policy")
+    }
+
+    private fun rawCount(sql: String): Int = ds.connection.use { c ->
+        c.prepareStatement(sql).use { ps -> ps.executeQuery().use { rs -> rs.next(); rs.getInt(1) } }
+    }
+}


### PR DESCRIPTION
Deleting a Cedar policy now stamps `deleted_at` instead of removing the row, matching the sibling entities (datasource #120, role/mask_fn #127, group #132). The row survives for audit; the name is freed for reuse.

The one runtime effect of deleting a policy is that it must leave the evaluated policy set. `CedarPolicyStore.enabledSources()` is the engine's only policy load, so filtering `deleted_at IS NULL` there — plus the existing per-mutation version bump that rebuilds the cached `PolicySet` — makes a soft-deleted policy (permit **or** forbid) stop applying immediately. Deleting a forbid intentionally stops it denying, exactly as the old hard delete did; the concern was only that the cached set actually rebuilds without it.

`list`/`get`/`getByName`, the `FOR UPDATE` origin/lock SELECTs, and the `update`/`setEnabled` UPDATE bodies all filter live rows. SYSTEM policies stay immutable (origin guard, unchanged). Make-inert: no FKs, no delete guard.

V16 drops the plain `policy_name_key` and adds partial-unique `policy_name_live_key ON policy(name) WHERE deleted_at IS NULL`.

Verification: `mise run verify` green; new DB test drives a permit+forbid through the real Cedar engine (Deny → soft-delete the forbid → Allow) and the name-reuse path; live HTTP e2e — create → 204 delete → invisible to reads while the row survives with `deleted_at` set → same-name recreate returns a new id.