### PR TITLE
fix(goproxy): repin sqlglot-go to v0.23.0 to match analyzer

### DIFF
--- a/goproxy/go.mod
+++ b/goproxy/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
-	github.com/ridi-oss/sqlglot-go v0.22.0 // indirect
+	github.com/ridi-oss/sqlglot-go v0.23.0 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/goproxy/go.sum
+++ b/goproxy/go.sum
@@ -107,8 +107,8 @@ github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/ridi-oss/proxy-monster/mysqlwire v0.1.2 h1:KM/b7PfadLw0drVrTU+/34eTJLLBRbIEfsPhp4+bzds=
 github.com/ridi-oss/proxy-monster/mysqlwire v0.1.2/go.mod h1:yielY+j1TFdAdh9cn7WGFUwUtLwligQEwpO7Xmfvinc=
-github.com/ridi-oss/sqlglot-go v0.22.0 h1:uPRNk6iFJYy46PsGz3Tjduejg+WcLzd7aNiyJ0bMQpM=
-github.com/ridi-oss/sqlglot-go v0.22.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
+github.com/ridi-oss/sqlglot-go v0.23.0 h1:yk4tCVNXOO/2amBKEAK800lvcEITh0ixQbiquvGIhsM=
+github.com/ridi-oss/sqlglot-go v0.23.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=


### PR DESCRIPTION
**Fixes the pm-goproxy image build**, which failed on the 0.1.10 release with:

```
go: updates to go.mod needed; to update it: go mod tidy
```

`analyzer/go.mod` requires **sqlglot-go v0.23.0**, but `goproxy/go.mod` pinned it transitively at **v0.22.0**. The workspace (`go.work`) resolves `analyzer` from `../analyzer` and masks the mismatch — so the workspace build *and* the PR `verify` check both pass — but the server-image build runs `GOWORK=off` against `goproxy/go.mod` and can't resolve the graph.

**Fix:** repin `goproxy`'s transitive `sqlglot-go` to `v0.23.0`. Verified with `go build ./cmd/goproxy` under `GOWORK=off` in `golang:1.26-bookworm` (the exact build image).

> Note: PR CI doesn't cover this class of drift (it builds in workspace mode). Worth a follow-up to add a `GOWORK=off` goproxy build to the gate; filing separately.
