### PR TITLE
feat(control-plane): re-home the console on shutdown via an SSE drain

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -80,6 +80,11 @@ private const val SSE_SESSION_RECHECK_MS = 30_000L
  *  hammer `/api/tasks/events` on its default ~3s retry (it cannot be told to stop after the 200 handshake). */
 private const val SSE_UNAUTH_RETRY_MS = 60_000L
 
+/** Reconnect backoff sent when the stream closes because the control-plane is draining (rolling restart), so
+ *  a watching tab re-homes to the replacement promptly instead of on EventSource's ~3s default. Short, not
+ *  zero: a brief gap lets the departing instance finish leaving the load balancer before the tab reconnects. */
+private const val SSE_DRAIN_RECONNECT_MS = 500L
+
 /**
  * One per-principal SSE stream of task terminal transitions (EXECUTED/FAILED/CANCELLED), so a
  * watching editor/approval tab updates immediately instead of on its next poll. Cookie-authenticated
@@ -117,7 +122,13 @@ internal fun Route.taskEventsRoute(
             while (true) {
                 val keepOpen = select {
                     events.onReceiveCatching { result ->
-                        val event = result.getOrNull() ?: return@onReceiveCatching false
+                        val event = result.getOrNull() ?: run {
+                            // The channel closed. On a drain (rolling restart) the hub closes every stream —
+                            // send a short retry so the browser reconnects to the replacement now rather than
+                            // waiting its ~3s default. Any other close is an ordinary end (nothing to send).
+                            if (taskCompletionHub.isDraining()) send(ServerSentEvent(retry = SSE_DRAIN_RECONNECT_MS))
+                            return@onReceiveCatching false
+                        }
                         // Bound the push to the SAME live `task.read` gate the poll/detail enforce, so a Cedar
                         // forbid (e.g. an untrusted zone) that 404s the poll also suppresses the push — the
                         // notification never reveals gated metadata. A denied/absent task is skipped.
@@ -366,8 +377,9 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
     val runExecService = RunExecService(core, config.queryTimeoutSeconds)
     // In-process push of task terminal transitions to the SSE stream, so a watching editor/approval tab
     // updates without waiting for its next poll. HTTP-only (the run coroutines + the SSE stream live here),
-    // single-replica, and a pure accelerator over the poll (see TaskCompletionHub).
-    val taskCompletionHub = TaskCompletionHub()
+    // single-replica, and a pure accelerator over the poll (see TaskCompletionHub). On `core` so the SIGTERM
+    // shutdown hook can drain the open streams (a rolling restart re-homes the console to the replacement).
+    val taskCompletionHub = core.taskCompletionHub
     val tableDetailService = TableDetailService(core)
     // AES-256-GCM at-rest crypto for PII-bearing rows we persist server-side: query results AND
     // encrypted refresh tokens for principal sessions. Null when PM_RESULT_KEY is unset — sensitive

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ControlPlaneCore.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ControlPlaneCore.kt
@@ -42,6 +42,12 @@ class ControlPlaneCore(val dataSource: DataSource) {
     // Open proxy Events streams (docs/datasource-registration.md) — liveness + refresh/run push.
     // Shared so the gRPC handlers and the HTTP routes agree on attached proxies and pending run dials.
     val proxyEventsHub = ProxyEventsHub()
+
+    // Per-principal fan-out of task terminal transitions to the console's SSE streams. Constructed here
+    // rather than in Application.module purely so the SIGTERM shutdown hook (which holds only `core`) can
+    // drain it — signalling every open browser stream to reconnect so a rolling restart re-homes the
+    // console to the replacement instead of leaving it on the draining instance until the LB cuts it.
+    val taskCompletionHub = TaskCompletionHub()
     val connectionCatalog = ConnectionCatalogRegistry()
     val runChannels = RunChannelRegistry()
     val tableDetailChannels = TableDetailChannelRegistry()

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Main.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Main.kt
@@ -12,6 +12,11 @@ private val log = LoggerFactory.getLogger("com.ridi.oss.proxymonster.controlplan
  * server anyway. Detach is near-instant (the proxy closes on the event); this only bounds a straggler. */
 private const val DRAIN_TIMEOUT_MS = 3_000L
 
