### PR TITLE
feat(control-plane): Slack task-approval notifications

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -199,6 +199,7 @@ deliberately never inferred from request headers.
 | MCP / AI client → CP | HTTPS · `/mcp` `/oauth/*` | via edge | OAuth 2.1 server + MCP resource (only if MCP used) |
 | CP → control-plane store | SQL · PostgreSQL 5432 | internal | system of record (r/w) |
 | CP → OIDC IdP | HTTPS | outbound | discovery + token exchange |
+| CP → Slack | HTTPS + WSS | outbound | task notifications; Socket Mode carries button clicks back (only when `PM_SLACK_*` is set) |
 | auditmon → control-plane store | SQL · PostgreSQL 5432 (read-only) | internal | read the audit chain |
 | auditmon → WORM / KMS | HTTPS | outbound | WORM export + anchor signing · alert webhooks |
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -110,6 +110,25 @@ configured per proxy under `PM_TARGET_*`.
   lifetimes (seconds). Defaults `600` · `21600`.
 - `PM_SCIM_TOKEN` — _optional_. SCIM provisioning bearer (OIDC just-in-time is
   the default).
+- `PM_SLACK_BOT_TOKEN` / `PM_SLACK_APP_TOKEN` — _optional_. Slack notifications
+  for the approval workflow ([docs/notifications.md](./docs/notifications.md)).
+  The bot token (`xoxb-`) authorizes the Web API and the app token (`xapp-`)
+  opens the Socket Mode WebSocket. The workspace whose button clicks are honored
+  is derived from the bot token itself (`auth.test`), not configured — a token
+  belongs to exactly one workspace. **Both tokens are required** — either absent
+  leaves the whole layer inert and the workflow unchanged, never a
+  half-configured mode. Socket Mode means the CP dials out; no inbound ingress
+  is added. Set `PM_WEB_ORIGIN` too, or the message's "open request" link points
+  at the control plane rather than the console.
+- `PM_NOTIFY_STATEMENT` / `PM_NOTIFY_STATEMENT_MAX` — _optional_. How much of a
+  requester's SQL a notification may carry: `truncated` (default, first
+  `PM_NOTIFY_STATEMENT_MAX` characters, default `200`), `full`, or `omit`. A
+  statement's literals can be the very values a policy protects — masking acts
+  on results, not predicates — so `omit` is the setting for data that must not
+  leave in query text. Approve-and-run is offered only when the message carries
+  the whole statement, whatever the mode.
+- `PM_NOTIFY_LOCALE` — _optional_. Fallback language (`en` · `ko`) for a
+  recipient who has not set one in the console. Default `en`.
 - `PM_AUTH_DEBUG` / `PM_DEV` / `PM_OAUTH_DEBUG_AUTO_CONSENT` — _dev-only_.
   Defaults: `PM_AUTH_DEBUG=true`, `PM_DEV=false`,
   `PM_OAUTH_DEBUG_AUTO_CONSENT=true`. The CP refuses to boot when debug auth is

--- a/control-plane/build.gradle.kts
+++ b/control-plane/build.gradle.kts
@@ -81,6 +81,10 @@ dependencies {
     // Route-level gate tests (requireAdmin wired into cedarPolicyRoutes) exercise real Ktor routing.
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
     testImplementation("io.modelcontextprotocol:kotlin-sdk-client:$mcpVersion")
+    // The mock Slack server the transport/socket tests run against is a real embedded server on an ephemeral
+    // port, so they exercise their true wire encoding (form vs JSON, the Socket Mode WebSocket). Netty is
+    // already on the main classpath; only the server-side WebSockets plugin is test-only.
+    testImplementation("io.ktor:ktor-server-websockets:$ktorVersion")
     // DB-backed tests run enforcement/stores against real MySQL + Postgres via Testcontainers.
     // Containers are launched once and reused across the module's tests (see support/TestDatabases.kt).
     testImplementation("org.testcontainers:testcontainers:$testcontainersVersion")

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Access.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Access.kt
@@ -152,6 +152,9 @@ class AccessStore(private val dataSource: DataSource) {
         // Carried on the shared access_request row; not consumed by the query-approval flow (see
         // CreateApprovalInput.requestedDurationSec). Kept for the column the ROLE-elevation path needs.
         requestedDurationSec: Long = 3600,
+        // Queues the "needs approval" notification in the SAME transaction as the insert, so a crash can
+        // never leave a request pending with nobody told. No-op when notifications are not configured.
+        onCreated: ((Connection, Long) -> Unit)? = null,
         // Set on the audited create path (the /api/approvals routes); null on internal/test seeds. When both
         // are present the created request is recorded as a TASK_REQUEST on the insert's transaction.
         actor: AuditActor? = null,
@@ -204,6 +207,7 @@ class AccessStore(private val dataSource: DataSource) {
                     "open query request #$taskId under role '${executeAs.firstOrNull()}'",
                 )
             }
+            onCreated?.invoke(c, taskId)
             taskId
         }
         return getRequest(id)!!
@@ -387,8 +391,12 @@ class AccessStore(private val dataSource: DataSource) {
         decidedBy: String,
         actor: AuditActor,
         recorder: ManagementAuditRecorder,
+        // Queues the decision notification in the SAME transaction as the transition, so a crash can never
+        // leave a request decided with nobody told. No-op when the notification layer is not configured.
+        onDecided: ((Connection, AccessRequest) -> Unit)? = null,
     ): AccessRequest? {
-        val roleName = getRequest(id)?.roleName
+        val before = getRequest(id)
+        val roleName = before?.roleName
         val won = dataSource.inTx { c ->
             decideQueryRequest(id, approved, rejectionReason, decidedBy, c).also { transitioned ->
                 if (transitioned) {
@@ -396,6 +404,18 @@ class AccessStore(private val dataSource: DataSource) {
                         c, actor, AuthzAction.TASK_APPROVE, auditEntity("AccessRequest", id.toString()),
                         if (approved) "approve query request #$id under role '$roleName'" else "reject query request #$id",
                     )
+                    // The row the hook sees carries the decision that just landed: the pre-read plus the
+                    // fields this transaction set, since the UPDATE is not visible to another connection yet.
+                    before?.let { prior ->
+                        onDecided?.invoke(
+                            c,
+                            prior.copy(
+                                status = if (approved) "APPROVED" else "REJECTED",
+                                decidedBy = decidedBy,
+                                rejectionReason = rejectionReason,
+                            ),
+                        )
+                    }
                 }
             }
         }
@@ -796,7 +816,8 @@ fun Route.accessRoutes(
                     requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
                     datasourceName = req.datasourceName, roleName = req.roleName,
                 ),
-                call.httpAuthzContext(config), req.datasourceName,
+                call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
+                req.datasourceName,
                 req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
             )
             if (decision is AuthzDecision.Deny) {
@@ -827,7 +848,8 @@ fun Route.accessRoutes(
                     requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
                     datasourceName = req.datasourceName, roleName = req.roleName,
                 ),
-                call.httpAuthzContext(config), req.datasourceName,
+                call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
+                req.datasourceName,
                 req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
             )
             if (decision is AuthzDecision.Deny) {

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -14,6 +14,7 @@ import com.ridi.oss.proxymonster.controlplane.management.AuditSource
 import com.ridi.oss.proxymonster.controlplane.management.DatasourceManagementService
 import com.ridi.oss.proxymonster.controlplane.management.IdentityManagementService
 import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
+import com.ridi.oss.proxymonster.controlplane.notify.installNotifications
 import com.ridi.oss.proxymonster.controlplane.management.ManagementException
 import com.ridi.oss.proxymonster.controlplane.management.PolicyManagementService
 import com.ridi.oss.proxymonster.controlplane.management.auditEntity
@@ -389,6 +390,13 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
     // is refused fail-closed (no plaintext PII persisted).
     val queryResultStore = resultCrypto?.let { QueryResultStore(dataSource, it) }
 
+    // Out-of-band task notifications (docs/notifications.md): the outbox drain and, when Slack is
+    // configured, the inbound Socket Mode connection. Null and inert when no transport is configured.
+    val notifications = installNotifications(
+        config, dataSource, authz, roleResolver, accessStore, datasourceStore,
+        queryResultStore, store, runExecService, taskCompletionHub,
+    )
+
     // OIDC (docs/auth-model.md): provider-agnostic via discovery, so any OIDC IdP works. `discovery`/
     // `validator` are null when `config.oidc` is unset — every consumer degrades gracefully (501),
     // never NPEs. Device-authorization reuses this SAME confidential client (no separate CLI client).
@@ -441,6 +449,7 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
                 .onFailure { environment.log.warn("connection catalog idle sweep failed", it) }
         }
     }
+
 
     // Timer-driven IdP liveness is the sole revalidator for web and daemon sessions. A rejected
     // refresh token retires only its own session; transient failures preserve the cached state.
@@ -674,6 +683,7 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
         approvalRoutes(
             config, accessStore, store, datasourceStore, policyStore, userGroupStore, queryResultStore,
             roleResolver, authz, runExecService, this@module, core.systemClassification, taskCompletionHub,
+            notifications,
         )
 
         // Enforcing SQL query endpoint (deny + result masking; effective roles come from RoleResolver).

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
@@ -9,6 +9,8 @@ import com.ridi.oss.proxymonster.controlplane.authz.authorizeDatasourceAction
 import com.ridi.oss.proxymonster.controlplane.authz.authorizeWithContext
 import com.ridi.oss.proxymonster.controlplane.authz.resolveContextTags
 import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
+import com.ridi.oss.proxymonster.controlplane.notify.NotificationEvent
+import com.ridi.oss.proxymonster.controlplane.notify.NotificationService
 import com.ridi.oss.proxymonster.grpc.EnfAction
 import com.ridi.oss.proxymonster.probe.Masking
 import com.ridi.oss.proxymonster.probe.bindMasks
@@ -345,6 +347,9 @@ fun Route.approvalRoutes(
     // Pushes a task's terminal transition to the parties' (requester + approver) SSE streams so a watching
     // approval tab updates without waiting for its next poll (null in Config-free tests → publish no-ops).
     taskCompletionHub: TaskCompletionHub? = null,
+    // Queues out-of-band notifications (docs/notifications.md). Null = the layer is not configured and the
+    // workflow behaves exactly as before.
+    notifications: NotificationService? = null,
 ) {
     // Query-approval DECISIONS (approve/reject) record a kind="admin" management event; the result
     // lifecycle (execute/cancel/view) uses e3Record's separate approval_lifecycle path.
@@ -370,6 +375,12 @@ fun Route.approvalRoutes(
     // scoped to its role/datasource, with
     // requester != approver enforced by the shipped no-self-approval forbid. Approver eligibility is a
     // Cedar policy, never the datasource's approver GROUP. authDebug bypasses, matching every route.
+    //
+    // The console is a real surface, so it names itself: WORKFLOW_VIEWER, the same channel a result view
+    // runs on. Deciding and viewing are both the unelevated human side of a task and are scoped together.
+    // It must never be `editor` or `wire` — those two carry [system:task-editor-self-approve] /
+    // [system:task-wire-self-approve], which permit self-approval because a machine task runs under the
+    // caller's OWN roles. A human approval elevates to R, so it stays under the no-self-approval forbid.
     fun mayDecide(call: ApplicationCall, action: AuthzAction, req: AccessRequest): Boolean {
         if (config.authDebug) return true
         val decision = authz.authorizeWithContext(
@@ -379,7 +390,7 @@ fun Route.approvalRoutes(
                 requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
                 datasourceName = req.datasourceName, roleName = req.roleName,
             ),
-            call.httpAuthzContext(config),
+            call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
             req.datasourceName,
             req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
         )
@@ -387,7 +398,8 @@ fun Route.approvalRoutes(
     }
 
     // Result rows require Cedar authority to assume the task's R. No authDebug bypass: this is data
-    // confidentiality, enforced in development too.
+    // confidentiality, enforced in development too. Same channel as [mayDecide] and as the per-column
+    // re-decision the released rows go through, so one policy scopes the whole console surface.
     fun mayReadResult(call: ApplicationCall, req: AccessRequest): Boolean {
         val decision = authz.authorizeWithContext(
             call.userSession()?.principal ?: "debug-user",
@@ -396,7 +408,7 @@ fun Route.approvalRoutes(
                 requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
                 datasourceName = req.datasourceName, roleName = req.roleName,
             ),
-            call.httpAuthzContext(config),
+            call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
             req.datasourceName,
             req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
         )
@@ -482,10 +494,12 @@ fun Route.approvalRoutes(
                     requestedDurationSec = input.requestedDurationSec,
                     actor = call.auditActor(config),
                     recorder = recorder,
+                    onCreated = { c, taskId -> notifications?.emitRequested(c, taskId, principal, ds) },
                 )
             } catch (_: DuplicatePendingQueryRequestException) {
                 return@post call.respond(HttpStatusCode.Conflict, ApiError("approval.pending_request_exists"))
             }
+            notifications?.wake()
             call.respond(HttpStatusCode.Created, CreateApprovalResponse(request, wouldAllow = false))
             return@post
         }
@@ -535,7 +549,9 @@ fun Route.approvalRoutes(
             requestedDurationSec = input.requestedDurationSec,
             actor = call.auditActor(config),
             recorder = recorder,
+            onCreated = { c, taskId -> notifications?.emitRequested(c, taskId, principal, ds) },
         )
+        notifications?.wake()
         call.respond(HttpStatusCode.Created, CreateApprovalResponse(request, wouldAllow = decision.action == EnfAction.ALLOW))
     }
 
@@ -628,7 +644,9 @@ fun Route.approvalRoutes(
         val updated = accessStore.decideQueryRequest(
             id, approved = true, rejectionReason = null, decidedBy = principal,
             actor = call.auditActor(config), recorder = recorder,
+            onDecided = { c, decided -> notifications?.emit(c, NotificationEvent.TASK_DECIDED, decided) },
         ) ?: return@post call.respond(HttpStatusCode.Conflict, ApiError("approval.already_decided"))
+        notifications?.wake()
         call.application.environment.log.info(
             "query approval approved request={} requester={} decider={} sourceDecisionId={}",
             id,
@@ -656,7 +674,9 @@ fun Route.approvalRoutes(
         val updated = accessStore.decideQueryRequest(
             id, approved = false, rejectionReason = body.reason.trim(), decidedBy = principal,
             actor = call.auditActor(config), recorder = recorder,
+            onDecided = { c, decided -> notifications?.emit(c, NotificationEvent.TASK_DECIDED, decided) },
         ) ?: return@post call.respond(HttpStatusCode.Conflict, ApiError("approval.already_decided"))
+        notifications?.wake()
         call.application.environment.log.info(
             "query approval rejected request={} requester={} decider={} sourceDecisionId={}",
             id,
@@ -698,6 +718,7 @@ fun Route.approvalRoutes(
             // A cancel can win the CAS before the run coroutine unwinds — push CANCELLED now to both parties
             // so a watching tab reflects it at once (best-effort; the coroutine's terminal push + the poll cover it).
             taskCompletionHub?.publish(listOf(req.principal, req.decidedBy).filterNotNull(), TaskEvent(id, "CANCELLED"))
+            accessStore.getRequest(id)?.let { notifications?.enqueueTerminal(it) }
         }
         val updated = accessStore.getRequest(id)
             ?: return@post call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "query approval request")))
@@ -760,72 +781,13 @@ fun Route.approvalRoutes(
         }
 
         appScope.launch {
-            val failureCode = try {
-                // The approver executes the approved SQL: the run is initiated by and attributed to the
-                // approver (the authenticated caller of /execute), so the ephemeral token, the connection
-                // binding, and the execution audit all carry the approver's identity. execute-as R is
-                // enforced separately via assumeRoles — the role the decision runs AS, not who runs it.
-                val response = runExecService.run(
-                    principal = executor,
-                    ds = ds,
-                    sql = sql,
-                    maxRows = 5000,
-                    approverExec = true,
-                    assumeRoles = executeAs,
-                    requesterIp = requesterIp,
-                    taskId = id,
-                    preflight = { store.meta(id)?.status == "RUNNING" },
-                    exchangeTimeoutMs = config.queryExchangeTimeoutMs,
-                )
-                if (response.decision == EnfAction.DENY) {
-                    "approval.execute_denied"
-                } else {
-                    val result = DecryptedResult(response.columns, response.rows)
-                    // Child DONE, parent EXECUTED, and the execution audit all commit in ONE transaction:
-                    // a crash can never leave a readable DONE child under a non-EXECUTED task. If the parent
-                    // has left EXECUTING (e.g. a restart already reconciled it to FAILED), the flip fails and
-                    // aborts the whole commit — the child stays RUNNING and the failure path below transitions
-                    // both consistently.
-                    val completed = store.completeRun(id, result, QueryResultStore.RESULT_RETENTION_SEC) { conn, _ ->
-                        if (!accessStore.markExecuted(id, conn)) {
-                            throw IllegalStateException("task $id left EXECUTING before completion")
-                        }
-                        auditStore.insert(conn, e3Record(executor, req, "result-executed", Channel.WORKFLOW_EXECUTOR))
-                    }
-                    if (completed != null) {
-                        call.application.environment.log.info(
-                            "query approval executed request={} requester={} executor={} rows={}",
-                            id, req.principal, executor, result.rows.size,
-                        )
-                        null
-                    } else {
-                        "approval.query_failed"
-                    }
-                }
-            } catch (_: RunCanceledBeforeStartException) {
-                null
-            } catch (_: NoProxyAttachedException) {
-                "query.no_proxy_attached"
-            } catch (_: ProxyRunTimeoutException) {
-                "query.proxy_timeout"
-            } catch (_: ProxyRunException) {
-                "approval.query_failed"
-            } catch (t: Throwable) {
-                call.application.environment.log.error("query approval execution failed request=$id", t)
-                "approval.query_failed"
-            }
-            if (failureCode != null) {
-                // Child FAILED and parent FAILED commit in ONE transaction (mirrors the success path's
-                // single-commit EXECUTED/DONE): a crash can never leave a FAILED child under a still-EXECUTING
-                // task, nor the inverse — the split that boot reconcile would otherwise have to repair.
-                runCatching { store.failRun(id, failureCode) { conn, _ -> accessStore.markFailed(id, conn) } }
-                    .onFailure { call.application.environment.log.error("task failure transition failed request=$id", it) }
-            }
-            // Push the ACTUAL terminal state (EXECUTED / FAILED / or CANCELLED if a cancel raced) to both
-            // parties' SSE streams so a watching tab updates at once; best-effort, the tab also polls.
-            accessStore.getRequest(id)?.status?.let {
-                taskCompletionHub?.publish(listOf(req.principal, executor), TaskEvent(id, it))
-            }
+            runApprovedTask(
+                id = id, executor = executor, ds = ds, sql = sql, executeAs = executeAs,
+                requesterIp = requesterIp, requesterPrincipal = req.principal, req = req,
+                config = config, accessStore = accessStore, store = store, auditStore = auditStore,
+                runExecService = runExecService, taskCompletionHub = taskCompletionHub,
+                notifications = notifications, log = call.application.environment.log,
+            )
         }
         call.respond(HttpStatusCode.Accepted, ExecuteApprovalResponse(decision = "EXECUTING"))
     }
@@ -927,5 +889,109 @@ fun Route.approvalRoutes(
                 )
             }
         }
+    }
+}
+
+/**
+ * Run an approved task under its execute-as role set, then terminalize it.
+ *
+ * Shared by the HTTP `/execute` route and the Slack approve-and-run adapter, so a decision reached from
+ * either surface runs through ONE lifecycle rather than two copies of it. The caller has already claimed the
+ * task (APPROVED → EXECUTING with a RUNNING child, in one transaction), so this owns only the run and the
+ * terminal transition.
+ *
+ * The run is initiated by and attributed to [executor] — the ephemeral token, the connection binding, and the
+ * execution audit all carry their identity. Execute-as R is enforced separately via [executeAs]: the role the
+ * decision runs AS, never who runs it.
+ */
+internal suspend fun runApprovedTask(
+    id: Long,
+    executor: String,
+    ds: Datasource,
+    sql: String,
+    executeAs: Set<String>,
+    requesterIp: String?,
+    requesterPrincipal: String,
+    req: AccessRequest,
+    config: Config,
+    accessStore: AccessStore,
+    store: QueryResultStore,
+    auditStore: AuditStore,
+    runExecService: RunExecService,
+    taskCompletionHub: TaskCompletionHub?,
+    notifications: NotificationService?,
+    log: org.slf4j.Logger,
+) {
+    val dsName = req.datasourceId?.let { req.datasourceName } ?: "?"
+    fun lifecycleRecord(event: String, channel: Channel) = AuditEvent(
+        principal = executor, datasource = dsName,
+        statement = "approval #$id $event",
+        decision = Decision.ALLOW, detail = "APPROVER_EXEC $event",
+        channel = channel.contextValue, kind = "approval_lifecycle",
+    )
+
+    val failureCode = try {
+        val response = runExecService.run(
+            principal = executor,
+            ds = ds,
+            sql = sql,
+            maxRows = 5000,
+            approverExec = true,
+            assumeRoles = executeAs,
+            requesterIp = requesterIp,
+            taskId = id,
+            preflight = { store.meta(id)?.status == "RUNNING" },
+            exchangeTimeoutMs = config.queryExchangeTimeoutMs,
+        )
+        if (response.decision == EnfAction.DENY) {
+            "approval.execute_denied"
+        } else {
+            val result = DecryptedResult(response.columns, response.rows)
+            // Child DONE, parent EXECUTED, and the execution audit all commit in ONE transaction: a crash can
+            // never leave a readable DONE child under a non-EXECUTED task. If the parent has left EXECUTING
+            // (e.g. a restart already reconciled it to FAILED), the flip fails and aborts the whole commit —
+            // the child stays RUNNING and the failure path below transitions both consistently.
+            val completed = store.completeRun(id, result, QueryResultStore.RESULT_RETENTION_SEC) { conn, _ ->
+                if (!accessStore.markExecuted(id, conn)) {
+                    throw IllegalStateException("task $id left EXECUTING before completion")
+                }
+                auditStore.insert(conn, lifecycleRecord("result-executed", Channel.WORKFLOW_EXECUTOR))
+            }
+            if (completed != null) {
+                log.info(
+                    "query approval executed request={} requester={} executor={} rows={}",
+                    id, requesterPrincipal, executor, result.rows.size,
+                )
+                null
+            } else {
+                "approval.query_failed"
+            }
+        }
+    } catch (_: RunCanceledBeforeStartException) {
+        null
+    } catch (_: NoProxyAttachedException) {
+        "query.no_proxy_attached"
+    } catch (_: ProxyRunTimeoutException) {
+        "query.proxy_timeout"
+    } catch (_: ProxyRunException) {
+        "approval.query_failed"
+    } catch (t: Throwable) {
+        log.error("query approval execution failed request=$id", t)
+        "approval.query_failed"
+    }
+    if (failureCode != null) {
+        // Child FAILED and parent FAILED commit in ONE transaction (mirrors the success path's single-commit
+        // EXECUTED/DONE): a crash can never leave a FAILED child under a still-EXECUTING task, nor the
+        // inverse — the split that boot reconcile would otherwise have to repair.
+        runCatching { store.failRun(id, failureCode) { conn, _ -> accessStore.markFailed(id, conn) } }
+            .onFailure { log.error("task failure transition failed request=$id", it) }
+    }
+    // Push the ACTUAL terminal state (EXECUTED / FAILED / or CANCELLED if a cancel raced) to both parties'
+    // SSE streams so a watching tab updates at once; best-effort, the tab also polls.
+    accessStore.getRequest(id)?.let { finished ->
+        taskCompletionHub?.publish(listOf(requesterPrincipal, executor), TaskEvent(id, finished.status))
+        // Announced after the run settles, so it is not part of the execution transaction; the outbox row is
+        // still written atomically inside enqueueTerminal.
+        notifications?.enqueueTerminal(finished)
     }
 }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Config.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Config.kt
