### PR TITLE
feat(goproxy): graceful drain of client connections on shutdown

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -413,6 +413,24 @@ logged at boot / proxy catalog-push.)
   but a MASK verdict carrying `unmaskable_permitted` may relay them unmasked
   when `sql.unmaskable` is granted. Detail:
   [`docs/access-model.md`](./docs/access-model.md).
+- 🟡 A graceful-shutdown drain can report a pipelined PostgreSQL statement as
+  failed. On a rolling redeploy the data plane drains: it stops accepting, lets
+  an in-flight statement finish, then hands each idle connection a
+  protocol-level shutdown notice (MySQL `ER_SERVER_SHUTDOWN`, PostgreSQL
+  `FATAL 57P01`) so the client's pool reconnects onto the replacement task.
+  Draining forces the client read deadline, which preempts a read even when the
+  next message already sits in the kernel buffer. So a pipelined
+  extended-protocol `Execute` whose `CommandComplete` was relayed but whose
+  `Sync` had not yet been read is not answered with `ReadyForQuery`: the
+  un-synced statement rolls back when the connection closes, and a client seeing
+  FATAL reconnects and retries it — but a client that had treated
+  `CommandComplete` as commit could believe a rolled-back operation succeeded.
+  The window is narrow (the drain must land between relaying `CommandComplete`
+  and reading the buffered `Sync`) and PostgreSQL is experimental. MySQL's
+  analogue is benign: a command still in the kernel buffer at drain is skipped
+  and retried on reconnect, with no completed-then-rolled-back ambiguity. A
+  deterministic fix — bounded reads through the pending `Sync` to a transaction
+  boundary before the notice — is a follow-up.
 
 ## Wire-cert distribution (direct clients and `pmon`)
 

