### PR TITLE
feat(control-plane): notification foundations (Cedar satisfiability + message catalog)

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
@@ -1,7 +1,6 @@
 package com.ridi.oss.proxymonster.controlplane.authz
 
 import com.cedarpolicy.model.AuthorizationResponse
-import com.cedarpolicy.model.entity.Entities
 import com.cedarpolicy.model.entity.Entity
 import com.cedarpolicy.value.CedarList
 import com.cedarpolicy.value.EntityTypeName
@@ -248,6 +247,68 @@ private fun dedupeByEuid(entities: List<Entity>): Set<Entity> {
 }
 
 /**
+ * The one marshalling point: the reusable actor graph a decision evaluates — [principal] carrying [roles] as
+ * parents, one entity per role, and [auxEntities] (any parents the focal resource resolves against: a
+ * datasource, the tables a column belongs to, tag entities). The focal resource itself is spliced in per
+ * call by the engine, so one graph answers for many resources.
+ *
+ * dedupeByEuid, not `.toSet()`: an auxiliary entity can repeat the SAME Role EUID the principal already
+ * carries as a parent (e.g. an `ApprovalRequest.roleName` equal to one of the principal's own roles), which
+ * cedar-java rejects as a duplicate entity ("duplicate entity entry").
+ */
+private fun marshal(principal: String, roles: Set<String>, auxEntities: List<Entity>): CedarRequest {
+    val roleEuids = roles.map { ROLE_TYPE.of(it) }
+    val principalEuid = USER_TYPE.of(principal)
+    val principalEntity = Entity(principalEuid, emptyMap(), roleEuids.toSet())
+    val roleEntities = roleEuids.map { Entity(it) }
+    return CedarRequest(principalEuid, dedupeByEuid(listOf(principalEntity) + roleEntities + auxEntities))
+}
+
+// The name-keyed resource EUID convention (docs/authz-model.md), defined once: a datasource's own NAME, then
+// its catalog identity, slash-joined. The delimiter guard at each call site (a component with '/' — or, for a
+// catalog identity, '.') denies fail-closed BEFORE this, so the join stays injective.
+private fun tableEuid(datasource: String, catalog: String, schema: String, table: String) =
+    TABLE_TYPE.of("$datasource/$catalog/$schema/$table")
+private fun columnEuid(datasource: String, catalog: String, schema: String, table: String, column: String) =
+    COLUMN_TYPE.of("$datasource/$catalog/$schema/$table/$column")
+private fun functionEuid(datasource: String, name: String) = FUNCTION_TYPE.of("$datasource/$name")
+private fun utilityEuid(datasource: String, command: String) = UTILITY_TYPE.of("$datasource/$command")
+
+/**
+ * The shared shape of the per-resource result-read gates (columns/tables/functions/utilities): build ONE
+ * shared graph for the whole batch, then decide each resource under `result.read.unmasked` / `.masked`.
+ * [build] returns each item key's focal entity plus any auxiliary parent entities (a key absent from the map
+ * — its identity had a delimiter — is [denied]); [verdict] turns a resource's (unmasked, masked) allow pair
+ * into its result, evaluated lazily so a masked check is skipped once unmasked already answered.
+ */
+private fun <V> Authz.authorizeReadResources(
+    principal: String,
+    roles: Set<String>,
+    datasource: String,
+    datasourceTags: List<String>,
+    context: AuthzContext,
+    keys: List<String>,
+    denied: V,
+    build: (dsEuid: EntityUID, tag: (String) -> EntityUID) -> Pair<Map<String, Entity>, List<Entity>>,
+    verdict: (unmasked: () -> Boolean, masked: () -> Boolean) -> V,
+): Map<String, V> {
+    val dsEuid = DATASOURCE_TYPE.of(datasource)
+    val tagEuids = HashMap<String, EntityUID>()
+    val dsEntity = datasourceEntity(dsEuid, datasource, datasourceTags, tagEuids)
+    val (focalByKey, auxEntities) = build(dsEuid) { tag -> tagEuids.getOrPut(tag) { TAG_TYPE.of(tag) } }
+    val request = marshal(principal, roles, listOf(dsEntity) + auxEntities + tagEuids.values.map { Entity(it) })
+    val contextMap = context.toCedarMap()
+    val unmasked = ACTION_TYPE.of(AuthzAction.RESULT_READ_UNMASKED.cedarId)
+    val masked = ACTION_TYPE.of(AuthzAction.RESULT_READ_MASKED.cedarId)
+    fun allows(resource: Entity, action: EntityUID) =
+        engine.isAuthorized(request, action, resource, contextMap).success.orElse(null)?.isAllowed == true
+    return keys.associateWith { key ->
+        val entity = focalByKey[key] ?: return@associateWith denied
+        verdict({ allows(entity, unmasked) }, { allows(entity, masked) })
+    }
+}
+
+/**
  * Translate a cedar-java [AuthorizationResponse] into our [AuthzDecision]: fail closed on an engine
  * error (no success payload), ALLOW iff a policy permits, else deny-by-default carrying the diagnosing
  * reasons. Shared by [Authz.authorize] and [authorizeDatasourceAction] so the two single-resource entry
@@ -295,11 +356,10 @@ class Authz(
      * verdict itself is irrelevant, only the absence of an engine ERROR is being tested.
      */
     fun evaluatesInCedar(ip: String): Boolean {
-        val principal = USER_TYPE.of("ip-probe")
-        val entities = Entities(setOf(Entity(principal, emptyMap(), emptySet())))
+        val request = marshal("ip-probe", emptySet(), emptyList())
         val context = AuthzContext(requesterIp = ip).toCedarMap()
         val response = runCatching {
-            engine.isAuthorized(principal, ACTION_TYPE.of(AuthzAction.SQL_SELECT.cedarId), SYSTEM_TYPE.of("system"), entities, context)
+            engine.isAuthorized(request, ACTION_TYPE.of(AuthzAction.SQL_SELECT.cedarId), Entity(SYSTEM_TYPE.of("system")), context)
         }.getOrNull() ?: return false
         return response.success.isPresent
     }
