### PR TITLE
test(gate): guard against go.mod drift in the image-built Go modules

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -241,8 +241,26 @@ mise run proto-check
 # run reports as a pass. These tests wait on containers and sockets far more than they compute, so the
 # detector costs a few seconds of wall clock rather than the usual multiple.
 go test -race ./analyzer/... ./auditmon/... ./goproxy/... ./mysqlwire/... ./pmon/...
+mise run check-image-gomod
 pnpm -C web test:unit
 pnpm -C web build
+'''
+
+[tasks.check-image-gomod]
+description = "Build each server-image Go module in go.mod mode (GOWORK=off), the way the image build does"
+shell = "bash -c"
+# The server images (goproxy/Dockerfile, auditmon/Dockerfile) build each module GOWORK=off, so it
+# resolves its OWN go.mod — not the workspace. Every other Go build here goes through go.work, which
+# resolves a sibling like analyzer from ../analyzer and hides a stale transitive pin in goproxy/go.mod:
+# the drift then surfaces only on the release image build (a broken pm-goproxy), never in `verify`.
+# Reproduce that resolution here so a stale pin fails on the author's machine and in PR CI instead.
+# `go build ./...` compiles every package and writes no binary.
+run = '''
+set -euo pipefail
+for m in goproxy auditmon; do
+  echo "=== $m (GOWORK=off go build ./...) ==="
+  (cd "$m" && GOWORK=off go build ./...)
+done
 '''
 
 [tasks.build-pmon]


### PR DESCRIPTION
Prevents the drift that broke the pm-goproxy image on the 0.1.10 release.

**Why it slipped through:** the server images build `GOWORK=off` against each module's own go.mod, but every build in `verify` goes through `go.work`, which resolves `analyzer` from `../analyzer` and masks a stale transitive pin in `goproxy/go.mod`. So the drift only ever fails the release image build, never a PR.

**Guard:** a `check-image-gomod` task runs `GOWORK=off go build ./...` for goproxy + auditmon (the two GOWORK=off image modules) and is wired into `verify` — so a stale pin fails on the author's machine and in PR CI (verify is a required check; with `strict` on, it blocks the merge).

**Mutation-verified:** reverting goproxy's sqlglot pin to the stale `v0.22.0` makes the guard fail (`missing go.sum entry`); it passes on the correct pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNNfvyiaiCWYy3XZkgCWeU