+/** How long shutdown waits for the closed console SSE streams to flush their reconnect hint and deregister.
+ * The flush is near-instant; the wait keeps this hook (and so the process, and Netty) alive long enough for it
+ * to land before the HTTP server stops. A straggler falls through to the browser's default reconnect. */
+private const val SSE_DRAIN_TIMEOUT_MS = 2_000L
+
 /**
  * How long one proxy-dialed run stream may live.
  *
@@ -67,17 +72,29 @@ fun main() {
     grpcServer.start()
     Runtime.getRuntime().addShutdownHook(
         Thread {
-            // Graceful drain on SIGTERM, so a rolling restart re-homes the proxies to the replacement rather
-            // than leaving datasources detached until a reconnect timer fires. Order matters:
-            //   1. close the hub to new streams/dispatches;
+            // Graceful drain on SIGTERM, so a rolling restart re-homes both the proxies (gRPC Events streams)
+            // and the console (SSE task-event streams) to the replacement rather than leaving them on the
+            // departing instance until an LB timer cuts them. Ktor installs its OWN shutdown hook that stops
+            // the HTTP server, and JVM hooks run concurrently in an unspecified order — so the SSE reconnect
+            // hint only lands if it flushes before that stop. This hook must therefore not just close the SSE
+            // streams but WAIT for their handlers to flush and deregister (step 4): the JVM keeps every hook's
+            // thread — and so Netty's I/O threads — alive until all hooks return. Order:
+            //   1. close both hubs to new streams/dispatches;
             //   2. begin gRPC shutdown — GOAWAY, so a proxy's reopen dials a fresh connection (re-homing to a
             //      live instance where an LB fronts several) instead of reusing this one;
-            //   3. signal + close the open streams so proxies reopen now;
-            //   4. wait (bounded) for them to detach;
+            //   3. signal + close the open streams so clients reopen now (the SSE close makes each browser's
+            //      EventSource reconnect; no GOAWAY equivalent is needed — a reconnect is a fresh request);
+            //   4. wait (bounded) for the proxies to detach and the SSE streams to flush their hint + deregister;
             //   5. finish gRPC shutdown (force-cancel any straggler), then exit.
             core.proxyEventsHub.beginDraining()
+            core.taskCompletionHub.beginDraining()
             grpcServer.beginShutdown()
             val closed = core.proxyEventsHub.broadcastDraining()
+            val sseClosed = core.taskCompletionHub.broadcastDraining()
+            if (sseClosed > 0) {
+                val flushed = core.taskCompletionHub.awaitDrained(SSE_DRAIN_TIMEOUT_MS)
+                log.info("drain: closed {} console SSE stream(s); {}", sseClosed, if (flushed) "hint flushed" else "flush timed out")
+            }
             if (closed > 0) {
                 val clean = core.proxyEventsHub.awaitDrained(DRAIN_TIMEOUT_MS)
                 log.info("drain: closed {} proxy stream(s); {}", closed, if (clean) "all detached" else "timed out waiting")

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/TaskCompletionHub.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/TaskCompletionHub.kt
@@ -31,12 +31,35 @@ class TaskCompletionHub {
     // publish iterates without locking against concurrent subscribe/unsubscribe.
     private val subscribers = ConcurrentHashMap<String, CopyOnWriteArrayList<Channel<TaskEvent>>>()
 
+    // Serializes the drain transition against subscribe(), so a read of [shuttingDown] and the map mutation
+    // that follows it are one atomic step: a subscribe racing the drain either registers before it (and is
+    // then closed by [broadcastDraining]) or sees the flag and is refused — never lands after the broadcast
+    // and lingers on the draining instance. publish() stays lock-free (the query hot path, best-effort).
+    private val lock = Any()
+
+    // Set once on shutdown, under [lock], before closing the open streams: a fresh subscribe is refused so a
+    // browser reconnecting onto this draining instance is bounced straight back off it.
+    private var shuttingDown = false
+
+    /** Enter drain mode: refuse new subscribers. Idempotent; call before [broadcastDraining]. */
+    fun beginDraining() = synchronized(lock) { shuttingDown = true }
+
+    /** True once the process is draining — the SSE handler reads it on a closed channel to decide whether the
+     *  close is a shutdown (send the reconnect hint) or an ordinary end. */
+    fun isDraining(): Boolean = synchronized(lock) { shuttingDown }
+
     /** Open a subscription for [principal]; the caller must [unsubscribe] it (a `finally`) when the stream ends. */
     fun subscribe(principal: String): ReceiveChannel<TaskEvent> {
         // Bounded + DROP_OLDEST: a slow/stuck client can never make publish() suspend or grow memory unbounded;
         // it just loses the oldest pushes and catches up on its next poll.
         val channel = Channel<TaskEvent>(capacity = 64, onBufferOverflow = BufferOverflow.DROP_OLDEST)
-        subscribers.compute(principal) { _, list -> (list ?: CopyOnWriteArrayList()).apply { add(channel) } }
+        synchronized(lock) {
+            // Draining: hand back an already-closed channel so the handler ends at once and re-homes, without
+            // registering it (which would leave a stream behind the broadcast, never told to leave).
+            if (shuttingDown) channel.close() else subscribers.compute(principal) { _, list ->
+                (list ?: CopyOnWriteArrayList()).apply { add(channel) }
+            }
+        }
         return channel
     }
 