@@ -332,37 +392,25 @@ class Authz(
         resource: AuthzResource,
         context: AuthzContext = AuthzContext(),
     ): AuthzDecision {
-        val roleEuids = roles.map { ROLE_TYPE.of(it) }
-        val principalEuid = USER_TYPE.of(principal)
-        val principalEntity = Entity(principalEuid, emptyMap(), roleEuids.toSet())
-        val roleEntities = roleEuids.map { Entity(it) }
-
-        val (resourceEuid, resourceEntities) = marshalResource(resource)
-        val actionEuid = ACTION_TYPE.of(action.cedarId)
-        val contextMap: Map<String, Value> = context.toCedarMap()
-
-        // dedupeByEuid, not a plain .toSet(): a resource can legitimately reference the SAME Role
-        // EUID the principal already carries as a parent (e.g. ApprovalRequest.roleName equal to one
-        // of the principal's own roles) — two structurally-identical-but-distinct Entity objects for
-        // one EUID, which cedar-java rejects outright ("duplicate entity entry").
-        val entities = Entities(dedupeByEuid(listOf(principalEntity) + roleEntities + resourceEntities))
-        return engine.isAuthorized(principalEuid, actionEuid, resourceEuid, entities, contextMap).toAuthzDecision()
+        val (resourceEntity, auxEntities) = marshalResource(resource)
+        val request = marshal(principal, roles, auxEntities)
+        return engine.isAuthorized(request, ACTION_TYPE.of(action.cedarId), resourceEntity, context.toCedarMap()).toAuthzDecision()
     }
 
-    private fun marshalResource(resource: AuthzResource): Pair<EntityUID, List<Entity>> = when (resource) {
-        AuthzResource.System -> SYSTEM_TYPE.of("system") to emptyList()
+    // The focal resource entity a single-resource decision evaluates, plus any auxiliary parent entities it
+    // resolves against (a scoping datasource/role). The engine reads the focal EUID off the entity and splices
+    // it into the actor graph, so — unlike the batch gates — the resource is never threaded as a bare EUID.
+    private fun marshalResource(resource: AuthzResource): Pair<Entity, List<Entity>> = when (resource) {
+        AuthzResource.System -> Entity(SYSTEM_TYPE.of("system")) to emptyList()
 
-        is AuthzResource.AuditRecord -> {
-            val recordEuid = AUDIT_RECORD_TYPE.of(resource.principal)
-            val recordEntity = Entity(
-                recordEuid,
+        is AuthzResource.AuditRecord ->
+            Entity(
+                AUDIT_RECORD_TYPE.of(resource.principal),
                 mapOf("principal" to USER_TYPE.of(resource.principal)),
                 emptySet(),
-            )
-            recordEuid to listOf(recordEntity)
-        }
+            ) to emptyList()
 
-        AuthzResource.AuditLog -> AUDIT_LOG_TYPE.of("all") to emptyList()
+        AuthzResource.AuditLog -> Entity(AUDIT_LOG_TYPE.of("all")) to emptyList()
 
         is AuthzResource.ApprovalRequest -> {
             val requesterEuid = USER_TYPE.of(resource.requester)
@@ -384,7 +432,7 @@ class Authz(
                 resource.approver?.let { put("approver", USER_TYPE.of(it)) }
                 resource.executedBy?.let { put("executedBy", USER_TYPE.of(it)) }
             }
-            reqEuid to (listOf(Entity(reqEuid, attrs, parents)) + extraEntities)
+            Entity(reqEuid, attrs, parents) to extraEntities
         }
 
         is AuthzResource.AccessGrant -> {
@@ -402,8 +450,7 @@ class Authz(
                 extraEntities += Entity(roleEuid)
             }
             val grantEuid = ACCESS_GRANT_TYPE.of("${resource.owner}#${resource.id}")
-            val grantEntity = Entity(grantEuid, mapOf("owner" to ownerEuid), parents)
-            grantEuid to (listOf(grantEntity) + extraEntities)
+            Entity(grantEuid, mapOf("owner" to ownerEuid), parents) to extraEntities
         }
 
         is AuthzResource.Token -> {
@@ -413,7 +460,7 @@ class Authz(
                 put("owner", ownerEuid)
                 resource.kind?.let { put("kind", PrimString(it.name)) }
             }
-            tokenEuid to listOf(Entity(tokenEuid, attrs, emptySet()))
+            Entity(tokenEuid, attrs, emptySet()) to emptyList()
         }
     }
 }