--- a/goproxy/boot/boot.go
+++ b/goproxy/boot/boot.go
@@ -2,6 +2,7 @@
 package boot
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"log/slog"
@@ -22,6 +23,10 @@ import (
 
 const bootRegisterAttempts = 3
 const ambientRefreshInterval = 12 * time.Minute
+
+// drainTimeout bounds the graceful shutdown: in-flight statements finish and idle connections get a
+// protocol-level shutdown notice, then any connection still live is force-closed and the process exits.
+const drainTimeout = 10 * time.Second
 
 var refreshMu sync.Mutex
 
@@ -52,13 +57,6 @@ func Run(registry spi.Registry) error {
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigCh
-		slog.Info("shutting down")
-		_ = enforcementClient.Close()
-		_ = configClient.Close()
-		os.Exit(0)
-	}()
 
 	provider := cfg.Provider
 	dbImpl := provider.NewDb()
@@ -152,7 +150,38 @@ func Run(registry spi.Registry) error {
 
 	server := provider.NewWireServer(cfg.ProxyPort, backend, enforcementClient, dbImpl, tlsProvider)
 	slog.Info("starting proxy-monster data plane", "engine", cfg.Engine, "control_plane", cfg.ControlPlaneGrpcTarget)
-	return server.Start()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- server.Start() }()
+
+	select {
+	case err := <-serveErr:
+		// The server stopped on its own (bind failure, accept error) without a shutdown signal.
+		return err
+	case <-sigCh:
+	}
+
+	// On SIGTERM (a rolling redeploy), drain gracefully: stop accepting, let in-flight statements finish,
+	// send idle clients a protocol-level shutdown notice, then close the control-plane clients and exit.
+	// The replacement task is already fronted by the NLB, so reconnects land there.
+	slog.Info("shutting down, draining client connections", "timeout", drainTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), drainTimeout)
+	defer cancel()
+	server.Drain(ctx)
+	// Serve returns nil once Drain closes the listener. A non-nil error is a genuine serve failure (e.g. a bind
+	// error that raced the signal, which select may pick over the serveErr case); surface it AND exit non-zero
+	// so a supervisor keying on exit code sees it. A clean signalled shutdown (nil) stays exit 0.
+	serveExitErr := <-serveErr
+	if serveExitErr != nil {
+		slog.Error("data plane serve error during shutdown", "error", serveExitErr)
+	}
+	_ = enforcementClient.Close()
+	_ = configClient.Close()
+	if serveExitErr != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+	return nil
 }
 
 func registerAndPushCatalog(

--- a/goproxy/mysqlproxy/conn.go
+++ b/goproxy/mysqlproxy/conn.go
@@ -20,6 +20,25 @@ const (
 	maxFrontendTokenPacket     = 64 << 10
 )
 
+const (
+	shutdownErrno    = 1053 // ER_SERVER_SHUTDOWN
+	shutdownSQLState = "08S01"
+	shutdownMessage  = "proxy-monster: server shutting down"
+	// shutdownNoticeSeq frames the unsolicited notice as the response to the client's next command
+	// (command seq 0 → response seq 1), which a driver reads as a normal error before reconnecting.
+	shutdownNoticeSeq = 1
+)
+
+// writeShutdownNotice tells an idle client the proxy is going away, so its pool reconnects onto the
+// replacement task instead of seeing a bare TCP reset. Best-effort: the connection closes regardless.
+func writeShutdownNotice(clientConn net.Conn) {
+	_ = mysqlwire.WritePacket(clientConn, shutdownNoticeSeq, mysqlwire.ErrPacketState(
+		shutdownErrno,
+		shutdownSQLState,
+		shutdownMessage,
+	))
+}
+
 // handleConn performs the frontend clear-password token handshake, authenticates the service-account
 // backend, then runs one blocking command at a time.
 func (s *Server) handleConn(clientConn net.Conn) {
@@ -113,7 +132,7 @@ func (s *Server) handleConn(clientConn net.Conn) {
 	if err := clientConn.SetReadDeadline(time.Time{}); err != nil {
 		return
 	}
-	clientConn = withIODeadlines(clientConn, frontendCommandIdleTimeout, socketWriteTimeout)
+	clientConn = withDrainAwareIODeadlines(clientConn, frontendCommandIdleTimeout, socketWriteTimeout, &s.draining)
 	token := mysqlwire.ParseClearPassword(tokenPayload)
 	clientAddr := clientConn.RemoteAddr().String()
 	identity, err := s.client.ValidateToken(token, clientAddr)
@@ -205,6 +224,14 @@ func (s *Server) handleConn(clientConn net.Conn) {
 			return
 		}
 		if err != nil || len(payload) == 0 {
+			// The single drain point. A drain forces the client read deadline, so a handler waiting here for the
+			// next command unblocks and forwards the shutdown notice, and its pool reconnects onto the
+			// replacement task. Checking only here (not before the read) lets a command already decoded above the
+			// socket be served first; a command still in the kernel read buffer is preempted by the forced
+			// deadline and simply retried on reconnect. A plain idle-timeout or disconnect stays a silent close.
+			if s.draining.Load() {
+				writeShutdownNotice(clientConn)
+			}
 			return
 		}
 		cmd := payload[0]

--- a/goproxy/mysqlproxy/deadline.go
+++ b/goproxy/mysqlproxy/deadline.go
@@ -2,6 +2,7 @@ package mysqlproxy
 
 import (
 	"net"
+	"sync/atomic"
 	"time"
 )
 
@@ -17,19 +18,37 @@ type deadlineConn struct {
 	net.Conn
 	readTimeout  time.Duration
 	writeTimeout time.Duration
+	draining     *atomic.Bool
 }
 
 func withIODeadlines(conn net.Conn, readTimeout, writeTimeout time.Duration) net.Conn {
-	if readTimeout <= 0 && writeTimeout <= 0 {
+	return withDrainAwareIODeadlines(conn, readTimeout, writeTimeout, nil)
+}
+
+// withDrainAwareIODeadlines is withIODeadlines plus a drain signal. Once draining is set, a read returns
+// promptly instead of waiting out the idle timeout, so a handler blocked for the next command can send the
+// shutdown notice and close without depending on the drainer having already forced the socket deadline.
+// Only the client-facing conn is wrapped this way; a backend read mid-relay must not be cut short.
+func withDrainAwareIODeadlines(conn net.Conn, readTimeout, writeTimeout time.Duration, draining *atomic.Bool) net.Conn {
+	if readTimeout <= 0 && writeTimeout <= 0 && draining == nil {
 		return conn
 	}
-	return &deadlineConn{Conn: conn, readTimeout: readTimeout, writeTimeout: writeTimeout}
+	return &deadlineConn{Conn: conn, readTimeout: readTimeout, writeTimeout: writeTimeout, draining: draining}
 }
 
 func (c *deadlineConn) Read(payload []byte) (int, error) {
+	if c.draining != nil && c.draining.Load() {
+		_ = c.SetReadDeadline(time.Now())
+		return c.Conn.Read(payload)
+	}
 	if c.readTimeout > 0 {
 		if err := c.SetReadDeadline(time.Now().Add(c.readTimeout)); err != nil {
 			return 0, err
+		}
+		// A drain that set the flag after the check above would have its forced deadline overwritten by the
+		// idle one just set, leaving this read blocked for the full idle timeout. Re-check and force it now.
+		if c.draining != nil && c.draining.Load() {
+			_ = c.SetReadDeadline(time.Now())
 		}
 	}
 	return c.Conn.Read(payload)

--- a/goproxy/mysqlproxy/drain_test.go
+++ b/goproxy/mysqlproxy/drain_test.go
@@ -1,0 +1,219 @@
+package mysqlproxy_test
+
+import (
+	"context"
+	"encoding/binary"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/ridi-oss/proxy-monster/goproxy/internal/pb"
+	"github.com/ridi-oss/proxy-monster/mysqlwire"
+)
+
+// drainTestTimeout is a generous graceful-drain bound for a local test: long enough that a short in-flight
+// statement always finishes inside it, short enough that a test never waits on the real 10s production value.
+const drainTestTimeout = 3 * time.Second
+
+func allowAll(*pb.DecisionRequest) (*pb.WireDecision, error) {
+	return wireVerdict(&pb.Verdict{Decision: pb.EnfAction_ALLOW}), nil
+}
+
+// assertShutdownNotice checks that payload is the MySQL ER_SERVER_SHUTDOWN (1053 / 08S01) notice, framed at
+// sequence 1 — the response sequence a driver expects after sending its next command as sequence 0.
+func assertShutdownNotice(t *testing.T, seq byte, payload []byte) {
+	t.Helper()
+	if seq != 1 {
+		t.Fatalf("shutdown packet sequence = %d, want 1 (the response to the client's next command)", seq)
+	}
+	if len(payload) < 9 || payload[0] != 0xff {
+		t.Fatalf("shutdown packet = %x, want an ERR packet", payload)
+	}
+	if code := binary.LittleEndian.Uint16(payload[1:3]); code != 1053 {
+		t.Fatalf("shutdown error code = %d, want 1053 (ER_SERVER_SHUTDOWN)", code)
+	}
+	if state := string(payload[4:9]); state != "08S01" {
+		t.Fatalf("shutdown SQLSTATE = %q, want 08S01", state)
+	}
+	if msg := mysqlwire.ErrString(payload); !strings.Contains(msg, "shutting down") {
+		t.Fatalf("shutdown message = %q, want a server-shutting-down notice", msg)
+	}
+}
+
+// An idle authenticated connection must be unblocked promptly on Drain and handed the shutdown notice —
+// this proves the forced read deadline actually propagates through the deadline wrapper.
+func TestDrainIdleConnectionReceivesShutdownNoticeThenCloses(t *testing.T) {
+	h := startBroker(t)
+	client := openRawClient(t, h.addr, validToken)
+
+	drained := make(chan struct{})
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), drainTestTimeout)
+		defer cancel()
+		h.server.Drain(ctx)
+		close(drained)
+	}()
+
+	if err := client.conn.SetReadDeadline(time.Now().Add(drainTestTimeout)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	seq, payload, err := mysqlwire.ReadPacket(client.conn)
+	if err != nil {
+		t.Fatalf("read shutdown notice: %v", err)
+	}
+	assertShutdownNotice(t, seq, payload)
+
+	if _, _, err := mysqlwire.ReadPacket(client.conn); err == nil {
+		t.Fatal("connection stayed open after the shutdown notice")
+	}
+	select {
+	case <-drained:
+	case <-time.After(drainTestTimeout):
+		t.Fatal("Drain did not return after the idle connection closed")
+	}
+}
+
+// A statement already relaying when Drain starts must deliver its full result before the connection is
+// wound down: forcing the client read deadline must not truncate an in-flight relay.
+func TestDrainLetsInFlightStatementComplete(t *testing.T) {
+	h := startBroker(t)
+	h.fake.decideFn = allowAll
+	client := openRawClient(t, h.addr, validToken)
+
+	// SLEEP holds the handler in the relay (reading the backend) across the Drain call.
+	if err := mysqlwire.WritePacket(client.conn, 0, mysqlwire.ComQueryPayload("SELECT SLEEP(0.5)")); err != nil {
+		t.Fatalf("write slow query: %v", err)
+	}
+	// Let the query reach the backend and begin relaying before draining.
+	time.Sleep(100 * time.Millisecond)
+
+	drained := make(chan struct{})
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), drainTestTimeout)
+		defer cancel()
+		h.server.Drain(ctx)
+		close(drained)
+	}()
+
+	if err := client.conn.SetReadDeadline(time.Now().Add(drainTestTimeout)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	// The complete SELECT SLEEP(...) result set (one column, one row, terminator) must arrive intact.
+	rows := readTextResult(t, client.conn, 1)
+	if len(rows) != 1 {
+		t.Fatalf("in-flight result rows = %d, want 1 (statement was truncated by the drain)", len(rows))
+	}
+	// Only after the statement completed does the now-idle handler forward the shutdown notice.
+	seq, payload, err := mysqlwire.ReadPacket(client.conn)
+	if err != nil {
+		t.Fatalf("read post-statement shutdown notice: %v", err)
+	}
+	assertShutdownNotice(t, seq, payload)
+	select {
+	case <-drained:
+	case <-time.After(drainTestTimeout):
+		t.Fatal("Drain did not return after the in-flight statement finished")
+	}
+}
+
+// Once Drain has started the listener is closed, so a fresh connection attempt is refused.
+func TestDrainRefusesNewConnections(t *testing.T) {
+	h := startBroker(t)
+	ctx, cancel := context.WithTimeout(context.Background(), drainTestTimeout)
+	defer cancel()
+	h.server.Drain(ctx)
+
+	conn, err := net.DialTimeout("tcp", h.addr, time.Second)
+	if err != nil {
+		return // refused at connect — the listener is gone
+	}
+	// Some stacks accept the socket then reset it; a greeting read must then fail.
+	defer conn.Close()
+	if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	if _, _, err := mysqlwire.ReadPacket(conn); err == nil {
+		t.Fatal("a new connection was served a greeting after Drain closed the listener")
+	}
+}
+
+// Drain must return within its bound even when a connection cannot be wound down in time, force-closing the
+// straggler rather than waiting for it.
+func TestDrainForceClosesStragglerPastTimeout(t *testing.T) {
+	h := startBroker(t)
+	h.fake.decideFn = allowAll
+	client := openRawClient(t, h.addr, validToken)
+
+	// A statement far longer than the drain bound keeps its handler in the relay past the timeout.
+	if err := mysqlwire.WritePacket(client.conn, 0, mysqlwire.ComQueryPayload("SELECT SLEEP(3)")); err != nil {
+		t.Fatalf("write slow query: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	readErr := make(chan error, 1)
+	go func() {
+		if err := client.conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+			readErr <- err
+			return
+		}
+		for {
+			if _, _, err := mysqlwire.ReadPacket(client.conn); err != nil {
+				readErr <- err
+				return
+			}
+		}
+	}()
+
+	const drainBound = 150 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), drainBound)
+	defer cancel()
+	start := time.Now()
+	h.server.Drain(ctx)
+	elapsed := time.Since(start)
+
+	if elapsed > time.Second {
+		t.Fatalf("Drain took %v; it waited on the stuck statement instead of force-closing it", elapsed)
+	}
+	select {
+	case err := <-readErr:
+		if err == nil {
+			t.Fatal("straggler read returned a clean result; the connection was not force-closed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("straggler connection was not force-closed after the drain timeout")
+	}
+}
+
+// readTextResult reads a complete text-protocol result set (column count, column defs, rows, terminator)
+// from a DEPRECATE_EOF connection and returns the row payloads.
+func readTextResult(t *testing.T, conn net.Conn, expectedColumns int) [][]byte {
+	t.Helper()
+	_, first, err := mysqlwire.ReadPacket(conn)
+	if err != nil {
+		t.Fatalf("read result header: %v", err)
+	}
+	if len(first) > 0 && first[0] == 0xff {
+		t.Fatalf("query error: %s", mysqlwire.ErrString(first))
+	}
+	count, err := mysqlwire.NewReader(first).Lenenc()
+	if err != nil || int(count) != expectedColumns {
+		t.Fatalf("result column count = %d (%v), want %d", count, err, expectedColumns)
+	}
+	for i := 0; i < expectedColumns; i++ {
+		if _, _, err := mysqlwire.ReadPacket(conn); err != nil {
+			t.Fatalf("read column definition: %v", err)
+		}
+	}
+	var rows [][]byte
+	for {
+		_, payload, err := mysqlwire.ReadPacket(conn)
+		if err != nil {
+			t.Fatalf("read result row: %v", err)
+		}
+		if mysqlwire.IsResultTerminator(payload) {
+			return rows
+		}
+		rows = append(rows, append([]byte(nil), payload...))
+	}
+}

--- a/goproxy/mysqlproxy/server.go
+++ b/goproxy/mysqlproxy/server.go
@@ -6,6 +6,7 @@
 package mysqlproxy
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 	"runtime/debug"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/ridi-oss/proxy-monster/goproxy/engine"
 	"github.com/ridi-oss/proxy-monster/goproxy/spi"
@@ -25,6 +27,12 @@ const (
 	// generation; the counter starts at 1 and can only reach this after 2^63 connections, so the guard
 	// is pure defense-in-depth.
 	maxBackendGeneration = uint64(1<<63 - 1)
+	// drainPollInterval is how often Drain rechecks whether every handler has returned.
+	drainPollInterval = 20 * time.Millisecond
+	// serveExitWait caps how long Drain waits for the accept loop to end. The loop returns within microseconds
+	// of the listener closing, so this only bounds the case where Serve never ran (a bind error raced the
+	// signal), keeping that pathological path off the full drain budget.
+	serveExitWait = 1 * time.Second
 )
 
 var backendGeneration atomic.Uint64
@@ -37,10 +45,14 @@ type Server struct {
 	db          engine.Db
 	tlsProvider func() (*tls.Config, error)
 
-	mu        sync.Mutex
-	ln        net.Listener
-	connID    atomic.Uint32
-	connSlots chan struct{}
+	mu          sync.Mutex
+	ln          net.Listener
+	closed      bool
+	conns       map[net.Conn]struct{}
+	connID      atomic.Uint32
+	connSlots   chan struct{}
+	draining    atomic.Bool
+	serveExited chan struct{} // closed when Serve's accept loop returns, so Drain can wait for every accepted conn to register
 }
 
 // New constructs a MySQL wire broker for one backend datasource.
@@ -52,6 +64,7 @@ func New(port int, backend spi.BackendTarget, client spi.EnforcementClient, dbIm
 		db:          dbImpl,
 		tlsProvider: tlsProvider,
 		connSlots:   make(chan struct{}, maxConcurrentConnections),
+		serveExited: make(chan struct{}),
 	}
 }
 
@@ -59,6 +72,14 @@ func New(port int, backend spi.BackendTarget, client spi.EnforcementClient, dbIm
 func (s *Server) Listen() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// A Drain/Shutdown that won the startup race (SIGTERM arriving before this goroutine bound the port) has
+	// already marked the server closed. Binding now would strand a listener with no Serve loop coming for it,
+	// and boot — waiting on Serve to return — would hang until SIGKILL. bind and Shutdown's close both hold
+	// s.mu, so this either binds before a concurrent Shutdown (which then closes the listener) or observes
+	// closed and does not bind.
+	if s.closed {
+		return nil
+	}
 	if s.ln != nil {
 		return errors.New("mysqlproxy: already listening")
 	}
@@ -73,10 +94,18 @@ func (s *Server) Listen() error {
 // Serve accepts client connections and handles each on its own goroutine. The bounded slot pool prevents
 // unauthenticated sockets from creating an unbounded goroutine population. Ports pmon/broker.go:35-40.
 func (s *Server) Serve() error {
+	// Signal Drain that the accept loop has ended, so it can conclude every accepted socket is now tracked.
+	defer close(s.serveExited)
 	s.mu.Lock()
 	ln := s.ln
+	closed := s.closed
 	s.mu.Unlock()
 	if ln == nil {
+		// A Shutdown/Drain that raced ahead of Serve nulls the listener; that is a clean stop, not a
+		// missing Listen call.
+		if closed {
+			return nil
+		}
 		return errors.New("mysqlproxy: Listen must be called before Serve")
 	}
 
@@ -92,8 +121,10 @@ func (s *Server) Serve() error {
 			_ = conn.Close()
 			continue
 		}
+		s.trackConn(conn)
 		go func() {
 			defer s.releaseConnection()
+			defer s.untrackConn(conn)
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					_ = conn.Close()
@@ -134,9 +165,96 @@ func (s *Server) Shutdown() {
 	s.mu.Lock()
 	ln := s.ln
 	s.ln = nil
+	s.closed = true
 	s.mu.Unlock()
 	if ln != nil {
 		_ = ln.Close()
+	}
+}
+
+// Drain gracefully winds the broker down for a rolling redeploy: it stops accepting new connections, lets
+// in-flight statements finish, and unblocks every idle handler so it can forward a protocol-level shutdown
+// notice (an ER_SERVER_SHUTDOWN packet, see conn.go) and close. It waits for all handlers to return,
+// bounded by ctx; any connection still live when ctx is done is force-closed. Forcing the client read
+// deadline only interrupts a handler blocked reading the next command — an in-flight relay reads the
+// backend and writes the client, so it is untouched and runs to completion.
+func (s *Server) Drain(ctx context.Context) {
+	s.Shutdown()
+	s.draining.Store(true)
+	// Wait for the accept loop to end before treating the connection set as complete. A socket returned by
+	// Accept just before Shutdown registers only after this point, so a waitForConns that ran first could see
+	// zero, report a clean drain, and let boot exit while that handler still holds an un-notified client.
+	s.awaitServeExit(ctx)
+	s.forEachConn(func(c net.Conn) { _ = c.SetReadDeadline(time.Now()) })
+	if s.waitForConns(ctx) {
+		return
+	}
+	s.forEachConn(func(c net.Conn) { _ = c.Close() })
+}
+
+// awaitServeExit blocks until the accept loop has returned (every accepted connection is then registered), or
+// ctx is done, or [serveExitWait] elapses. Serve always closes serveExited on return, including its early-out
+// paths; the timer only matters when Serve never ran (a bind error that raced the signal).
+func (s *Server) awaitServeExit(ctx context.Context) {
+	t := time.NewTimer(serveExitWait)
+	defer t.Stop()
+	select {
+	case <-s.serveExited:
+	case <-ctx.Done():
+	case <-t.C:
+	}
+}
+
+func (s *Server) trackConn(c net.Conn) {
+	s.mu.Lock()
+	if s.conns == nil {
+		s.conns = make(map[net.Conn]struct{})
+	}
+	s.conns[c] = struct{}{}
+	draining := s.draining.Load()
+	s.mu.Unlock()
+	// A drain that began between Accept and registration would otherwise miss this connection; unblock it
+	// here so its handler still sees the drain rather than blocking out the full idle timeout.
+	if draining {
+		_ = c.SetReadDeadline(time.Now())
+	}
+}
+
+func (s *Server) untrackConn(c net.Conn) {
+	s.mu.Lock()
+	delete(s.conns, c)
+	s.mu.Unlock()
+}
+
+func (s *Server) forEachConn(fn func(net.Conn)) {
+	s.mu.Lock()
+	conns := make([]net.Conn, 0, len(s.conns))
+	for c := range s.conns {
+		conns = append(conns, c)
+	}
+	s.mu.Unlock()
+	for _, c := range conns {
+		fn(c)
+	}
+}
+
+// waitForConns blocks until every tracked handler has returned, or ctx is done. It reports whether the
+// connection set emptied before the deadline.
+func (s *Server) waitForConns(ctx context.Context) bool {
+	ticker := time.NewTicker(drainPollInterval)
+	defer ticker.Stop()
+	for {
+		s.mu.Lock()
+		remaining := len(s.conns)
+		s.mu.Unlock()
+		if remaining == 0 {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+		}
 	}
 }
 

--- a/goproxy/pgproxy/conn.go
+++ b/goproxy/pgproxy/conn.go
@@ -169,7 +169,7 @@ startupComplete:
 	defer backendConn.Close()
 
 	client.SetMaxBodyLen(maxFrontendFrameBody)
-	clientIO.Conn = withIODeadlines(clientConn, frontendCommandIdleTimeout, socketWriteTimeout)
+	clientIO.Conn = withDrainAwareIODeadlines(clientConn, frontendCommandIdleTimeout, socketWriteTimeout, &s.draining)
 	clientIO.strictReads = false
 	backendConn = withIODeadlines(backendConn, backendResponseIdleTimeout, socketWriteTimeout)
 	backend := pgproto3.NewFrontend(backendConn, backendConn)
@@ -218,6 +218,16 @@ startupComplete:
 	for {
 		message, err := client.Receive()
 		if err != nil {
+			// The single drain point. A drain forces the client read deadline, so a handler waiting here for the
+			// next message unblocks and sends the FATAL shutdown notice, and its pool reconnects onto the
+			// replacement task. Checking only here (not before the read) lets a Sync already decoded above the
+			// socket after a completed Execute be answered with ReadyForQuery first; a Sync still in the kernel
+			// read buffer is preempted by the forced deadline, so the completed Execute is rolled back on close
+			// and the client reconnects and retries it (the pipelined-drain limitation in KNOWN_LIMITATIONS).
+			// A plain idle-timeout or client disconnect stays a silent close.
+			if s.draining.Load() {
+				_ = sendShutdownNotice(client)
+			}
 			return
 		}
 		if sess.skipToSync {
@@ -279,6 +289,14 @@ startupComplete:
 			return
 		}
 	}
+}
+
+// sendShutdownNotice tells an idle client the proxy is going away, so its pool reconnects onto the
+// replacement task instead of seeing a bare TCP reset. FATAL 57P01 (admin_shutdown) is what PostgreSQL
+// itself sends on shutdown, so a driver already treats it as a reconnect signal. Best-effort: the
+// connection closes regardless.
+func sendShutdownNotice(client *pgproto3.Backend) error {
+	return sendError(client, "FATAL", "57P01", "proxy-monster: server shutting down", false, 0)
 }
 
 func sendError(client *pgproto3.Backend, severity, code, message string, ready bool, txStatus byte) error {

--- a/goproxy/pgproxy/deadline.go
+++ b/goproxy/pgproxy/deadline.go
@@ -2,6 +2,7 @@ package pgproxy
 
 import (
 	"net"
+	"sync/atomic"
 	"time"
 )
 
@@ -17,13 +18,22 @@ type deadlineConn struct {
 	net.Conn
 	readTimeout  time.Duration
 	writeTimeout time.Duration
+	draining     *atomic.Bool
 }
 
 func withIODeadlines(conn net.Conn, readTimeout, writeTimeout time.Duration) net.Conn {
-	if readTimeout <= 0 && writeTimeout <= 0 {
+	return withDrainAwareIODeadlines(conn, readTimeout, writeTimeout, nil)
+}
+
+// withDrainAwareIODeadlines is withIODeadlines plus a drain signal. Once draining is set, a read returns
+// promptly instead of waiting out the idle timeout, so a handler blocked for the next message can send the
+// shutdown notice and close without depending on the drainer having already forced the socket deadline.
+// Only the client-facing conn is wrapped this way; a backend read mid-relay must not be cut short.
+func withDrainAwareIODeadlines(conn net.Conn, readTimeout, writeTimeout time.Duration, draining *atomic.Bool) net.Conn {
+	if readTimeout <= 0 && writeTimeout <= 0 && draining == nil {
 		return conn
 	}
-	return &deadlineConn{Conn: conn, readTimeout: readTimeout, writeTimeout: writeTimeout}
+	return &deadlineConn{Conn: conn, readTimeout: readTimeout, writeTimeout: writeTimeout, draining: draining}
 }
 
 // switchConn lets a pgproto3 codec retain its buffered reader while the underlying socket changes. During
@@ -42,9 +52,18 @@ func (c *switchConn) Read(payload []byte) (int, error) {
 }
 
 func (c *deadlineConn) Read(payload []byte) (int, error) {
+	if c.draining != nil && c.draining.Load() {
+		_ = c.SetReadDeadline(time.Now())
+		return c.Conn.Read(payload)
+	}
 	if c.readTimeout > 0 {
 		if err := c.SetReadDeadline(time.Now().Add(c.readTimeout)); err != nil {
 			return 0, err
+		}
+		// A drain that set the flag after the check above would have its forced deadline overwritten by the
+		// idle one just set, leaving this read blocked for the full idle timeout. Re-check and force it now.
+		if c.draining != nil && c.draining.Load() {
+			_ = c.SetReadDeadline(time.Now())
 		}
 	}
 	return c.Conn.Read(payload)

--- a/goproxy/pgproxy/drain_test.go
+++ b/goproxy/pgproxy/drain_test.go
@@ -1,0 +1,196 @@
+package pgproxy_test
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+)
+
+// drainTestTimeout is a generous graceful-drain bound for a local test: long enough that a short in-flight
+// statement always finishes inside it, short enough that a test never waits on the real 10s production value.
+const drainTestTimeout = 3 * time.Second
+
+// assertPGShutdownNotice checks that message is the PostgreSQL FATAL admin_shutdown (57P01) notice.
+func assertPGShutdownNotice(t *testing.T, message pgproto3.BackendMessage) {
+	t.Helper()
+	errResp, ok := message.(*pgproto3.ErrorResponse)
+	if !ok {
+		t.Fatalf("shutdown message = %T, want *pgproto3.ErrorResponse", message)
+	}
+	if errResp.Severity != "FATAL" {
+		t.Fatalf("shutdown severity = %q, want FATAL", errResp.Severity)
+	}
+	if errResp.Code != "57P01" {
+		t.Fatalf("shutdown SQLSTATE = %q, want 57P01 (admin_shutdown)", errResp.Code)
+	}
+	if !strings.Contains(errResp.Message, "shutting down") {
+		t.Fatalf("shutdown message = %q, want a server-shutting-down notice", errResp.Message)
+	}
+}
+
+// An idle authenticated connection must be unblocked promptly on Drain and handed the shutdown notice —
+// this proves the forced read deadline actually propagates through the deadline wrapper.
+func TestDrainIdleConnectionReceivesShutdownNoticeThenCloses(t *testing.T) {
+	h := startBroker(t)
+	client := newRawPGClient(t, h)
+
+	drained := make(chan struct{})
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), drainTestTimeout)
+		defer cancel()
+		h.server.Drain(ctx)
+		close(drained)
+	}()
+
+	if err := client.conn.SetReadDeadline(time.Now().Add(drainTestTimeout)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	message, err := client.frontend.Receive()
+	if err != nil {
+		t.Fatalf("receive shutdown notice: %v", err)
+	}
+	assertPGShutdownNotice(t, message)
+
+	if _, err := client.frontend.Receive(); err == nil {
+		t.Fatal("connection stayed open after the shutdown notice")
+	}
+	select {
+	case <-drained:
+	case <-time.After(drainTestTimeout):
+		t.Fatal("Drain did not return after the idle connection closed")
+	}
+}
+
+// A statement already relaying when Drain starts must deliver its full result — through ReadyForQuery —
+// before the connection is wound down: forcing the client read deadline must not truncate an in-flight relay.
+func TestDrainLetsInFlightStatementComplete(t *testing.T) {
+	h := startBroker(t)
+	client := newRawPGClient(t, h)
+
+	// pg_sleep holds the handler in the relay (reading the backend) across the Drain call.
+	client.frontend.Send(&pgproto3.Query{String: "SELECT pg_sleep(0.5)"})
+	if err := client.frontend.Flush(); err != nil {
+		t.Fatalf("send slow query: %v", err)
+	}
+	// Let the query reach the backend and begin relaying before draining.
+	time.Sleep(100 * time.Millisecond)
+
+	drained := make(chan struct{})
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), drainTestTimeout)
+		defer cancel()
+		h.server.Drain(ctx)
+		close(drained)
+	}()
+
+	if err := client.conn.SetReadDeadline(time.Now().Add(drainTestTimeout)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	sawRow, sawRFQ := false, false
+	for !sawRFQ {
+		message, err := client.frontend.Receive()
+		if err != nil {
+			t.Fatalf("receive in-flight result: %v", err)
+		}
+		switch message.(type) {
+		case *pgproto3.DataRow:
+			sawRow = true
+		case *pgproto3.ReadyForQuery:
+			sawRFQ = true
+		}
+	}
+	if !sawRow {
+		t.Fatal("in-flight statement produced no row; it was truncated by the drain")
+	}
+	// Only after the statement completed does the now-idle handler forward the shutdown notice.
+	message, err := client.frontend.Receive()
+	if err != nil {
+		t.Fatalf("receive post-statement shutdown notice: %v", err)
+	}
+	assertPGShutdownNotice(t, message)
+	select {
+	case <-drained:
+	case <-time.After(drainTestTimeout):
+		t.Fatal("Drain did not return after the in-flight statement finished")
+	}
+}
+
+// Once Drain has started the listener is closed, so a fresh connection attempt is refused.
+func TestDrainRefusesNewConnections(t *testing.T) {
+	h := startBroker(t)
+	ctx, cancel := context.WithTimeout(context.Background(), drainTestTimeout)
+	defer cancel()
+	h.server.Drain(ctx)
+
+	conn, err := net.DialTimeout("tcp", h.addr, time.Second)
+	if err != nil {
+		return // refused at connect — the listener is gone
+	}
+	defer conn.Close()
+	// A served connection would answer the startup handshake; after Drain closed the listener it must not.
+	frontend := pgproto3.NewFrontend(conn, conn)
+	frontend.Send(&pgproto3.StartupMessage{
+		ProtocolVersion: pgproto3.ProtocolVersionNumber,
+		Parameters:      map[string]string{"user": "pm", "database": "app"},
+	})
+	if err := frontend.Flush(); err != nil {
+		return // write failed on the reset socket
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	if _, err := frontend.Receive(); err == nil {
+		t.Fatal("a new connection was served after Drain closed the listener")
+	}
+}
+
+// Drain must return within its bound even when a connection cannot be wound down in time, force-closing the
+// straggler rather than waiting for it.
+func TestDrainForceClosesStragglerPastTimeout(t *testing.T) {
+	h := startBroker(t)
+	client := newRawPGClient(t, h)
+
+	// A statement far longer than the drain bound keeps its handler in the relay past the timeout.
+	client.frontend.Send(&pgproto3.Query{String: "SELECT pg_sleep(3)"})
+	if err := client.frontend.Flush(); err != nil {
+		t.Fatalf("send slow query: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	readErr := make(chan error, 1)
+	go func() {
+		if err := client.conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+			readErr <- err
+			return
+		}
+		for {
+			if _, err := client.frontend.Receive(); err != nil {
+				readErr <- err
+				return
+			}
+		}
+	}()
+
+	const drainBound = 150 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), drainBound)
+	defer cancel()
+	start := time.Now()
+	h.server.Drain(ctx)
+	elapsed := time.Since(start)
+
+	if elapsed > time.Second {
+		t.Fatalf("Drain took %v; it waited on the stuck statement instead of force-closing it", elapsed)
+	}
+	select {
+	case err := <-readErr:
+		if err == nil {
+			t.Fatal("straggler read returned cleanly; the connection was not force-closed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("straggler connection was not force-closed after the drain timeout")
+	}
+}

--- a/goproxy/pgproxy/proxy_test.go
+++ b/goproxy/pgproxy/proxy_test.go
@@ -249,8 +249,9 @@ func seedBackend(t *testing.T) dbtest.Backend {
 }
 
 type brokerHarness struct {
-	fake *fakeControlPlane
-	addr string
+	fake   *fakeControlPlane
+	addr   string
+	server *pgproxy.Server
 }
 
 func startBroker(t *testing.T) *brokerHarness {
@@ -314,7 +315,7 @@ func startBrokerServer(t *testing.T, fake *fakeControlPlane, server *pgproxy.Ser
 			t.Errorf("pgproxy.Serve: %v", err)
 		}
 	})
-	return &brokerHarness{fake: fake, addr: server.Addr().String()}
+	return &brokerHarness{fake: fake, addr: server.Addr().String(), server: server}
 }
 
 func (h *brokerHarness) connect(t *testing.T, token string, simple bool) (*pgx.Conn, error) {

--- a/goproxy/pgproxy/server.go
+++ b/goproxy/pgproxy/server.go
@@ -4,6 +4,7 @@
 package pgproxy
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"runtime/debug"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/ridi-oss/proxy-monster/goproxy/engine"
 	"github.com/ridi-oss/proxy-monster/goproxy/spi"
@@ -20,6 +22,12 @@ import (
 const (
 	maxConcurrentConnections = 256
 	maxBackendGeneration     = uint64(1<<63 - 1)
+	// drainPollInterval is how often Drain rechecks whether every handler has returned.
+	drainPollInterval = 20 * time.Millisecond
+	// serveExitWait caps how long Drain waits for the accept loop to end. The loop returns within microseconds
+	// of the listener closing, so this only bounds the case where Serve never ran (a bind error raced the
+	// signal), keeping that pathological path off the full drain budget.
+	serveExitWait = 1 * time.Second
 )
 
 var backendGeneration atomic.Uint64
@@ -32,9 +40,13 @@ type Server struct {
 	db          engine.Db
 	tlsProvider func() (*tls.Config, error)
 
-	mu        sync.Mutex
-	ln        net.Listener
-	connSlots chan struct{}
+	mu          sync.Mutex
+	ln          net.Listener
+	closed      bool
+	conns       map[net.Conn]struct{}
+	connSlots   chan struct{}
+	draining    atomic.Bool
+	serveExited chan struct{} // closed when Serve's accept loop returns, so Drain can wait for every accepted conn to register
 }
 
 // New constructs a PostgreSQL wire broker for one backend datasource.
@@ -46,6 +58,7 @@ func New(port int, backend spi.BackendTarget, client spi.EnforcementClient, dbIm
 		db:          dbImpl,
 		tlsProvider: tlsProvider,
 		connSlots:   make(chan struct{}, maxConcurrentConnections),
+		serveExited: make(chan struct{}),
 	}
 }
 
@@ -53,6 +66,14 @@ func New(port int, backend spi.BackendTarget, client spi.EnforcementClient, dbIm
 func (s *Server) Listen() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// A Drain/Shutdown that won the startup race (SIGTERM arriving before this goroutine bound the port) has
+	// already marked the server closed. Binding now would strand a listener with no Serve loop coming for it,
+	// and boot — waiting on Serve to return — would hang until SIGKILL. bind and Shutdown's close both hold
+	// s.mu, so this either binds before a concurrent Shutdown (which then closes the listener) or observes
+	// closed and does not bind.
+	if s.closed {
+		return nil
+	}
 	if s.ln != nil {
 		return errors.New("pgproxy: already listening")
 	}
@@ -67,10 +88,18 @@ func (s *Server) Listen() error {
 // Serve accepts client connections and handles each on its own goroutine. The bounded slot pool prevents
 // unauthenticated sockets from creating an unbounded goroutine population.
 func (s *Server) Serve() error {
+	// Signal Drain that the accept loop has ended, so it can conclude every accepted socket is now tracked.
+	defer close(s.serveExited)
 	s.mu.Lock()
 	ln := s.ln
+	closed := s.closed
 	s.mu.Unlock()
 	if ln == nil {
+		// A Shutdown/Drain that raced ahead of Serve nulls the listener; that is a clean stop, not a
+		// missing Listen call.
+		if closed {
+			return nil
+		}
 		return errors.New("pgproxy: Listen must be called before Serve")
 	}
 
@@ -86,8 +115,10 @@ func (s *Server) Serve() error {
 			_ = conn.Close()
 			continue
 		}
+		s.trackConn(conn)
 		go func() {
 			defer s.releaseConnection()
+			defer s.untrackConn(conn)
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					_ = conn.Close()
@@ -128,9 +159,96 @@ func (s *Server) Shutdown() {
 	s.mu.Lock()
 	ln := s.ln
 	s.ln = nil
+	s.closed = true
 	s.mu.Unlock()
 	if ln != nil {
 		_ = ln.Close()
+	}
+}
+
+// Drain gracefully winds the broker down for a rolling redeploy: it stops accepting new connections, lets
+// in-flight statements finish, and unblocks every idle handler so it can forward a protocol-level shutdown
+// notice (a FATAL admin_shutdown ErrorResponse, see conn.go) and close. It waits for all handlers to
+// return, bounded by ctx; any connection still live when ctx is done is force-closed. Forcing the client
+// read deadline only interrupts a handler blocked reading the next message — an in-flight relay reads the
+// backend and writes the client, so it is untouched and runs to completion.
+func (s *Server) Drain(ctx context.Context) {
+	s.Shutdown()
+	s.draining.Store(true)
+	// Wait for the accept loop to end before treating the connection set as complete. A socket returned by
+	// Accept just before Shutdown registers only after this point, so a waitForConns that ran first could see
+	// zero, report a clean drain, and let boot exit while that handler still holds an un-notified client.
+	s.awaitServeExit(ctx)
+	s.forEachConn(func(c net.Conn) { _ = c.SetReadDeadline(time.Now()) })
+	if s.waitForConns(ctx) {
+		return
+	}
+	s.forEachConn(func(c net.Conn) { _ = c.Close() })
+}
+
+// awaitServeExit blocks until the accept loop has returned (every accepted connection is then registered), or
+// ctx is done, or [serveExitWait] elapses. Serve always closes serveExited on return, including its early-out
+// paths; the timer only matters when Serve never ran (a bind error that raced the signal).
+func (s *Server) awaitServeExit(ctx context.Context) {
+	t := time.NewTimer(serveExitWait)
+	defer t.Stop()
+	select {
+	case <-s.serveExited:
+	case <-ctx.Done():
+	case <-t.C:
+	}
+}
+
+func (s *Server) trackConn(c net.Conn) {
+	s.mu.Lock()
+	if s.conns == nil {
+		s.conns = make(map[net.Conn]struct{})
+	}
+	s.conns[c] = struct{}{}
+	draining := s.draining.Load()
+	s.mu.Unlock()
+	// A drain that began between Accept and registration would otherwise miss this connection; unblock it
+	// here so its handler still sees the drain rather than blocking out the full idle timeout.
+	if draining {
+		_ = c.SetReadDeadline(time.Now())
+	}
+}
+
+func (s *Server) untrackConn(c net.Conn) {
+	s.mu.Lock()
+	delete(s.conns, c)
+	s.mu.Unlock()
+}
+
+func (s *Server) forEachConn(fn func(net.Conn)) {
+	s.mu.Lock()
+	conns := make([]net.Conn, 0, len(s.conns))
+	for c := range s.conns {
+		conns = append(conns, c)
+	}
+	s.mu.Unlock()
+	for _, c := range conns {
+		fn(c)
+	}
+}
+
+// waitForConns blocks until every tracked handler has returned, or ctx is done. It reports whether the
+// connection set emptied before the deadline.
+func (s *Server) waitForConns(ctx context.Context) bool {
+	ticker := time.NewTicker(drainPollInterval)
+	defer ticker.Stop()
+	for {
+		s.mu.Lock()
+		remaining := len(s.conns)
+		s.mu.Unlock()
+		if remaining == 0 {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+		}
 	}
 }
 

--- a/goproxy/spi/spi.go
+++ b/goproxy/spi/spi.go
@@ -84,10 +84,13 @@ type TableDetailClient interface {
 }
 
 // WireServer is the enforcing native-wire broker's boot contract: Start blocks serving connections until
-// the process is asked to stop; Shutdown requests that stop.
+// the process is asked to stop; Shutdown closes the listener; Drain closes the listener and then gracefully
+// winds down live client connections — in-flight statements finish, idle connections get a protocol-level
+// shutdown notice and close — bounded by ctx, force-closing any that outlast it.
 type WireServer interface {
 	Start() error
 	Shutdown()
+	Drain(ctx context.Context)
 }
 
 // BackendSession is one dedicated run backend session.


### PR DESCRIPTION
## What
On SIGTERM (a rolling redeploy) the data plane replaces `os.Exit(0)` with a graceful drain: stop accepting → let in-flight statements finish → hand each idle client a protocol shutdown notice (MySQL `1053`/`08S01`, PostgreSQL `FATAL 57P01`) → bounded 10s, force-close stragglers. `spi.WireServer` gains `Drain(ctx)`, implemented by both the MySQL and PostgreSQL servers; `boot` drives it on the signal.

## Why
The old hard exit reset every client connection and killed in-flight queries on every redeploy. A drain lets a connection pool reconnect onto the replacement task (via the NLB) cleanly, and interactive clients get a "server shutting down" notice instead of a raw reset. Session state (temp tables, prepared statements, open transactions) can't survive a proxy swap, so forwarding a clean shutdown is correct.

## Trap
One documented caveat (KNOWN_LIMITATIONS.md → Data plane): a pipelined PostgreSQL `Execute` whose `Sync` isn't yet read when the drain fires is reported failed (rolled back, the client retries) — narrow and PostgreSQL-experimental. MySQL (the correctness bar) is unaffected.

## Verify
`mise run verify` green; the drain tests are transport-level, DB-backed, and run under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)