@@ -57,5 +80,40 @@ class TaskCompletionHub {
     /** Push [event] to a set of parties (e.g. a workflow task's requester + approver), de-duplicated. */
     fun publish(principals: Collection<String>, event: TaskEvent) {
         for (principal in principals.toSet()) publish(principal, event)
+    }
+
+    /**
+     * On shutdown, close every open SSE stream. The close is the guarantee: it ends the handler, which ends the
+     * Ktor response, so the browser's EventSource reconnects — re-homing to the replacement instance (a rolling
+     * restart) instead of waiting out the LB's connection drain on the departing one. Before ending, the handler
+     * sees [isDraining] and writes a short `retry` so that reconnect is prompt rather than on the ~3s default;
+     * that hint is best-effort (it must flush before the HTTP server stops — see [awaitDrained] — and a straggler
+     * simply reconnects on the default, which the console's poll covers). Returns the number of streams closed.
+     * Call after [beginDraining].
+     */
+    fun broadcastDraining(): Int = synchronized(lock) {
+        var closed = 0
+        for ((_, channels) in subscribers) {
+            for (channel in channels) {
+                channel.close()
+                closed++
+            }
+        }
+        return closed
+    }
+
+    /**
+     * Block up to [timeoutMs] for every stream closed by [broadcastDraining] to run its handler's close path —
+     * the `send(retry)` then the `finally` that unsubscribes, which is what empties [subscribers]. This is what
+     * keeps the process (and so Netty's I/O threads) alive long enough for the retry to flush before shutdown
+     * tears the HTTP server down; a straggler just falls through to the browser's default reconnect, which the
+     * console's poll then covers. Returns true if the hub emptied in time.
+     */
+    fun awaitDrained(timeoutMs: Long): Boolean {
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000
+        while (subscribers.isNotEmpty() && System.nanoTime() < deadline) {
+            Thread.sleep(20)
+        }
+        return subscribers.isEmpty()
     }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TaskCompletionHubTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TaskCompletionHubTest.kt
@@ -1,11 +1,15 @@
 package com.ridi.oss.proxymonster.controlplane
 
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -81,5 +85,89 @@ class TaskCompletionHubTest {
         assertTrue(drained.isNotEmpty())
         // The most recent event is always retained; the oldest are the ones dropped.
         assertEquals(500L, drained.last().taskId)
+    }
+
+    @Test
+    fun `isDraining is false until beginDraining`() {
+        val hub = TaskCompletionHub()
+        assertFalse(hub.isDraining())
+        hub.beginDraining()
+        assertTrue(hub.isDraining())
+    }
+
+    @Test
+    fun `broadcastDraining closes every open stream and returns the count`() {
+        val hub = TaskCompletionHub()
+        val alice = hub.subscribe("alice")
+        val bobTab1 = hub.subscribe("bob")
+        val bobTab2 = hub.subscribe("bob")
+
+        assertEquals(3, hub.broadcastDraining(), "every open stream across principals is closed")
+
+        // A closed stream ends its SSE handler, which the browser's EventSource then reconnects.
+        for (stream in listOf(alice, bobTab1, bobTab2)) {
+            assertTrue(stream.tryReceive().isClosed, "the stream is closed by the drain")
+        }
+    }
+
+    @Test
+    fun `awaitDrained blocks until the closed streams deregister, then reports drained`() {
+        val hub = TaskCompletionHub()
+        val stream = hub.subscribe("alice")
+        hub.beginDraining()
+        hub.broadcastDraining()
+
+        // broadcastDraining closes the channel but the subscriber map only empties when the handler's `finally`
+        // unsubscribes (off-thread in production). Until then the hub is not drained: the wait must report that
+        // rather than return early, so shutdown keeps the process alive for the reconnect hint to flush.
+        assertFalse(hub.awaitDrained(50), "still holding a closed-but-not-yet-deregistered stream")
+
+        // Simulate the handler's finally running after it flushed its hint.
+        hub.unsubscribe("alice", stream)
+        assertTrue(hub.awaitDrained(200), "drained once the last stream deregisters")
+    }
+
+    @Test
+    fun `once draining, a new subscribe is refused with an already-closed channel`() {
+        val hub = TaskCompletionHub()
+        hub.beginDraining()
+
+        val late = hub.subscribe("alice")
+        // Handed back closed so its handler ends at once (and the browser re-homes), and never registered —
+        // so a browser reconnecting onto this draining instance is bounced straight back off it.
+        assertTrue(late.tryReceive().isClosed, "a subscribe during drain is handed a closed channel")
+        hub.publish("alice", TaskEvent(1, "EXECUTED"))
+        assertTrue(late.tryReceive().isClosed, "and it was never registered, so nothing is delivered")
+    }
+
+    @Test
+    fun `concurrent subscribe cannot survive a drain`() {
+        // The subscribe barrier must be atomic with the drain: however subscribes interleave with
+        // beginDraining + broadcastDraining, none may be left OPEN (registered but unclosed) — such a stream
+        // would linger on the draining instance, never told to reconnect. Without subscribe()'s lock, a check
+        // that reads shuttingDown as false can insert its (open) channel after broadcastDraining already swept.
+        // subscribe() owns the channel it returns (the SSE handler does not supply one, unlike a proxy Events
+        // stream), so the deterministic parking-close ProxyEventsHubTest uses is not available here — this
+        // stresses the check-then-insert window across many interleavings instead.
+        repeat(200) {
+            val hub = TaskCompletionHub()
+            val start = CountDownLatch(1)
+            val streams = ConcurrentLinkedQueue<ReceiveChannel<TaskEvent>>()
+            val subscribers = (1..12).map { i ->
+                Thread { start.await(); streams.add(hub.subscribe("p-$i")) }
+            }
+            val drainer = Thread { start.await(); hub.beginDraining(); hub.broadcastDraining() }
+            val threads = subscribers + drainer
+            threads.forEach(Thread::start)
+            start.countDown()
+            threads.forEach { it.join(5000) }
+            assertTrue(threads.none(Thread::isAlive), "no thread should be stuck (a deadlock regression)")
+
+            assertEquals(12, streams.size, "every subscribe returned a stream")
+            // Each stream must be closed — broadcast-closed if it registered before the drain, refuse-closed if
+            // it raced in after the flag. An OPEN (empty, not closed) stream is a lost subscribe that would sit
+            // on the dying instance forever.
+            streams.forEach { assertTrue(it.tryReceive().isClosed, "every stream must be closed by the drain, none left open") }
+        }
     }
 }


### PR DESCRIPTION
## What
On SIGTERM the control-plane now drains the console's task-event SSE streams alongside the proxy gRPC streams (which landed in #140). `TaskCompletionHub` gains a lock-guarded drain — refuse new subscribers, close the open ones — and on a drain-close the SSE handler sends a short `retry` so each browser's `EventSource` re-homes to the replacement CP promptly. The shutdown hook waits (bounded) for that flush before the HTTP server stops.

## Why
A rolling CP restart left open console tabs bound to the departing instance until the load balancer cut the connection. Now they re-home the same way the proxies do.

## Notes
The re-home is guaranteed by the stream *closing* (the browser reconnects, and the poll fallback covers the gap); the `retry` is a best-effort speedup. Ktor installs its own shutdown hook, so the drain must wait for the flush rather than race it — hence `awaitDrained`.

## Verify
`mise run verify` green; 12 hub tests, including a mutation-verified concurrent subscribe/drain race and the `awaitDrained` flush wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)