@@ -451,77 +498,41 @@ fun Authz.authorizeColumns(
     // Column is `in Tag::"…"` through its Datasource parent), which is how the shipped conditional forbids
     // and preset permits reach a column.
     datasourceTags: List<String> = emptyList(),
-): Map<String, ColumnVerdict> {
-    val roleEuids = roles.map { ROLE_TYPE.of(it) }
-    val principalEuid = USER_TYPE.of(principal)
-    val principalEntity = Entity(principalEuid, emptyMap(), roleEuids.toSet())
-    val roleEntities = roleEuids.map { Entity(it) }
-
-    val dsEuid = DATASOURCE_TYPE.of(datasource)
-    val tagEuids = HashMap<String, EntityUID>()
-    val dsEntity = datasourceEntity(dsEuid, datasource, datasourceTags, tagEuids)
-
-    // EUIDs slash-join their segments — and BOTH '/' and '.' are legal INSIDE a quoted SQL identifier
-    // (the analyzer key delimits components with '.', the Cedar EUID with '/'). A delimiter inside a
-    // component would let two DISTINCT identities render to one EUID → a wrong-grant collision (e.g.
-    // schema "public/a"+table "users" vs schema "public"+table "a/users" both → ".../public/a/users").
-    // Such identifiers are pathological and a real ambiguity/injection risk, so any column whose
-    // resolved identity contains a delimiter is DENIED fail-closed (mirroring the analyzer's own
-    // rejection of dot-rendering collisions). Because delimiter-bearing identities never reach the
-    // join, the EUID slash-joins raw and stays injective.
-    fun hasDelim(s: String) = '/' in s || '.' in s
-    val tableEuids = HashMap<Triple<String, String, String>, EntityUID>()
-    val columnEuids = HashMap<String, EntityUID>()
-    val columnEntities = ArrayList<Entity>()
-    for (col in columns) {
-        if (hasDelim(datasource) || hasDelim(col.catalog) || hasDelim(col.schema) ||
-            hasDelim(col.table) || hasDelim(col.column)
-        ) {
-            continue // no EUID built → denied in the final mapping below
+): Map<String, ColumnVerdict> = authorizeReadResources(
+    principal, roles, datasource, datasourceTags, context, columns.map { it.key }, ColumnVerdict.DENIED,
+    build = { dsEuid, tag ->
+        fun hasDelim(s: String) = '/' in s || '.' in s
+        val tableEuids = HashMap<Triple<String, String, String>, EntityUID>()
+        val columnEntities = LinkedHashMap<String, Entity>()
+        for (col in columns) {
+            if (hasDelim(datasource) || hasDelim(col.catalog) || hasDelim(col.schema) ||
+                hasDelim(col.table) || hasDelim(col.column)
+            ) {
+                continue // delimiter in the identity → no entity → denied
+            }
+            val tblEuid = tableEuids.getOrPut(Triple(col.catalog, col.schema, col.table)) {
+                tableEuid(datasource, col.catalog, col.schema, col.table)
+            }
+            val colEuid = columnEuid(datasource, col.catalog, col.schema, col.table, col.column)
+            columnEntities[col.key] = Entity(colEuid, emptyMap(), (setOf(tblEuid, dsEuid) + col.tags.map(tag)).toSet())
         }
-        val tableIdentity = Triple(col.catalog, col.schema, col.table)
-        val tableEuid = tableEuids.getOrPut(tableIdentity) {
-            TABLE_TYPE.of("$datasource/${col.catalog}/${col.schema}/${col.table}")
+        // Each Table entity carries its datasource parent + its system tag, so a Column inherits the system
+        // classification through its Table parent (no second direct system tag on the column).
+        val tableEntities = tableEuids.map { (identity, euid) ->
+            val parents = mutableSetOf(dsEuid)
+            systemTags[identity]?.let { parents += tag(it) }
+            Entity(euid, emptyMap(), parents)
         }
-        val colEuid = COLUMN_TYPE.of("$datasource/${col.catalog}/${col.schema}/${col.table}/${col.column}")
-        columnEuids[col.key] = colEuid
-        val tagParents = col.tags.map { tag -> tagEuids.getOrPut(tag) { TAG_TYPE.of(tag) } }
-        columnEntities += Entity(colEuid, emptyMap(), (setOf(tableEuid, dsEuid) + tagParents).toSet())
-    }
-    // Each Table entity carries its datasource parent + its system tag, so a Column inherits
-    // the system classification through its Table parent (no second direct system tag on the column).
-    val tableEntities = tableEuids.map { (identity, euid) ->
-        val parents = mutableSetOf(dsEuid)
-        systemTags[identity]?.let { parents += tagEuids.getOrPut(it) { TAG_TYPE.of(it) } }
-        Entity(euid, emptyMap(), parents)
-    }
-    val tagEntities = tagEuids.values.map { Entity(it) }
-
-    val contextMap: Map<String, Value> = context.toCedarMap()
-    // dedupeByEuid, not a plain .toSet(): see the comment on the identical call in [authorize] — the
-    // per-column build already dedupes tables/tags among themselves, but a role name theoretically
-    // colliding with a datasource/table/tag id can't (different Cedar TYPES => different EUIDs), so
-    // this is defensive, not load-bearing, for this call specifically.
-    val entities = Entities(
-        dedupeByEuid(listOf(principalEntity, dsEntity) + roleEntities + tableEntities + tagEntities + columnEntities),
-    )
-    val unmaskedAction = ACTION_TYPE.of(AuthzAction.RESULT_READ_UNMASKED.cedarId)
-    val maskedAction = ACTION_TYPE.of(AuthzAction.RESULT_READ_MASKED.cedarId)
-
-    fun allowed(action: EntityUID, resource: EntityUID): Boolean =
-        engine.isAuthorized(principalEuid, action, resource, entities, contextMap).success.orElse(null)?.isAllowed == true
-
-    return columns.associate { col ->
-        // a column with no EUID was rejected above (a delimiter in its resolved identity) → deny-closed
-        val colEuid = columnEuids[col.key] ?: return@associate col.key to ColumnVerdict.DENIED
-        val verdict = when {
-            allowed(unmaskedAction, colEuid) -> ColumnVerdict.UNMASKED
-            allowed(maskedAction, colEuid) -> ColumnVerdict.MASKED
+        columnEntities to tableEntities
+    },
+    verdict = { unmasked, masked ->
+        when {
+            unmasked() -> ColumnVerdict.UNMASKED
+            masked() -> ColumnVerdict.MASKED
             else -> ColumnVerdict.DENIED
         }
-        col.key to verdict
-    }
-}
+    },
+)
 
 /**
  * Table-scan authz (docs/facts-emission.md). An UNCOVERED scanned table — read with zero traced
@@ -550,55 +561,25 @@ fun Authz.authorizeTables(
     // conditional forbid (`… unless resource in Tag::"system:development"`) sees an uncovered system-table scan
     // on a dev datasource through the Table's Datasource parent.
     datasourceTags: List<String> = emptyList(),
-): Map<String, TableVerdict> {
-    val roleEuids = roles.map { ROLE_TYPE.of(it) }
-    val principalEuid = USER_TYPE.of(principal)
-    val principalEntity = Entity(principalEuid, emptyMap(), roleEuids.toSet())
-    val roleEntities = roleEuids.map { Entity(it) }
-
-    val dsEuid = DATASOURCE_TYPE.of(datasource)
-    val tagEuids = HashMap<String, EntityUID>()
-    val dsEntity = datasourceEntity(dsEuid, datasource, datasourceTags, tagEuids)
-
-    // Same delimiter guard as authorizeColumns: '/' (EUID join) and '.' (analyzer key join) inside a
-    // component would let two distinct identities render to one EUID → a wrong-grant collision. Such a
-    // table builds no EUID and is DENIED below (never silently authorized).
-    fun hasDelim(s: String) = '/' in s || '.' in s
-    val tableEuids = HashMap<String, EntityUID>()
-    val tableEntities = ArrayList<Entity>()
-    for (t in tables) {
-        if (hasDelim(datasource) || hasDelim(t.catalog) || hasDelim(t.schema) || hasDelim(t.table)) {
-            continue // no EUID built → denied in the final mapping below
+): Map<String, TableVerdict> = authorizeReadResources(
+    principal, roles, datasource, datasourceTags, context, tables.map { it.key }, TableVerdict.DENIED,
+    build = { dsEuid, tag ->
+        fun hasDelim(s: String) = '/' in s || '.' in s
+        val tableEntities = LinkedHashMap<String, Entity>()
+        for (t in tables) {
+            if (hasDelim(datasource) || hasDelim(t.catalog) || hasDelim(t.schema) || hasDelim(t.table)) {
+                continue // delimiter in the identity → no entity → denied
+            }
+            tableEntities.getOrPut(t.key) {
+                val parents = mutableSetOf(dsEuid)
+                systemTags[Triple(t.catalog, t.schema, t.table)]?.let { parents += tag(it) }
+                Entity(tableEuid(datasource, t.catalog, t.schema, t.table), emptyMap(), parents)
+            }
         }
-        val euid = tableEuids.getOrPut(t.key) {
-            TABLE_TYPE.of("$datasource/${t.catalog}/${t.schema}/${t.table}")
-        }
-        val parents = mutableSetOf(dsEuid)
-        systemTags[Triple(t.catalog, t.schema, t.table)]?.let { parents += tagEuids.getOrPut(it) { TAG_TYPE.of(it) } }
-        tableEntities += Entity(euid, emptyMap(), parents)
-    }
-    val tagEntities = tagEuids.values.map { Entity(it) }
-
-    val contextMap: Map<String, Value> = context.toCedarMap()
-    val entities = Entities(
-        dedupeByEuid(listOf(principalEntity, dsEntity) + roleEntities + tableEntities + tagEntities),
-    )
-    val unmaskedAction = ACTION_TYPE.of(AuthzAction.RESULT_READ_UNMASKED.cedarId)
-    val maskedAction = ACTION_TYPE.of(AuthzAction.RESULT_READ_MASKED.cedarId)
-
-    fun allowed(action: EntityUID, resource: EntityUID): Boolean =
-        engine.isAuthorized(principalEuid, action, resource, entities, contextMap).success.orElse(null)?.isAllowed == true
-
-    return tables.associate { t ->
-        val euid = tableEuids[t.key] ?: return@associate t.key to TableVerdict.DENIED
-        val verdict = if (allowed(unmaskedAction, euid) || allowed(maskedAction, euid)) {
-            TableVerdict.READ
-        } else {
-            TableVerdict.DENIED
-        }
-        t.key to verdict
-    }
-}
+        tableEntities to emptyList<Entity>()
+    },
+    verdict = { unmasked, masked -> if (unmasked() || masked()) TableVerdict.READ else TableVerdict.DENIED },
+)
 
 /**
  * Authorize the DANGEROUS functions a query calls (facts-emission.md). Mirrors
@@ -622,52 +603,23 @@ fun Authz.authorizeFunctions(
     // The datasource's `system:*` posture tags — attached to the Datasource entity so a
     // conditional forbid can relax a dangerous function on a dev datasource through its Datasource parent.
     datasourceTags: List<String> = emptyList(),
-): Map<String, FunctionVerdict> {
-    val roleEuids = roles.map { ROLE_TYPE.of(it) }
-    val principalEuid = USER_TYPE.of(principal)
-    val principalEntity = Entity(principalEuid, emptyMap(), roleEuids.toSet())
-    val roleEntities = roleEuids.map { Entity(it) }
-
-    val dsEuid = DATASOURCE_TYPE.of(datasource)
-    val tagEuids = HashMap<String, EntityUID>()
-    val dsEntity = datasourceEntity(dsEuid, datasource, datasourceTags, tagEuids)
-
-    // Same delimiter guard as authorizeTables: '/' (EUID join) inside a component would collide two
-    // identities to one EUID. A function name with a delimiter builds no EUID and is DENIED below.
-    fun hasDelim(s: String) = '/' in s
-    val fnEuids = HashMap<String, EntityUID>()
-    val fnEntities = ArrayList<Entity>()
-    for (f in functions) {
-        if (hasDelim(datasource) || hasDelim(f.name)) {
-            continue // no EUID built → denied in the final mapping below
+): Map<String, FunctionVerdict> = authorizeReadResources(
+    principal, roles, datasource, datasourceTags, context, functions.map { it.name }, FunctionVerdict.DENIED,
+    build = { dsEuid, tag ->
+        fun hasDelim(s: String) = '/' in s
+        val fnEntities = LinkedHashMap<String, Entity>()
+        for (f in functions) {
+            if (hasDelim(datasource) || hasDelim(f.name)) continue // delimiter → no entity → denied
+            fnEntities.getOrPut(f.name) {
+                val parents = mutableSetOf(dsEuid)
+                systemTags[f.name]?.let { parents += tag(it) }
+                Entity(functionEuid(datasource, f.name), emptyMap(), parents)
+            }
         }
-        val euid = fnEuids.getOrPut(f.name) { FUNCTION_TYPE.of("$datasource/${f.name}") }
-        val parents = mutableSetOf(dsEuid)
-        systemTags[f.name]?.let { parents += tagEuids.getOrPut(it) { TAG_TYPE.of(it) } }
-        fnEntities += Entity(euid, emptyMap(), parents)
-    }
-    val tagEntities = tagEuids.values.map { Entity(it) }
-
-    val contextMap: Map<String, Value> = context.toCedarMap()
-    val entities = Entities(
-        dedupeByEuid(listOf(principalEntity, dsEntity) + roleEntities + fnEntities + tagEntities),
-    )
-    val unmaskedAction = ACTION_TYPE.of(AuthzAction.RESULT_READ_UNMASKED.cedarId)
-    val maskedAction = ACTION_TYPE.of(AuthzAction.RESULT_READ_MASKED.cedarId)
-
-    fun allowed(action: EntityUID, resource: EntityUID): Boolean =
-        engine.isAuthorized(principalEuid, action, resource, entities, contextMap).success.orElse(null)?.isAllowed == true
-
-    return functions.associate { f ->
-        val euid = fnEuids[f.name] ?: return@associate f.name to FunctionVerdict.DENIED
-        val verdict = if (allowed(unmaskedAction, euid) || allowed(maskedAction, euid)) {
-            FunctionVerdict.ALLOWED
-        } else {
-            FunctionVerdict.DENIED
-        }
-        f.name to verdict
-    }
-}
+        fnEntities to emptyList<Entity>()
+    },
+    verdict = { unmasked, masked -> if (unmasked() || masked()) FunctionVerdict.ALLOWED else FunctionVerdict.DENIED },
+)
 
 /**
  * Authorize the resource-bearing UTILITY commands a query performs (facts-emission.md). Mirrors
@@ -689,50 +641,23 @@ fun Authz.authorizeUtilities(
     context: AuthzContext = AuthzContext(),
     systemTags: Map<String, String> = emptyMap(),
     datasourceTags: List<String> = emptyList(),
-): Map<String, UtilityVerdict> {
-    val roleEuids = roles.map { ROLE_TYPE.of(it) }
-    val principalEuid = USER_TYPE.of(principal)
-    val principalEntity = Entity(principalEuid, emptyMap(), roleEuids.toSet())
-    val roleEntities = roleEuids.map { Entity(it) }
-
-    val dsEuid = DATASOURCE_TYPE.of(datasource)
-    val tagEuids = HashMap<String, EntityUID>()
-    val dsEntity = datasourceEntity(dsEuid, datasource, datasourceTags, tagEuids)
-
-    fun hasDelim(s: String) = '/' in s
-    val utilEuids = HashMap<String, EntityUID>()
-    val utilEntities = ArrayList<Entity>()
-    for (u in utilities) {
-        if (hasDelim(datasource) || hasDelim(u.command)) {
-            continue // no EUID built → denied in the final mapping below
+): Map<String, UtilityVerdict> = authorizeReadResources(
+    principal, roles, datasource, datasourceTags, context, utilities.map { it.command }, UtilityVerdict.DENIED,
+    build = { dsEuid, tag ->
+        fun hasDelim(s: String) = '/' in s
+        val utilEntities = LinkedHashMap<String, Entity>()
+        for (u in utilities) {
+            if (hasDelim(datasource) || hasDelim(u.command)) continue // delimiter → no entity → denied
+            utilEntities.getOrPut(u.command) {
+                val parents = mutableSetOf(dsEuid)
+                systemTags[u.command]?.let { parents += tag(it) }
+                Entity(utilityEuid(datasource, u.command), emptyMap(), parents)
+            }
         }
-        val euid = utilEuids.getOrPut(u.command) { UTILITY_TYPE.of("$datasource/${u.command}") }
-        val parents = mutableSetOf(dsEuid)
-        systemTags[u.command]?.let { parents += tagEuids.getOrPut(it) { TAG_TYPE.of(it) } }
-        utilEntities += Entity(euid, emptyMap(), parents)
-    }
-    val tagEntities = tagEuids.values.map { Entity(it) }
-
-    val contextMap: Map<String, Value> = context.toCedarMap()
-    val entities = Entities(
-        dedupeByEuid(listOf(principalEntity, dsEntity) + roleEntities + utilEntities + tagEntities),
-    )
-    val unmaskedAction = ACTION_TYPE.of(AuthzAction.RESULT_READ_UNMASKED.cedarId)
-    val maskedAction = ACTION_TYPE.of(AuthzAction.RESULT_READ_MASKED.cedarId)
-
-    fun allowed(action: EntityUID, resource: EntityUID): Boolean =
-        engine.isAuthorized(principalEuid, action, resource, entities, contextMap).success.orElse(null)?.isAllowed == true
-
-    return utilities.associate { u ->
-        val euid = utilEuids[u.command] ?: return@associate u.command to UtilityVerdict.DENIED
-        val verdict = if (allowed(unmaskedAction, euid) || allowed(maskedAction, euid)) {
-            UtilityVerdict.USE
-        } else {
-            UtilityVerdict.DENIED
-        }
-        u.command to verdict
-    }
-}
+        utilEntities to emptyList<Entity>()
+    },
+    verdict = { unmasked, masked -> if (unmasked() || masked()) UtilityVerdict.USE else UtilityVerdict.DENIED },
+)
 
 /**
  * The two once-per-query gates ahead of the catalog/analyzer/column loop (docs/authz-model.md:
@@ -755,18 +680,14 @@ fun Authz.authorizeDatasourceAction(
     // this datasource. A datasource-level action's resource IS the Datasource, so its own tag parent suffices.
     datasourceTags: List<String> = emptyList(),
 ): AuthzDecision {
-    val principalEuid = USER_TYPE.of(principal)
-    val principalEntity = Entity(principalEuid, emptyMap(), roles.map { ROLE_TYPE.of(it) }.toSet())
-    val roleEntities = roles.map { Entity(ROLE_TYPE.of(it)) }
-
     val dsEuid = DATASOURCE_TYPE.of(datasource)
     val tagEuids = HashMap<String, EntityUID>()
     val dsEntity = datasourceEntity(dsEuid, datasource, datasourceTags, tagEuids)
     val tagEntities = tagEuids.values.map { Entity(it) }
 
     val contextMap: Map<String, Value> = context.toCedarMap()
-    val entities = Entities(dedupeByEuid(listOf(principalEntity, dsEntity) + roleEntities + tagEntities))
-    return engine.isAuthorized(principalEuid, ACTION_TYPE.of(action.cedarId), dsEuid, entities, contextMap).toAuthzDecision()
+    val request = marshal(principal, roles, tagEntities)
+    return engine.isAuthorized(request, ACTION_TYPE.of(action.cedarId), dsEntity, contextMap).toAuthzDecision()
 }
 
 /**
@@ -793,22 +714,18 @@ fun Authz.resolveContextTags(
     val vocab = engine.contextTagVocabulary()
     if (vocab.isEmpty()) return emptySet()
 
-    val principalEuid = USER_TYPE.of(principal)
-    val principalEntity = Entity(principalEuid, emptyMap(), roles.map { ROLE_TYPE.of(it) }.toSet())
-    val roleEntities = roles.map { Entity(ROLE_TYPE.of(it)) }
-
     val dsEuid = DATASOURCE_TYPE.of(datasource)
     val tagEuids = HashMap<String, EntityUID>()
     val dsEntity = datasourceEntity(dsEuid, datasource, datasourceTags, tagEuids)
     val tagEntities = tagEuids.values.map { Entity(it) }
 
-    val entities = Entities(dedupeByEuid(listOf(principalEntity, dsEntity) + roleEntities + tagEntities))
+    val request = marshal(principal, roles, tagEntities)
     // includeTags = false: pass-1 must not expose `tags` at all (no tag-on-tag). The generated tag-action
     // schema also omits it, so a rule reading context.tags won't validate; omitting it here closes the eval side.
     val contextMap: Map<String, Value> = rawContext.toCedarMap(includeTags = false)
 
     return vocab.filterTo(sortedSetOf()) { tag ->
-        engine.isAuthorized(principalEuid, ACTION_TYPE.of("context.tag::$tag"), dsEuid, entities, contextMap)
+        engine.isAuthorized(request, ACTION_TYPE.of("context.tag::$tag"), dsEntity, contextMap)
             .success.orElse(null)?.isAllowed == true
     }
 }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
@@ -7,6 +7,7 @@ import com.cedarpolicy.value.EntityTypeName
 import com.cedarpolicy.value.EntityUID
 import com.cedarpolicy.value.IpAddress
 import com.cedarpolicy.value.PrimString
+import com.cedarpolicy.value.Unknown
 import com.cedarpolicy.value.Value
 import com.ridi.oss.proxymonster.controlplane.ApiError
 import com.ridi.oss.proxymonster.controlplane.Config
@@ -362,6 +363,33 @@ class Authz(
             engine.isAuthorized(request, ACTION_TYPE.of(AuthzAction.SQL_SELECT.cedarId), Entity(SYSTEM_TYPE.of("system")), context)
         }.getOrNull() ?: return false
         return response.success.isPresent
+    }
+
+    /**
+     * Could this principal EVER be authorized, with some request attributes not yet knowable? Strictly weaker
+     * than [authorizeAs] and MUST NEVER gate access — it exists only to route notifications, where the
+     * recipient's address is unknowable until they act (docs/notifications.md). Every real action still runs
+     * the full decision.
+     *
+     * [unknownContextKeys] are marked UNKNOWN, not omitted: an absent attribute makes a conditioning policy
+     * deny and would silently drop a principal who could in fact act. Only the verdict is read — anything
+     * short of a definite Deny is a genuine maybe, so an undecided forbid does not skip a real candidate.
+     */
+    fun satisfiableAs(
+        principal: String,
+        roles: Set<String>,
+        action: AuthzAction,
+        resource: AuthzResource,
+        knownChannel: String? = null,
+        unknownContextKeys: Set<String> = emptySet(),
+    ): SatisfiableVerdict {
+        val (resourceEntity, auxEntities) = marshalResource(resource)
+        val request = marshal(principal, roles, auxEntities)
+        val context = buildMap<String, Value> {
+            knownChannel?.let { put("channel", PrimString(it)) }
+            unknownContextKeys.forEach { put(it, Unknown(it)) }
+        }
+        return engine.satisfiable(request, ACTION_TYPE.of(action.cedarId), resourceEntity, context)
     }
 
     /**

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/CedarEngine.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/CedarEngine.kt
@@ -5,6 +5,7 @@ import com.cedarpolicy.model.AuthorizationRequest
 import com.cedarpolicy.model.AuthorizationResponse
 import com.cedarpolicy.model.ValidationRequest
 import com.cedarpolicy.model.entity.Entities
+import com.cedarpolicy.model.entity.Entity
 import com.cedarpolicy.model.exception.AuthException
 import com.cedarpolicy.model.policy.Policy
 import com.cedarpolicy.model.policy.PolicySet
@@ -74,6 +75,15 @@ fun contextTagLint(enabledSources: List<Pair<Long, String>>): List<String> {
         }
     }
 }
+
+/** The reusable half of a decision: the [principal] and the shared [entities] graph (its roles plus any
+ *  auxiliary parents). The focal resource is spliced in per call by [CedarEngine.isAuthorized], which reads
+ *  its EUID off the entity — so one graph answers for many resources (the per-column/table/function batches
+ *  build it once). */
+internal data class CedarRequest(
+    val principal: EntityUID,
+    val entities: Set<Entity>,
+)
 
 object CedarSchema {
     private const val RESOURCE_PATH = "/authz/schema.cedarschema"
@@ -245,14 +255,17 @@ class CedarEngine private constructor(private val sources: () -> List<Pair<Long,
         return cachedVocab
     }
 
-    fun isAuthorized(
-        principal: EntityUID,
+    internal fun isAuthorized(
+        request: CedarRequest,
         action: EntityUID,
-        resource: EntityUID,
-        entities: Entities,
+        resource: Entity,
         context: Map<String, Value> = emptyMap(),
     ): AuthorizationResponse =
-        CedarSchema.isAuthorized(AuthorizationRequest(principal, action, resource, context), policySet(), entities)
+        CedarSchema.isAuthorized(
+            AuthorizationRequest(request.principal, action, resource.getEUID(), context),
+            policySet(),
+            Entities(request.entities + resource),
+        )
 
     /** Parse+validate a single candidate policy against the schema; see [CedarSchema.validate]. */
     fun validate(cedarSrc: String): List<String> = CedarSchema.validate(cedarSrc)

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/CedarEngine.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/CedarEngine.kt
@@ -3,6 +3,8 @@ package com.ridi.oss.proxymonster.controlplane.authz
 import com.cedarpolicy.BasicAuthorizationEngine
 import com.cedarpolicy.model.AuthorizationRequest
 import com.cedarpolicy.model.AuthorizationResponse
+import com.cedarpolicy.model.PartialAuthorizationRequest
+import com.cedarpolicy.model.PartialAuthorizationResponse
 import com.cedarpolicy.model.ValidationRequest
 import com.cedarpolicy.model.entity.Entities
 import com.cedarpolicy.model.entity.Entity
@@ -76,6 +78,20 @@ fun contextTagLint(enabledSources: List<Pair<Long, String>>): List<String> {
     }
 }
 
+/**
+ * Whether a request COULD be authorized once the unknowns are filled in — the answer to a partial
+ * evaluation ([CedarEngine.satisfiable]). Strictly weaker than an authorization decision and never a gate:
+ * it decides only who is told something is waiting.
+ */
+enum class SatisfiableVerdict {
+    /** Allowed regardless of how the unknowns resolve. */
+    ALLOWED,
+    /** Undecided: some assignment of the unknowns would allow it. */
+    POSSIBLE,
+    /** Denied under every assignment. */
+    IMPOSSIBLE,
+}
+
 /** The reusable half of a decision: the [principal] and the shared [entities] graph (its roles plus any
  *  auxiliary parents). The focal resource is spliced in per call by [CedarEngine.isAuthorized], which reads
  *  its EUID off the entity — so one graph answers for many resources (the per-column/table/function batches
@@ -146,6 +162,13 @@ object CedarSchema {
 
     fun isAuthorized(request: AuthorizationRequest, policies: PolicySet, entities: Entities): AuthorizationResponse =
         engine.isAuthorized(request, policies, entities)
+
+    /** Partial evaluation — see [CedarEngine.satisfiable]. Experimental upstream; used only for routing. */
+    fun isAuthorizedPartial(
+        request: PartialAuthorizationRequest,
+        policies: PolicySet,
+        entities: Entities,
+    ): PartialAuthorizationResponse = engine.isAuthorizedPartial(request, policies, entities)
 
     /**
      * Parse+validate a single candidate Cedar policy against the schema, independent of any other
@@ -266,6 +289,43 @@ class CedarEngine private constructor(private val sources: () -> List<Pair<Long,
             policySet(),
             Entities(request.entities + resource),
         )
+
+    /**
+     * Ask whether SOME assignment of the unknowns in [context] would authorize this request — Cedar's partial
+     * evaluation ([com.cedarpolicy.value.Unknown] values), used only by notification routing.
+     *
+     * Read the VERDICT, never the residual's contents. Cedar returns a definite Deny when a forbid fires
+     * under every assignment, so anything short of Deny is a genuine maybe. Inspecting which policies stayed
+     * unresolved and treating an undecided forbid as denying would skip every candidate whenever a
+     * restriction is written as a forbid over the unknown axis.
+     *
+     * Partial evaluation is upstream-experimental, so a failure here degrades to [SatisfiableVerdict.POSSIBLE]
+     * rather than propagating: this decides only who is TOLD something is waiting, and every real action runs
+     * the ordinary full evaluation. Failing the other way would silently drop recipients.
+     */
+    internal fun satisfiable(
+        request: CedarRequest,
+        action: EntityUID,
+        resource: Entity,
+        context: Map<String, Value> = emptyMap(),
+    ): SatisfiableVerdict {
+        val response = runCatching {
+            CedarSchema.isAuthorizedPartial(
+                PartialAuthorizationRequest.builder()
+                    .principal(request.principal).action(action).resource(resource.getEUID()).context(context).build(),
+                policySet(),
+                Entities(request.entities + resource),
+            )
+        }.getOrElse { return SatisfiableVerdict.POSSIBLE }
+
+        val success = response.success.orElse(null) ?: return SatisfiableVerdict.POSSIBLE
+        return when (success.decision?.toString()) {
+            "Deny" -> SatisfiableVerdict.IMPOSSIBLE
+            "Allow" -> SatisfiableVerdict.ALLOWED
+            // No decision: a residual remains, so some assignment of the unknowns could still allow it.
+            else -> SatisfiableVerdict.POSSIBLE
+        }
+    }
 
     /** Parse+validate a single candidate policy against the schema; see [CedarSchema.validate]. */
     fun validate(cedarSrc: String): List<String> = CedarSchema.validate(cedarSrc)

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/i18n/MessageCatalog.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/i18n/MessageCatalog.kt
@@ -1,0 +1,51 @@
+package com.ridi.oss.proxymonster.controlplane.i18n
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * The control plane's server-side message catalog (docs/l10n.md).
+ *
+ * Everywhere the console can translate for us, the server returns a stable error CODE. A message the server
+ * itself renders — a Slack DM today, an email next — has no browser to do that, so it is localized here. One
+ * catalog per domain, loaded from `resources/messages/<locale>/<domain>.json` and keyed by dot path.
+ * Interpolation is plain `{name}` substitution; no ICU, because nothing here needs plurals or gender.
+ */
+class MessageCatalog(
+    private val domain: String,
+    private val defaultLocale: String = FALLBACK,
+    private val catalogs: Map<String, JsonObject> = load(domain),
+) {
+    /** [key] in [locale], falling back to the default locale, then English, then the key itself. */
+    fun text(key: String, locale: String, params: Map<String, String> = emptyMap()): String {
+        val raw = lookup(locale, key) ?: lookup(defaultLocale, key) ?: lookup(FALLBACK, key) ?: return key
+        return params.entries.fold(raw) { acc, (k, v) -> acc.replace("{$k}", v) }
+    }
+
+    private fun lookup(locale: String, key: String): String? {
+        var node = catalogs[locale] ?: return null
+        val parts = key.split('.')
+        for ((i, part) in parts.withIndex()) {
+            val child = node[part] ?: return null
+            if (i == parts.lastIndex) return (child as? JsonPrimitive)?.let { runCatching { it.content }.getOrNull() }
+            node = runCatching { child.jsonObject }.getOrNull() ?: return null
+        }
+        return null
+    }
+
+    companion object {
+        const val FALLBACK = "en"
+
+        /** The locales every domain must provide a file for — the l10n invariant is enforced by [load]. */
+        val LOCALES = listOf("en", "ko")
+
+        private fun load(domain: String): Map<String, JsonObject> = LOCALES.associateWith { locale ->
+            val path = "/messages/$locale/$domain.json"
+            val text = MessageCatalog::class.java.getResourceAsStream(path)?.bufferedReader()?.use { it.readText() }
+                ?: error("i18n: $path is missing from the classpath")
+            Json.parseToJsonElement(text).jsonObject
+        }
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/authz/AuthzSatisfiableTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/authz/AuthzSatisfiableTest.kt
@@ -1,0 +1,117 @@
+package com.ridi.oss.proxymonster.controlplane.authz
+
+import java.sql.Connection
+import java.util.logging.Logger
+import javax.sql.DataSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The satisfiability primitive that notification routing rests on, proven at the Cedar-decision level with an
+ * in-memory policy set — no DB. The two properties that matter: an unknown attribute is marked UNKNOWN (so a
+ * conditioned permit stays a maybe instead of dropping a real approver), and only the verdict is read (so an
+ * undecided forbid is not mistaken for a deny). [AuthzTest] uses the same off-Docker construction.
+ */
+class AuthzSatisfiableTest {
+    private object UnusedDataSource : DataSource {
+        override fun getConnection(): Connection = error("not used")
+        override fun getConnection(username: String?, password: String?): Connection = error("not used")
+        override fun getLogWriter() = error("not used")
+        override fun setLogWriter(out: java.io.PrintWriter?) = error("not used")
+        override fun setLoginTimeout(seconds: Int) = error("not used")
+        override fun getLoginTimeout() = error("not used")
+        override fun getParentLogger(): Logger = error("not used")
+        override fun <T : Any?> unwrap(iface: Class<T>?): T = error("not used")
+        override fun isWrapperFor(iface: Class<*>?): Boolean = false
+    }
+
+    private val approve = AuthzAction.TASK_APPROVE
+    private val resource = AuthzResource.ApprovalRequest(requester = "someone@example.com", datasourceName = "prod-db")
+
+    private fun authz(vararg policies: String): Authz {
+        val engine = CedarEngine(policies.mapIndexed { i, src -> (i + 1).toLong() to src })
+        return Authz(engine, CedarPolicyStore(UnusedDataSource), RoleSource { emptySet() })
+    }
+
+    private fun Authz.verdict(
+        roles: Set<String>,
+        channel: String? = null,
+        unknown: Set<String> = emptySet(),
+    ) = satisfiableAs("bob@example.com", roles, approve, resource, knownChannel = channel, unknownContextKeys = unknown)
+
+    @Test
+    fun `an unconditional permit is ALLOWED regardless of the unknowns`() {
+        val authz = authz("""permit(principal in Role::"approver", action == Action::"task.approve", resource);""")
+        assertEquals(
+            SatisfiableVerdict.ALLOWED,
+            authz.verdict(setOf("approver"), unknown = setOf("requester_ip")),
+            "nothing the permit reads is unknown, so it allows under every assignment",
+        )
+    }
+
+    @Test
+    fun `no matching permit is IMPOSSIBLE`() {
+        val authz = authz("""permit(principal in Role::"approver", action == Action::"task.approve", resource);""")
+        assertEquals(
+            SatisfiableVerdict.IMPOSSIBLE,
+            authz.verdict(setOf("some-other-role")),
+            "a principal no permit covers is denied under every assignment",
+        )
+    }
+
+    @Test
+    fun `a permit conditioned on an UNKNOWN attribute is POSSIBLE`() {
+        val authz = authz(
+            """permit(principal in Role::"office-approver", action == Action::"task.approve", resource)
+               when { context has requester_ip && context.requester_ip.isInRange(ip("10.0.0.0/8")) };""",
+        )
+        assertEquals(
+            SatisfiableVerdict.POSSIBLE,
+            authz.verdict(setOf("office-approver"), unknown = setOf("requester_ip")),
+            "some address would satisfy the permit, so the approver must be told",
+        )
+    }
+
+    /** The property the UNKNOWN marking exists for: omitting the attribute drops a real approver. */
+    @Test
+    fun `omitting the attribute the permit reads makes it IMPOSSIBLE — the bug UNKNOWN prevents`() {
+        val authz = authz(
+            """permit(principal in Role::"office-approver", action == Action::"task.approve", resource)
+               when { context has requester_ip && context.requester_ip.isInRange(ip("10.0.0.0/8")) };""",
+        )
+        assertEquals(
+            SatisfiableVerdict.IMPOSSIBLE,
+            authz.verdict(setOf("office-approver"), unknown = emptySet()),
+            "absent requester_ip makes `context has requester_ip` false, so the permit never fires",
+        )
+    }
+
+    @Test
+    fun `a known channel is supplied concretely and decides the permit`() {
+        val authz = authz(
+            """permit(principal in Role::"approver", action == Action::"task.approve", resource)
+               when { context has channel && context.channel == "slack" };""",
+        )
+        assertEquals(SatisfiableVerdict.ALLOWED, authz.verdict(setOf("approver"), channel = "slack"))
+        assertEquals(
+            SatisfiableVerdict.IMPOSSIBLE,
+            authz.verdict(setOf("approver"), channel = "editor"),
+            "the permit is fully decided against a concrete channel; the wrong one denies",
+        )
+    }
+
+    /** Reading only the verdict: an undecided forbid over the unknown axis is not a deny. */
+    @Test
+    fun `an undecided forbid does not make a permitted principal IMPOSSIBLE`() {
+        val authz = authz(
+            """permit(principal in Role::"approver", action == Action::"task.approve", resource);""",
+            """forbid(principal, action == Action::"task.approve", resource)
+               when { context has requester_ip && !context.requester_ip.isInRange(ip("10.0.0.0/8")) };""",
+        )
+        assertEquals(
+            SatisfiableVerdict.POSSIBLE,
+            authz.verdict(setOf("approver"), unknown = setOf("requester_ip")),
+            "the forbid is undecided under an unknown address; treating it as a deny would skip a real approver",
+        )
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/i18n/MessageCatalogTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/i18n/MessageCatalogTest.kt
@@ -1,0 +1,43 @@
+package com.ridi.oss.proxymonster.controlplane.i18n
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The server-side message catalog, against fixture domains under `test/resources/messages/<locale>/`. No DB.
+ */
+class MessageCatalogTest {
+    private val catalog = MessageCatalog(domain = "test-catalog")
+
+    @Test
+    fun `looks up a key and interpolates named params`() {
+        assertEquals("Hello Sam", catalog.text("greeting", "en", mapOf("name" to "Sam")))
+        assertEquals("안녕 Sam", catalog.text("greeting", "ko", mapOf("name" to "Sam")))
+    }
+
+    @Test
+    fun `resolves a nested dot path`() {
+        assertEquals("deep-ko", catalog.text("nested.deep", "ko"))
+    }
+
+    @Test
+    fun `falls back to the default locale for a key a locale is missing`() {
+        assertEquals("english only", catalog.text("only_en", "ko"), "ko lacks the key, so it falls to en")
+    }
+
+    @Test
+    fun `an unknown locale falls back to the default`() {
+        assertEquals("Hello X", catalog.text("greeting", "fr", mapOf("name" to "X")))
+    }
+
+    @Test
+    fun `an unknown key returns the key itself rather than throwing`() {
+        assertEquals("no.such.key", catalog.text("no.such.key", "en"))
+    }
+
+    @Test
+    fun `a missing domain file fails fast`() {
+        val error = runCatching { MessageCatalog(domain = "does-not-exist") }.exceptionOrNull()
+        assertEquals(true, error is IllegalStateException, "the l10n invariant is fail-fast, not silent")
+    }
+}

--- a/control-plane/src/test/resources/messages/en/test-catalog.json
+++ b/control-plane/src/test/resources/messages/en/test-catalog.json
@@ -1,0 +1,7 @@
+{
+  "greeting": "Hello {name}",
+  "nested": {
+    "deep": "deep-en"
+  },
+  "only_en": "english only"
+}

--- a/control-plane/src/test/resources/messages/ko/test-catalog.json
+++ b/control-plane/src/test/resources/messages/ko/test-catalog.json
@@ -1,0 +1,6 @@
+{
+  "greeting": "안녕 {name}",
+  "nested": {
+    "deep": "deep-ko"
+  }
+}


### PR DESCRIPTION
The control-plane groundwork the Slack notification layer builds on, split out so it lands and reviews on its own. Three self-contained commits:

1. **refactor(authz): one marshalling path for every Cedar decision** — collapse the entity-graph construction each `authorize*` path built by hand. `CedarRequest` is the reusable actor graph (principal + roles + auxiliary parents); the engine takes the focal `Entity`, reads its EUID off it, and splices it in — so one graph answers for a whole query's columns. The four batch gates share `authorizeReadResources`; EUID construction lives in one place. Pure refactor of pre-existing code, behavior unchanged.
2. **feat(authz): a Cedar satisfiability verdict** — `satisfiableAs` answers "could this principal *ever* be authorized, once unknown request attributes are filled in?" via Cedar partial evaluation. It exists only to route notifications ("who could approve"); it is never a gate, and every real action still runs the full decision.
3. **feat(control-plane): a server-side message catalog** — `MessageCatalog` renders locale prose from `resources/messages/<locale>/<domain>.json`, the CP-side i18n the notification renderer uses.

Traps worth knowing:
- Satisfiability reads only the partial-eval **verdict** — anything short of a definite Deny is a genuine maybe — and degrades to `POSSIBLE` on engine error. Failing the other way would silently drop a valid recipient.
- The engine splices the focal resource into the shared graph per call; its EUID is never threaded separately, so a resource's identity has exactly one source (the entity).

Verification: full `mise run verify` green.