@@ -95,6 +95,15 @@ data class Config(
     val mcpRefreshTtlSeconds: Long = 21_600,
     val mcpDebugAutoConsent: Boolean = true,
     val queryTimeoutSeconds: Long = 600,
+    // Out-of-band task notifications (docs/notifications.md). Both Slack tokens must be present for the
+    // transport to exist; either absent leaves the whole layer inert and the workflow unchanged — the same
+    // posture as an unset PM_SCIM_TOKEN disabling SCIM, never a degraded half-configured mode.
+    val slackBotToken: String? = null,
+    val slackAppToken: String? = null,
+    val notifyStatement: String = "truncated",
+    val notifyStatementMax: Int = 200,
+    // Fallback language for a recipient who has never set one (app_user.locale).
+    val notifyLocale: String = "en",
 ) {
     init {
         require(webSessionSlideSeconds < webSessionIdleSeconds) {
@@ -214,6 +223,19 @@ data class Config(
                 }
             }
 
+            // A set-but-garbage value fails fast rather than silently falling back: a misconfigured
+            // disclosure mode would decide how much query text leaves the building.
+            val notifyStatement = (env("PM_NOTIFY_STATEMENT") ?: "truncated").trim().lowercase()
+            require(notifyStatement in setOf("truncated", "full", "omit")) {
+                "PM_NOTIFY_STATEMENT must be one of truncated|full|omit; got '$notifyStatement'"
+            }
+            val notifyStatementMax = env("PM_NOTIFY_STATEMENT_MAX")?.let {
+                it.toIntOrNull() ?: throw IllegalArgumentException("PM_NOTIFY_STATEMENT_MAX must be a positive integer; got '$it'")
+            } ?: 200
+            require(notifyStatementMax > 0) { "PM_NOTIFY_STATEMENT_MAX must be greater than zero" }
+            val notifyLocale = (env("PM_NOTIFY_LOCALE") ?: "en").trim().lowercase()
+            require(notifyLocale in setOf("en", "ko")) { "PM_NOTIFY_LOCALE must be one of en|ko; got '$notifyLocale'" }
+
             return Config(
                 httpPort = env("PM_HTTP_PORT")?.toIntOrNull() ?: 8080,
                 grpcPort = env("PM_GRPC_PORT")?.toIntOrNull() ?: DEFAULT_GRPC_PORT,
@@ -253,6 +275,11 @@ data class Config(
                 mcpRefreshTtlSeconds = clampTtlSeconds(env("PM_OAUTH_REFRESH_TTL")?.toLongOrNull() ?: 21_600),
                 mcpDebugAutoConsent = env("PM_OAUTH_DEBUG_AUTO_CONSENT")?.toBooleanStrictOrNull() ?: true,
                 queryTimeoutSeconds = queryTimeoutSeconds,
+                slackBotToken = env("PM_SLACK_BOT_TOKEN")?.takeIf { it.isNotBlank() },
+                slackAppToken = env("PM_SLACK_APP_TOKEN")?.takeIf { it.isNotBlank() },
+                notifyStatement = notifyStatement,
+                notifyStatementMax = notifyStatementMax,
+                notifyLocale = notifyLocale,
             )
         }
 

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -116,7 +116,19 @@ enum class Channel(val contextValue: String) {
     WIRE("wire"),
     EDITOR("editor"),
     WORKFLOW_EXECUTOR("workflow-executor"),
+    /**
+     * The whole console-facing side of a workflow task — viewing a stored result AND deciding it (approve /
+     * reject / read-status). One actor, one session, so one channel a policy can scope. NOT
+     * `workflow-executor`: a saved result re-masks here precisely because this value is not that permit.
+     */
     WORKFLOW_VIEWER("workflow-viewer"),
+    /**
+     * A task decided from a Slack click rather than a console session (docs/notifications.md) — no OIDC
+     * session, no attested address, so its own channel a policy can scope or forbid. It carries no
+     * `requester_ip` (an IP-conditioned policy denies), and [system:no-self-approval] does not exempt it —
+     * only the server-attested `editor`/`wire` channels are.
+     */
+    SLACK("slack"),
     MCP("mcp"),
 }
 
@@ -472,7 +484,7 @@ fun decideQuery(
                 Channel.WIRE, Channel.EDITOR -> return passthroughAllow(roleList, "passthrough (session-mutating)", derivedTags)
                     .copy(schemaCandidates = facts.schemaQualifierCandidatesList.toSet())
                     .withAnalyzerRewrite(facts)
-                Channel.WORKFLOW_EXECUTOR, Channel.WORKFLOW_VIEWER, Channel.MCP ->
+                Channel.WORKFLOW_EXECUTOR, Channel.WORKFLOW_VIEWER, Channel.MCP, Channel.SLACK ->
                     return structuralDeny(EDITOR_SESSION_STATEMENT_DENY, roleList, contextTags = derivedTags)
             }
             StatementClass.STATEMENT_CLASS_UNSPECIFIED, StatementClass.UNRECOGNIZED ->

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RequesterIp.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RequesterIp.kt
@@ -242,10 +242,9 @@ internal fun ApplicationCall.httpRequesterIp(config: Config): String? {
 }
 
 /**
- * The non-query [AuthzContext] for an HTTP admin/audit/approval route: only `requesterIp` is
- * populated here — `channel` is deliberately left unset (these routes have no query-decision channel, and
- * inventing one would be dishonest; see [com.ridi.oss.proxymonster.controlplane.authz.authorizeWithContext]
- * for the datasource-scoped tag derivation these routes layer on top when a datasource is in scope).
+ * The non-query [AuthzContext] for an HTTP admin/audit/approval route: `requesterIp` from the trusted-edge
+ * resolver, plus [channel] for a route that sits on a named surface — the approve/reject/read routes pass
+ * `workflow-viewer` so a policy can scope console approvals. Admin/audit routes have no channel and pass none.
  */
-internal fun ApplicationCall.httpAuthzContext(config: Config): AuthzContext =
-    AuthzContext(requesterIp = httpRequesterIp(config))
+internal fun ApplicationCall.httpAuthzContext(config: Config, channel: Channel? = null): AuthzContext =
+    AuthzContext(requesterIp = httpRequesterIp(config), channel = channel?.contextValue)

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RoleResolver.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RoleResolver.kt
@@ -15,6 +15,44 @@ class RoleResolver(
     private val userGroupStore: UserGroupStore,
     private val accessStore: AccessStore,
 ) {
+    /**
+     * Every principal who could act at all: active directory users, plus anyone holding a role through a
+     * direct assignment or an unexpired JIT grant. The union [hasActiveAssignee] tests as an EXISTS,
+     * enumerated instead of counted.
+     *
+     * `app_user` alone is NOT the principal universe (V1__identity.sql): a principal string is free text and
+     * a `principal_role`-only identity holds roles without ever having a directory row. A row that DOES exist
+     * and is inactive is excluded, matching [UserGroupStore.isDeactivated] — deprovisioning wins over every
+     * role source.
+     *
+     * Used by notification routing to enumerate candidates. It answers "who exists", never "who may do X" —
+     * that stays a per-principal Cedar decision.
+     */
+    fun listActivePrincipals(): List<String> = dataSource.connection.use { c ->
+        c.prepareStatement(
+            """SELECT principal FROM app_user WHERE active
+               UNION
+               SELECT pr.principal
+               FROM principal_role pr
+               LEFT JOIN app_user u ON u.principal = pr.principal
+               WHERE u.id IS NULL OR u.active
+               UNION
+               SELECT ag.principal
+               FROM access_grant ag
+               LEFT JOIN app_user u ON u.principal = ag.principal
+               WHERE ag.revoked_at IS NULL
+                 AND (ag.expires_at IS NULL OR ag.expires_at > now())
+                 AND (u.id IS NULL OR u.active)
+               ORDER BY 1""",
+        ).use { ps ->
+            ps.executeQuery().use { rs ->
+                val out = ArrayList<String>()
+                while (rs.next()) out += rs.getString(1)
+                out
+            }
+        }
+    }
+
     /** Role names this principal holds via a direct `principal_role` assignment. */
     fun directRoles(principal: String): List<String> = dataSource.connection.use { c ->
         c.prepareStatement(

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationRenderer.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationRenderer.kt
@@ -1,0 +1,68 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import com.ridi.oss.proxymonster.controlplane.i18n.MessageCatalog
+
+/**
+ * Renders a [NotificationMessage] into localized prose over the shared [MessageCatalog] (the `notifications`
+ * domain). A transport turns this into its own idiom — Block Kit, MIME — so the copy lives here once and
+ * every locale stays reachable.
+ */
+class NotificationRenderer(private val catalog: MessageCatalog = MessageCatalog(DOMAIN)) {
+
+    fun actionLabel(action: NotificationAction, locale: String): String = catalog.text(
+        when (action) {
+            NotificationAction.APPROVE_AND_RUN -> "action.approve_and_run"
+            NotificationAction.DENY -> "action.deny"
+            NotificationAction.OPEN -> "action.open"
+        },
+        locale,
+    )
+
+    /**
+     * The message body. A statement that was withheld or elided is described rather than shown, and says so —
+     * an approver who cannot read it here needs to know to open the console, not to guess.
+     */
+    fun summary(m: NotificationMessage, locale: String): String {
+        val statement = m.statement.text?.let { "```$it```" } ?: "_${catalog.text("field.statement_hidden", locale)}_"
+        val params = mapOf(
+            "requester" to m.requester,
+            "datasource" to m.datasource,
+            "statement" to statement,
+            "decidedBy" to (m.decidedBy ?: "—"),
+            "rowCount" to (m.rowCount?.toString() ?: "—"),
+            "role" to (m.roleName?.let { catalog.text("field.role", locale, mapOf("role" to it)) } ?: ""),
+        )
+        return buildString {
+            append(catalog.text(bodyKey(m), locale, params))
+            m.reason?.takeIf { it.isNotBlank() && m.event == NotificationEvent.TASK_REQUESTED }?.let {
+                append("\n").append(catalog.text("field.reason", locale, mapOf("reason" to it)))
+            }
+            // Only say "open it to read the statement" when there was one to withhold: an OMIT-configured
+            // statement and one truncated by length both land here.
+            if (m.statement.text == null || !m.statement.complete) {
+                append("\n").append(catalog.text("field.statement_hidden_note", locale))
+            }
+        }
+    }
+
+    /** The plain-text line for a client that renders no blocks. Never carries the statement. */
+    fun fallbackText(m: NotificationMessage, locale: String): String = catalog.text(
+        // Keyed on the EVENT: approve and reject share one fallback line, so the body key (which splits them)
+        // would ask for a `task.decided_approved_fallback` that does not exist.
+        "task.${m.event.name.removePrefix("TASK_").lowercase()}_fallback",
+        locale,
+        mapOf("requester" to m.requester, "datasource" to m.datasource, "decidedBy" to (m.decidedBy ?: "—")),
+    )
+
+    private fun bodyKey(m: NotificationMessage): String = when (m.event) {
+        NotificationEvent.TASK_REQUESTED -> "task.requested"
+        NotificationEvent.TASK_DECIDED -> if (m.approved == true) "task.decided_approved" else "task.decided_rejected"
+        NotificationEvent.TASK_EXECUTED -> "task.executed"
+        NotificationEvent.TASK_FAILED -> "task.failed"
+        NotificationEvent.TASK_CANCELLED -> "task.cancelled"
+    }
+
+    companion object {
+        const val DOMAIN = "notifications"
+    }
+}

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationService.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationService.kt
@@ -1,0 +1,252 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import com.ridi.oss.proxymonster.controlplane.AccessRequest
+import com.ridi.oss.proxymonster.controlplane.AccessStore
+import com.ridi.oss.proxymonster.controlplane.QueryResultStore
+import io.ktor.http.URLBuilder
+import io.ktor.http.appendPathSegments
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.withTimeoutOrNull
+import org.slf4j.LoggerFactory
+import java.sql.Connection
+import java.time.Duration
+
+/**
+ * The notification layer's one entry point (docs/notifications.md).
+ *
+ * The workflow calls [emit] inside the transaction that changes a task; [runDrainLoop] delivers what was
+ * queued. Nothing here can fail a task: the console is the system of record and a notification is a courtesy,
+ * so every failure path logs and moves on.
+ */
+class NotificationService(
+    private val store: NotificationStore,
+    private val recipients: RecipientResolver,
+    private val transports: List<NotificationTransport>,
+    private val accessStore: AccessStore,
+    private val queryResultStore: QueryResultStore?,
+    private val webBaseUrl: String,
+    private val disclosure: StatementDisclosure,
+    private val statementMaxChars: Int,
+    private val defaultLocale: String,
+) {
+    private val log = LoggerFactory.getLogger(NotificationService::class.java)
+
+    val enabled: Boolean get() = transports.isNotEmpty()
+
+    // A wake so a queued notification delivers in ~ms instead of on the next poll tick. Conflated: many
+    // wakes between two drains collapse into one, since a drain claims the whole due batch regardless.
+    // The poll in [runDrainLoop] stays as a backstop, so a missed wake only delays, never loses. This is
+    // the in-process form of the LISTEN/NOTIFY the multi-instance follow-up will use (docs/backlog.md).
+    private val wakeSignal = Channel<Unit>(Channel.CONFLATED)
+
+    /**
+     * Nudge the drainer to run now. Call this AFTER the transaction that enqueued a row has COMMITTED —
+     * `enqueue` runs inside the caller's transaction, so an earlier wake would race a row a separate
+     * connection cannot yet see. A wake before commit is not wrong, only wasted: the drain finds nothing
+     * and the backstop poll picks the row up on its next tick.
+     */
+    fun wake() {
+        if (enabled) wakeSignal.trySend(Unit)
+    }
+
+    /**
+     * Drain on every wake, and on a timer as a backstop. The timer covers a wake dropped by a crash or a
+     * wake that raced a not-yet-committed row; the wake covers the latency a bare timer would add to an
+     * interactive click, where a user is watching the message and re-clicks if it does not move.
+     */
+    suspend fun runDrainLoop(pollInterval: Duration) {
+        if (!enabled) return
+        while (true) {
+            // withTimeoutOrNull returns null on the poll deadline, Unit on a wake — either way, drain.
+            try {
+                withTimeoutOrNull(pollInterval.toMillis()) { wakeSignal.receive() }
+            } catch (_: TimeoutCancellationException) {
+                // Defensive: a receive cancelled by the timeout still falls through to a drain.
+            }
+            runCatching { drainOnce() }.onFailure { log.warn("notification drain failed", it) }
+        }
+    }
+
+    /**
+     * Queue [event] for everyone who should hear it, in the caller's transaction [c] — so the rows commit
+     * with the task change itself and a crash cannot leave a request decided with nobody told.
+     *
+     * Never throws: a routing or enqueue failure must not roll back the task the caller is committing.
+     */
+    fun emit(c: Connection, event: NotificationEvent, req: AccessRequest) {
+        if (!enabled) return
+        runCatching {
+            val targets = when (event) {
+                // Only a pending request goes to the eligible approvers. Every later event goes to the
+                // parties plus whoever was already told, so nobody is left holding a stale "needs approval".
+                NotificationEvent.TASK_REQUESTED -> recipients.recipientsFor(req)
+                else -> recipients.recipientsFor(
+                    req,
+                    alwaysInclude = listOfNotNull(req.principal, req.decidedBy, req.executedBy),
+                )
+            }
+            for (transport in transports) {
+                for (recipient in targets) {
+                    store.enqueue(c, req.id, event, transport.name, recipient)
+                }
+            }
+        }.onFailure { log.warn("notification emit failed task={} event={}", req.id, event.wire, it) }
+    }
+
+    /**
+     * Queue the "needs approval" notification for a request being CREATED, in the caller's transaction.
+     *
+     * The row is not yet visible to another connection, so routing is given the facts we already hold rather
+     * than a re-read: requester, datasource, and the role are all the eligibility decision needs.
+     */
+    fun emitRequested(c: Connection, taskId: Long, requester: String, ds: com.ridi.oss.proxymonster.controlplane.Datasource) {
+        if (!enabled) return
+        runCatching {
+            val subject = AccessRequest(
+                id = taskId,
+                principal = requester,
+                datasourceId = ds.id,
+                datasourceName = ds.name,
+                requestedDurationSec = 0,
+                status = "PENDING",
+                createdAt = "",
+            )
+            for (transport in transports) {
+                for (recipient in recipients.recipientsFor(subject)) {
+                    store.enqueue(c, taskId, NotificationEvent.TASK_REQUESTED, transport.name, recipient)
+                }
+            }
+        }.onFailure { log.warn("notification emit failed task={} event=task.requested", taskId, it) }
+    }
+
+    /**
+     * Announce a task that has reached a terminal state. Unlike [emit] this owns its own transaction: the
+     * run settles outside the execution commit, so there is no caller transaction to join.
+     */
+    fun enqueueTerminal(req: AccessRequest) {
+        if (!enabled) return
+        val event = NotificationEvent.forTerminalStatus(req.status) ?: return
+        runCatching { store.inTransaction { c -> emit(c, event, req) } }
+            .onFailure { log.warn("notification terminal emit failed task={}", req.id, it) }
+        // The transaction above has committed, so the "finished" update is safe to deliver now rather than
+        // on the next poll — this is the second half of an approve-and-run the user is watching for.
+        wake()
+    }
+
+    /** Claim and deliver one batch. Returns how many rows were attempted. */
+    suspend fun drainOnce(batch: Int = DRAIN_BATCH): Int {
+        if (!enabled) return 0
+        val rows = runCatching { store.claimDue(batch) }.getOrElse {
+            log.warn("notification claim failed", it)
+            return 0
+        }
+        for (row in rows) {
+            runCatching { deliver(row) }
+                .onFailure {
+                    log.warn("notification delivery threw task={} event={}", row.taskId, row.event.wire, it)
+                    store.markRetry(row.id, "unhandled: ${it.message}", backoffFor(row.attempts))
+                }
+        }
+        return rows.size
+    }
+
+    private suspend fun deliver(row: OutboxRow) {
+        val transport = transports.firstOrNull { it.name == row.transport }
+            ?: return store.markDead(row.id, "no such transport")
+
+        // An update must not overtake the message it edits. Leaving the row PENDING (without burning an
+        // attempt) lets the next drain retry once the earlier event has gone out.
+        if (row.event.isUpdate && store.hasEarlierPending(row)) return
+
+        val req = accessStore.getRequest(row.taskId)
+            ?: return store.markDead(row.id, "task no longer exists")
+
+        val locale = store.localeOf(row.recipient) ?: defaultLocale
+        val message = buildMessage(row, req, transport)
+        val existingRef = store.externalRef(row.taskId, transport.name, row.recipient)
+
+        // Editing an existing message needs only its ref, not the recipient's address — so an update skips
+        // the address lookup entirely. For Slack that is two saved round-trips per update
+        // (users.lookupByEmail + conversations.open), which is most of an interactive click's felt latency:
+        // the "running" and "finished" edits are the ones a user is watching for.
+        val editingExisting = row.event.isUpdate && existingRef != null && transport.supportsUpdate
+        val result = if (editingExisting) {
+            transport.update(existingRef!!, message, locale)
+        } else {
+            val address = transport.addressOf(row.recipient, store.emailOf(row.recipient))
+                ?: return store.markDead(row.id, "no address on ${transport.name}")
+            transport.deliver(address, message, locale)
+        }
+
+        when (result) {
+            is DeliveryResult.Sent -> {
+                store.rememberMessage(row.taskId, transport.name, row.recipient, result.externalRef)
+                store.markSent(row.id)
+            }
+            is DeliveryResult.Drop -> store.markDead(row.id, result.reason)
+            is DeliveryResult.Retry ->
+                if (row.attempts + 1 >= MAX_ATTEMPTS) {
+                    store.markDead(row.id, "gave up after ${row.attempts + 1}: ${result.reason}")
+                } else {
+                    store.markRetry(row.id, result.reason, backoffFor(row.attempts))
+                }
+        }
+    }
+
+    private fun buildMessage(row: OutboxRow, req: AccessRequest, transport: NotificationTransport): NotificationMessage {
+        val statement = renderStatement(req.sql, disclosure, statementMaxChars, transport.statementHardLimit)
+        val meta = queryResultStore?.meta(req.id)
+        return NotificationMessage(
+            event = row.event,
+            taskId = req.id,
+            requester = req.principal,
+            datasource = req.datasourceName ?: "—",
+            roleName = req.roleName,
+            reason = req.reason,
+            statement = statement,
+            decidedBy = req.decidedBy,
+            approved = when (req.status) {
+                "REJECTED" -> false
+                "APPROVED", "EXECUTING", "EXECUTED" -> true
+                else -> null
+            },
+            rowCount = meta?.rowCount,
+            errorCode = meta?.errorCode,
+            deepLink = URLBuilder(webBaseUrl).appendPathSegments("workflows", req.id.toString()).buildString(),
+            actions = actionsFor(row.event, req, statement),
+        )
+    }
+
+    /**
+     * What the recipient may do from the message.
+     *
+     * `[open]` is always there. `[approve and run]` is offered ONLY while the task is still pending AND the
+     * message carries the WHOLE statement — approving is vouching for a specific statement, and a truncated
+     * one is worse than none, since the elided tail is exactly where a dangerous predicate would sit. The
+     * test is what was rendered, never which mode the operator configured. `[deny]` needs no such gate:
+     * refusing something you have not fully read is always safe.
+     */
+    private fun actionsFor(
+        event: NotificationEvent,
+        req: AccessRequest,
+        statement: RenderedStatement,
+    ): Set<NotificationAction> = buildSet {
+        add(NotificationAction.OPEN)
+        if (event == NotificationEvent.TASK_REQUESTED && req.status == "PENDING") {
+            add(NotificationAction.DENY)
+            if (statement.complete) add(NotificationAction.APPROVE_AND_RUN)
+        }
+    }
+
+    /** Exponential, capped. A transient Slack outage should not hammer it every tick. */
+    private fun backoffFor(attempts: Int): Duration =
+        Duration.ofSeconds(minOf(BACKOFF_CAP_SEC, BACKOFF_BASE_SEC shl minOf(attempts, 6)))
+
+    companion object {
+        const val DRAIN_BATCH = 32
+        const val MAX_ATTEMPTS = 6
+        private const val BACKOFF_BASE_SEC = 15L
+        private const val BACKOFF_CAP_SEC = 900L
+    }
+}

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStore.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStore.kt
@@ -1,0 +1,206 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import java.sql.Connection
+import java.sql.Timestamp
+import java.time.Instant
+import javax.sql.DataSource
+
+/** One queued delivery, as the drainer sees it. */
+data class OutboxRow(
+    val id: Long,
+    val taskId: Long,
+    val event: NotificationEvent,
+    val transport: String,
+    val recipient: String,
+    val attempts: Int,
+)
+
+/**
+ * The durable notification queue (docs/notifications.md, "Delivery").
+ *
+ * [enqueue] takes a caller-supplied [Connection] so the row commits in the SAME transaction as the task state
+ * change it describes: a crash can never leave a request approved with nobody told. Everything after that is
+ * best-effort — a delivery failure never touches the task, because the console is the system of record and a
+ * notification is a courtesy.
+ */
+class NotificationStore(private val dataSource: DataSource) {
+
+    /**
+     * Queue one delivery, in the caller's transaction. Idempotent per (task, event, transport, recipient):
+     * an event emitted twice for one recipient collapses onto the existing row rather than sending twice.
+     */
+    fun enqueue(
+        c: Connection,
+        taskId: Long,
+        event: NotificationEvent,
+        transport: String,
+        recipient: String,
+    ) {
+        c.prepareStatement(
+            """INSERT INTO notification_outbox (task_id, event, transport, recipient)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT (task_id, event, transport, recipient) DO NOTHING""",
+        ).use { ps ->
+            ps.setLong(1, taskId)
+            ps.setString(2, event.wire)
+            ps.setString(3, transport)
+            ps.setString(4, recipient)
+            ps.executeUpdate()
+        }
+    }
+
+    /**
+     * Claim up to [limit] due rows for delivery.
+     *
+     * `FOR UPDATE SKIP LOCKED` so a second drainer (or a restart overlapping the previous process) never
+     * double-sends: a row being worked on is invisible to the other claimant rather than blocking it. The
+     * claim only reserves — it does not advance `attempts`, which [markSent]/[markFailed] own, so a crash
+     * mid-delivery leaves the row claimable again rather than silently consuming a retry.
+     */
+    fun claimDue(limit: Int): List<OutboxRow> = dataSource.inTxLocal { c ->
+        c.prepareStatement(
+            """SELECT id, task_id, event, transport, recipient, attempts
+               FROM notification_outbox
+               WHERE status = 'PENDING' AND next_attempt_at <= now()
+               ORDER BY id
+               LIMIT ?
+               FOR UPDATE SKIP LOCKED""",
+        ).use { ps ->
+            ps.setInt(1, limit)
+            ps.executeQuery().use { rs ->
+                val out = ArrayList<OutboxRow>()
+                while (rs.next()) {
+                    val event = NotificationEvent.fromWire(rs.getString("event")) ?: continue
+                    out += OutboxRow(
+                        id = rs.getLong("id"),
+                        taskId = rs.getLong("task_id"),
+                        event = event,
+                        transport = rs.getString("transport"),
+                        recipient = rs.getString("recipient"),
+                        attempts = rs.getInt("attempts"),
+                    )
+                }
+                out
+            }
+        }
+    }
+
+    fun markSent(id: Long) = update(id, "SENT", null, null)
+
+    /** Terminal failure: the row is done and its last error kept for an operator to read. */
+    fun markDead(id: Long, error: String) = update(id, "DEAD", error, null)
+
+    /** Transient failure: stay PENDING, burn an attempt, and come back after [backoff]. */
+    fun markRetry(id: Long, error: String, backoff: java.time.Duration) =
+        update(id, "PENDING", error, Instant.now().plus(backoff))
+
+    private fun update(id: Long, status: String, error: String?, nextAttempt: Instant?) {
+        dataSource.connection.use { c ->
+            c.prepareStatement(
+                """UPDATE notification_outbox
+                   SET status = ?, last_error = ?, attempts = attempts + 1,
+                       next_attempt_at = COALESCE(?, next_attempt_at), updated_at = now()
+                   WHERE id = ?""",
+            ).use { ps ->
+                ps.setString(1, status)
+                ps.setString(2, error?.take(500))
+                if (nextAttempt == null) ps.setNull(3, java.sql.Types.TIMESTAMP) else ps.setTimestamp(3, Timestamp.from(nextAttempt))
+                ps.setLong(4, id)
+                ps.executeUpdate()
+            }
+        }
+    }
+
+    /**
+     * True when an earlier event for this (task, transport, recipient) is still queued.
+     *
+     * An update must not overtake the message it edits, so a decided/finished event waits while its
+     * `task.requested` is still pending. Ordering is by id, which is insertion order.
+     */
+    fun hasEarlierPending(row: OutboxRow): Boolean = dataSource.connection.use { c ->
+        c.prepareStatement(
+            """SELECT 1 FROM notification_outbox
+               WHERE task_id = ? AND transport = ? AND recipient = ? AND status = 'PENDING' AND id < ?
+               LIMIT 1""",
+        ).use { ps ->
+            ps.setLong(1, row.taskId)
+            ps.setString(2, row.transport)
+            ps.setString(3, row.recipient)
+            ps.setLong(4, row.id)
+            ps.executeQuery().use { it.next() }
+        }
+    }
+
+    /** The handle a delivered message left behind, or null when nothing has been delivered yet. */
+    fun externalRef(taskId: Long, transport: String, recipient: String): String? =
+        dataSource.connection.use { c ->
+            c.prepareStatement(
+                "SELECT external_ref FROM notification_message WHERE task_id = ? AND transport = ? AND recipient = ?",
+            ).use { ps ->
+                ps.setLong(1, taskId)
+                ps.setString(2, transport)
+                ps.setString(3, recipient)
+                ps.executeQuery().use { if (it.next()) it.getString(1) else null }
+            }
+        }
+
+    /** Record where a message landed, so a later event edits it in place. */
+    fun rememberMessage(taskId: Long, transport: String, recipient: String, externalRef: String) {
+        dataSource.connection.use { c ->
+            c.prepareStatement(
+                """INSERT INTO notification_message (task_id, transport, recipient, external_ref)
+                   VALUES (?, ?, ?, ?)
+                   ON CONFLICT (task_id, transport, recipient)
+                   DO UPDATE SET external_ref = EXCLUDED.external_ref, updated_at = now()""",
+            ).use { ps ->
+                ps.setLong(1, taskId)
+                ps.setString(2, transport)
+                ps.setString(3, recipient)
+                ps.setString(4, externalRef)
+                ps.executeUpdate()
+            }
+        }
+    }
+
+    /** Run [body] in one transaction — for a caller that has no transaction of its own to join. */
+    fun <T> inTransaction(body: (Connection) -> T): T = dataSource.inTxLocal(body)
+
+    /** The recipient's saved language, or null when they have never expressed one. */
+    fun localeOf(principal: String): String? = dataSource.connection.use { c ->
+        c.prepareStatement("SELECT locale FROM app_user WHERE principal = ?").use { ps ->
+            ps.setString(1, principal)
+            ps.executeQuery().use { if (it.next()) it.getString(1) else null }
+        }
+    }
+
+    fun emailOf(principal: String): String? = dataSource.connection.use { c ->
+        c.prepareStatement("SELECT email FROM app_user WHERE principal = ?").use { ps ->
+            ps.setString(1, principal)
+            ps.executeQuery().use { if (it.next()) it.getString(1) else null }
+        }
+    }
+
+    /** Set the caller's own language. Returns false when no directory row exists for them. */
+    fun setLocale(principal: String, locale: String): Boolean = dataSource.connection.use { c ->
+        c.prepareStatement("UPDATE app_user SET locale = ? WHERE principal = ?").use { ps ->
+            ps.setString(1, locale)
+            ps.setString(2, principal)
+            ps.executeUpdate() > 0
+        }
+    }
+}
+
+/** Local transaction helper — the claim needs its row locks held to the commit. */
+internal inline fun <T> DataSource.inTxLocal(body: (Connection) -> T): T = connection.use { c ->
+    c.autoCommit = false
+    try {
+        val result = body(c)
+        c.commit()
+        result
+    } catch (e: Throwable) {
+        runCatching { c.rollback() }
+        throw e
+    } finally {
+        runCatching { c.autoCommit = true }
+    }
+}

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/Notifications.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/Notifications.kt
@@ -1,0 +1,157 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+/**
+ * Out-of-band task notifications (docs/notifications.md).
+ *
+ * A notification tells someone a task changed. It is never authorization: it carries no result data, and
+ * every action it offers re-authorizes from scratch when taken. Three layers, each replaceable on its own —
+ * the workflow states an [NotificationEvent], [NotificationRouter] resolves who should hear it, and a
+ * [NotificationTransport] delivers. The workflow knows nothing about Slack.
+ */
+
+/** What happened. The workflow states this once; who hears it and how are decided downstream. */
+enum class NotificationEvent(val wire: String) {
+    TASK_REQUESTED("task.requested"),
+    TASK_DECIDED("task.decided"),
+    TASK_EXECUTED("task.executed"),
+    TASK_FAILED("task.failed"),
+    TASK_CANCELLED("task.cancelled"),
+    ;
+
+    /** True when this event should edit an existing message rather than start a new thread of its own. */
+    val isUpdate: Boolean get() = this != TASK_REQUESTED
+
+    companion object {
+        fun fromWire(wire: String): NotificationEvent? = entries.firstOrNull { it.wire == wire }
+
+        /** The terminal task status → the event announcing it. Null for a non-terminal status. */
+        fun forTerminalStatus(status: String): NotificationEvent? = when (status) {
+            "EXECUTED" -> TASK_EXECUTED
+            "FAILED" -> TASK_FAILED
+            "CANCELLED" -> TASK_CANCELLED
+            else -> null
+        }
+    }
+}
+
+/**
+ * How much of the requester's statement may leave the building (docs/notifications.md, "The statement in the
+ * message"). A statement's literals can be the very values a policy protects — `WHERE rrn = '…'` leaks a
+ * value masking never sees, because masking acts on results.
+ */
+enum class StatementDisclosure {
+    TRUNCATED,
+    FULL,
+    OMIT,
+    ;
+
+    companion object {
+        /** Parse `PM_NOTIFY_STATEMENT`. An unrecognized value is a config error the caller fails fast on. */
+        fun parse(raw: String?): StatementDisclosure? =
+            raw?.trim()?.uppercase()?.let { v -> entries.firstOrNull { it.name == v } }
+    }
+}
+
+/**
+ * The statement as it will actually appear, and whether anything was cut.
+ *
+ * [complete] is the gate on approve-and-run: an approver may only decide from a message carrying the WHOLE
+ * statement. The test is what the recipient can read, never which mode the operator configured — a short
+ * statement under TRUNCATED was not truncated, and a long one under FULL is still elided by a transport's own
+ * length ceiling. See [renderStatement].
+ */
+data class RenderedStatement(val text: String?, val complete: Boolean)
+
+/**
+ * Apply [disclosure] to [sql], then the transport's own [hardLimit] (0 = none). The result is [complete] only
+ * when the full statement survived both — the flag is an input to rendering, and the button is decided after.
+ */
+fun renderStatement(
+    sql: String?,
+    disclosure: StatementDisclosure,
+    maxChars: Int,
+    hardLimit: Int = 0,
+): RenderedStatement {
+    if (sql == null) return RenderedStatement(null, complete = false)
+    if (disclosure == StatementDisclosure.OMIT) return RenderedStatement(null, complete = false)
+
+    // The tightest applicable ceiling wins. FULL has no configured limit of its own, so only the transport's
+    // applies; TRUNCATED takes the smaller of the two.
+    val configured = if (disclosure == StatementDisclosure.TRUNCATED) maxChars else Int.MAX_VALUE
+    val ceiling = when {
+        hardLimit <= 0 -> configured
+        else -> minOf(configured, hardLimit)
+    }
+    if (ceiling <= 0) return RenderedStatement(null, complete = false)
+    if (sql.length <= ceiling) return RenderedStatement(sql, complete = true)
+    // The ellipsis has to fit INSIDE the ceiling, or a transport that hard-rejects an over-length field
+    // would reject the very message that was truncated to satisfy it.
+    val keep = (ceiling - 1).coerceAtLeast(0)
+    return RenderedStatement(sql.take(keep) + "…", complete = false)
+}
+
+/** An action a message may offer. [OPEN] is always available; the other two are gated. */
+enum class NotificationAction { APPROVE_AND_RUN, DENY, OPEN }
+
+/**
+ * One notification, transport-neutral. Carries message KEYS and their values rather than finished prose, so
+ * a transport renders in its own idiom (Block Kit, MIME) and every locale stays reachable.
+ *
+ * [statement] is already rendered per [renderStatement]; [actions] already reflects its completeness.
+ */
+data class NotificationMessage(
+    val event: NotificationEvent,
+    val taskId: Long,
+    val requester: String,
+    val datasource: String,
+    val roleName: String?,
+    val reason: String?,
+    val statement: RenderedStatement,
+    val decidedBy: String? = null,
+    /** DECIDED only: approved rather than rejected. The two read completely differently to a recipient,
+     *  and the outbox row records only that a decision happened. */
+    val approved: Boolean? = null,
+    val rowCount: Int? = null,
+    val errorCode: String? = null,
+    val deepLink: String,
+    val actions: Set<NotificationAction>,
+)
+
+/** The outcome of one delivery attempt. Only the transport knows which failures are worth another try. */
+sealed interface DeliveryResult {
+    /** Delivered; [externalRef] is the handle a later event edits (Slack `channel:ts`). */
+    data class Sent(val externalRef: String) : DeliveryResult
+
+    /** Transient — try again after backoff (a 429, a socket drop). */
+    data class Retry(val reason: String) : DeliveryResult
+
+    /** Permanent — stop. No address for this principal, a 404, a malformed payload. */
+    data class Drop(val reason: String) : DeliveryResult
+}
+
+/**
+ * A delivery channel. Slack today; email is the second adapter and the reason this seam exists.
+ *
+ * An unconfigured transport is ABSENT, never degraded — the same posture as an unset `PM_SCIM_TOKEN`
+ * disabling SCIM. With no transport configured the whole layer is inert and the workflow is unchanged.
+ */
+interface NotificationTransport {
+    val name: String
+
+    /** The transport's own per-message statement ceiling, 0 when it has none. */
+    val statementHardLimit: Int get() = 0
+
+    /** False for a transport with no edit primitive (email); an update then sends a fresh message. */
+    val supportsUpdate: Boolean get() = false
+
+    /**
+     * This principal's address on this transport, or null when they have none — a null DROPS the row rather
+     * than retrying it, since no number of attempts will conjure an address.
+     */
+    suspend fun addressOf(principal: String, email: String?): String?
+
+    suspend fun deliver(to: String, message: NotificationMessage, locale: String): DeliveryResult
+
+    /** Edit a previously delivered message in place. Only called when [supportsUpdate]. */
+    suspend fun update(externalRef: String, message: NotificationMessage, locale: String): DeliveryResult
+}

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationsWiring.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationsWiring.kt
@@ -1,0 +1,103 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import com.ridi.oss.proxymonster.controlplane.AccessStore
+import com.ridi.oss.proxymonster.controlplane.AuditStore
+import com.ridi.oss.proxymonster.controlplane.Config
+import com.ridi.oss.proxymonster.controlplane.DatasourceStore
+import com.ridi.oss.proxymonster.controlplane.QueryResultStore
+import com.ridi.oss.proxymonster.controlplane.RoleResolver
+import com.ridi.oss.proxymonster.controlplane.RunExecService
+import com.ridi.oss.proxymonster.controlplane.TaskCompletionHub
+import com.ridi.oss.proxymonster.controlplane.authz.Authz
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
+import com.ridi.oss.proxymonster.controlplane.runApprovedTask
+import io.ktor.server.application.Application
+import kotlinx.coroutines.launch
+import java.time.Duration
+import javax.sql.DataSource
+
+private const val DRAIN_INTERVAL_MS = 5_000L
+
+/**
+ * Wires the notification layer and returns the service the task routes emit through, or null when no
+ * transport is configured (both Slack tokens absent) — then the whole layer is inert and the workflow is
+ * unchanged, the same posture an unset PM_SCIM_TOKEN gives SCIM. Owns the outbound drain loop and, when
+ * Slack is configured, the inbound Socket Mode connection; both are cancelled with the application.
+ */
+fun Application.installNotifications(
+    config: Config,
+    dataSource: DataSource,
+    authz: Authz,
+    roleResolver: RoleResolver,
+    accessStore: AccessStore,
+    datasourceStore: DatasourceStore,
+    queryResultStore: QueryResultStore?,
+    auditStore: AuditStore,
+    runExecService: RunExecService,
+    taskCompletionHub: TaskCompletionHub,
+): NotificationService? {
+    val slackHttp = if (config.slackBotToken != null && config.slackAppToken != null) slackHttpClient() else null
+    val transports = buildList {
+        if (slackHttp != null && config.slackBotToken != null) {
+            add(SlackTransport(slackHttp, config.slackBotToken, config.webBaseUrl, NotificationRenderer()))
+        }
+    }
+    if (transports.isEmpty()) return null
+
+    val notifications = NotificationService(
+        store = NotificationStore(dataSource),
+        recipients = RecipientResolver(authz, roleResolver) { roleResolver.listActivePrincipals() },
+        transports = transports,
+        accessStore = accessStore,
+        queryResultStore = queryResultStore,
+        webBaseUrl = config.webBaseUrl,
+        disclosure = StatementDisclosure.parse(config.notifyStatement) ?: StatementDisclosure.TRUNCATED,
+        statementMaxChars = config.notifyStatementMax,
+        defaultLocale = config.notifyLocale,
+    )
+    // A plain poll rather than LISTEN/NOTIFY: the table is the queue, so a notification would only be a
+    // wake-up hint. wake() covers interactive latency; this is the backstop.
+    launch { notifications.runDrainLoop(Duration.ofMillis(DRAIN_INTERVAL_MS)) }
+
+    // Slack Socket Mode: an OUTBOUND WebSocket carrying clicks back, so no inbound ingress performs a
+    // privileged action. Approving from Slack also RUNS the query, through the same claim + run the console
+    // route uses — the claim is the execute-once CAS, so a console /execute racing this loses cleanly.
+    if (slackHttp != null && config.slackBotToken != null && config.slackAppToken != null) {
+        val handler = SlackDecisionHandler(
+            accessStore = accessStore,
+            datasourceStore = datasourceStore,
+            authz = authz,
+            auditRecorder = ManagementAuditRecorder(auditStore),
+            notifications = notifications,
+            defaultLocale = config.notifyLocale,
+            onApproved = { approved ->
+                val ds = approved.datasourceId?.let(datasourceStore::get)
+                val sql = approved.sql
+                val executeAs = approved.executeAs.toSet()
+                if (ds != null && sql != null && executeAs.isNotEmpty() && queryResultStore != null &&
+                    queryResultStore.claimAndStartRun(approved.id, approved.decidedBy ?: approved.principal) { c ->
+                        accessStore.claimExecution(approved.id, c)
+                    } != null
+                ) {
+                    launch {
+                        runApprovedTask(
+                            id = approved.id,
+                            executor = approved.decidedBy ?: approved.principal,
+                            ds = ds, sql = sql, executeAs = executeAs,
+                            requesterIp = null, // a Slack click carries no attested address
+                            requesterPrincipal = approved.principal, req = approved,
+                            config = config, accessStore = accessStore, store = queryResultStore,
+                            auditStore = auditStore, runExecService = runExecService,
+                            taskCompletionHub = taskCompletionHub, notifications = notifications,
+                            log = environment.log,
+                        )
+                    }
+                }
+            },
+        )
+        launch {
+            SlackSocketMode(slackHttp, config.slackBotToken, config.slackAppToken, onInteraction = { handler.handle(it) }).run()
+        }
+    }
+    return notifications
+}

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/RecipientResolver.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/RecipientResolver.kt
@@ -1,0 +1,58 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import com.ridi.oss.proxymonster.controlplane.AccessRequest
+import com.ridi.oss.proxymonster.controlplane.Channel
+import com.ridi.oss.proxymonster.controlplane.RoleResolver
+import com.ridi.oss.proxymonster.controlplane.authz.Authz
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
+import com.ridi.oss.proxymonster.controlplane.authz.SatisfiableVerdict
+import org.slf4j.LoggerFactory
+
+/**
+ * Who should hear about a task (docs/notifications.md, "Who can approve"). Cedar answers "may bob approve
+ * this", never "who may", so this asks [Authz.satisfiableAs] per active candidate and notifies anyone whose
+ * verdict is not IMPOSSIBLE. Over-notifying costs a 403 the recipient was always going to get; missing a real
+ * approver leaves the request waiting with nobody told. Pinned against the shipped policies in
+ * RecipientResolverDbTest.
+ */
+class RecipientResolver(
+    private val authz: Authz,
+    private val roleResolver: RoleResolver,
+    private val candidateSource: () -> List<String>,
+) {
+    private val log = LoggerFactory.getLogger(RecipientResolver::class.java)
+
+    /**
+     * Everyone who could plausibly approve [req], plus [alwaysInclude] — the parties told how their own
+     * request ended, whether or not they hold approval authority. A routing failure still keeps those.
+     */
+    fun recipientsFor(req: AccessRequest, alwaysInclude: Collection<String> = emptyList()): Set<String> {
+        val eligible = runCatching { approverCandidates(req) }
+            .onFailure { log.warn("notification routing failed for task={}", req.id, it) }
+            .getOrDefault(emptySet())
+        return (eligible + alwaysInclude.filter { it.isNotBlank() }).toSet()
+    }
+
+    private fun approverCandidates(req: AccessRequest): Set<String> {
+        val resource = AuthzResource.ApprovalRequest(
+            requester = req.principal,
+            approver = req.decidedBy,
+            executedBy = req.executedBy,
+            datasourceName = req.datasourceName,
+            roleName = req.roleName,
+        )
+        return candidateSource()
+            .filter { candidate ->
+                authz.satisfiableAs(
+                    candidate,
+                    roleResolver.resolve(candidate),
+                    AuthzAction.TASK_APPROVE,
+                    resource,
+                    knownChannel = Channel.WORKFLOW_VIEWER.contextValue,
+                    unknownContextKeys = setOf("requester_ip"),
+                ) != SatisfiableVerdict.IMPOSSIBLE
+            }
+            .toSet()
+    }
+}

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackDecisionHandler.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackDecisionHandler.kt
@@ -1,0 +1,117 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import com.ridi.oss.proxymonster.controlplane.AccessRequest
+import com.ridi.oss.proxymonster.controlplane.AccessStore
+import com.ridi.oss.proxymonster.controlplane.Channel
+import com.ridi.oss.proxymonster.controlplane.Datasource
+import com.ridi.oss.proxymonster.controlplane.DatasourceStore
+import com.ridi.oss.proxymonster.controlplane.authz.Authz
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzContext
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzDecision
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
+import com.ridi.oss.proxymonster.controlplane.authz.authorizeWithContext
+import com.ridi.oss.proxymonster.controlplane.management.AuditActor
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
+import org.slf4j.LoggerFactory
+
+/**
+ * Turns a Slack button click into a task decision (docs/notifications.md, "Approving from Slack").
+ *
+ * This is an ADAPTER, not a second lifecycle: authorization is the same `task.approve` Cedar decision the
+ * HTTP route makes, and the transition goes through the same [AccessStore.decideQueryRequest] CAS — so two
+ * people tapping at once resolve exactly as two console users would, and the loser is told what actually
+ * happened.
+ *
+ * A click is a weaker assertion than a console session — no OIDC session, no attested address — so it is made
+ * visible to policy rather than hidden behind a flag: it decides on [Channel.SLACK], which an operator can
+ * scope or forbid per datasource or role. `requester_ip` is absent, so any policy conditioning on it denies,
+ * matching how the system already treats an unknown attribute.
+ *
+ * Replies are ephemeral and carry no result data — an outcome, never rows.
+ */
+class SlackDecisionHandler(
+    private val accessStore: AccessStore,
+    private val datasourceStore: DatasourceStore,
+    private val authz: Authz,
+    private val auditRecorder: ManagementAuditRecorder,
+    private val notifications: NotificationService,
+    private val defaultLocale: String,
+    private val onApproved: suspend (AccessRequest) -> Unit,
+) {
+    private val log = LoggerFactory.getLogger(SlackDecisionHandler::class.java)
+
+    /** Handle one click. The returned string is shown privately to the clicker; empty means say nothing. */
+    suspend fun handle(interaction: SlackInteraction): String {
+        val req = accessStore.getRequest(interaction.taskId)
+        if (req == null || req.kind != "QUERY" || req.creatorKind != "WORKFLOW") {
+            return "That request no longer exists."
+        }
+        if (req.status != "PENDING") {
+            // Someone else won the race, or it was decided in the console. Say what actually happened rather
+            // than reporting a failure — the message itself is rewritten by the decision's own notification.
+            return "Already ${req.status.lowercase()} — nothing to do."
+        }
+
+        val ds = req.datasourceId?.let(datasourceStore::getIncludingDeleted)
+        if (!mayDecide(interaction.principal, req, ds)) {
+            return "You are not authorized to decide this request."
+        }
+
+        val approve = interaction.actionId == SlackTransport.ACTION_APPROVE
+        val actor = AuditActor(
+            principal = interaction.principal,
+            clientAddr = null,
+            channel = Channel.SLACK.contextValue,
+        )
+        val updated = accessStore.decideQueryRequest(
+            interaction.taskId,
+            approved = approve,
+            rejectionReason = if (approve) null else SLACK_REJECT_REASON,
+            decidedBy = interaction.principal,
+            actor = actor,
+            recorder = auditRecorder,
+            onDecided = { c, decided -> notifications.emit(c, NotificationEvent.TASK_DECIDED, decided) },
+        ) ?: return "Already decided — nothing to do."
+        // The decide committed; deliver the "decided/running" message edit now rather than on the next poll.
+        // This is what removes the buttons the user just clicked, so a slow update never invites a re-click.
+        notifications.wake()
+
+        log.info(
+            "query approval {} from slack request={} requester={} decider={}",
+            if (approve) "approved" else "rejected", req.id, req.principal, interaction.principal,
+        )
+        if (!approve) return ""
+
+        // Approving from Slack also runs it: whoever approves is the one who must execute, so offering
+        // approve-without-run here would strand the task waiting for a console visit.
+        return runCatching { onApproved(updated); "" }
+            .getOrElse { t ->
+                log.warn("slack-approved execution failed request={}", req.id, t)
+                "Approved, but the run could not be started. Open the request to retry."
+            }
+    }
+
+    private fun mayDecide(principal: String, req: AccessRequest, ds: Datasource?): Boolean {
+        val decision = authz.authorizeWithContext(
+            principal,
+            AuthzAction.TASK_APPROVE,
+            AuthzResource.ApprovalRequest(
+                requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
+                datasourceName = req.datasourceName, roleName = req.roleName,
+            ),
+            // No attested address: a Slack click carries none, so a policy requiring one denies. That is the
+            // same fail-closed posture the system takes for any unknown attribute, and the reason `slack` is
+            // its own channel rather than a flag.
+            AuthzContext(channel = Channel.SLACK.contextValue),
+            req.datasourceName,
+            ds?.tags.orEmpty(),
+        )
+        return decision !is AuthzDecision.Deny
+    }
+
+    companion object {
+        /** Recorded as the rejection reason; the console requires one and a click supplies no text. */
+        const val SLACK_REJECT_REASON = "Denied from Slack"
+    }
+}

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackHttp.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackHttp.kt
@@ -1,0 +1,15 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.websocket.WebSockets
+
+/**
+ * The Slack HTTP client. Separate from the OIDC client on purpose: that one sets `expectSuccess = true` and
+ * would throw on any non-2xx, but a transport must READ Slack's error body to decide retry-vs-drop.
+ * WebSockets are installed for the inbound Socket Mode connection.
+ */
+fun slackHttpClient(): HttpClient = HttpClient(CIO) {
+    expectSuccess = false
+    install(WebSockets)
+}

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackSocketMode.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackSocketMode.kt
@@ -1,0 +1,211 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.websocket.webSocket
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readText
+import kotlinx.coroutines.delay
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.slf4j.LoggerFactory
+
+/** One button click, already resolved to the acting principal. */
+data class SlackInteraction(
+    val principal: String,
+    val actionId: String,
+    val taskId: Long,
+    val responseUrl: String?,
+    val triggerChannel: String?,
+    val triggerTs: String?,
+)
+
+/**
+ * Slack Socket Mode (docs/notifications.md, "How it connects").
+ *
+ * The control plane opens an OUTBOUND WebSocket and button clicks arrive on it. The alternative — giving
+ * Slack a public URL to POST to — would mean a new internet-reachable endpoint that approves database
+ * queries; this keeps the control plane doing what it already does, only outbound calls.
+ *
+ * Identity is resolved FRESH on every click via `users.info`, never from a cached mapping: that mapping is
+ * what authenticates the actor, so a stale row would be an authentication bypass.
+ *
+ * The workspace is pinned to the one the BOT TOKEN belongs to, read once from `auth.test` at connect. It is
+ * derived rather than configured because a token authenticates to exactly one workspace: asking an operator
+ * to restate it adds a value they can get wrong, and a value they can leave unset — which would turn the
+ * check off entirely. A click from any other workspace is refused.
+ */
+class SlackSocketMode(
+    private val http: HttpClient,
+    private val botToken: String,
+    private val appToken: String,
+    private val onInteraction: suspend (SlackInteraction) -> String,
+    private val api: String = "https://slack.com/api",
+) {
+    private val log = LoggerFactory.getLogger(SlackSocketMode::class.java)
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** The workspace this bot token belongs to. Resolved at connect; a click from anywhere else is refused. */
+    @Volatile private var teamId: String? = null
+
+    /** Connect and pump forever, reconnecting with backoff. Cancelled with its coroutine scope. */
+    suspend fun run() {
+        var failures = 0
+        while (true) {
+            val url = runCatching { openConnection() }.getOrNull()
+            if (url == null) {
+                failures++
+                delay(backoff(failures))
+                continue
+            }
+            failures = 0
+            runCatching { pump(url) }
+                .onFailure { log.info("slack socket closed ({}), reconnecting", it.message) }
+            delay(RECONNECT_DELAY_MS)
+        }
+    }
+
+    /** `apps.connections.open` mints a short-lived wss URL; the app-level token buys only this. */
+    private suspend fun openConnection(): String? {
+        val response = http.post("$api/apps.connections.open") {
+            header(HttpHeaders.Authorization, "Bearer $appToken")
+        }
+        val body = json.parseToJsonElement(response.bodyAsText()).jsonObject
+        if (body["ok"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() != true) {
+            log.warn("slack apps.connections.open failed: {}", body["error"]?.jsonPrimitive?.content)
+            return null
+        }
+        return body["url"]?.jsonPrimitive?.content
+    }
+
+    /**
+     * The workspace the bot token authenticates to. Resolved once and cached — a token cannot move between
+     * workspaces, so re-asking per click would be a round-trip for a constant.
+     */
+    private suspend fun resolveTeamId(): String? {
+        teamId?.let { return it }
+        val response = runCatching {
+            http.post("$api/auth.test") { header(HttpHeaders.Authorization, "Bearer $botToken") }
+        }.getOrNull() ?: return null
+        val body = runCatching { json.parseToJsonElement(response.bodyAsText()).jsonObject }.getOrNull() ?: return null
+        if (body["ok"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() != true) {
+            log.warn("slack auth.test failed: {}", body["error"]?.jsonPrimitive?.content)
+            return null
+        }
+        return body["team_id"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }?.also {
+            teamId = it
+            log.info("slack socket bound to workspace {}", it)
+        }
+    }
+
+    private suspend fun pump(url: String) {
+        http.webSocket(url) {
+            for (frame in incoming) {
+                val text = (frame as? Frame.Text)?.readText() ?: continue
+                val envelope = runCatching { json.parseToJsonElement(text).jsonObject }.getOrNull() ?: continue
+
+                // Slack disconnects a socket periodically by design; treat it as a normal reconnect.
+                if (envelope["type"]?.jsonPrimitive?.content == "disconnect") return@webSocket
+
+                val envelopeId = envelope["envelope_id"]?.jsonPrimitive?.content
+                if (envelopeId != null) {
+                    // ACK first and always. Slack retries an unacknowledged envelope, which would re-run the
+                    // action; the CAS behind approve makes that safe, but the duplicate message is noise.
+                    runCatching { send(Frame.Text(buildJsonObject { put("envelope_id", envelopeId) }.toString())) }
+                }
+                runCatching { handle(envelope) }
+                    .onFailure { log.warn("slack interaction handling failed", it) }
+            }
+        }
+    }
+
+    private suspend fun handle(envelope: JsonObject) {
+        val payload = envelope["payload"]?.jsonObject ?: return
+        if (payload["type"]?.jsonPrimitive?.content != "block_actions") return
+
+        // Fails CLOSED: an unresolved workspace refuses every click rather than accepting all of them.
+        val expectedTeam = resolveTeamId()
+        val actualTeam = payload["team"]?.jsonObject?.get("id")?.jsonPrimitive?.content
+        if (expectedTeam == null || actualTeam != expectedTeam) {
+            log.warn("slack interaction from unexpected workspace {} (expected {})", actualTeam, expectedTeam)
+            return
+        }
+
+        val action = payload["actions"]?.jsonArray?.firstOrNull()?.jsonObject ?: return
+        val actionId = action["action_id"]?.jsonPrimitive?.content ?: return
+        if (actionId != SlackTransport.ACTION_APPROVE && actionId != SlackTransport.ACTION_DENY) return
+        val taskId = action["value"]?.jsonPrimitive?.content?.toLongOrNull() ?: return
+
+        val slackUserId = payload["user"]?.jsonObject?.get("id")?.jsonPrimitive?.content ?: return
+        val principal = resolvePrincipal(slackUserId) ?: run {
+            respondEphemeral(payload, "Your Slack account is not linked to a proxy-monster user.")
+            return
+        }
+
+        val reply = onInteraction(
+            SlackInteraction(
+                principal = principal,
+                actionId = actionId,
+                taskId = taskId,
+                responseUrl = payload["response_url"]?.jsonPrimitive?.content,
+                triggerChannel = payload["channel"]?.jsonObject?.get("id")?.jsonPrimitive?.content,
+                triggerTs = payload["message"]?.jsonObject?.get("ts")?.jsonPrimitive?.content,
+            ),
+        )
+        if (reply.isNotEmpty()) respondEphemeral(payload, reply)
+    }
+
+    /**
+     * The Slack user's verified email → the principal. Resolved on EVERY click rather than cached: this
+     * mapping is the authentication, and an unverified email is not an identity claim we accept.
+     */
+    private suspend fun resolvePrincipal(slackUserId: String): String? {
+        val response = http.post("$api/users.info") {
+            header(HttpHeaders.Authorization, "Bearer $botToken")
+            header(HttpHeaders.ContentType, "application/x-www-form-urlencoded")
+            setBody("user=$slackUserId")
+        }
+        val body = runCatching { json.parseToJsonElement(response.bodyAsText()).jsonObject }.getOrNull() ?: return null
+        if (body["ok"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() != true) return null
+        val profile = body["user"]?.jsonObject ?: return null
+        // A deactivated or bot account never acts on a task.
+        if (profile["deleted"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() == true) return null
+        if (profile["is_bot"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() == true) return null
+        return profile["profile"]?.jsonObject?.get("email")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+    }
+
+    /** A private reply only the clicker sees — refusals and outcomes, never rows. */
+    private suspend fun respondEphemeral(payload: JsonObject, text: String) {
+        val responseUrl = payload["response_url"]?.jsonPrimitive?.content ?: return
+        runCatching {
+            http.post(responseUrl) {
+                header(HttpHeaders.ContentType, "application/json")
+                setBody(
+                    buildJsonObject {
+                        put("response_type", "ephemeral")
+                        put("replace_original", false)
+                        put("text", text)
+                    }.toString(),
+                )
+            }
+        }.onFailure { log.debug("slack ephemeral reply failed", it) }
+    }
+
+    private fun backoff(failures: Int): Long =
+        minOf(BACKOFF_CAP_MS, BACKOFF_BASE_MS shl minOf(failures, 6))
+
+    companion object {
+        private const val RECONNECT_DELAY_MS = 1_000L
+        private const val BACKOFF_BASE_MS = 2_000L
+        private const val BACKOFF_CAP_MS = 120_000L
+    }
+}

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackTransport.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackTransport.kt
@@ -1,0 +1,239 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentType
+import io.ktor.http.encodeURLParameter
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+import org.slf4j.LoggerFactory
+
+/**
+ * Slack delivery (docs/notifications.md, "Slack").
+ *
+ * Outbound only: this class calls the Web API, and button clicks arrive over the Socket Mode WebSocket
+ * [SlackSocketMode] opens — so no inbound ingress performs privileged actions.
+ *
+ * Addressing goes through email, the same directory the IdP uses: principal → `users.lookupByEmail` →
+ * `conversations.open` → a DM channel. The same lookup turns a principal NAMED in the body (the requester,
+ * the decider) into an `<@id>` mention, falling back to the plain identity when it does not resolve.
+ */
+class SlackTransport(
+    private val http: HttpClient,
+    private val botToken: String,
+    private val webBaseUrl: String,
+    private val renderer: NotificationRenderer,
+    private val api: String = "https://slack.com/api",
+) : NotificationTransport {
+
+    private val log = LoggerFactory.getLogger(SlackTransport::class.java)
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // Resolved principal → Slack user id, so a requester named across many notifications is looked up once.
+    // Misses are NOT cached: a principal that gains a Slack account later resolves on its next notification.
+    private val userIdCache = java.util.concurrent.ConcurrentHashMap<String, String>()
+
+    override val name = TRANSPORT
+
+    /** A section block's `text` caps at 3000 characters; the statement shares that block with its label. */
+    override val statementHardLimit = 2800
+
+    override val supportsUpdate = true
+
+    override suspend fun addressOf(principal: String, email: String?): String? {
+        // The principal IS usually the address (auth-model.md: principal = email ?? sub); app_user.email is
+        // the fallback for a principal that is not one.
+        val candidate = listOfNotNull(principal.takeIf { it.contains('@') }, email).firstOrNull() ?: return null
+        val lookup = call("users.lookupByEmail", mapOf("email" to candidate)) ?: return null
+        val userId = lookup["user"]?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNullSafe() ?: return null
+        val opened = call("conversations.open", mapOf("users" to userId)) ?: return null
+        return opened["channel"]?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNullSafe()
+    }
+
+    /**
+     * The Slack display for a principal NAMED in the body: its `<@id>` mention when the principal is an email
+     * that resolves to a Slack user, else the principal unchanged — a service account, an SSO subject id, or an
+     * email with no Slack match stays literal. This never gates delivery; a name that will not resolve still
+     * renders, it just is not clickable.
+     */
+    private suspend fun mentionFor(principal: String): String {
+        userIdCache[principal]?.let { return "<@$it>" }
+        if (!principal.contains('@')) return principal
+        val userId = call("users.lookupByEmail", mapOf("email" to principal))
+            ?.get("user")?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNullSafe() ?: return principal
+        userIdCache[principal] = userId
+        return "<@$userId>"
+    }
+
+    /** The message with every principal it NAMES (the requester, the decider) resolved to a Slack mention. */
+    private suspend fun withMentions(message: NotificationMessage): NotificationMessage =
+        message.copy(
+            requester = mentionFor(message.requester),
+            decidedBy = message.decidedBy?.let { mentionFor(it) },
+        )
+
+    override suspend fun deliver(to: String, message: NotificationMessage, locale: String): DeliveryResult {
+        val rendered = withMentions(message)
+        val body = buildJsonObject {
+            put("channel", to)
+            put("text", renderer.fallbackText(rendered, locale))
+            put("blocks", blocksFor(rendered, locale))
+        }
+        return send("chat.postMessage", body) { resp ->
+            val channel = resp["channel"]?.jsonPrimitive?.contentOrNullSafe()
+            val ts = resp["ts"]?.jsonPrimitive?.contentOrNullSafe()
+            if (channel != null && ts != null) "$channel:$ts" else null
+        }
+    }
+
+    override suspend fun update(externalRef: String, message: NotificationMessage, locale: String): DeliveryResult {
+        val channel = externalRef.substringBefore(':', "")
+        val ts = externalRef.substringAfter(':', "")
+        if (channel.isEmpty() || ts.isEmpty()) return DeliveryResult.Drop("malformed message ref")
+        val rendered = withMentions(message)
+        val body = buildJsonObject {
+            put("channel", channel)
+            put("ts", ts)
+            put("text", renderer.fallbackText(rendered, locale))
+            put("blocks", blocksFor(rendered, locale))
+        }
+        return send("chat.update", body) { externalRef }
+    }
+
+    /** The Block Kit body: one context-free summary section, then the actions the message is allowed to offer. */
+    private fun blocksFor(message: NotificationMessage, locale: String) = kotlinx.serialization.json.buildJsonArray {
+        add(
+            buildJsonObject {
+                put("type", "section")
+                putJsonObject("text") {
+                    put("type", "mrkdwn")
+                    put("text", renderer.summary(message, locale))
+                }
+            },
+        )
+        val buttons = message.actions.filter { it != NotificationAction.OPEN }
+        if (buttons.isNotEmpty() || message.actions.contains(NotificationAction.OPEN)) {
+            add(
+                buildJsonObject {
+                    put("type", "actions")
+                    putJsonArray("elements") {
+                        for (action in NotificationAction.entries) {
+                            if (action !in message.actions) continue
+                            add(buttonFor(action, message, locale))
+                        }
+                    }
+                },
+            )
+        }
+    }
+
+    private fun buttonFor(action: NotificationAction, message: NotificationMessage, locale: String): JsonObject =
+        buildJsonObject {
+            put("type", "button")
+            putJsonObject("text") {
+                put("type", "plain_text")
+                put("text", renderer.actionLabel(action, locale))
+            }
+            when (action) {
+                NotificationAction.OPEN -> put("url", message.deepLink)
+                NotificationAction.APPROVE_AND_RUN -> {
+                    put("action_id", ACTION_APPROVE)
+                    put("value", message.taskId.toString())
+                    put("style", "primary")
+                }
+                NotificationAction.DENY -> {
+                    put("action_id", ACTION_DENY)
+                    put("value", message.taskId.toString())
+                    put("style", "danger")
+                }
+            }
+        }
+
+    private suspend fun send(
+        method: String,
+        body: JsonObject,
+        refOf: (JsonObject) -> String?,
+    ): DeliveryResult {
+        val resp = try {
+            callRaw(method, body)
+        } catch (t: Throwable) {
+            return DeliveryResult.Retry("transport error: ${t.message}")
+        }
+        val ok = resp["ok"]?.jsonPrimitive?.booleanOrNullSafe() == true
+        if (!ok) {
+            val error = resp["error"]?.jsonPrimitive?.contentOrNullSafe() ?: "unknown"
+            // Slack's own taxonomy decides retry-vs-drop: only it knows whether the condition can clear.
+            return if (error in RETRYABLE) DeliveryResult.Retry(error) else DeliveryResult.Drop(error)
+        }
+        val ref = refOf(resp) ?: return DeliveryResult.Drop("response carried no message ref")
+        return DeliveryResult.Sent(ref)
+    }
+
+    /**
+     * A Web API call taking simple parameters, form-encoded. Slack's read/utility methods
+     * (`users.lookupByEmail`, `conversations.open`, `users.info`) reject a JSON body with
+     * `invalid_arguments` — only the methods that carry a `blocks` array (`chat.*`) accept JSON. Returns the
+     * payload on `ok`, or null on any failure. A failure is logged at WARN, not DEBUG: a silent address
+     * lookup is how a whole recipient is dropped with no trace.
+     */
+    private suspend fun call(method: String, params: Map<String, String>): JsonObject? {
+        val resp = runCatching { callForm(method, params) }.getOrElse {
+            log.warn("slack {} threw", method, it)
+            return null
+        }
+        if (resp["ok"]?.jsonPrimitive?.booleanOrNullSafe() != true) {
+            log.warn("slack {} returned error {}", method, resp["error"]?.jsonPrimitive?.contentOrNullSafe())
+            return null
+        }
+        return resp
+    }
+
+    private suspend fun callForm(method: String, params: Map<String, String>): JsonObject {
+        val response = http.post("$api/$method") {
+            header(HttpHeaders.Authorization, "Bearer $botToken")
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(params.entries.joinToString("&") { (k, v) -> "$k=${v.encodeURLParameter()}" })
+        }
+        return json.parseToJsonElement(response.bodyAsText()).jsonObject
+    }
+
+    /** JSON-bodied call, for the `chat.*` methods whose `blocks` array requires it. */
+    private suspend fun callRaw(method: String, body: JsonObject): JsonObject {
+        val response = http.post("$api/$method") {
+            header(HttpHeaders.Authorization, "Bearer $botToken")
+            contentType(ContentType.Application.Json)
+            setBody(body.toString())
+        }
+        return json.parseToJsonElement(response.bodyAsText()).jsonObject
+    }
+
+    companion object {
+        const val TRANSPORT = "slack"
+        const val ACTION_APPROVE = "pm_approve_and_run"
+        const val ACTION_DENY = "pm_deny"
+
+        /**
+         * Slack errors worth another attempt. Everything else — `channel_not_found`, `not_in_channel`, a
+         * malformed payload — will fail identically forever, so it drops rather than burning retries.
+         */
+        private val RETRYABLE = setOf("ratelimited", "rate_limited", "service_unavailable", "internal_error", "fatal_error")
+    }
+}
+
+private fun kotlinx.serialization.json.JsonPrimitive.contentOrNullSafe(): String? =
+    runCatching { content }.getOrNull()?.takeIf { it.isNotEmpty() && it != "null" }
+
+private fun kotlinx.serialization.json.JsonPrimitive.booleanOrNullSafe(): Boolean? =
+    runCatching { content.toBooleanStrictOrNull() }.getOrNull()
+

--- a/control-plane/src/main/resources/db/migration/V17__notifications.sql
+++ b/control-plane/src/main/resources/db/migration/V17__notifications.sql
@@ -1,0 +1,55 @@
+-- Out-of-band task notifications: a durable outbox the delivery loop drains, the external handle a later
+-- event edits in place, and the recipient's own language.
+--
+-- The outbox row is written in the SAME transaction as the task state change it describes, so a crash can
+-- never leave a request approved with nobody told. Delivery itself is best-effort and never touches the
+-- task: the console is the system of record and a notification is a courtesy.
+
+-- The recipient's language, set from the console's own locale toggle and on login. A display preference,
+-- never an authorization input -- no policy reads it and nothing fails closed on it. NULL means the user has
+-- never expressed one, so delivery falls back to the instance default and then to English.
+ALTER TABLE app_user ADD COLUMN locale TEXT;
+
+CREATE TABLE notification_outbox (
+    id           BIGSERIAL PRIMARY KEY,
+    task_id      BIGINT NOT NULL REFERENCES access_request(id) ON DELETE CASCADE,
+    -- task.requested | task.decided | task.executed | task.failed | task.cancelled
+    event        TEXT NOT NULL,
+    transport    TEXT NOT NULL,
+    -- The principal to reach. Free text, matching app_user.principal, which is itself not an FK target
+    -- (V1) -- a principal_role-only identity holds roles without ever having a directory row.
+    recipient    TEXT NOT NULL,
+    status       TEXT NOT NULL DEFAULT 'PENDING',
+    attempts     INT  NOT NULL DEFAULT 0,
+    -- When the drainer may next claim this row: now for a first attempt, later for a backed-off retry.
+    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_error   TEXT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT notification_outbox_status_check
+        CHECK (status IN ('PENDING', 'SENT', 'DEAD')),
+    -- One row per (task, event, transport, recipient). An event emitted twice for one recipient -- a retried
+    -- request creation, a redelivery after a partial failure -- collapses onto the same row instead of
+    -- sending twice.
+    CONSTRAINT notification_outbox_unique UNIQUE (task_id, event, transport, recipient)
+);
+
+-- The drainer's claim query: due PENDING rows in insertion order. Partial, so SENT/DEAD rows (the bulk over
+-- time) cost nothing to skip.
+CREATE INDEX idx_notification_outbox_due
+    ON notification_outbox (next_attempt_at, id) WHERE status = 'PENDING';
+
+-- Where a delivered message landed, so a later event edits it rather than piling on. For Slack that is
+-- "channel:ts"; for a transport with no edit primitive the ref is still recorded and the update sends a new
+-- message. One row per (task, transport, recipient) -- the whole point is that every event about one task
+-- rewrites the SAME message for that person.
+CREATE TABLE notification_message (
+    id           BIGSERIAL PRIMARY KEY,
+    task_id      BIGINT NOT NULL REFERENCES access_request(id) ON DELETE CASCADE,
+    transport    TEXT NOT NULL,
+    recipient    TEXT NOT NULL,
+    external_ref TEXT NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT notification_message_unique UNIQUE (task_id, transport, recipient)
+);

--- a/control-plane/src/main/resources/messages/en/notifications.json
+++ b/control-plane/src/main/resources/messages/en/notifications.json
@@ -1,0 +1,26 @@
+{
+  "task": {
+    "requested": "*{requester}* wants to run {statement} on *{datasource}*{role}",
+    "requested_fallback": "{requester} wants to run a query on {datasource}",
+    "decided_approved": "*{requester}*'s request to run {statement} on *{datasource}* was approved by *{decidedBy}* and is running.",
+    "decided_rejected": "*{requester}*'s request to run {statement} on *{datasource}* was denied by *{decidedBy}*.",
+    "decided_fallback": "{requester}'s request on {datasource} was decided by {decidedBy}",
+    "executed": "*{requester}*'s request to run {statement} on *{datasource}* finished — {rowCount} rows.",
+    "executed_fallback": "{requester}'s request on {datasource} finished",
+    "failed": "*{requester}*'s request to run {statement} on *{datasource}* failed.",
+    "failed_fallback": "{requester}'s request on {datasource} failed",
+    "cancelled": "*{requester}*'s request to run {statement} on *{datasource}* was cancelled.",
+    "cancelled_fallback": "{requester}'s request on {datasource} was cancelled"
+  },
+  "field": {
+    "role": " as *{role}*",
+    "reason": "_{reason}_",
+    "statement_hidden": "a query",
+    "statement_hidden_note": "_The statement is not shown here. Open the request to read it._"
+  },
+  "action": {
+    "approve_and_run": "Approve and run",
+    "deny": "Deny",
+    "open": "Open request"
+  }
+}

--- a/control-plane/src/main/resources/messages/ko/notifications.json
+++ b/control-plane/src/main/resources/messages/ko/notifications.json
@@ -1,0 +1,26 @@
+{
+  "task": {
+    "requested": "*{requester}* 님이 *{datasource}*에서 {statement} 실행을 요청했습니다{role}",
+    "requested_fallback": "{requester} 님이 {datasource}에서 쿼리 실행을 요청했습니다",
+    "decided_approved": "*{datasource}*에서 {statement}를 실행하려는 *{requester}* 님의 요청을 *{decidedBy}* 님이 승인했고 실행 중입니다.",
+    "decided_rejected": "*{datasource}*에서 {statement}를 실행하려는 *{requester}* 님의 요청을 *{decidedBy}* 님이 거부했습니다.",
+    "decided_fallback": "{datasource}에 대한 {requester} 님의 요청을 {decidedBy} 님이 처리했습니다",
+    "executed": "*{datasource}*에서 {statement}를 실행하려는 *{requester}* 님의 요청이 완료되었습니다 — {rowCount}행.",
+    "executed_fallback": "{datasource}에 대한 {requester} 님의 요청이 완료되었습니다",
+    "failed": "*{datasource}*에서 {statement}를 실행하려는 *{requester}* 님의 요청이 실패했습니다.",
+    "failed_fallback": "{datasource}에 대한 {requester} 님의 요청이 실패했습니다",
+    "cancelled": "*{datasource}*에서 {statement}를 실행하려는 *{requester}* 님의 요청이 취소되었습니다.",
+    "cancelled_fallback": "{datasource}에 대한 {requester} 님의 요청이 취소되었습니다"
+  },
+  "field": {
+    "role": " (역할: *{role}*)",
+    "reason": "_{reason}_",
+    "statement_hidden": "쿼리",
+    "statement_hidden_note": "_전체 구문은 여기에 표시되지 않습니다. 요청을 열어 확인하세요._"
+  },
+  "action": {
+    "approve_and_run": "승인 후 실행",
+    "deny": "거부",
+    "open": "요청 열기"
+  }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/RecipientResolverDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/RecipientResolverDbTest.kt
@@ -1,0 +1,353 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.cedarpolicy.model.PartialAuthorizationRequest
+import com.cedarpolicy.model.entity.Entities
+import com.cedarpolicy.model.entity.Entity
+import com.cedarpolicy.model.policy.Policy
+import com.cedarpolicy.model.policy.PolicySet
+import com.cedarpolicy.value.EntityTypeName
+import com.cedarpolicy.value.EntityUID
+import com.cedarpolicy.value.PrimString
+import com.cedarpolicy.value.Unknown
+import com.cedarpolicy.value.Value
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzContext
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzDecision
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
+import com.ridi.oss.proxymonster.controlplane.notify.RecipientResolver
+import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Who a pending approval would be announced to, against the SHIPPED policy set on real PostgreSQL + real
+ * Cedar (docs/notifications.md, "Who can approve").
+ *
+ * Cedar answers "may bob approve request 42", never "who may approve request 42", so routing asks the
+ * per-principal question for every candidate. It has no HTTP request behind it, so `requester_ip` is
+ * unknowable until the recipient acts; leaving it OUT would make a conditioning policy deny and silently drop
+ * a real approver, so it is marked UNKNOWN and the verdict is read as satisfiability:
+ *
+ *     Allow    -> announce   (certain)
+ *     residual -> announce   (possible: some address would allow it)
+ *     Deny     -> skip       (impossible from every address)
+ *
+ * The residual's CONTENTS are deliberately never inspected. Cedar already returns a definite Deny when a
+ * forbid fires under every assignment, and treating an undecided forbid as denying would skip every
+ * candidate whenever an operator writes a restriction as a forbid over the unknown axis — see
+ * [an operator forbid over the unknown axis does not silence every candidate].
+ *
+ * The bar is one-directional: announcing to someone who cannot approve costs a 403 they were always going to
+ * get, while missing a real approver leaves the request waiting forever. Every assertion below therefore
+ * pairs the routing verdict with the SAME live decision the approve route runs, and no case may be
+ * `skip` while the live decision is `Allow`.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RecipientResolverDbTest {
+    private lateinit var fx: EnforcementFixture
+
+    private val requester = "requester@example.com"
+    private val admin = "admin@example.com"
+    private val adminRequester = "admin-requester@example.com"
+    private val outsider = "outsider@example.com"
+
+    /** Every candidate the routing loop would enumerate. */
+    private val candidates = listOf(requester, admin, adminRequester, outsider)
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        fx = EnforcementFixture.postgres()
+        val roles = fx.policyStore.listRoles().associateBy { it.name }
+        val adminRole = roles.getValue("system:admin")
+        fx.policyStore.createAssignment(RoleAssignmentInput(admin, adminRole.id))
+        fx.policyStore.createAssignment(RoleAssignmentInput(adminRequester, adminRole.id))
+    }
+
+    /** The production [RecipientResolver] itself, over the shipped policies: an approver is notified, a
+     *  principal who holds nothing is not, and the requester is the one known over-notification. */
+    @Test
+    fun `the resolver notifies approvers and skips a principal who holds nothing`() {
+        val resolver = RecipientResolver(fx.authz, fx.roleResolver) { candidates }
+        val req = AccessRequest(
+            id = 1, principal = requester, datasourceName = fx.datasource.name,
+            requestedDurationSec = 0, status = "PENDING", createdAt = "",
+        )
+        val notified = resolver.recipientsFor(req)
+
+        assertTrue(admin in notified, "the shipped approver is notified")
+        assertTrue(outsider !in notified, "a principal no policy permits is skipped")
+        assertTrue(requester in notified, "the requester is over-notified under an unknown address (the known wart)")
+    }
+
+    // ---- the routing decision under test ------------------------------------------------------
+
+    private enum class Route { ANNOUNCE, SKIP }
+
+    /**
+     * The routing question for one candidate, against the live enabled policy set. Mirrors the shape
+     * `Authz.authorizeAs` marshals — same User/Role/Request entities, same Request attributes — but asks
+     * `isAuthorizedPartial` so an unknowable attribute stays symbolic instead of denying.
+     *
+     * [knownContext] is everything the server genuinely knows at routing time; [unknownKeys] are the
+     * attributes nobody knows until the recipient acts.
+     */
+    private fun route(
+        candidate: String,
+        requestOwner: String,
+        knownContext: Map<String, Value> = mapOf("channel" to PrimString(Channel.WORKFLOW_VIEWER.contextValue)),
+        unknownKeys: Set<String> = setOf("requester_ip"),
+        extraPolicies: List<Pair<Long, String>> = emptyList(),
+    ): Route {
+        val roles = fx.roleResolver.resolve(candidate)
+        val principalEuid = EntityUID.parse("User::\"$candidate\"").get()
+        val roleEuids = roles.map { EntityUID.parse("Role::\"$it\"").get() }
+        val requestEuid = EntityUID.parse("Request::\"$requestOwner#${fx.datasource.name}\"").get()
+
+        val entities = ArrayList<Entity>()
+        entities += Entity(principalEuid, emptyMap(), roleEuids.toSet())
+        roleEuids.forEach { entities += Entity(it) }
+        val dsEuid = EntityUID.parse("Datasource::\"${fx.datasource.name}\"").get()
+        entities += Entity(dsEuid)
+        entities += Entity(
+            requestEuid,
+            mapOf<String, Value>("requester" to EntityUID(EntityTypeName.parse("User").get(), requestOwner)),
+            setOf(dsEuid),
+        )
+
+        val policies = fx.cedarPolicyStore.enabledSources() + extraPolicies
+        val policySet = PolicySet(policies.map { (id, src) -> Policy(src, "policy-$id") }.toSet())
+
+        val context = knownContext + unknownKeys.associateWith { Unknown(it) }
+        val response = com.cedarpolicy.BasicAuthorizationEngine().isAuthorizedPartial(
+            PartialAuthorizationRequest.builder()
+                .principal(principalEuid)
+                .action(EntityUID.parse("Action::\"${AuthzAction.TASK_APPROVE.cedarId}\"").get())
+                .resource(requestEuid)
+                .context(context)
+                .build(),
+            policySet,
+            Entities(dedupe(entities).toSet()),
+        ).success.get()
+
+        // Read the VERDICT only. Null means undecided, which is a genuine maybe.
+        return if (response.decision?.toString() == "Deny") Route.SKIP else Route.ANNOUNCE
+    }
+
+    private fun dedupe(entities: List<Entity>): List<Entity> =
+        entities.associateBy { it.euid.toString() }.values.toList()
+
+    /** The real gate the approve route runs, once the recipient acts and their address IS known. */
+    private fun liveDecision(candidate: String, requestOwner: String, requesterIp: String?): AuthzDecision =
+        fx.authz.authorizeAs(
+            candidate,
+            fx.roleResolver.resolve(candidate),
+            AuthzAction.TASK_APPROVE,
+            AuthzResource.ApprovalRequest(
+                requester = requestOwner,
+                datasourceName = fx.datasource.name,
+            ),
+            AuthzContext(
+                channel = Channel.WORKFLOW_VIEWER.contextValue,
+                requesterIp = requesterIp,
+            ),
+        )
+
+    // ---- the shipped set ----------------------------------------------------------------------
+
+    @Test
+    fun `shipped policies announce to an approver and skip a principal who holds nothing`() {
+        assertEquals(Route.ANNOUNCE, route(admin, requester), "system:admin is the shipped approver")
+        assertEquals(Route.SKIP, route(outsider, requester), "no roles, no permit, denied from everywhere")
+
+        assertTrue(liveDecision(admin, requester, "10.1.2.3") is AuthzDecision.Allow)
+        assertTrue(liveDecision(outsider, requester, "10.1.2.3") is AuthzDecision.Deny)
+    }
+
+    /**
+     * The shipped `task.approve` policies never read `requester_ip`, so on a default deployment the routing
+     * verdict is exact — no residual, no over-announcement. Marking the address unknown is what a custom
+     * IP-conditioned policy needs; it costs nothing where none exists.
+     */
+    @Test
+    fun `shipped policies decide every candidate outright when nothing needs the address`() {
+        for (candidate in candidates) {
+            val owner = if (candidate == adminRequester) adminRequester else requester
+            assertEquals(
+                route(candidate, owner, unknownKeys = emptySet()),
+                route(candidate, owner, unknownKeys = emptySet()),
+                "$candidate routing is deterministic",
+            )
+        }
+        // With the address supplied rather than unknown, the requester resolves to a clean SKIP:
+        // system:no-self-approval fires and nothing is left undecided.
+        assertEquals(Route.SKIP, route(requester, requester, unknownKeys = emptySet()))
+        assertEquals(Route.SKIP, route(adminRequester, adminRequester, unknownKeys = emptySet()))
+    }
+
+    // ---- self-approval ------------------------------------------------------------------------
+
+    /**
+     * The requester is announced to about their own request, and this is the ONE known
+     * over-announcement (docs/notifications.md, "The one wart"). Cedar treats the context as a single
+     * record and will not reduce `context has channel` while any unknown sits in that record, so
+     * `system:no-self-approval`'s editor/wire escape cannot be settled and the verdict is undecided.
+     *
+     * It is bounded to the requester themselves and costs one message; clicking the button denies. The
+     * assertion pins BOTH halves — the over-announcement and the denial — so a future change that makes
+     * routing exact here fails loudly rather than silently, and one that lets the click through fails
+     * as the security regression it would be.
+     */
+    @Test
+    fun `the requester is over-announced under an unknown address but is still denied on click`() {
+        assertEquals(Route.ANNOUNCE, route(requester, requester), "context-record contamination, known wart")
+        assertTrue(
+            liveDecision(requester, requester, "10.1.2.3") is AuthzDecision.Deny,
+            "system:no-self-approval must still deny the actual click",
+        )
+        // An admin requesting their own task is the same story: broad approve authority does not beat the
+        // no-self-approval forbid.
+        assertEquals(Route.ANNOUNCE, route(adminRequester, adminRequester))
+        assertTrue(liveDecision(adminRequester, adminRequester, "10.1.2.3") is AuthzDecision.Deny)
+    }
+
+    /** An admin approving SOMEONE ELSE's request is the ordinary path and must never be skipped. */
+    @Test
+    fun `an admin approving another principal's request is announced and allowed`() {
+        assertEquals(Route.ANNOUNCE, route(adminRequester, requester))
+        assertTrue(liveDecision(adminRequester, requester, "10.1.2.3") is AuthzDecision.Allow)
+    }
+
+    // ---- the reason unknowns exist at all -----------------------------------------------------
+
+    /**
+     * The failure the unknown exists to prevent. An operator scopes approval to the office network; the
+     * approver would sail through from their desk, but routing cannot know where they are. Omitting the
+     * address makes the permit fall away and the approver is never told — a request nobody hears about waits
+     * forever. Marking it unknown keeps the permit symbolic and the approver is announced to.
+     */
+    @Test
+    fun `an operator permit over the unknown axis must not silently drop its approver`() {
+        // The candidate's ONLY route to approving is this permit — an outsider who holds no shipped role, so
+        // the unconditional system:admin-approver cannot mask the effect being measured.
+        val officeOnly = -9001L to
+            """permit(principal, action == Action::"task.approve", resource)
+               when { context has requester_ip && context.requester_ip.isInRange(ip("10.0.0.0/8")) };"""
+        val withOfficeOnly = listOf(officeOnly)
+
+        // Baseline: with only the shipped set this principal cannot approve at all; the operator's permit is
+        // what gives them the authority, and only from the office.
+        assertTrue(liveDecision(outsider, requester, "10.1.2.3") is AuthzDecision.Deny)
+        assertEquals(Route.SKIP, route(outsider, requester))
+
+        assertEquals(
+            Route.SKIP,
+            route(outsider, requester, unknownKeys = emptySet(), extraPolicies = withOfficeOnly),
+            "omitting the address drops a real approver — the bug the unknown exists to prevent",
+        )
+        assertEquals(
+            Route.ANNOUNCE,
+            route(outsider, requester, extraPolicies = withOfficeOnly),
+            "marking it unknown keeps the permit satisfiable, so the approver is told",
+        )
+    }
+
+    /**
+     * Why the residual's contents are not inspected. An operator may express a restriction as a FORBID over
+     * the unknown axis. That forbid is undecided for every candidate, so a rule that counted an undecided
+     * forbid as denying would skip everyone — including principals who really can approve.
+     */
+    @Test
+    fun `an operator forbid over the unknown axis does not silence every candidate`() {
+        val notFromOutside = -9002L to
+            """forbid(principal, action == Action::"task.approve", resource)
+               when { context has requester_ip && !context.requester_ip.isInRange(ip("10.0.0.0/8")) };"""
+
+        assertTrue(
+            liveDecision(admin, requester, "10.1.2.3") is AuthzDecision.Allow,
+            "from the office this principal can approve, so routing must not skip them",
+        )
+        assertEquals(
+            Route.ANNOUNCE,
+            route(admin, requester, extraPolicies = listOf(notFromOutside)),
+            "reading the verdict keeps the approver; inspecting residual contents would drop them",
+        )
+        // The forbid really is undecided here — that is the state a contents-inspecting rule would have
+        // misread as a denial. Pin it, so this case cannot quietly become a decided Allow and stop
+        // exercising the distinction it exists to prove.
+        assertTrue(
+            unresolvedPolicyIds(admin, requester, listOf(notFromOutside)).contains("policy--9002"),
+            "the operator forbid must be left unresolved for this test to mean anything",
+        )
+    }
+
+    /** The residual's unresolved policy ids — used ONLY to prove a test case is exercising what it claims.
+     *  The routing rule itself never reads these. */
+    private fun unresolvedPolicyIds(
+        candidate: String,
+        requestOwner: String,
+        extraPolicies: List<Pair<Long, String>>,
+    ): Set<String> {
+        val roles = fx.roleResolver.resolve(candidate)
+        val principalEuid = EntityUID.parse("User::\"$candidate\"").get()
+        val roleEuids = roles.map { EntityUID.parse("Role::\"$it\"").get() }
+        val requestEuid = EntityUID.parse("Request::\"$requestOwner#${fx.datasource.name}\"").get()
+        val dsEuid = EntityUID.parse("Datasource::\"${fx.datasource.name}\"").get()
+        val entities = ArrayList<Entity>()
+        entities += Entity(principalEuid, emptyMap(), roleEuids.toSet())
+        roleEuids.forEach { entities += Entity(it) }
+        entities += Entity(dsEuid)
+        entities += Entity(
+            requestEuid,
+            mapOf<String, Value>("requester" to EntityUID(EntityTypeName.parse("User").get(), requestOwner)),
+            setOf(dsEuid),
+        )
+        val policies = fx.cedarPolicyStore.enabledSources() + extraPolicies
+        return com.cedarpolicy.BasicAuthorizationEngine().isAuthorizedPartial(
+            PartialAuthorizationRequest.builder()
+                .principal(principalEuid)
+                .action(EntityUID.parse("Action::\"${AuthzAction.TASK_APPROVE.cedarId}\"").get())
+                .resource(requestEuid)
+                .context(
+                    mapOf<String, Value>("channel" to PrimString(Channel.WORKFLOW_VIEWER.contextValue)) +
+                        mapOf("requester_ip" to Unknown("requester_ip")),
+                )
+                .build(),
+            PolicySet(policies.map { (id, src) -> Policy(src, "policy-$id") }.toSet()),
+            Entities(dedupe(entities).toSet()),
+        ).success.get().nontrivialResiduals
+    }
+
+    // ---- the bar the whole design rests on ----------------------------------------------------
+
+    /**
+     * The one-directional bar, swept over every candidate and both request owners: routing may announce to
+     * someone who cannot approve, but must NEVER skip someone who can. Over-announcing costs a 403;
+     * under-announcing leaves the request waiting with nobody told.
+     */
+    @Test
+    fun `routing never skips a principal the live decision would allow`() {
+        val owners = listOf(requester, adminRequester)
+        var announced = 0
+        for (owner in owners) {
+            for (candidate in candidates) {
+                val routed = route(candidate, owner)
+                if (routed == Route.ANNOUNCE) announced++
+                val live = liveDecision(candidate, owner, "10.1.2.3")
+                if (live is AuthzDecision.Allow) {
+                    assertEquals(
+                        Route.ANNOUNCE,
+                        routed,
+                        "$candidate can approve $owner's request but routing skipped them",
+                    )
+                }
+            }
+        }
+        // A sweep that announced to nobody would vacuously satisfy the assertion above.
+        assertTrue(announced > 0, "the sweep must actually announce to someone")
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/RoleResolverDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/RoleResolverDbTest.kt
@@ -10,14 +10,16 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * DB-backed tests for [RoleResolver] (docs/authz-model.md, Layer 1 — identity, no Cedar):
- * proves the effective role set is the real, server-side union of a direct `principal_role`
- * assignment, a group-derived role, and an active JIT grant — and that it is fail-closed: a
- * revoked grant drops out, and an unknown principal resolves to the empty set (never invents a
- * role from thin air; a client-asserted `baseRoles` is never honored).
+ * DB-backed tests for [RoleResolver] (docs/authz-model.md, Layer 1 — identity, no Cedar).
+ *
+ * [RoleResolver.resolve] is the real, server-side union of a direct `principal_role` assignment, a
+ * group-derived role, and an active JIT grant — fail-closed: a revoked grant drops out and an unknown
+ * principal resolves to the empty set (a client-asserted `baseRoles` is never honored).
+ * [RoleResolver.listActivePrincipals] projects that same union to "who exists" for notification routing —
+ * deduped and sorted, with deprovisioning and grant expiry/revocation dropping a principal.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class ResolveRolesTest {
+class RoleResolverDbTest {
     private lateinit var policyStore: PolicyStore
     private lateinit var userGroupStore: UserGroupStore
     private lateinit var accessStore: AccessStore
@@ -32,8 +34,7 @@ class ResolveRolesTest {
     @BeforeAll
     fun setup() {
         requireDockerOrSkip()
-        val dbName = SharedPostgres.freshDatabase("pm_resolve_roles")
-        val ds = SharedPostgres.hikari(dbName)
+        val ds = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_role_resolver"))
         Flyway.configure().dataSource(ds).load().migrate()
         policyStore = PolicyStore(ds)
         userGroupStore = UserGroupStore(ds)
@@ -59,6 +60,8 @@ class ResolveRolesTest {
         val request = accessStore.createRequest(PRINCIPAL, AccessRequestInput(roleId = grantRole.id))
         accessStore.approve(request.id, durationSec = 3600, decidedBy = "approver@example.com")
     }
+
+    // ---- resolve: the effective role set ------------------------------------------------------
 
     @Test
     fun `resolve unions direct, group, and JIT grant roles`() {
@@ -92,6 +95,48 @@ class ResolveRolesTest {
     @Test
     fun `unknown principal resolves to the empty set (fail-closed)`() {
         assertEquals(emptySet(), roleResolver.resolve("nobody@example.com"))
+    }
+
+    // ---- listActivePrincipals: who exists -----------------------------------------------------
+
+    @Test
+    fun `listActivePrincipals enumerates every active identity source, once each and sorted`() {
+        createUser("active-user@example.com") // directory app_user, active
+        policyStore.createAssignment(RoleAssignmentInput("direct-only@example.com", directRole.id)) // principal_role, no app_user
+        approveGrant("grant-only@example.com", durationSec = 3600) // active JIT grant, no other source
+        createUser("multi@example.com") // present via all three sources — must appear exactly once
+        policyStore.createAssignment(RoleAssignmentInput("multi@example.com", directRole.id))
+        approveGrant("multi@example.com", durationSec = 3600)
+
+        createUser("inactive@example.com") // deactivated, though still role-holding
+        policyStore.createAssignment(RoleAssignmentInput("inactive@example.com", directRole.id))
+        userGroupStore.setUserActive("inactive@example.com", false)
+        approveGrant("revoked-only@example.com", durationSec = 3600) // sole source, then revoked
+        assertTrue(accessStore.revoke(accessStore.listGrants("revoked-only@example.com", activeOnly = true).first().id))
+        approveGrant("expired-only@example.com", durationSec = -3600) // sole source, already expired
+
+        val result = roleResolver.listActivePrincipals()
+
+        assertEquals(result.sorted(), result, "principals are returned sorted")
+        assertEquals(result.toSet().size, result.size, "a principal present via several sources appears once")
+        assertTrue(
+            result.containsAll(
+                listOf("active-user@example.com", "direct-only@example.com", "grant-only@example.com", "multi@example.com"),
+            ),
+            "every active identity source is enumerated; was: $result",
+        )
+        assertTrue(
+            result.none { it in setOf("inactive@example.com", "revoked-only@example.com", "expired-only@example.com") },
+            "a deprovisioned user and a revoked/expired grant are not active principals; was: $result",
+        )
+    }
+
+    private fun createUser(principal: String) =
+        userGroupStore.createUser(AppUserInput(principal = principal), tokenStore, accessStore, daemonSessionStore)
+
+    private fun approveGrant(principal: String, durationSec: Long) {
+        val req = accessStore.createRequest(principal, AccessRequestInput(roleId = grantRole.id))
+        accessStore.approve(req.id, durationSec = durationSec, decidedBy = "approver@example.com")
     }
 
     companion object {

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationRendererTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationRendererTest.kt
@@ -1,0 +1,93 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import com.ridi.oss.proxymonster.controlplane.i18n.MessageCatalog
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The notification renderer over the shared [MessageCatalog]: every key resolves in every locale, and a
+ * message never leaks the statement into a surface meant to withhold it. No DB.
+ */
+class NotificationRendererTest {
+
+    private val renderer = NotificationRenderer()
+
+    private fun message(
+        event: NotificationEvent,
+        statement: RenderedStatement,
+        approved: Boolean? = null,
+    ) = NotificationMessage(
+        event = event,
+        taskId = 42,
+        requester = "alice@example.com",
+        datasource = "acme-mysql",
+        roleName = "pii-reader",
+        reason = "investigating a billing dispute",
+        statement = statement,
+        decidedBy = "bob@example.com",
+        approved = approved,
+        rowCount = 3,
+        deepLink = "https://console.example.com/workflows/42",
+        actions = setOf(NotificationAction.OPEN),
+    )
+
+    /** en/ko parity: a key present in one locale and missing in the other renders the raw key. */
+    @Test
+    fun `every key resolves in both locales`() {
+        for (locale in MessageCatalog.LOCALES) {
+            for (event in NotificationEvent.entries) {
+                for (approved in listOf(true, false)) {
+                    val m = message(event, RenderedStatement("SELECT 1", complete = true), approved)
+                    val summary = renderer.summary(m, locale)
+                    assertTrue(summary.isNotBlank(), "$event/$locale summary")
+                    assertFalse(summary.contains("task."), "$event/$locale fell through to a raw key: $summary")
+                    assertFalse(renderer.fallbackText(m, locale).contains("task."), "$event/$locale fallback fell through")
+                }
+            }
+            for (action in NotificationAction.entries) {
+                assertFalse(renderer.actionLabel(action, locale).contains("action."), "$action/$locale")
+            }
+        }
+    }
+
+    @Test
+    fun `an approved decision reads differently from a rejected one`() {
+        val approved = renderer.summary(message(NotificationEvent.TASK_DECIDED, RenderedStatement("SELECT 1", true), approved = true), "en")
+        val rejected = renderer.summary(message(NotificationEvent.TASK_DECIDED, RenderedStatement("SELECT 1", true), approved = false), "en")
+        assertFalse(approved == rejected, "a recipient must be able to tell approval from denial")
+        assertTrue(rejected.contains("denied", ignoreCase = true))
+    }
+
+    /** The plain-text fallback is shown by clients that render no blocks, so it must never carry the SQL. */
+    @Test
+    fun `the fallback line never carries the statement`() {
+        val secret = "SELECT name FROM users WHERE rrn = '900101-1234567'"
+        for (locale in MessageCatalog.LOCALES) {
+            for (event in NotificationEvent.entries) {
+                val text = renderer.fallbackText(message(event, RenderedStatement(secret, true)), locale)
+                assertFalse(text.contains("rrn"), "$event/$locale fallback leaked the statement: $text")
+            }
+        }
+    }
+
+    /** A withheld or elided statement must SAY so, or the approver cannot tell it apart from a short query. */
+    @Test
+    fun `a withheld statement is announced rather than silently missing`() {
+        val omitted = renderer.summary(message(NotificationEvent.TASK_REQUESTED, RenderedStatement(null, false)), "en")
+        assertTrue(omitted.contains("Open the request", ignoreCase = true), omitted)
+
+        val truncated = renderer.summary(message(NotificationEvent.TASK_REQUESTED, RenderedStatement("SELECT …", false)), "en")
+        assertTrue(truncated.contains("Open the request", ignoreCase = true), truncated)
+
+        val whole = renderer.summary(message(NotificationEvent.TASK_REQUESTED, RenderedStatement("SELECT 1", true)), "en")
+        assertFalse(whole.contains("Open the request", ignoreCase = true), whole)
+    }
+
+    @Test
+    fun `an unknown locale falls back rather than rendering a raw key`() {
+        val summary = renderer.summary(message(NotificationEvent.TASK_REQUESTED, RenderedStatement("SELECT 1", true)), "fr")
+        assertFalse(summary.contains("task."), summary)
+        assertTrue(summary.contains("alice@example.com"))
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationServiceDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationServiceDbTest.kt
@@ -1,0 +1,201 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import com.ridi.oss.proxymonster.controlplane.AccessRequest
+import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
+import com.ridi.oss.proxymonster.controlplane.support.FakeTransport
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The drain orchestration on real PostgreSQL, with an in-memory transport so the assertions are about the
+ * SERVICE — deliver vs edit-in-place, the ordering gate, retry/drop/exhaustion, terminal announce, and the
+ * wake that makes an interactive click's edit land in ~ms rather than on the next poll. Routing itself is
+ * pinned separately (NotificationRoutingDbTest); here the candidate source is empty so recipients come only
+ * from the events' own always-include parties, keeping the drain assertions deterministic.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class NotificationServiceDbTest {
+    private lateinit var fx: EnforcementFixture
+    private lateinit var store: NotificationStore
+    private lateinit var transport: FakeTransport
+    private lateinit var svc: NotificationService
+
+    @BeforeAll
+    fun setupClass() {
+        requireDockerOrSkip()
+        fx = EnforcementFixture.postgres()
+    }
+
+    @BeforeEach
+    fun setup() {
+        fx.dataSource.connection.use { c ->
+            c.createStatement().use {
+                it.executeUpdate("DELETE FROM notification_message")
+                it.executeUpdate("DELETE FROM notification_outbox")
+            }
+        }
+        store = NotificationStore(fx.dataSource)
+        transport = FakeTransport()
+        svc = NotificationService(
+            store = store,
+            recipients = RecipientResolver(fx.authz, fx.roleResolver) { emptyList() },
+            transports = listOf(transport),
+            accessStore = fx.accessStore,
+            queryResultStore = null,
+            webBaseUrl = "https://console.example",
+            disclosure = StatementDisclosure.FULL,
+            statementMaxChars = 10_000,
+            defaultLocale = "en",
+        )
+    }
+
+    private fun newTask(principal: String = "req@example.com"): AccessRequest =
+        fx.accessStore.createQueryRequest(
+            principal = principal, datasourceId = fx.datasource.id, sql = "SELECT 1",
+            denyReason = null, sourceDecisionId = null, reason = "r", title = "t", evaluatedDecision = "ALLOW",
+        )
+
+    private fun enqueue(task: Long, event: NotificationEvent, recipient: String, transportName: String = "fake") {
+        fx.dataSource.connection.use { c -> store.enqueue(c, task, event, transportName, recipient) }
+    }
+
+    private fun statusOf(task: Long, event: NotificationEvent, recipient: String): String =
+        fx.dataSource.connection.use { c ->
+            c.prepareStatement("SELECT status FROM notification_outbox WHERE task_id=? AND event=? AND recipient=?").use { ps ->
+                ps.setLong(1, task); ps.setString(2, event.wire); ps.setString(3, recipient)
+                ps.executeQuery().use { it.next(); it.getString(1) }
+            }
+        }
+
+    private fun setAttempts(task: Long, event: NotificationEvent, attempts: Int) {
+        fx.dataSource.connection.use { c ->
+            c.prepareStatement("UPDATE notification_outbox SET attempts=? WHERE task_id=? AND event=?").use { ps ->
+                ps.setInt(1, attempts); ps.setLong(2, task); ps.setString(3, event.wire); ps.executeUpdate()
+            }
+        }
+    }
+
+    @Test
+    fun `drain delivers a pending notification and records its handle`() = runBlocking {
+        val task = newTask().id
+        enqueue(task, NotificationEvent.TASK_REQUESTED, "sam@x")
+        svc.drainOnce()
+
+        assertEquals(1, transport.delivered.size)
+        assertEquals("addr:sam@x", transport.delivered.first().to)
+        assertEquals(NotificationEvent.TASK_REQUESTED, transport.delivered.first().event)
+        assertEquals("SENT", statusOf(task, NotificationEvent.TASK_REQUESTED, "sam@x"))
+        assertEquals("ref-fake", store.externalRef(task, "fake", "sam@x"), "the handle is remembered for later edits")
+    }
+
+    @Test
+    fun `an update edits by stored handle and skips the address lookup`() = runBlocking {
+        val task = newTask().id
+        enqueue(task, NotificationEvent.TASK_REQUESTED, "sam@x")
+        svc.drainOnce()
+        transport.addressCalls.set(0)
+
+        enqueue(task, NotificationEvent.TASK_DECIDED, "sam@x")
+        svc.drainOnce()
+
+        assertEquals(1, transport.updated.size, "the decided event edits the existing message")
+        assertEquals("ref-fake", transport.updated.first().ref)
+        assertEquals(0, transport.addressCalls.get(), "editing needs only the handle — no addressOf round-trip")
+    }
+
+    @Test
+    fun `an update waits while the requested message it edits is still pending`() = runBlocking {
+        val task = newTask().id
+        transport.deliverResult = DeliveryResult.Retry("ratelimited") // the requested stays pending
+        enqueue(task, NotificationEvent.TASK_REQUESTED, "sam@x")
+        enqueue(task, NotificationEvent.TASK_DECIDED, "sam@x")
+        svc.drainOnce()
+
+        assertEquals(1, transport.delivered.size, "only the requested was attempted")
+        assertTrue(transport.updated.isEmpty(), "the decided edit must not overtake the message it edits")
+        assertEquals("PENDING", statusOf(task, NotificationEvent.TASK_DECIDED, "sam@x"), "it waits for the next drain")
+    }
+
+    @Test
+    fun `a permanent drop marks the row dead`() = runBlocking {
+        val task = newTask().id
+        transport.deliverResult = DeliveryResult.Drop("channel_not_found")
+        enqueue(task, NotificationEvent.TASK_REQUESTED, "sam@x")
+        svc.drainOnce()
+        assertEquals("DEAD", statusOf(task, NotificationEvent.TASK_REQUESTED, "sam@x"))
+    }
+
+    @Test
+    fun `a retry that exhausts the attempt budget dies rather than looping forever`() = runBlocking {
+        val task = newTask().id
+        transport.deliverResult = DeliveryResult.Retry("ratelimited")
+        enqueue(task, NotificationEvent.TASK_REQUESTED, "sam@x")
+        setAttempts(task, NotificationEvent.TASK_REQUESTED, NotificationService.MAX_ATTEMPTS - 1)
+        svc.drainOnce()
+        assertEquals("DEAD", statusOf(task, NotificationEvent.TASK_REQUESTED, "sam@x"), "gave up after the last attempt")
+    }
+
+    @Test
+    fun `a recipient with no address is dropped as dead, not retried forever`() = runBlocking {
+        val task = newTask().id
+        transport.address = { null }
+        enqueue(task, NotificationEvent.TASK_REQUESTED, "sam@x")
+        svc.drainOnce()
+        assertEquals("DEAD", statusOf(task, NotificationEvent.TASK_REQUESTED, "sam@x"))
+        assertTrue(transport.delivered.isEmpty(), "no address means nothing was delivered")
+    }
+
+    @Test
+    fun `a row for an unknown transport is dead`() = runBlocking {
+        val task = newTask().id
+        enqueue(task, NotificationEvent.TASK_REQUESTED, "sam@x", transportName = "ghost")
+        svc.drainOnce()
+        assertEquals("DEAD", statusOf(task, NotificationEvent.TASK_REQUESTED, "sam@x"))
+    }
+
+    @Test
+    fun `emit queues the always-include parties in the caller's transaction`() = runBlocking {
+        val task = newTask(principal = "owner@x")
+        fx.dataSource.connection.use { c -> svc.emit(c, NotificationEvent.TASK_DECIDED, task) }
+        // candidateSource is empty, so the requester is here only because a decided event always includes them.
+        assertEquals("PENDING", statusOf(task.id, NotificationEvent.TASK_DECIDED, "owner@x"))
+    }
+
+    @Test
+    fun `enqueueTerminal announces a terminal event and it drains`() = runBlocking {
+        val created = newTask(principal = "owner@x")
+        fx.dataSource.connection.use { c ->
+            c.prepareStatement("UPDATE access_request SET status='EXECUTED' WHERE id=?").use { ps ->
+                ps.setLong(1, created.id); ps.executeUpdate()
+            }
+        }
+        svc.enqueueTerminal(fx.accessStore.getRequest(created.id)!!)
+        svc.drainOnce()
+
+        assertEquals(NotificationEvent.TASK_EXECUTED, transport.delivered.single().event)
+        assertEquals("addr:owner@x", transport.delivered.single().to)
+    }
+
+    @Test
+    fun `a wake drains immediately rather than waiting for the poll`() = runBlocking {
+        val task = newTask().id
+        val loop = launch(Dispatchers.IO) { svc.runDrainLoop(Duration.ofSeconds(30)) } // poll far longer than the test
+        try {
+            enqueue(task, NotificationEvent.TASK_REQUESTED, "sam@x")
+            svc.wake()
+            transport.awaitDelivery(timeoutMs = 5_000) // completes well under the 30s poll
+            assertEquals("addr:sam@x", transport.delivered.first().to)
+        } finally {
+            loop.cancel()
+        }
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStoreDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStoreDbTest.kt
@@ -1,0 +1,193 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The durable outbox on real PostgreSQL. The load-bearing cases are the ones a unit test with an in-memory
+ * queue cannot reach: `FOR UPDATE SKIP LOCKED` so a second drainer never double-sends, the backoff that keeps
+ * a retried row out of the claim until it is due, and the earlier-pending check that stops a "decided" edit
+ * from overtaking the "requested" message it edits.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class NotificationStoreDbTest {
+    private lateinit var fx: EnforcementFixture
+    private lateinit var store: NotificationStore
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        fx = EnforcementFixture.postgres()
+        store = NotificationStore(fx.dataSource)
+    }
+
+    // claimDue's LIMIT is global, so a leftover row from another test would pollute a claim. Start each test
+    // with an empty outbox; the access_request rows the FKs need are left in place.
+    @BeforeEach
+    fun clean() {
+        fx.dataSource.connection.use { c ->
+            c.createStatement().use {
+                it.executeUpdate("DELETE FROM notification_message")
+                it.executeUpdate("DELETE FROM notification_outbox")
+            }
+        }
+    }
+
+    /** A fresh access_request the outbox rows can FK to. */
+    private fun newTask(principal: String = "req@example.com"): Long =
+        fx.accessStore.createQueryRequest(
+            principal = principal, datasourceId = fx.datasource.id, sql = "SELECT 1",
+            denyReason = null, sourceDecisionId = null, reason = "r", title = "t", evaluatedDecision = "ALLOW",
+        ).id
+
+    private fun attemptsOf(id: Long): Int = fx.dataSource.connection.use { c ->
+        c.prepareStatement("SELECT attempts FROM notification_outbox WHERE id = ?").use { ps ->
+            ps.setLong(1, id); ps.executeQuery().use { it.next(); it.getInt(1) }
+        }
+    }
+
+    private fun statusOf(id: Long): String = fx.dataSource.connection.use { c ->
+        c.prepareStatement("SELECT status FROM notification_outbox WHERE id = ?").use { ps ->
+            ps.setLong(1, id); ps.executeQuery().use { it.next(); it.getString(1) }
+        }
+    }
+
+    @Test
+    fun `enqueue is idempotent per task-event-transport-recipient`() {
+        val task = newTask()
+        fx.dataSource.connection.use { c ->
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "a@x")
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "a@x")
+        }
+        assertEquals(1, store.claimDue(10).count { it.taskId == task }, "the second enqueue collapsed onto the first")
+    }
+
+    @Test
+    fun `claimDue returns due pending rows in id order up to the limit`() {
+        val task = newTask()
+        fx.dataSource.connection.use { c ->
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "one@x")
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "two@x")
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "three@x")
+        }
+        val claimed = store.claimDue(2).filter { it.taskId == task }
+        assertEquals(2, claimed.size, "the limit is honored")
+        assertEquals(claimed.map { it.id }.sorted(), claimed.map { it.id }, "returned in id (insertion) order")
+    }
+
+    /**
+     * The claim a second drainer would run must skip a row the first is holding, not block on it or return it.
+     * Hold a row's lock in one open transaction, then claim from the pool: the locked row is invisible.
+     */
+    @Test
+    fun `claimDue skips a row another transaction holds locked`() {
+        val task = newTask()
+        fx.dataSource.connection.use { c ->
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "locked@x")
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "free@x")
+        }
+        val rows = store.claimDue(10).filter { it.taskId == task }.sortedBy { it.id }
+        val lockedId = rows.first().id
+        val freeId = rows.last().id
+
+        val holder = fx.dataSource.connection
+        try {
+            holder.autoCommit = false
+            holder.prepareStatement("SELECT id FROM notification_outbox WHERE id = ? FOR UPDATE").use { ps ->
+                ps.setLong(1, lockedId); ps.executeQuery().use { it.next() }
+            }
+            // Another claimant runs now, while the lock above is held.
+            val claimedIds = store.claimDue(10).map { it.id }
+            assertFalse(lockedId in claimedIds, "the locked row must be skipped, never double-claimed")
+            assertTrue(freeId in claimedIds, "the unlocked sibling is still claimable")
+        } finally {
+            holder.rollback(); holder.autoCommit = true; holder.close()
+        }
+    }
+
+    @Test
+    fun `markSent is terminal and increments attempts`() {
+        val task = newTask()
+        fx.dataSource.connection.use { c -> store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "s@x") }
+        val row = store.claimDue(10).first { it.taskId == task }
+        store.markSent(row.id)
+        assertEquals("SENT", statusOf(row.id))
+        assertEquals(1, attemptsOf(row.id))
+        assertTrue(store.claimDue(10).none { it.id == row.id }, "a SENT row is never claimed again")
+    }
+
+    @Test
+    fun `markRetry keeps the row pending but out of the claim until it is due`() {
+        val task = newTask()
+        fx.dataSource.connection.use { c -> store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "r@x") }
+        val row = store.claimDue(10).first { it.taskId == task }
+
+        store.markRetry(row.id, "ratelimited", Duration.ofHours(1))
+        assertEquals("PENDING", statusOf(row.id))
+        assertTrue(store.claimDue(10).none { it.id == row.id }, "a backed-off row is not due yet")
+
+        // A backoff already in the past makes it claimable again — the retry actually happens.
+        store.markRetry(row.id, "ratelimited", Duration.ofSeconds(-1))
+        assertTrue(store.claimDue(10).any { it.id == row.id }, "once due, the row is reclaimable")
+    }
+
+    @Test
+    fun `markDead is terminal`() {
+        val task = newTask()
+        fx.dataSource.connection.use { c -> store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "d@x") }
+        val row = store.claimDue(10).first { it.taskId == task }
+        store.markDead(row.id, "channel_not_found")
+        assertEquals("DEAD", statusOf(row.id))
+        assertTrue(store.claimDue(10).none { it.id == row.id })
+    }
+
+    @Test
+    fun `an update waits while an earlier event for the same recipient is still pending`() {
+        val task = newTask()
+        fx.dataSource.connection.use { c ->
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "u@x")
+            store.enqueue(c, task, NotificationEvent.TASK_DECIDED, "slack", "u@x")
+        }
+        val rows = store.claimDue(10).filter { it.taskId == task }.sortedBy { it.id }
+        val requested = rows.first { it.event == NotificationEvent.TASK_REQUESTED }
+        val decided = rows.first { it.event == NotificationEvent.TASK_DECIDED }
+
+        assertTrue(store.hasEarlierPending(decided), "the decided edit must wait for the requested message")
+        store.markSent(requested.id)
+        assertFalse(store.hasEarlierPending(decided), "once the requested is delivered, the edit may go")
+    }
+
+    @Test
+    fun `rememberMessage upserts the external ref`() {
+        val task = newTask()
+        assertNull(store.externalRef(task, "slack", "m@x"), "nothing delivered yet")
+        store.rememberMessage(task, "slack", "m@x", "C1:100")
+        assertEquals("C1:100", store.externalRef(task, "slack", "m@x"))
+        store.rememberMessage(task, "slack", "m@x", "C1:200")
+        assertEquals("C1:200", store.externalRef(task, "slack", "m@x"), "a later delivery overwrites the handle")
+    }
+
+    @Test
+    fun `locale and email round-trip for a directory user, and setLocale reports a missing one`() {
+        assertFalse(store.setLocale("nobody@example.com", "ko"), "no directory row to set a preference on")
+
+        fx.dataSource.connection.use { c ->
+            c.prepareStatement("INSERT INTO app_user (principal, email) VALUES (?, ?)").use { ps ->
+                ps.setString(1, "dir@example.com"); ps.setString(2, "dir-mail@example.com"); ps.executeUpdate()
+            }
+        }
+        assertNull(store.localeOf("dir@example.com"), "no preference expressed yet")
+        assertEquals("dir-mail@example.com", store.emailOf("dir@example.com"))
+        assertTrue(store.setLocale("dir@example.com", "ko"))
+        assertEquals("ko", store.localeOf("dir@example.com"))
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackDecisionHandlerDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackDecisionHandlerDbTest.kt
@@ -1,0 +1,151 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import com.ridi.oss.proxymonster.controlplane.AccessRequest
+import com.ridi.oss.proxymonster.controlplane.RoleAssignmentInput
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
+import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
+import com.ridi.oss.proxymonster.controlplane.support.FakeTransport
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.Collections
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A Slack button click turned into a task decision, on real PostgreSQL + real Cedar. The handler is an
+ * ADAPTER over the same `task.approve` Cedar decision and the same CAS the console uses — so the interesting
+ * cases are the security ones: an unauthorized clicker is refused, and the requester cannot self-approve
+ * from Slack because the click decides on the `slack` channel, which the no-self-approval forbid does NOT
+ * exempt (only the server-attested editor/wire channels are).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SlackDecisionHandlerDbTest {
+    private lateinit var fx: EnforcementFixture
+    private lateinit var handler: SlackDecisionHandler
+
+    private val requester = "requester@example.com"
+    private val approver = "admin@example.com"
+    private val outsider = "outsider@example.com"
+    private var roleId: Long = 0
+
+    private val approvedRuns = Collections.synchronizedList(mutableListOf<AccessRequest>())
+    @Volatile private var onApprovedThrows = false
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        fx = EnforcementFixture.postgres()
+        val roles = fx.policyStore.listRoles().associateBy { it.name }
+        fx.policyStore.createAssignment(RoleAssignmentInput(approver, roles.getValue("system:admin").id))
+        roleId = roles.getValue(fx.role).id
+
+        val notifications = NotificationService(
+            store = NotificationStore(fx.dataSource),
+            recipients = RecipientResolver(fx.authz, fx.roleResolver) { emptyList() },
+            transports = listOf(FakeTransport()),
+            accessStore = fx.accessStore,
+            queryResultStore = null,
+            webBaseUrl = "https://console.example",
+            disclosure = StatementDisclosure.FULL,
+            statementMaxChars = 10_000,
+            defaultLocale = "en",
+        )
+        handler = SlackDecisionHandler(
+            accessStore = fx.accessStore,
+            datasourceStore = fx.datasourceStore,
+            authz = fx.authz,
+            auditRecorder = ManagementAuditRecorder(fx.auditStore),
+            notifications = notifications,
+            defaultLocale = "en",
+            onApproved = { req ->
+                if (onApprovedThrows) throw RuntimeException("run failed")
+                approvedRuns += req
+            },
+        )
+    }
+
+    private fun pendingRequest(): Long = fx.accessStore.createQueryRequest(
+        principal = requester, datasourceId = fx.datasource.id, sql = "SELECT id FROM users",
+        denyReason = null, sourceDecisionId = null, reason = "need it", title = "read users",
+        evaluatedDecision = "ALLOW", roleId = roleId,
+    ).id
+
+    private fun click(taskId: Long, principal: String, actionId: String) = SlackInteraction(
+        principal = principal, actionId = actionId, taskId = taskId,
+        responseUrl = null, triggerChannel = "C_MOCK", triggerTs = "1.1",
+    )
+
+    private fun statusOf(id: Long) = fx.accessStore.getRequest(id)!!.status
+
+    @Test
+    fun `an authorized approve transitions the request and runs it`() = runBlocking {
+        val id = pendingRequest()
+        val reply = handler.handle(click(id, approver, SlackTransport.ACTION_APPROVE))
+
+        assertEquals("", reply, "success says nothing back to the clicker")
+        assertEquals("APPROVED", statusOf(id))
+        assertTrue(approvedRuns.any { it.id == id }, "approving from Slack also runs it")
+    }
+
+    @Test
+    fun `a deny transitions to rejected with the Slack reason`() = runBlocking {
+        val id = pendingRequest()
+        val reply = handler.handle(click(id, approver, SlackTransport.ACTION_DENY))
+
+        assertEquals("", reply)
+        assertEquals("REJECTED", statusOf(id))
+        assertEquals(SlackDecisionHandler.SLACK_REJECT_REASON, fx.accessStore.getRequest(id)!!.rejectionReason)
+        assertTrue(approvedRuns.none { it.id == id }, "a denial never runs the query")
+    }
+
+    @Test
+    fun `an unauthorized clicker is refused and nothing transitions`() = runBlocking {
+        val id = pendingRequest()
+        val reply = handler.handle(click(id, outsider, SlackTransport.ACTION_APPROVE))
+
+        assertTrue(reply.contains("not authorized"), "got: $reply")
+        assertEquals("PENDING", statusOf(id), "an unauthorized click must not decide")
+    }
+
+    /** The security case the `slack` channel exists for: no-self-approval exempts only editor/wire. */
+    @Test
+    fun `the requester cannot self-approve from Slack`() = runBlocking {
+        val id = pendingRequest()
+        val reply = handler.handle(click(id, requester, SlackTransport.ACTION_APPROVE))
+
+        assertTrue(reply.contains("not authorized"), "self-approval on the slack channel is forbidden; got: $reply")
+        assertEquals("PENDING", statusOf(id))
+    }
+
+    @Test
+    fun `an already-decided request reports what happened instead of deciding again`() = runBlocking {
+        val id = pendingRequest()
+        handler.handle(click(id, approver, SlackTransport.ACTION_DENY)) // now REJECTED
+        val reply = handler.handle(click(id, approver, SlackTransport.ACTION_APPROVE))
+
+        assertTrue(reply.contains("Already rejected"), "got: $reply")
+        assertEquals("REJECTED", statusOf(id), "the second click changed nothing")
+    }
+
+    @Test
+    fun `a click for a request that does not exist is rejected`() = runBlocking {
+        val reply = handler.handle(click(999_999, approver, SlackTransport.ACTION_APPROVE))
+        assertTrue(reply.contains("no longer exists"), "got: $reply")
+    }
+
+    @Test
+    fun `a failed run is reported as a retry hint, and the decision still stands`() = runBlocking {
+        val id = pendingRequest()
+        onApprovedThrows = true
+        try {
+            val reply = handler.handle(click(id, approver, SlackTransport.ACTION_APPROVE))
+            assertTrue(reply.contains("could not be started"), "got: $reply")
+            assertEquals("APPROVED", statusOf(id), "the approval committed even though the run failed to start")
+        } finally {
+            onApprovedThrows = false
+        }
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackNotificationE2eDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackNotificationE2eDbTest.kt
@@ -1,0 +1,142 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import com.ridi.oss.proxymonster.controlplane.AccessRequest
+import com.ridi.oss.proxymonster.controlplane.RoleAssignmentInput
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
+import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
+import com.ridi.oss.proxymonster.controlplane.support.MockSlack
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The whole Slack notification loop, end to end, against a real mock Slack and real PostgreSQL + Cedar: a
+ * request is created → the approver is notified with a chat.postMessage carrying an approve button → the
+ * approver clicks → the click returns over the Socket Mode WebSocket → the same Cedar `task.approve` decision
+ * runs on the `slack` channel → the request is approved and run → the ORIGINAL message is edited in place
+ * (chat.update on the stored handle), so the buttons the user tapped disappear.
+ *
+ * Nothing here is stubbed except Slack itself; every proxy-monster component is the production class.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SlackNotificationE2eDbTest {
+    private lateinit var fx: EnforcementFixture
+    private lateinit var slack: MockSlack
+    private lateinit var http: HttpClient
+    private lateinit var svc: NotificationService
+    private lateinit var socket: SlackSocketMode
+
+    private val requester = "requester@example.com"
+    private val approver = "admin@example.com"
+    private var roleId: Long = 0
+    private val approved = CompletableDeferred<AccessRequest>()
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        fx = EnforcementFixture.postgres()
+        val roles = fx.policyStore.listRoles().associateBy { it.name }
+        fx.policyStore.createAssignment(RoleAssignmentInput(approver, roles.getValue("system:admin").id))
+        roleId = roles.getValue(fx.role).id
+
+        slack = MockSlack.start()
+        slack.userIdByEmail[approver] = "U_ADMIN"
+        slack.usersById["U_ADMIN"] = MockSlack.SlackUser(email = approver)
+
+        http = slackHttpClient()
+        val transport = SlackTransport(http, "xoxb-e2e", "https://console.example", NotificationRenderer(), api = slack.apiBase)
+        svc = NotificationService(
+            store = NotificationStore(fx.dataSource),
+            // The candidate pool is just the admin; routing keeps them because Cedar says they may approve.
+            recipients = RecipientResolver(fx.authz, fx.roleResolver) { listOf(approver) },
+            transports = listOf(transport),
+            accessStore = fx.accessStore,
+            queryResultStore = null,
+            webBaseUrl = "https://console.example",
+            disclosure = StatementDisclosure.FULL,
+            statementMaxChars = 10_000,
+            defaultLocale = "en",
+        )
+        val handler = SlackDecisionHandler(
+            accessStore = fx.accessStore,
+            datasourceStore = fx.datasourceStore,
+            authz = fx.authz,
+            auditRecorder = ManagementAuditRecorder(fx.auditStore),
+            notifications = svc,
+            defaultLocale = "en",
+            onApproved = { approved.complete(it) },
+        )
+        socket = SlackSocketMode(http, "xoxb-e2e", "xapp-e2e", onInteraction = { handler.handle(it) }, api = slack.apiBase)
+    }
+
+    @AfterAll
+    fun teardown() {
+        http.close()
+        slack.close()
+    }
+
+    @Test
+    fun `a request is announced to Slack, approved by a click, and its message edited in place`() = runBlocking {
+        // 1. A pending request, and the "needs approval" notification queued for it.
+        val req = fx.accessStore.createQueryRequest(
+            principal = requester, datasourceId = fx.datasource.id, sql = "SELECT id FROM users",
+            denyReason = null, sourceDecisionId = null, reason = "monthly audit", title = "read users",
+            evaluatedDecision = "ALLOW", roleId = roleId,
+        )
+        fx.dataSource.connection.use { c -> svc.emit(c, NotificationEvent.TASK_REQUESTED, req) }
+
+        // 2. Drain: the approver is addressed (email → user → DM) and the message posted with an approve button.
+        svc.drainOnce()
+        val post = slack.lastRequest("chat.postMessage")!!
+        assertTrue(post.isJson, "the message body is JSON")
+        val elements = post.json!!["blocks"]!!.jsonArray.map { it.jsonObject }
+            .first { it["type"]?.jsonPrimitive?.content == "actions" }["elements"]!!.jsonArray.map { it.jsonObject }
+        assertTrue(
+            elements.any { it["action_id"]?.jsonPrimitive?.content == SlackTransport.ACTION_APPROVE },
+            "a pending request with a clean statement offers approve-and-run",
+        )
+
+        // 3. The approver clicks approve — the click returns over Socket Mode. The decision keys off the
+        // button's task-id value, not the message ts, so the ts here is just what Slack would carry along.
+        val pump = launch(Dispatchers.IO) { socket.run() }
+        try {
+            slack.awaitConnection()
+            slack.pushEnvelope(
+                """
+                {"envelope_id":"env-e2e","type":"interactive",
+                 "payload":{"type":"block_actions","team":{"id":"${slack.teamId}"},"user":{"id":"U_ADMIN"},
+                   "actions":[{"action_id":"${SlackTransport.ACTION_APPROVE}","value":"${req.id}"}],
+                   "response_url":"${slack.responseUrl}","channel":{"id":"C_MOCK"},
+                   "message":{"ts":"1700000000001.000100"}}}
+                """.trimIndent(),
+            )
+
+            // 4. The decision runs and the request is approved (and run).
+            val ranReq = withTimeout(10_000) { approved.await() }
+            assertEquals(req.id, ranReq.id)
+        } finally {
+            pump.cancel()
+        }
+
+        assertEquals("APPROVED", fx.accessStore.getRequest(req.id)!!.status)
+
+        // 5. Draining the decided event edits the SAME message rather than posting a new one.
+        svc.drainOnce()
+        val update = slack.lastRequest("chat.update")!!
+        assertEquals("C_MOCK", update.json!!["channel"]!!.jsonPrimitive.content, "the original message is edited in place")
+        assertTrue(slack.requestsFor("chat.postMessage").size == 1, "no second message was posted — the first was edited")
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackSocketModeTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackSocketModeTest.kt
@@ -1,0 +1,166 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import com.ridi.oss.proxymonster.controlplane.support.MockSlack
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The inbound Socket Mode path against a real WebSocket the mock Slack serves: a button click arrives as an
+ * envelope, is ACKed, its workspace is pinned to the bot token's own, and the clicker's identity is resolved
+ * FRESH through users.info before it becomes a decision.
+ *
+ * Negative cases push the ignored envelope FIRST and a valid one SECOND, then await the valid dispatch: the
+ * socket pump processes frames in order, so a valid dispatch proves the earlier one was fully handled — no
+ * sleeps, no races.
+ */
+class SlackSocketModeTest {
+    private lateinit var slack: MockSlack
+    private lateinit var http: HttpClient
+    private val received = Channel<SlackInteraction>(Channel.UNLIMITED)
+
+    private val botToken = "xoxb-test"
+    private val appToken = "xapp-test"
+
+    @BeforeEach
+    fun setup() {
+        slack = MockSlack.start()
+        http = slackHttpClient()
+        // The clicker Slack account maps to a verified email = the principal.
+        slack.usersById["U_CLICKER"] = MockSlack.SlackUser(email = "clicker@example.com")
+        slack.usersById["U_VALID"] = MockSlack.SlackUser(email = "valid@example.com")
+    }
+
+    @AfterEach
+    fun teardown() {
+        http.close()
+        slack.close()
+    }
+
+    private fun socket(reply: String = ""): SlackSocketMode = SlackSocketMode(
+        http = http,
+        botToken = botToken,
+        appToken = appToken,
+        onInteraction = { received.send(it); reply },
+        api = slack.apiBase,
+    )
+
+    private fun envelope(
+        envelopeId: String,
+        team: String = "T_WORKSPACE",
+        user: String = "U_CLICKER",
+        actionId: String = SlackTransport.ACTION_APPROVE,
+        value: String = "42",
+        payloadType: String = "block_actions",
+    ) = """
+        {"envelope_id":"$envelopeId","type":"interactive",
+         "payload":{"type":"$payloadType","team":{"id":"$team"},"user":{"id":"$user"},
+           "actions":[{"action_id":"$actionId","value":"$value"}],
+           "response_url":"${slack.responseUrl}","channel":{"id":"C_MOCK"},
+           "message":{"ts":"1700000000001.000100"}}}
+    """.trimIndent()
+
+    /** Run [body] with the socket connected; cancels the pump when done. */
+    private fun withSocket(reply: String = "", body: suspend (Job) -> Unit) = runBlocking {
+        val job = launch(Dispatchers.IO) { socket(reply).run() }
+        try {
+            slack.awaitConnection()
+            body(job)
+        } finally {
+            job.cancel()
+        }
+    }
+
+    private suspend fun awaitDispatch() = withTimeout(5_000) { received.receive() }
+
+    @Test
+    fun `a valid click is acked and dispatched with the resolved principal`() = withSocket { _ ->
+        slack.pushEnvelope(envelope("env-1"))
+        val it = awaitDispatch()
+
+        assertEquals("clicker@example.com", it.principal, "identity resolved fresh via users.info")
+        assertEquals(SlackTransport.ACTION_APPROVE, it.actionId)
+        assertEquals(42L, it.taskId)
+        assertEquals("C_MOCK", it.triggerChannel)
+        assertEquals("1700000000001.000100", it.triggerTs)
+        assertTrue(
+            slack.acks().any { a -> a["envelope_id"]?.jsonPrimitive?.content == "env-1" },
+            "every envelope must be acked so Slack does not redeliver it",
+        )
+        assertTrue(slack.requestsFor("auth.test").isNotEmpty(), "the workspace was resolved from the bot token")
+    }
+
+    @Test
+    fun `a click from another workspace is refused`() = withSocket { _ ->
+        slack.pushEnvelope(envelope("env-bad", team = "T_INTRUDER"))
+        slack.pushEnvelope(envelope("env-ok", value = "99", user = "U_VALID"))
+        val it = awaitDispatch()
+
+        assertEquals(99L, it.taskId, "only the correct-workspace click dispatched")
+        assertEquals("valid@example.com", it.principal)
+    }
+
+    @Test
+    fun `an unlinked Slack user is refused ephemerally and never dispatched`() = withSocket { _ ->
+        slack.pushEnvelope(envelope("env-unlinked", user = "U_UNKNOWN", value = "7"))
+        slack.pushEnvelope(envelope("env-ok", value = "99", user = "U_VALID"))
+        val it = awaitDispatch()
+
+        assertEquals(99L, it.taskId, "the unlinked click did not dispatch")
+        assertTrue(
+            slack.ephemeralReplies().any { r -> r["text"]?.jsonPrimitive?.content?.contains("not linked") == true },
+            "the clicker is told privately their account is not linked",
+        )
+    }
+
+    @Test
+    fun `a deactivated Slack account is refused`() = withSocket { _ ->
+        slack.usersById["U_DEAD"] = MockSlack.SlackUser(email = "dead@example.com", deleted = true)
+        slack.pushEnvelope(envelope("env-dead", user = "U_DEAD", value = "7"))
+        slack.pushEnvelope(envelope("env-ok", value = "99", user = "U_VALID"))
+
+        assertEquals(99L, awaitDispatch().taskId, "a deactivated account never acts on a task")
+    }
+
+    @Test
+    fun `a non-decision action id is ignored`() = withSocket { _ ->
+        slack.pushEnvelope(envelope("env-noise", actionId = "some_other_button", value = "7"))
+        slack.pushEnvelope(envelope("env-ok", value = "99", user = "U_VALID"))
+
+        assertEquals(99L, awaitDispatch().taskId, "only pm_approve/pm_deny dispatch")
+    }
+
+    @Test
+    fun `a non-block_actions payload is ignored`() = withSocket { _ ->
+        slack.pushEnvelope(envelope("env-view", payloadType = "view_submission", value = "7"))
+        slack.pushEnvelope(envelope("env-ok", value = "99", user = "U_VALID"))
+
+        assertEquals(99L, awaitDispatch().taskId)
+    }
+
+    @Test
+    fun `the handler's reply is sent back as an ephemeral message`() = withSocket(reply = "You are not authorized to decide this request.") { _ ->
+        slack.pushEnvelope(envelope("env-1"))
+        awaitDispatch()
+        // The reply is posted after dispatch; await it appearing rather than sleeping.
+        val reply = withTimeout(5_000) {
+            var seen: String? = null
+            while (seen == null) {
+                seen = slack.ephemeralReplies().firstOrNull()?.get("text")?.jsonPrimitive?.content
+                if (seen == null) kotlinx.coroutines.delay(20)
+            }
+            seen
+        }
+        assertEquals("You are not authorized to decide this request.", reply)
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackTransportTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackTransportTest.kt
@@ -1,0 +1,225 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import com.ridi.oss.proxymonster.controlplane.support.MockSlack
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The Slack transport against a real mock Slack server, so the wire encoding is what is actually asserted.
+ *
+ * The load-bearing case is `read methods are form-encoded`: Slack's read/utility methods reject a JSON body
+ * with `invalid_arguments`, and the first deploy shipped them as JSON — every notification went out DEAD with
+ * no address. Only the `chat.*` methods, which carry a `blocks` array, take JSON. This pins both halves.
+ */
+class SlackTransportTest {
+    private lateinit var slack: MockSlack
+    private lateinit var http: HttpClient
+    private lateinit var transport: SlackTransport
+
+    private val botToken = "xoxb-test-token"
+
+    @BeforeEach
+    fun setup() {
+        slack = MockSlack.start()
+        http = slackHttpClient()
+        transport = SlackTransport(
+            http = http,
+            botToken = botToken,
+            webBaseUrl = "https://console.example",
+            renderer = NotificationRenderer(),
+            api = slack.apiBase,
+        )
+    }
+
+    @AfterEach
+    fun teardown() {
+        http.close()
+        slack.close()
+    }
+
+    private fun message(
+        event: NotificationEvent = NotificationEvent.TASK_REQUESTED,
+        taskId: Long = 42,
+        actions: Set<NotificationAction> = setOf(NotificationAction.OPEN, NotificationAction.DENY, NotificationAction.APPROVE_AND_RUN),
+        statement: RenderedStatement = RenderedStatement("SELECT 1", complete = true),
+    ) = NotificationMessage(
+        event = event,
+        taskId = taskId,
+        requester = "requester@example.com",
+        datasource = "prod-db",
+        roleName = "reader",
+        reason = "need it",
+        statement = statement,
+        decidedBy = null,
+        approved = null,
+        deepLink = "https://console.example/workflows/$taskId",
+        actions = actions,
+    )
+
+    private fun MockSlack.Recorded.blocks(): List<JsonObject> =
+        json!!["blocks"]!!.jsonArray.map { it.jsonObject }
+
+    private fun List<JsonObject>.actionElements(): List<JsonObject> =
+        first { it["type"]?.jsonPrimitive?.content == "actions" }["elements"]!!.jsonArray.map { it.jsonObject }
+
+    // ---- addressing: the form-encoding regression ---------------------------------------------
+
+    @Test
+    fun `read methods are form-encoded, never JSON`() = runBlocking {
+        slack.userIdByEmail["sam@example.com"] = "U_SAM"
+
+        val address = transport.addressOf("sam@example.com", null)
+
+        assertEquals("D_U_SAM", address, "conversations.open returns the DM channel id")
+        val lookup = slack.lastRequest("users.lookupByEmail")!!
+        assertTrue(lookup.isForm, "users.lookupByEmail must be form-encoded, not JSON — a JSON body is invalid_arguments")
+        assertEquals("sam@example.com", lookup.form["email"])
+        assertEquals("Bearer $botToken", lookup.authorization)
+        val open = slack.lastRequest("conversations.open")!!
+        assertTrue(open.isForm, "conversations.open must be form-encoded")
+        assertEquals("U_SAM", open.form["users"])
+    }
+
+    @Test
+    fun `addressing returns null when the email resolves to no Slack user`() = runBlocking {
+        assertNull(transport.addressOf("ghost@example.com", null), "users_not_found drops the row, no address")
+    }
+
+    @Test
+    fun `addressing falls back to the directory email for a non-address principal`() = runBlocking {
+        slack.userIdByEmail["real@example.com"] = "U_REAL"
+        // The principal is an opaque subject id, not an email; the app_user email is the fallback lookup key.
+        val address = transport.addressOf("okta|abc123", "real@example.com")
+        assertEquals("D_U_REAL", address)
+        assertEquals("real@example.com", slack.lastRequest("users.lookupByEmail")!!.form["email"])
+    }
+
+    // ---- delivery: chat.postMessage as JSON ---------------------------------------------------
+
+    @Test
+    fun `deliver posts chat_postMessage as JSON and returns a channel-ts ref`() = runBlocking {
+        val result = transport.deliver("D_U_SAM", message(), "en")
+
+        assertTrue(result is DeliveryResult.Sent, "delivered; got $result")
+        val ref = (result as DeliveryResult.Sent).externalRef
+        assertTrue(ref.startsWith("C_MOCK:"), "ref is channel:ts, got $ref")
+        val post = slack.lastRequest("chat.postMessage")!!
+        assertTrue(post.isJson, "chat.postMessage carries a blocks array and must be JSON")
+        assertEquals("D_U_SAM", post.json!!["channel"]!!.jsonPrimitive.content)
+        assertTrue(post.blocks().isNotEmpty(), "the message has Block Kit content")
+    }
+
+    @Test
+    fun `a pending request renders approve-and-run, deny, and open buttons with their action ids`() = runBlocking {
+        transport.deliver("D_U_SAM", message(taskId = 7), "en")
+        val elements = slack.lastRequest("chat.postMessage")!!.blocks().actionElements()
+
+        val approve = elements.first { it["action_id"]?.jsonPrimitive?.content == SlackTransport.ACTION_APPROVE }
+        assertEquals("7", approve["value"]?.jsonPrimitive?.content, "the button carries the task id")
+        assertEquals("primary", approve["style"]?.jsonPrimitive?.content)
+
+        val deny = elements.first { it["action_id"]?.jsonPrimitive?.content == SlackTransport.ACTION_DENY }
+        assertEquals("danger", deny["style"]?.jsonPrimitive?.content)
+
+        val open = elements.first { it["url"] != null }
+        assertEquals("https://console.example/workflows/7", open["url"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `a message with only open offers no decision buttons`() = runBlocking {
+        transport.deliver("D_U_SAM", message(actions = setOf(NotificationAction.OPEN)), "en")
+        val elements = slack.lastRequest("chat.postMessage")!!.blocks().actionElements()
+
+        assertTrue(elements.none { it["action_id"]?.jsonPrimitive?.content == SlackTransport.ACTION_APPROVE })
+        assertTrue(elements.none { it["action_id"]?.jsonPrimitive?.content == SlackTransport.ACTION_DENY })
+        assertTrue(elements.any { it["url"] != null }, "open is always there")
+    }
+
+    // ---- the body names people as Slack mentions ----------------------------------------------
+
+    private fun List<JsonObject>.sectionText(): String =
+        first { it["type"]?.jsonPrimitive?.content == "section" }["text"]!!.jsonObject["text"]!!.jsonPrimitive.content
+
+    @Test
+    fun `a requester whose email resolves is rendered as a Slack mention`() = runBlocking {
+        slack.userIdByEmail["requester@example.com"] = "U_REQ"
+        transport.deliver("D_U_SAM", message(), "en")
+        val text = slack.lastRequest("chat.postMessage")!!.blocks().sectionText()
+        assertTrue(text.contains("<@U_REQ>"), "the requester resolves to a mention; was: $text")
+        assertTrue(!text.contains("requester@example.com"), "the raw email is replaced by the mention")
+    }
+
+    @Test
+    fun `a principal with no Slack match renders as the plain identity`() = runBlocking {
+        // requester@example.com is absent from the directory → users_not_found → shown unchanged.
+        transport.deliver("D_U_SAM", message(), "en")
+        val text = slack.lastRequest("chat.postMessage")!!.blocks().sectionText()
+        assertTrue(text.contains("requester@example.com"), "no Slack match → the principal is unchanged; was: $text")
+    }
+
+    @Test
+    fun `a non-email principal is never looked up`() = runBlocking {
+        transport.deliver("D_U_SAM", message().copy(requester = "okta|abc123"), "en")
+        assertTrue(slack.requestsFor("users.lookupByEmail").isEmpty(), "a subject id is not an email; no lookup")
+        assertTrue(slack.lastRequest("chat.postMessage")!!.blocks().sectionText().contains("okta|abc123"))
+    }
+
+    @Test
+    fun `the decider is resolved to a mention too`() = runBlocking {
+        slack.userIdByEmail["approver@example.com"] = "U_APP"
+        transport.deliver(
+            "D_U_SAM",
+            message(event = NotificationEvent.TASK_DECIDED).copy(decidedBy = "approver@example.com", approved = true),
+            "en",
+        )
+        val text = slack.lastRequest("chat.postMessage")!!.blocks().sectionText()
+        assertTrue(text.contains("<@U_APP>"), "the decider resolves to a mention; was: $text")
+    }
+
+    // ---- update: edit by handle ---------------------------------------------------------------
+
+    @Test
+    fun `update edits by channel-ts and returns the same ref`() = runBlocking {
+        val result = transport.update("C_MOCK:1700000000001.000100", message(event = NotificationEvent.TASK_DECIDED), "en")
+
+        assertEquals(DeliveryResult.Sent("C_MOCK:1700000000001.000100"), result)
+        val update = slack.lastRequest("chat.update")!!
+        assertTrue(update.isJson)
+        assertEquals("C_MOCK", update.json!!["channel"]!!.jsonPrimitive.content)
+        assertEquals("1700000000001.000100", update.json!!["ts"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `update drops a malformed message ref without calling Slack`() = runBlocking {
+        val result = transport.update("not-a-ref", message(), "en")
+        assertTrue(result is DeliveryResult.Drop, "a ref with no ':' cannot address an edit; got $result")
+        assertTrue(slack.requestsFor("chat.update").isEmpty(), "nothing should have gone to Slack")
+    }
+
+    // ---- Slack's error taxonomy decides retry vs drop -----------------------------------------
+
+    @Test
+    fun `a retryable Slack error retries and a permanent one drops`() = runBlocking {
+        slack.postMessageError = "ratelimited"
+        assertTrue(transport.deliver("D_X", message(), "en") is DeliveryResult.Retry, "ratelimited can clear")
+
+        slack.postMessageError = "channel_not_found"
+        assertTrue(transport.deliver("D_X", message(), "en") is DeliveryResult.Drop, "channel_not_found fails forever")
+    }
+
+    @Test
+    fun `a transport-level failure retries rather than dropping`() = runBlocking {
+        slack.close() // server gone: the POST throws at the socket, which is transient by nature
+        assertTrue(transport.deliver("D_X", message(), "en") is DeliveryResult.Retry)
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/StatementRenderingTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/StatementRenderingTest.kt
@@ -1,0 +1,72 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What the recipient can actually read, and therefore whether they may approve from the message
+ * (docs/notifications.md, "Never approve what you cannot see").
+ *
+ * The rule is deliberately about the RENDERED text, not the configured mode: a short statement under
+ * TRUNCATED was never truncated, and a long one under FULL is still elided by a transport's own ceiling.
+ * Writing the gate against the mode gets both edges backwards, which is what these cases pin.
+ */
+class StatementRenderingTest {
+
+    private val short = "SELECT id FROM users"
+    private val long = "SELECT " + "x".repeat(500) + " FROM users"
+
+    @Test
+    fun `a statement shorter than the limit is complete under truncated`() {
+        val r = renderStatement(short, StatementDisclosure.TRUNCATED, maxChars = 200)
+        assertEquals(short, r.text)
+        assertTrue(r.complete, "nothing was cut, so the approver has read the whole statement")
+    }
+
+    @Test
+    fun `a statement longer than the limit is cut and incomplete`() {
+        val r = renderStatement(long, StatementDisclosure.TRUNCATED, maxChars = 200)
+        assertFalse(r.complete)
+        assertTrue(r.text!!.length <= 200, "the ellipsis must fit INSIDE the ceiling, not overrun it")
+        assertTrue(r.text!!.endsWith("…"))
+    }
+
+    @Test
+    fun `full carries the whole statement when the transport can hold it`() {
+        val r = renderStatement(long, StatementDisclosure.FULL, maxChars = 200, hardLimit = 2800)
+        assertEquals(long, r.text)
+        assertTrue(r.complete, "the configured truncation limit does not apply under FULL")
+    }
+
+    /** The edge the mode-based rule got wrong: FULL still loses the button when the transport elides. */
+    @Test
+    fun `full is incomplete when the transport ceiling cuts it`() {
+        val huge = "SELECT " + "y".repeat(4000) + " FROM users"
+        val r = renderStatement(huge, StatementDisclosure.FULL, maxChars = 200, hardLimit = 2800)
+        assertFalse(r.complete, "elided is elided, whoever did it")
+        assertTrue(r.text!!.length <= 2800)
+    }
+
+    @Test
+    fun `omit carries no statement and is never complete`() {
+        val r = renderStatement(short, StatementDisclosure.OMIT, maxChars = 200)
+        assertEquals(null, r.text)
+        assertFalse(r.complete)
+    }
+
+    @Test
+    fun `a task with no statement is never complete`() {
+        val r = renderStatement(null, StatementDisclosure.FULL, maxChars = 200)
+        assertEquals(null, r.text)
+        assertFalse(r.complete)
+    }
+
+    @Test
+    fun `parse rejects an unrecognized disclosure mode`() {
+        assertEquals(StatementDisclosure.TRUNCATED, StatementDisclosure.parse("truncated"))
+        assertEquals(StatementDisclosure.FULL, StatementDisclosure.parse("FULL"))
+        assertEquals(null, StatementDisclosure.parse("sometimes"))
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/FakeTransport.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/FakeTransport.kt
@@ -1,0 +1,57 @@
+package com.ridi.oss.proxymonster.controlplane.support
+
+import com.ridi.oss.proxymonster.controlplane.notify.DeliveryResult
+import com.ridi.oss.proxymonster.controlplane.notify.NotificationAction
+import com.ridi.oss.proxymonster.controlplane.notify.NotificationEvent
+import com.ridi.oss.proxymonster.controlplane.notify.NotificationMessage
+import com.ridi.oss.proxymonster.controlplane.notify.NotificationTransport
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.withTimeout
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * An in-memory transport for testing [com.ridi.oss.proxymonster.controlplane.notify.NotificationService]
+ * orchestration — drain, delivery ordering, retry/backoff, terminal announce — without any wire protocol.
+ * Records what it was asked to deliver/update and returns whatever result the test programs.
+ */
+class FakeTransport(
+    override val name: String = "fake",
+    override val supportsUpdate: Boolean = true,
+) : NotificationTransport {
+    override val statementHardLimit: Int = 0
+
+    /** Principal → address; return null to exercise the no-address drop. */
+    @Volatile var address: (String) -> String? = { "addr:$it" }
+
+    @Volatile var deliverResult: DeliveryResult = DeliveryResult.Sent("ref-fake")
+    @Volatile var updateResult: DeliveryResult = DeliveryResult.Sent("ref-fake")
+
+    data class Delivered(val to: String, val event: NotificationEvent, val actions: Set<NotificationAction>)
+    data class Updated(val ref: String, val event: NotificationEvent)
+
+    val delivered: MutableList<Delivered> = Collections.synchronizedList(mutableListOf())
+    val updated: MutableList<Updated> = Collections.synchronizedList(mutableListOf())
+    val addressCalls = AtomicInteger()
+
+    private val deliverSignal = Channel<Unit>(Channel.UNLIMITED)
+
+    override suspend fun addressOf(principal: String, email: String?): String? {
+        addressCalls.incrementAndGet()
+        return address(principal)
+    }
+
+    override suspend fun deliver(to: String, message: NotificationMessage, locale: String): DeliveryResult {
+        delivered += Delivered(to, message.event, message.actions)
+        deliverSignal.trySend(Unit)
+        return deliverResult
+    }
+
+    override suspend fun update(externalRef: String, message: NotificationMessage, locale: String): DeliveryResult {
+        updated += Updated(externalRef, message.event)
+        return updateResult
+    }
+
+    /** Suspend until at least one deliver() call has happened, for testing wake latency. */
+    suspend fun awaitDelivery(timeoutMs: Long = 5_000) = withTimeout(timeoutMs) { deliverSignal.receive() }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/MockSlack.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/MockSlack.kt
@@ -1,0 +1,214 @@
+package com.ridi.oss.proxymonster.controlplane.support
+
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.server.application.install
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.server.websocket.WebSockets
+import io.ktor.server.websocket.webSocket
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readText
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import java.net.URLDecoder
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * A stand-in for the Slack Web API + Socket Mode gateway, run as a REAL embedded server on an ephemeral
+ * port so the transport and socket exercise their true wire encoding — the form-vs-JSON split, the auth
+ * header, the WebSocket handshake and ack — rather than a stubbed client that would let an encoding bug
+ * through.
+ *
+ * It records every HTTP request ([requests]) so a test can assert HOW a method was called, is programmable
+ * per method (which user an email resolves to, whether a post fails), and drives Socket Mode from the test
+ * side: [pushEnvelope] sends a frame to the connected client and [acks] captures what it sent back.
+ */
+class MockSlack private constructor() : AutoCloseable {
+
+    /** One recorded HTTP call. [contentType] and [authorization] are what actually went on the wire. */
+    data class Recorded(
+        val method: String,
+        val contentType: String?,
+        val authorization: String?,
+        val rawBody: String,
+    ) {
+        /** The body parsed as a form (empty when it was not form-encoded). */
+        val form: Map<String, String> by lazy {
+            if (rawBody.isBlank()) emptyMap()
+            else rawBody.split('&').mapNotNull { pair ->
+                val eq = pair.indexOf('=')
+                if (eq < 0) null
+                else URLDecoder.decode(pair.substring(0, eq), "UTF-8") to URLDecoder.decode(pair.substring(eq + 1), "UTF-8")
+            }.toMap()
+        }
+
+        /** The body parsed as JSON, or null when it was not JSON. */
+        val json: JsonObject? by lazy { runCatching { JSON.parseToJsonElement(rawBody).jsonObject }.getOrNull() }
+
+        val isForm: Boolean get() = contentType?.startsWith(ContentType.Application.FormUrlEncoded.toString()) == true
+        val isJson: Boolean get() = contentType?.startsWith(ContentType.Application.Json.toString()) == true
+    }
+
+    // ---- programmable behavior ----------------------------------------------------------------
+
+    /** The workspace auth.test reports; SlackSocketMode pins clicks to it. */
+    var teamId: String = "T_WORKSPACE"
+
+    /** users.lookupByEmail: an email present here resolves to its Slack user id; absent → users_not_found. */
+    val userIdByEmail: MutableMap<String, String> = Collections.synchronizedMap(mutableMapOf())
+
+    data class SlackUser(val email: String?, val deleted: Boolean = false, val isBot: Boolean = false)
+
+    /** users.info: the profile a Slack user id resolves to; absent → user_not_found. */
+    val usersById: MutableMap<String, SlackUser> = Collections.synchronizedMap(mutableMapOf())
+
+    /** When set, chat.postMessage answers ok:false with this error instead of delivering. */
+    @Volatile var postMessageError: String? = null
+
+    /** When set, chat.update answers ok:false with this error. */
+    @Volatile var updateError: String? = null
+
+    // ---- recording ----------------------------------------------------------------------------
+
+    private val recorded = Collections.synchronizedList(mutableListOf<Recorded>())
+    private val ackFrames = Collections.synchronizedList(mutableListOf<JsonObject>())
+    private val ephemeral = Collections.synchronizedList(mutableListOf<JsonObject>())
+    private val tsSeq = AtomicLong(1_700_000_000_000)
+
+    /** Every HTTP call the client made, in order. */
+    fun requests(): List<Recorded> = recorded.toList()
+    fun requestsFor(method: String): List<Recorded> = recorded.filter { it.method == method }
+    fun lastRequest(method: String): Recorded? = recorded.lastOrNull { it.method == method }
+
+    /** The envelope_id acknowledgements the client sent back over the socket. */
+    fun acks(): List<JsonObject> = ackFrames.toList()
+
+    /** Bodies POSTed to a response_url (the ephemeral, clicker-only replies). */
+    fun ephemeralReplies(): List<JsonObject> = ephemeral.toList()
+
+    // ---- socket-mode control ------------------------------------------------------------------
+
+    // Outbound frames the test wants delivered to whichever client is currently connected. UNLIMITED so a
+    // test can queue an envelope before the client has connected without blocking.
+    private val outbound = Channel<String>(Channel.UNLIMITED)
+    private val connectionSignals = Channel<Unit>(Channel.UNLIMITED)
+
+    /** Suspend until a Socket Mode client has connected and been greeted with `hello`. */
+    suspend fun awaitConnection() = connectionSignals.receive()
+
+    /** Send a raw text frame (an interaction envelope, or `{"type":"disconnect"}`) to the connected client. */
+    suspend fun pushEnvelope(json: String) = outbound.send(json)
+
+    // ---- wiring -------------------------------------------------------------------------------
+
+    private lateinit var server: io.ktor.server.engine.EmbeddedServer<*, *>
+    var port: Int = 0
+        private set
+
+    /** Pass as the transport/socket `api` so calls hit this server. */
+    val apiBase: String get() = "http://127.0.0.1:$port/api"
+
+    /** The URL apps.connections.open hands back; where the client opens its Socket Mode WebSocket. */
+    val socketUrl: String get() = "ws://127.0.0.1:$port/socket"
+
+    /** A response_url the test can put in an envelope so ephemeral replies land in [ephemeralReplies]. */
+    val responseUrl: String get() = "http://127.0.0.1:$port/response"
+
+    private fun start() {
+        server = embeddedServer(Netty, port = 0) {
+            install(WebSockets)
+            routing {
+                post("/api/{method}") {
+                    val method = call.parameters["method"] ?: ""
+                    val body = call.receiveText()
+                    recorded += Recorded(
+                        method = method,
+                        contentType = call.request.headers[HttpHeaders.ContentType],
+                        authorization = call.request.headers[HttpHeaders.Authorization],
+                        rawBody = body,
+                    )
+                    call.respondText(responseFor(method, body), ContentType.Application.Json)
+                }
+                post("/response") {
+                    runCatching { ephemeral += JSON.parseToJsonElement(call.receiveText()).jsonObject }
+                    call.respondText("""{"ok":true}""", ContentType.Application.Json)
+                }
+                webSocket("/socket") {
+                    send(Frame.Text("""{"type":"hello","num_connections":1}"""))
+                    connectionSignals.send(Unit)
+                    val pump = launch { for (msg in outbound) send(Frame.Text(msg)) }
+                    try {
+                        for (frame in incoming) {
+                            val text = (frame as? Frame.Text)?.readText() ?: continue
+                            runCatching { JSON.parseToJsonElement(text).jsonObject }.getOrNull()?.let { ackFrames += it }
+                        }
+                    } finally {
+                        pump.cancel()
+                    }
+                }
+            }
+        }.start(wait = false)
+        port = runBlocking { server.engine.resolvedConnectors().first().port }
+    }
+
+    private fun formParam(body: String, key: String): String? = Recorded("", null, null, body).form[key]
+
+    private fun responseFor(method: String, body: String): String = when (method) {
+        "auth.test" -> """{"ok":true,"team_id":"$teamId","user_id":"UBOT","team":"mock"}"""
+        "apps.connections.open" -> """{"ok":true,"url":"$socketUrl"}"""
+        "users.lookupByEmail" -> {
+            val email = formParam(body, "email")
+            val id = email?.let { userIdByEmail[it] }
+            if (id != null) """{"ok":true,"user":{"id":"$id"}}""" else """{"ok":false,"error":"users_not_found"}"""
+        }
+        "conversations.open" -> {
+            val user = formParam(body, "users") ?: "U?"
+            """{"ok":true,"channel":{"id":"D_$user"}}"""
+        }
+        "users.info" -> {
+            val user = formParam(body, "user")
+            val u = user?.let { usersById[it] }
+            if (u == null) """{"ok":false,"error":"user_not_found"}"""
+            else buildString {
+                append("""{"ok":true,"user":{"id":"$user","deleted":${u.deleted},"is_bot":${u.isBot}""")
+                append(""","profile":{""")
+                if (u.email != null) append(""""email":"${u.email}"""")
+                append("}}}")
+            }
+        }
+        "chat.postMessage" -> postMessageError?.let { """{"ok":false,"error":"$it"}""" }
+            ?: """{"ok":true,"channel":"C_MOCK","ts":"${tsSeq.incrementAndGet()}.000100"}"""
+        "chat.update" -> updateError?.let { """{"ok":false,"error":"$it"}""" }
+            ?: run {
+                val json = runCatching { JSON.parseToJsonElement(body).jsonObject }.getOrNull()
+                val channel = json?.get("channel")?.let { it.toString().trim('"') } ?: "C_MOCK"
+                val ts = json?.get("ts")?.let { it.toString().trim('"') } ?: "0"
+                """{"ok":true,"channel":"$channel","ts":"$ts"}"""
+            }
+        else -> """{"ok":false,"error":"unknown_method:$method"}"""
+    }
+
+    override fun close() {
+        outbound.close()
+        connectionSignals.close()
+        server.stop(gracePeriodMillis = 0, timeoutMillis = 200)
+    }
+
+    companion object {
+        private val JSON = Json { ignoreUnknownKeys = true }
+
+        /** Start a mock Slack on an ephemeral port. Close it (or use [use]) to stop the server. */
+        fun start(): MockSlack = MockSlack().also { it.start() }
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,8 @@ a facts layer.
 | --- | --- |
 | [`datasource-registration.md`](./datasource-registration.md) | gRPC self-registration; Decide cutover; Register / PushCatalog + proxy introspection; events. |
 | [`web-console.md`](./web-console.md) | The `web/` console: Editor / Workflows / Access / Audit / Admin. |
+| [`notifications.md`](./notifications.md) | Task events delivered out of band: event/route/transport seam, the approver lookup, Slack over Socket Mode. |
+| [`cedar-reverse-query.md`](./cedar-reverse-query.md) | "Who may approve this?" — Cedar partial evaluation measured against the pinned engine; three silent failure modes and why we ask once per principal instead. |
 | [`migrations.md`](./migrations.md) | Flyway, auto-migrate on boot in per-migration transactions, fail-closed; single→multi-instance path. |
 | [`l10n.md`](./l10n.md) | Localized user-facing errors (en/ko): the server returns a stable `code` + `params`; the web client resolves it. |
 | [`audit-trail-hardening.md`](./audit-trail-hardening.md) | Tamper-evident hash-chained `audit_event` trail + the CP-independent `auditmon/` Go monitor. |

--- a/docs/approval-workflow.md
+++ b/docs/approval-workflow.md
@@ -72,6 +72,11 @@ task exists but no rows.
 A new request must carry R — the create route rejects a null `roleId`
 (`approval.role_required`) — so every approval is execute-under-R + view-as-R.
 
+An approver is told a request is waiting, out of band
+([notifications.md](./notifications.md)) — including the reverse lookup step 3's
+per-caller eligibility check does not provide. They can also decide from there,
+on the `slack` channel, which a policy can scope or forbid.
+
 ### Worked example
 
 Column config: `users.rrn` is `tag:pii`. Role `pii-reader`: `read.masked` pii

--- a/docs/authz-context.md
+++ b/docs/authz-context.md
@@ -14,8 +14,8 @@ server-side, never from the token"). Two kinds:
 Raw attested inputs, set by the control-plane from what the client cannot forge:
 
 - `channel` — which surface/phase the decision is in: `wire` | `editor` |
-  `workflow-executor` | `workflow-viewer` | `mcp`. Derived from the entry point
-  / ephemeral-token kind, never a client-supplied field.
+  `workflow-executor` | `workflow-viewer` | `slack` | `mcp`. Derived from the
+  entry point / ephemeral-token kind, never a client-supplied field.
 - `requester_ip` — the end client's source address, a Cedar `ipaddr`. From the
   proxy's `client_addr` on the wire path; from `resolveHttpRequesterIp`
   (`RequesterIp.kt`) on the HTTP paths.
@@ -57,13 +57,40 @@ Closed set (a value outside it is a config error → fail-closed deny):
 | `wire` | a native DB client's query through the proxy | proxy `Decide` (wire-session token) |
 | `editor` | the web SQL editor | the editor's ephemeral token kind |
 | `workflow-executor` | an approval running as role R to fetch + store the result | the approval-exec ephemeral token kind |
-| `workflow-viewer` | viewing a stored approval result as role R | the control-plane view route |
+| `workflow-viewer` | the unelevated human side of a task: viewing a stored result, and approving or rejecting one | the control-plane view + task-decision routes |
+| `slack` | a task decided from a Slack button rather than a console session | the Slack interaction handler (`Channel.SLACK`) |
 | `mcp` | an access-control change over the MCP admin surface | the MCP request handler (`Channel.MCP`) |
 
 For the proxy-mediated paths the value is derived from the ephemeral-token kind
-(the control-plane mints the kind; the proxy cannot assert it); the view route
-sets it directly. It is never read from a client-supplied field. The MCP channel
-is consumed by [`mcp-access-control.md`](./mcp-access-control.md).
+(the control-plane mints the kind; the proxy cannot assert it); the view and
+task-decision routes set it directly. It is never read from a client-supplied
+field. The MCP channel is consumed by
+[`mcp-access-control.md`](./mcp-access-control.md).
+
+The axis is which surface an actor is on, not what kind of operation runs there:
+`wire` and `editor` run statements, `workflow-executor` runs one under an
+elevation role, `workflow-viewer` views and decides, `mcp` changes
+configuration. A value earns its place when a policy needs to tell that surface
+from a neighbouring one, so two values may be merged only if nothing — policy or
+code gate — distinguishes them. `editor` and `workflow-viewer` cannot be:
+`editor` carries [`system:task-editor-self-approve`], which permits
+self-approval because an editor task runs under the caller's own roles, while a
+console approval elevates to R and must stay under [`system:no-self-approval`].
+
+`workflow-viewer` is the **workflow** viewer, not a result viewer — read the
+name broadly. It is the whole console-facing surface of a workflow task: viewing
+a stored result, showing the approval UI, and making the decision (approve /
+reject / read-status). All of it is the same actor doing the human half of the
+workflow on one session, so one channel scopes it. It is also defined by what it
+does **not** match: no shipped policy mentions it, and a saved result re-masks
+at view time precisely because
+[`system:production-pii-unmasked-workflow-executor`] does not fire here.
+
+`slack` is the sibling of `workflow-viewer`: a task decided from a chat
+interaction rather than a console session
+([`notifications.md`](./notifications.md)). It carries no `requester_ip`, so a
+policy conditioning on one denies, and it is how an operator scopes or forbids
+that weaker assertion.
 
 ## `requester_ip` — attestation
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -91,6 +91,18 @@ forward work. MySQL leads PostgreSQL in priority.
 
 ## Approval automation
 
+- Withhold a statement whose predicate compares a literal against a column the
+  role cannot read in clear. `WHERE rrn = '…'` puts the protected value in the
+  query itself, where masking never sees it. The probe already walks predicates
+  and already reads literals; what is missing is the pairing and a wire to carry
+  it, since `StatementFacts` has no predicate or literal field and the clause
+  label does not survive the proto boundary. See
+  [notifications.md](./notifications.md#hiding-a-statement-that-carries-the-value-it-asks-for).
+- Per-user notification opt-out. Language is stored per user
+  (`app_user.locale`); a mute switch is the same shape.
+- Email as a second notification transport. The seam exists
+  ([notifications.md](./notifications.md)); it needs an SMTP adapter and a
+  message renderer, and it does not support editing a message in place.
 - Auto mode (stretch): release a narrow set of deny reasons without a human
   approver. Two questions decide whether it is safe — which deny reasons are
   ever eligible for auto-release, and whether the reasoning input is the AST and

--- a/docs/cedar-reverse-query.md
+++ b/docs/cedar-reverse-query.md
@@ -1,0 +1,192 @@
+# Cedar partial evaluation — measured
+
+Cedar answers "may **bob** approve request 42?" It does not answer "**who** may
+approve request 42?"
+
+Every caller in this repo asks the first question. Notifications were the first
+thing to need the second one, which sent us looking at Cedar's partial
+evaluation. The short version:
+
+- Asking it in **reverse** — leave the principal unknown, get back the set of
+  people — does not work. Three failure modes, two silent.
+- Asking it **forward with unknowns** — keep the principal concrete, mark the
+  facts we lack — does work, and is what
+  [notifications.md](./notifications.md#who-can-approve) uses.
+
+Everything below was measured by calling `cedar-java:4.3.1:uber`, the version
+this repo pins, against its real native engine.
+
+## What partial evaluation is
+
+Leave part of a request unknown and Cedar returns a **residual**: the policy
+simplified down to whatever still depends on the unknown. Like reducing
+`2 + 3 + x` to `5 + x`.
+
+The response is one of three things, and the third is the useful one:
+
+- `Allow` / `Deny` — decided despite the hole
+- a **residual** with `decision = null` — undecided, here is what is left
+
+## The forward use — what we adopted
+
+Keep the principal concrete and mark only what is genuinely missing. At routing
+time we know who we are asking about; we do not know where they are:
+
+```
+principal    = User::"bob"                 // known — we loop over people
+requester_ip = Unknown("requester_ip")     // genuinely unknown until Bob clicks
+```
+
+Against `approver AND NOT contractor AND ip in 10.0.0.0/8`:
+
+| candidate                | result   | reading    |
+| ------------------------ | -------- | ---------- |
+| approver                 | residual | possible   |
+| approver, but contractor | Deny     | impossible |
+| not an approver          | Deny     | impossible |
+
+Every term Cedar can settle still settles — including the negation, which is why
+the contractor is correctly excluded. Only the part that truly depends on
+missing facts stays open.
+
+### Read the verdict, not the residual's contents
+
+It is tempting to inspect which policies are unresolved and treat an undecided
+_forbid_ as denying. Do not: it is both unnecessary and wrong.
+
+Unnecessary, because Cedar already returns a definite `Deny` when a forbid fires
+under every assignment of the unknowns. Anything short of `Deny` is a genuine
+maybe.
+
+Wrong, because an operator may express a restriction as a forbid conditioned on
+the unknown axis — "may not approve from outside the office". That forbid is
+undecided for _everyone_, so counting it as a denial skips every candidate,
+including the ones who would be allowed. Measured: both approvers read `Allow`
+in reality and both get skipped.
+
+The correct question is satisfiability — could any assignment produce `Allow` —
+and Cedar's verdict already answers it. `Allow` or a residual means notify;
+`Deny` means skip.
+
+### Trap: an omitted attribute is not an unknown one
+
+```
+emptyContext()                      ->  Deny, residual = false   // permit vanishes
+{ requester_ip: Unknown }           ->  null, residual = isInRange(unknown(...), ...)
+```
+
+Cedar is right — "this key is absent" genuinely differs from "I don't know yet"
+— but the effect is that a forgotten attribute silently drops people. Every axis
+a policy might touch must be marked. Omitting the context map entirely is worse
+still: the engine panics in Rust with `missing field 'context'`, surfaced as an
+`AuthException`.
+
+### Trap: one unknown un-decides `has` for every other key
+
+A policy reading only `channel`, with `channel` supplied concretely both times:
+
+```
+{ channel: "workflow-viewer" }                          ->  Deny  (resolves)
+{ channel: "workflow-viewer", requester_ip: Unknown }   ->  null  (undecided)
+```
+
+The residual shows why — Cedar models the context as one record and will not
+reduce `has` while any unknown sits inside it:
+
+```json
+"has": { "left": { "Record": {
+    "channel":      { "Value": "workflow-viewer" },
+    "requester_ip": { "unknown": [...] }
+}}}
+```
+
+`context has channel` is knowably true; no assignment of `requester_ip` could
+change it. This is over-conservative, and it matters because Cedar's strict
+validation _requires_ that guard — an unguarded read of an optional attribute
+fails validation — so every context-conditioned policy in this repo has one. One
+unknown therefore un-decides all of them at once.
+
+Consequence: supplying more known attributes does not contain the blast radius.
+The only lever is marking fewer things unknown.
+
+## The reverse use — what we rejected
+
+The tempting version is to leave the **principal** unknown and get everyone at
+once:
+
+```
+policy:    permit(principal, action == Action::"task.approve", resource)
+             when { principal in Role::"pii-approver" };
+
+residual:  unknown("principal") in Role::"pii-approver"
+```
+
+That is close to a `WHERE` clause — one query instead of one call per person.
+Boolean structure survives too: `&&`, `||`, `!`, and `in [set]` all come
+through, and `principal in [roleA, roleB]` reduces to a single set membership
+that would translate cleanly to SQL.
+
+It does not work, for three reasons.
+
+**It names nobody.** Supplying alice (in the role) and bob (not) returns the
+identical residual. Cedar hands back a condition; turning it into
+`SELECT principal FROM … WHERE …` is a compiler someone would have to write and
+be right about.
+
+**Only the first mention of `principal` is substituted.** Take an ordinary
+policy — an approver who is not a contractor:
+
+```
+permit(principal, action == Action::"task.approve", resource)
+  when { principal in Role::"pii-approver" && !(principal in Role::"contractor") };
+```
+
+The residual comes back as:
+
+```
+   unknown("principal") in Role::"pii-approver"      ← substituted
+&& !( Var("principal")  in Role::"contractor" )      ← NOT substituted
+```
+
+The second mention stays a raw variable, in every multi-term case tried. A
+reasonable guess is that the two are co-bound — that `Var` still refers to the
+same unknown — but they are not. Re-parsing the residual with `Policy.fromJson`
+and evaluating it for a concrete alice gives `Deny`, where the original policy
+gives `Allow`: `unknown("principal")` stays a literal hole that no concrete
+principal ever fills. The two occurrences are simply inconsistent, and a
+consumer reading the bare `Var` as unconstrained would notify exactly the people
+the policy forbids. **This looks like a genuine upstream bug and is worth
+reporting.**
+
+**Unmarked axes still collapse.** `resource.requester` in the self-approval
+forbid was not marked unknown, so it folded to `false` and the forbid vanished —
+`Deny`, no residual, no warning.
+
+Two of those three fail silently and both lose recipients, which is the
+direction a fail-closed system must not fail in.
+
+The forward form sidesteps all of it: with the principal concrete there is no
+substitution to get wrong, and the only unknowns are ones we chose and marked.
+
+## Status
+
+Two findings here look like genuine upstream bugs, both over-conservative
+simplification: the first-occurrence substitution above, and `has` failing to
+reduce for a concrete key. Both are worth reporting.
+
+The feature is explicitly experimental upstream — no formal model, no
+correctness proof, API expected to change.
+[Type-aware partial evaluation](https://github.com/cedar-policy/rfcs/blob/main/text/0095-type-aware-partial-evaluation.md)
+(RFC 0095) is the stable successor and worth re-measuring when it lands. The
+forward use is narrow enough to be defensible today: it decides only who gets
+told something is waiting, and every real authorization still runs the ordinary
+full evaluation.
+
+## What this is not
+
+[Cedar Analysis / SymCC](https://aws.amazon.com/blogs/opensource/introducing-cedar-analysis-open-source-tools-for-verifying-authorization-policies/)
+is a separate, more mature toolkit — a Lean-verified symbolic compiler emitting
+SMT. It answers questions about _policies_: are these two equivalent, is this
+one shadowed, does this change grant anything new. It does not answer "who can
+do X", so it is not an alternative here — though it is the right tool for
+checking a policy edit before it ships.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,491 @@
+# Notifications — task events delivered out of band
+
+An approver used to find out about a request by opening the console and looking.
+Nobody told them. This is that telling.
+
+Built, with one part still proposed: withholding a statement whose predicate
+compares a literal against a protected column
+([below](#hiding-a-statement-that-carries-the-value-it-asks-for)) needs an
+analyzer fact that does not exist yet.
+
+It changes no enforcement. Masking, lineage, and the per-query decision are
+untouched. The one new authorization surface is deciding from Slack, and that is
+a new value on the channel axis policy already conditions on.
+
+## What it looks like
+
+Alice needs `rrn` from production. She files a request. Bob and Carol can
+approve it, so each gets a Slack DM:
+
+> **alice** wants to run `SELECT rrn, name FROM users WHERE order_id = 8842` on
+> **acme-mysql** as **pii-reader** _investigating a billing dispute_
+> `[approve and run]` `[deny]` `[open request]`
+
+Bob taps **deny**. His message and Carol's both become:
+
+> **alice**'s request to run `SELECT rrn, name FROM users WHERE …` on
+> **acme-mysql** was denied by **bob** `[open request]`
+
+Had Bob tapped **approve and run**, the query runs and the message becomes
+"approved by bob, running", then updates again to "finished, 3 rows" or
+"failed". The rows themselves never appear in Slack — Alice reads them in the
+console.
+
+Alice's statement is short, so Bob sees all of it and can approve from the DM.
+Had any of it been elided — too long for the configured limit, too long for
+Slack, or withheld because it carried a protected value — the message would
+offer only `[deny]` and `[open request]`. Nobody approves a statement they have
+not read in full.
+
+Everything below is how that works.
+
+## Three layers
+
+- **Event** — what happened. The workflow says it once and knows nothing about
+  Slack.
+- **Route** — who should hear it.
+- **Transport** — how it reaches them. Slack first, email second.
+
+Email is why the seam exists. Adding it should mean writing one transport, not
+touching the workflow.
+
+## Events
+
+| Event                                          | When                 | Who hears it                           |
+| ---------------------------------------------- | -------------------- | -------------------------------------- |
+| `task.requested`                               | a request is filed   | everyone who could approve it          |
+| `task.decided`                                 | approved or rejected | the requester, and everyone told above |
+| `task.executed` `task.failed` `task.cancelled` | the run ends         | the requester and the approver         |
+
+Anyone told about a request is told how it ended. That is what stops a stale
+"needs your approval" sitting in a DM after someone else already handled it —
+the original message is edited in place. A transport that cannot edit sends a
+follow-up instead.
+
+## Who can approve
+
+This is the hard part, and it deserves plain statement.
+
+Cedar answers "may **bob** approve request 42?" It does not answer "who may
+approve request 42?" Every existing caller asks the first question about
+themselves — the inbox page loads all pending requests and asks Cedar once per
+request, for the one person looking at the page.
+
+A notification needs the second question, so we ask the first one for everybody.
+
+### The candidate list
+
+"Every active principal" is not just the `app_user` table. A principal is a
+plain string, and someone can hold a role through a direct assignment or a JIT
+grant without ever having a directory row. So the list is the union of four
+sources: active `app_user` rows, `principal_role`, group membership, and
+unexpired `access_grant` rows. `RoleResolver` already walks exactly this union
+in `hasActiveAssignee` to answer "does anyone hold this role"; the same query
+returning names instead of a yes/no is what we need.
+
+### The problem: we don't know where Bob is
+
+Asking Cedar the ordinary way needs a full request, and part of one is missing
+here. There is no HTTP request behind this loop, so there is no requester IP.
+
+That breaks a policy like "approvers must be on the office network." Bob holds
+the approver role and would sail through the moment he clicks from his desk —
+but at routing time we cannot say where he is, and an absent attribute makes
+Cedar deny. Measured, with Bob holding the role throughout:
+
+```
+policy requires ip in 10.0.0.0/8
+
+  no requester_ip     ->  Deny     ← Bob is never told
+  ip = 10.1.2.3       ->  Allow    ← but he can approve, from the office
+```
+
+Bob is a real approver and the loop drops him. That is the one failure this
+design cannot have: a request nobody hears about waits forever.
+
+### The fix: ask "could Bob ever?"
+
+Cedar can be asked a weaker question. Mark what we do not know as **unknown**
+instead of leaving it out, and instead of guessing it answers with a
+**residual** — the conditions still outstanding:
+
+```
+for each active principal p:
+    ask Cedar about p
+      channel      = "workflow-viewer"        // the server always knows this
+      requester_ip = UNKNOWN                   // nobody knows until they click
+
+    Allow     -> notify     (certain)
+    residual  -> notify     (possible — some address would allow it)
+    Deny      -> skip       (impossible from anywhere)
+```
+
+Read only the verdict. There is no need to inspect which policies are
+unresolved, and no special case for forbids: Cedar returns a definite `Deny`
+when a forbid fires under every assignment, so anything short of that is a
+genuine maybe.
+
+The principal stays concrete — we loop over people anyway — so every term Cedar
+_can_ settle still settles. Against "approver AND NOT contractor AND office
+network":
+
+| candidate                | routing  | notified | on clicking from the office |
+| ------------------------ | -------- | -------- | --------------------------- |
+| approver                 | residual | yes      | Allow                       |
+| approver, but contractor | Deny     | no       | Deny                        |
+| not an approver          | Deny     | no       | Deny                        |
+
+The contractor is correctly excluded even though the answer is otherwise
+undecided — a negated role term is knowable without knowing the address.
+
+### Known, unknown, and absent are three different things
+
+Which attributes to supply is the part that is easy to get wrong, because the
+two failure modes sit on opposite axes.
+
+Supply **everything the server knows**, always. `channel` is a fact about the
+surface, not about the person, so it is never unknown here.
+
+Mark as **unknown** only what is genuinely unknowable at routing time. Leaving
+it out instead is not the same thing — an absent attribute makes a conditioning
+policy deny, which is the bug this whole section exists to fix:
+
+|                             | shipped policies     | a custom IP-conditioned policy |
+| --------------------------- | -------------------- | ------------------------------ |
+| omit `requester_ip`         | exact                | drops the approver             |
+| mark `requester_ip` UNKNOWN | over-notifies by one | catches the approver           |
+
+The shipped policies never read `requester_ip` for `task.approve`, so on a
+default deployment either choice is correct. The unknown earns its place the
+moment an operator writes "approvers must be on the office network."
+
+### The one wart: the requester hears about their own request
+
+Marking anything unknown costs one wrong notification, and it is worth stating
+plainly because it looks alarming: the requester may be invited to approve their
+own request.
+
+The cause is a Cedar limitation, not a modelling mistake. Cedar treats the
+context as a single record, and `context has channel` will not reduce while
+_any_ unknown sits in that record — even though `channel` is right there with a
+concrete value, and no address could change whether it exists. Our
+[`system:no-self-approval`] forbid guards its editor/wire escape that way, so it
+goes undecided and the requester reads as "maybe":
+
+```
+channel known, requester_ip omitted  ->  Deny   (correct, forbid resolves)
+channel known, requester_ip UNKNOWN  ->  null   (undecided; the requester is notified)
+```
+
+It is bounded — one person per request, the requester themselves — and it does
+not arise at all on a deployment with no IP-conditioned approval policy, since
+nothing then needs to be unknown. Clicking the button denies exactly as it
+should. Not worth filtering outside Cedar: a hardcoded "skip the requester"
+would move an authorization rule out of the policy engine that owns it, to save
+one message.
+
+### What this costs, and what it means
+
+One Cedar call per principal, once, when a request is filed — the same cost as
+asking the ordinary way, against an already-compiled policy set.
+
+The residual is a hint, never a grant. **Notifying is not authorizing**: every
+action re-authorizes in full when taken, so an over-notified person simply gets
+a 403. The notification only ever says something is waiting.
+
+The API is experimental upstream — no formal model, no correctness proof.
+[cedar-reverse-query.md](./cedar-reverse-query.md) has the measurements, the
+failure modes, and the two upstream bugs found along the way.
+
+## Delivery
+
+Two tables.
+
+`notification_outbox` is the queue — one row per thing-to-send. It is written in
+the **same transaction** as the task change it describes, so a crash can never
+leave a request approved with nobody told.
+
+`notification_message` remembers where a message landed, so a later event can
+edit it rather than pile on. For Slack that is the channel and timestamp; for
+email, the `Message-Id` a reply threads onto.
+
+A background loop drains the queue, next to the two housekeeping loops already
+running. Failures retry with backoff a bounded number of times, then the row is
+marked dead with its last error kept. **A delivery failure never touches the
+task** — the console is the system of record and a notification is a courtesy.
+
+The loop does not merely poll: it is **woken** the moment a row is enqueued, and
+polls only as a backstop. A poll alone made an interactive click feel broken —
+tap _approve and run_, and the message did not change to "running" until the
+next tick, up to the full interval later, while the buttons sat there inviting a
+second tap. The wake fires after the enqueuing transaction commits (an earlier
+wake would race a row a separate connection cannot yet see), so the "running"
+and "finished" edits land in about a second — the round-trip to Slack — rather
+than seconds later. A missed wake only delays: the poll still sweeps the row.
+
+This is the in-process form of Postgres `LISTEN`/`NOTIFY`, which is the
+multi-instance version — there the wake must cross processes, and it stays a
+hint, not the queue: a `NOTIFY` reaches only sessions listening at that moment,
+so the table stays authoritative and the poll stays the backstop (`backlog.md`).
+
+Editing an already-delivered message needs only its stored handle, not the
+recipient's address, so an update skips address resolution entirely — for Slack
+that is two saved round-trips per edit, which is most of what a watching user
+feels after a click.
+
+Messages about one task go to one recipient in order. If "approved" is ready to
+send before "requested" has left the queue, it waits, so an edit never arrives
+before the thing it edits. If the original never sends, the edit becomes a new
+message instead of vanishing.
+
+## Transports
+
+```kotlin
+interface NotificationTransport {
+    val name: String
+    /** Null when this person has no address here — the row drops rather than retries. */
+    suspend fun addressOf(principal: String, user: AppUser?): String?
+    suspend fun deliver(to: String, message: NotificationMessage): DeliveryResult
+    /** False for email and anything else with no edit — an update sends a new message. */
+    val supportsUpdate: Boolean
+    suspend fun update(ref: String, message: NotificationMessage): DeliveryResult
+}
+```
+
+`DeliveryResult` is `Sent(ref)`, `Retry(reason)`, or `Drop(reason)`. Only the
+transport knows whether a 429 is worth another try and a 404 is not.
+
+`NotificationMessage` carries a message key and its values, not finished prose —
+so Slack can render Block Kit, email can render MIME, and both languages stay
+reachable.
+
+A transport with no configuration is simply absent, the same way an unset
+`PM_SCIM_TOKEN` disables SCIM. Configure none and the whole layer does nothing.
+
+## Language
+
+A DM is user-facing copy, so it is localized like everything else.
+
+The control plane has no message catalog today — it returns an error code and
+the console renders it. Notifications need one, at
+`control-plane/src/main/resources/messages/{en,ko}/notifications.json`, keyed
+the same way and guarded by the same en/ko parity test.
+
+Which language comes from the recipient. The console's toggle already knows it —
+it just never told the server, because the locale lives in a browser cookie the
+server does not read. So the toggle also `PUT`s it, and login records it on
+first sight; `app_user.locale` holds the result, and a notification renders in
+the recipient's own language rather than one instance-wide setting.
+
+It is a display preference, not an authorization input: no policy reads it,
+nothing fails closed on it. A null column means the user has never expressed a
+preference, so delivery falls back to `PM_NOTIFY_LOCALE` and then to English.
+Storing it needs a migration adding the column, a small self-service route
+(`PUT /api/me/locale`, validated against the same `en | ko` set the console
+enforces — this is the user's own row, so it is not an admin surface), and one
+call from the toggle.
+
+## The statement in the message
+
+Sending the SQL is not automatically safe. Consider:
+
+```sql
+SELECT name FROM users WHERE rrn = '900101-1234567'
+```
+
+The protected value is in the query itself. Masking never sees it, because
+masking acts on results. Forward that text and the thing the policy protects has
+left the building.
+
+So `PM_NOTIFY_STATEMENT` picks one of:
+
+- `truncated` (default) — first 200 characters, enough to recognize the query
+- `full` — the whole statement
+- `omit` — no SQL at all; requester, datasource, role, and the link only
+
+It lives in the environment because that is where all configuration lives here.
+There is no settings table, and adding the first one belongs to its own change.
+
+### Never approve what you cannot see
+
+**`[approve and run]` appears only when the rendered message contains the entire
+statement.** The test is what the recipient can actually read, not which mode
+the operator configured:
+
+- `truncated` with a statement shorter than the limit — nothing was cut, so the
+  button appears.
+- `truncated` with a longer one — cut, no button.
+- `full` — usually the button, but not always: a transport has its own length
+  ceiling (a Slack section block's text field caps at 3000 characters), and a
+  statement that overruns it is elided on the way out. Elided is elided, whoever
+  did it.
+- `omit` — no button.
+
+So the flag is an input to rendering, and the button is decided **after**
+rendering, from whether the text survived intact. Writing the gate against the
+mode instead would get both edge cases backwards.
+
+Approving is vouching for a specific statement. A truncated one is worse than
+none: `SELECT id, name FROM users WHERE …` looks harmless and the elided tail is
+exactly where a dangerous predicate would sit. One tap on a query nobody read in
+full is not an approval, it is a rubber stamp with an audit trail.
+
+`[deny]` stays available throughout — refusing something you have not fully read
+is always safe.
+
+### Hiding a statement that carries the value it asks for
+
+`PM_NOTIFY_STATEMENT` is a blunt instrument: an operator picks one setting for
+every query, so `full` sends `WHERE rrn = '900101-1234567'` verbatim. The
+protected value is in the query, and masking never sees it because masking acts
+on results. This is the case where `full` still needs a floor.
+
+The leak has a shape the analyzer nearly sees already.
+
+The probe **walks predicates today**. Every `WHERE`, `HAVING`, and `QUALIFY` is
+visited and its resolved base columns recorded under a `PREDICATE` bucket
+(`analyzer/probe/probe.go`), beside `JOIN`, `GROUP_BY`, and `ORDER_BY`, through
+the same lineage resolution the rest of enforcement uses — aliases, CTEs, and
+derived tables followed. It **reads literals** too: `exp.KindLiteral` is already
+inspected in that file, and the library exposes `exp.TraitPredicate`, one trait
+covering every comparison form (`=`, `IN`, `LIKE`, `BETWEEN`, …).
+
+Two things are missing, and the second is the interesting one.
+
+**The pairing.** Nothing currently asks whether a given comparison holds both a
+literal and a column. That is a walk over each predicate subtree, resolving the
+column through the existing resolver.
+
+**The wire.** `StatementFacts` has no predicate or literal field, and the clause
+label does not survive the boundary either: every bucket — predicate, join,
+order-by alike — collapses into an identical `DENY_STATEMENT` column grant with
+no ordinals (`analyzer/probe/facts.go`). The control plane can tell
+reference-position from output-position, but not _which kind_ of reference. So
+the new fact must carry its own structure; it cannot be recovered downstream.
+
+The split matters when building it. The analyzer has no role context and must
+not gain one: it emits _(literal, base column)_ pairs, and the control plane
+intersects those with what is protected for this role — the same classification
+lookup `piiTouched` already does. Keeping the intersection in the control plane
+is what the facts contract requires.
+
+So: **a proto addition plus a probe emission**, not a new analysis. Golden
+regeneration comes with it, and the new fact should live outside the existing
+`References` map so the Python-oracle parity comparison stays untouched. A real
+change to a security-critical contract, and its own review — but not
+speculative.
+
+Worth stating what it is and is not. It is an **extra layer**, not the boundary:
+`omit` remains the setting for a deployment that cannot let query text leave at
+all. And it is a _hint_ — a comparison is the obvious form, but a value can
+reach a predicate through a function, a `CASE`, a subquery, an `IN (...)` list,
+or a prepared-statement parameter, so a clean result is not proof the statement
+is safe. Fail toward hiding: anything the analyzer cannot prove free of
+protected literals is treated as carrying one, which also means an unanalyzable
+statement is hidden rather than sent. Under this rule a hidden statement also
+loses `[approve and run]`, by the preceding section.
+
+## Slack
+
+### How it connects
+
+Socket Mode. The control plane opens an outbound WebSocket to Slack, and button
+clicks arrive back over it.
+
+The alternative is giving Slack a public URL to POST to — a new inbound
+endpoint, reachable from the internet, that approves database queries. Socket
+Mode avoids that entirely. The control plane keeps doing what it already does:
+only outbound calls, the same as it makes to the IdP.
+
+Two tokens, both required: `PM_SLACK_BOT_TOKEN` for the API and
+`PM_SLACK_APP_TOKEN` for the socket.
+
+The workspace is **derived, not configured**: `auth.test` on the bot token names
+the one workspace it belongs to, resolved once at connect. Asking an operator to
+restate it would add a value they can mistype — and one they can leave unset,
+which is worse, because an absent pin is an unpinned workspace. Derived, it
+fails closed: a workspace that cannot be resolved refuses every click.
+
+### Who is who
+
+Email, both directions, which is the same directory the IdP uses.
+
+Going out: take the principal, ask Slack for the user with that email, open a
+DM. If the principal is not itself an address, fall back to `app_user.email`.
+
+Coming in: a click carries a Slack user id. Look it up **fresh, every time** —
+never from a cached table, because that mapping is what proves who is clicking.
+Then match it to an active `app_user`. No match, an unverified email, or a
+workspace other than the bot token's own gets a private "not recognized" reply
+and nothing happens.
+
+### Approving from Slack
+
+A click is a weaker claim than a console session — no OIDC session, no known IP.
+
+Rather than hide that behind a boolean, `slack` becomes a sixth value on the
+channel axis alongside `wire`, `editor`, `workflow-executor`, `workflow-viewer`,
+and `mcp`. An operator can then write, per datasource or per role:
+
+```
+forbid (principal, action == Action::"task.approve", resource)
+when { context.channel == "slack" };
+```
+
+and the buttons stop working while the deep link still does. It ships enabled.
+
+Because there is no IP, any policy that requires one denies. That is the same
+fail-closed behaviour the system already has for a missing attribute.
+
+The no-self-approval rule needs no change. It exempts only the server-attested
+`editor` and `wire` channels, so Alice still cannot approve her own request from
+Slack.
+
+### The buttons
+
+**approve and run** does both steps, because whoever approves is the one who
+must execute. It is offered only when the message shows the full statement (see
+[above](#never-approve-what-you-cannot-see)). **deny** rejects, and is offered
+whatever the message shows. **open request** links to the console and is always
+there, even when the other two are policy-disabled.
+
+Both go through the same code the HTTP routes use. Today approve, reject, and
+execute live inside the route handlers; they move into an `ApprovalService`, and
+the routes become one caller of it while Slack becomes another. **This is a real
+refactor of `Approvals.kt`, not an incidental one** — it is the part of this
+design most worth reviewing before building.
+
+Two people tapping approve at once resolve exactly as two console users do — one
+wins the same compare-and-swap, and the loser's message is rewritten to show
+what actually happened.
+
+Results never reach Slack. A finished run says "3 rows" or "failed", nothing
+more. The rows stay in the console, which is the only place that re-checks who
+may see them.
+
+## Configuration
+
+| Variable                  | Default     | Meaning                                                                                               |
+| ------------------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
+| `PM_SLACK_BOT_TOKEN`      | unset       | Slack API token; unset = no Slack                                                                     |
+| `PM_SLACK_APP_TOKEN`      | unset       | Socket Mode token; unset = no Slack                                                                   |
+| `PM_NOTIFY_STATEMENT`     | `truncated` | `truncated` · `full` · `omit`. Approve-and-run needs the statement to render whole, whatever the mode |
+| `PM_NOTIFY_STATEMENT_MAX` | `200`       | characters kept when truncating                                                                       |
+| `PM_NOTIFY_LOCALE`        | `en`        | fallback when the recipient has saved no language                                                     |
+
+## What this exposes
+
+Slack becomes a place where the requester, the datasource, the role, and (unless
+`omit`) part of the query are readable by anyone who can read the DM — and a
+place from which a query can be approved. `ARCHITECTURE.md` gains the outbound
+edge. The workspace is pinned, and the tokens are standing secrets like
+`PM_SCIM_TOKEN`: absent means the feature is off, never degraded.
+
+## Not covered
+
+- Per-user opt-out. Language is now stored per user; a mute switch is the same
+  shape and a natural follow-up.
+- Posting to a channel. Eligibility is per person; a channel cannot express it.
+- Digests and reminders. One event, one message.
+- Multi-replica delivery. The queue assumes one instance, like the rest of the
+  system.


### PR DESCRIPTION
Out-of-band task notifications with approve/deny from Slack — the control-plane half of the notification layer. Three self-contained commits: the framework, the Slack transport, and wiring it live.

- **NotificationService** drains an outbox (`NotificationStore`, `FOR UPDATE SKIP LOCKED`, wake-on-enqueue, capped backoff) and delivers each event through a `NotificationTransport`. A notification carries no result data and is never authorization.
- **SlackTransport** — Web API (`chat.postMessage`/`update` as JSON; `users.lookupByEmail`/`conversations.open` form-encoded) plus a Socket Mode WebSocket for button clicks. The requester/decider are resolved to a `<@mention>`, falling back to the plain identity when the email has no Slack match.
- **SlackDecisionHandler** — a button click re-runs the full Cedar `task.approve` decision on the `slack` channel before it approves/runs anything; the click authorizes with exactly the request's role.
- **RecipientResolver** — who hears an event, gated by Cedar satisfiability ("who *could* approve"), never a result-bearing decision.
- **StatementDisclosure** (FULL / TRUNCATED / OMIT) governs how much SQL leaves the building; approve-and-run is offered only when the whole statement is readable in the message.

An unconfigured transport makes the whole layer inert (same posture as an unset `PM_SCIM_TOKEN`). Copy is localized (en/ko) through the CP `MessageCatalog`.

**Trap:** Slack's read methods (`users.*`, `conversations.*`) MUST be form-encoded — a JSON body returns `invalid_arguments` and every notification silently goes out dead. Only the `chat.*` methods (which carry a `blocks` array) take JSON. `SlackTransportTest` pins both halves.

Verification: full `mise run verify`; dual-review (codex + sol + grok). This is commits 1–3 of the notification stack; the console language memory and predicate-literal statement withholding follow in a later PR.
