### PR TITLE
feat(control-plane): the task-notification outbox and model

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStore.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStore.kt
@@ -1,0 +1,238 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import java.sql.Connection
+import java.sql.Timestamp
+import java.time.Instant
+import javax.sql.DataSource
+
+/** One queued delivery, as the drainer sees it. */
+data class OutboxRow(
+    val id: Long,
+    val taskId: Long,
+    val event: NotificationEvent,
+    val transport: String,
+    val recipient: String,
+    val attempts: Int,
+)
+
+/**
+ * The durable notification queue (docs/notifications.md, "Delivery").
+ *
+ * [enqueue] takes a caller-supplied [Connection] so the row commits in the SAME transaction as the task state
+ * change it describes: a crash can never leave a request approved with nobody told. Everything after that is
+ * best-effort — a delivery failure never touches the task, because the console is the system of record and a
+ * notification is a courtesy.
+ */
+class NotificationStore(private val dataSource: DataSource) {
+
+    /**
+     * Queue one delivery, in the caller's transaction. Idempotent per (task, event, transport, recipient):
+     * an event emitted twice for one recipient collapses onto the existing row rather than sending twice.
+     */
+    fun enqueue(
+        c: Connection,
+        taskId: Long,
+        event: NotificationEvent,
+        transport: String,
+        recipient: String,
+    ) {
+        c.prepareStatement(
+            """INSERT INTO notification_outbox (task_id, event, transport, recipient)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT (task_id, event, transport, recipient) DO NOTHING""",
+        ).use { ps ->
+            ps.setLong(1, taskId)
+            ps.setString(2, event.wire)
+            ps.setString(3, transport)
+            ps.setString(4, recipient)
+            ps.executeUpdate()
+        }
+    }
+
+    /**
+     * Claim up to [limit] due rows for delivery.
+     *
+     * `FOR UPDATE SKIP LOCKED` so a second drainer (or a restart overlapping the previous process) never
+     * double-sends: a row being worked on is invisible to the other claimant rather than blocking it. The
+     * claim only reserves — it does not advance `attempts`, which [markSent]/[markFailed] own, so a crash
+     * mid-delivery leaves the row claimable again rather than silently consuming a retry.
+     */
+    fun claimDue(limit: Int): List<OutboxRow> = dataSource.inTxLocal { c ->
+        c.prepareStatement(
+            """SELECT id, task_id, event, transport, recipient, attempts
+               FROM notification_outbox
+               WHERE status = 'PENDING' AND next_attempt_at <= now()
+               ORDER BY id
+               LIMIT ?
+               FOR UPDATE SKIP LOCKED""",
+        ).use { ps ->
+            ps.setInt(1, limit)
+            val out = ArrayList<OutboxRow>()
+            val poison = ArrayList<Pair<Long, String>>()
+            ps.executeQuery().use { rs ->
+                while (rs.next()) {
+                    val wire = rs.getString("event")
+                    val event = NotificationEvent.fromWire(wire)
+                    if (event == null) {
+                        // An unknown event wire value can never be delivered; dead-letter it in the claim
+                        // transaction rather than skip it, or it stays PENDING and is re-selected every drain.
+                        poison += rs.getLong("id") to wire
+                        continue
+                    }
+                    out += OutboxRow(
+                        id = rs.getLong("id"),
+                        taskId = rs.getLong("task_id"),
+                        event = event,
+                        transport = rs.getString("transport"),
+                        recipient = rs.getString("recipient"),
+                        attempts = rs.getInt("attempts"),
+                    )
+                }
+            }
+            for ((id, wire) in poison) {
+                c.prepareStatement("UPDATE notification_outbox SET status = 'DEAD', last_error = ? WHERE id = ?").use { u ->
+                    u.setString(1, "unknown event: $wire")
+                    u.setLong(2, id)
+                    u.executeUpdate()
+                }
+            }
+            out
+        }
+    }
+
+    fun markSent(id: Long) = update(id, "SENT", null, null)
+
+    /** Terminal failure: the row is done and its last error kept for an operator to read. */
+    fun markDead(id: Long, error: String) = update(id, "DEAD", error, null)
+
+    /** Transient failure: stay PENDING, burn an attempt, and come back after [backoff]. */
+    fun markRetry(id: Long, error: String, backoff: java.time.Duration) =
+        update(id, "PENDING", error, Instant.now().plus(backoff))
+
+    private fun update(id: Long, status: String, error: String?, nextAttempt: Instant?) {
+        dataSource.connection.use { c ->
+            c.prepareStatement(
+                """UPDATE notification_outbox
+                   SET status = ?, last_error = ?, attempts = attempts + 1,
+                       next_attempt_at = COALESCE(?, next_attempt_at), updated_at = now()
+                   WHERE id = ?""",
+            ).use { ps ->
+                ps.setString(1, status)
+                ps.setString(2, error?.take(500))
+                if (nextAttempt == null) ps.setNull(3, java.sql.Types.TIMESTAMP) else ps.setTimestamp(3, Timestamp.from(nextAttempt))
+                ps.setLong(4, id)
+                ps.executeUpdate()
+            }
+        }
+    }
+
+    /**
+     * True when an earlier event for this (task, transport, recipient) is still queued.
+     *
+     * An update must not overtake the message it edits, so a decided/finished event waits while its
+     * `task.requested` is still pending. Ordering is by id, which is insertion order.
+     */
+    fun hasEarlierPending(row: OutboxRow): Boolean = dataSource.connection.use { c ->
+        c.prepareStatement(
+            """SELECT 1 FROM notification_outbox
+               WHERE task_id = ? AND transport = ? AND recipient = ? AND status = 'PENDING' AND id < ?
+               LIMIT 1""",
+        ).use { ps ->
+            ps.setLong(1, row.taskId)
+            ps.setString(2, row.transport)
+            ps.setString(3, row.recipient)
+            ps.setLong(4, row.id)
+            ps.executeQuery().use { it.next() }
+        }
+    }
+
+    /** The handle a delivered message left behind, or null when nothing has been delivered yet. */
+    fun externalRef(taskId: Long, transport: String, recipient: String): String? =
+        dataSource.connection.use { c ->
+            c.prepareStatement(
+                "SELECT external_ref FROM notification_message WHERE task_id = ? AND transport = ? AND recipient = ?",
+            ).use { ps ->
+                ps.setLong(1, taskId)
+                ps.setString(2, transport)
+                ps.setString(3, recipient)
+                ps.executeQuery().use { if (it.next()) it.getString(1) else null }
+            }
+        }
+
+    /**
+     * Everyone the "needs approval" notification for [taskId] was enqueued to. A later event edits exactly
+     * these messages in place — so an approver whose role was revoked after they were notified still has their
+     * live "needs approval" buttons removed, instead of a recompute silently skipping them. Reads on the
+     * caller's connection [c] since a later event runs inside the decide/terminal transaction.
+     */
+    fun recipientsOfRequest(c: Connection, taskId: Long): Set<String> =
+        c.prepareStatement("SELECT DISTINCT recipient FROM notification_outbox WHERE task_id = ? AND event = ?").use { ps ->
+            ps.setLong(1, taskId)
+            ps.setString(2, NotificationEvent.TASK_REQUESTED.wire)
+            ps.executeQuery().use { rs ->
+                val out = LinkedHashSet<String>()
+                while (rs.next()) out += rs.getString(1)
+                out
+            }
+        }
+
+    /** Record where a message landed, so a later event edits it in place. */
+    fun rememberMessage(taskId: Long, transport: String, recipient: String, externalRef: String) {
+        dataSource.connection.use { c ->
+            c.prepareStatement(
+                """INSERT INTO notification_message (task_id, transport, recipient, external_ref)
+                   VALUES (?, ?, ?, ?)
+                   ON CONFLICT (task_id, transport, recipient)
+                   DO UPDATE SET external_ref = EXCLUDED.external_ref, updated_at = now()""",
+            ).use { ps ->
+                ps.setLong(1, taskId)
+                ps.setString(2, transport)
+                ps.setString(3, recipient)
+                ps.setString(4, externalRef)
+                ps.executeUpdate()
+            }
+        }
+    }
+
+    /** Run [body] in one transaction — for a caller that has no transaction of its own to join. */
+    fun <T> inTransaction(body: (Connection) -> T): T = dataSource.inTxLocal(body)
+
+    /** The recipient's saved language, or null when they have never expressed one. */
+    fun localeOf(principal: String): String? = dataSource.connection.use { c ->
+        c.prepareStatement("SELECT locale FROM app_user WHERE principal = ?").use { ps ->
+            ps.setString(1, principal)
+            ps.executeQuery().use { if (it.next()) it.getString(1) else null }
+        }
+    }
+
+    fun emailOf(principal: String): String? = dataSource.connection.use { c ->
+        c.prepareStatement("SELECT email FROM app_user WHERE principal = ?").use { ps ->
+            ps.setString(1, principal)
+            ps.executeQuery().use { if (it.next()) it.getString(1) else null }
+        }
+    }
+
+    /** Set the caller's own language. Returns false when no directory row exists for them. */
+    fun setLocale(principal: String, locale: String): Boolean = dataSource.connection.use { c ->
+        c.prepareStatement("UPDATE app_user SET locale = ? WHERE principal = ?").use { ps ->
+            ps.setString(1, locale)
+            ps.setString(2, principal)
+            ps.executeUpdate() > 0
+        }
+    }
+}
+
+/** Local transaction helper — the claim needs its row locks held to the commit. */
+internal inline fun <T> DataSource.inTxLocal(body: (Connection) -> T): T = connection.use { c ->
+    c.autoCommit = false
+    try {
+        val result = body(c)
+        c.commit()
+        result
+    } catch (e: Throwable) {
+        runCatching { c.rollback() }
+        throw e
+    } finally {
+        runCatching { c.autoCommit = true }
+    }
+}

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/Notifications.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/Notifications.kt
@@ -1,0 +1,158 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+/**
+ * Out-of-band task notifications (docs/notifications.md).
+ *
+ * A notification tells someone a task changed. It is never authorization: it carries no result data, and
+ * every action it offers re-authorizes from scratch when taken. Three layers, each replaceable on its own —
+ * the workflow states an [NotificationEvent], [NotificationRouter] resolves who should hear it, and a
+ * [NotificationTransport] delivers. The workflow knows nothing about Slack.
+ */
+
+/** What happened. The workflow states this once; who hears it and how are decided downstream. */
+enum class NotificationEvent(val wire: String) {
+    TASK_REQUESTED("task.requested"),
+    TASK_DECIDED("task.decided"),
+    TASK_EXECUTED("task.executed"),
+    TASK_FAILED("task.failed"),
+    TASK_CANCELLED("task.cancelled"),
+    ;
+
+    /** True when this event should edit an existing message rather than start a new thread of its own. */
+    val isUpdate: Boolean get() = this != TASK_REQUESTED
+
+    companion object {
+        fun fromWire(wire: String): NotificationEvent? = entries.firstOrNull { it.wire == wire }
+
+        /** The terminal task status → the event announcing it. Null for a non-terminal status. */
+        fun forTerminalStatus(status: String): NotificationEvent? = when (status) {
+            "EXECUTED" -> TASK_EXECUTED
+            "FAILED" -> TASK_FAILED
+            "CANCELLED" -> TASK_CANCELLED
+            else -> null
+        }
+    }
+}
+
+/**
+ * How much of the requester's statement may leave the building (docs/notifications.md, "The statement in the
+ * message"). A statement's literals can be the very values a policy protects — `WHERE rrn = '…'` leaks a
+ * value masking never sees, because masking acts on results.
+ */
+enum class StatementDisclosure {
+    TRUNCATED,
+    FULL,
+    OMIT,
+    ;
+
+    companion object {
+        /** Parse `PM_NOTIFY_STATEMENT`. An unrecognized value is a config error the caller fails fast on. */
+        fun parse(raw: String?): StatementDisclosure? =
+            raw?.trim()?.uppercase()?.let { v -> entries.firstOrNull { it.name == v } }
+    }
+}
+
+/**
+ * The statement as it will actually appear, and whether anything was cut.
+ *
+ * [complete] is the gate on approve-and-run: an approver may only decide from a message carrying the WHOLE
+ * statement. The test is what the recipient can read, never which mode the operator configured — a short
+ * statement under TRUNCATED was not truncated, and a long one under FULL is still elided by a transport's own
+ * length ceiling. See [renderStatement].
+ */
+data class RenderedStatement(val text: String?, val complete: Boolean)
+
+/**
+ * Apply [disclosure] to [sql], then the transport's own [hardLimit] (0 = none). The result is [complete] only
+ * when the full statement survived both — the flag is an input to rendering, and the button is decided after.
+ */
+fun renderStatement(
+    sql: String?,
+    disclosure: StatementDisclosure,
+    maxChars: Int,
+    hardLimit: Int = 0,
+): RenderedStatement {
+    if (sql == null) return RenderedStatement(null, complete = false)
+    if (disclosure == StatementDisclosure.OMIT) return RenderedStatement(null, complete = false)
+
+    // The tightest applicable ceiling wins. FULL has no configured limit of its own, so only the transport's
+    // applies; TRUNCATED takes the smaller of the two.
+    val configured = if (disclosure == StatementDisclosure.TRUNCATED) maxChars else Int.MAX_VALUE
+    val ceiling = when {
+        hardLimit <= 0 -> configured
+        else -> minOf(configured, hardLimit)
+    }
+    if (ceiling <= 0) return RenderedStatement(null, complete = false)
+    if (sql.length <= ceiling) return RenderedStatement(sql, complete = true)
+    // The ellipsis has to fit INSIDE the ceiling, or a transport that hard-rejects an over-length field
+    // would reject the very message that was truncated to satisfy it.
+    val keep = (ceiling - 1).coerceAtLeast(0)
+    return RenderedStatement(sql.take(keep) + "…", complete = false)
+}
+
+/** An action a message may offer. [OPEN] is always available; the other two are gated. */
+enum class NotificationAction { APPROVE_AND_RUN, DENY, OPEN }
+
+/**
+ * One notification, transport-neutral. Carries message KEYS and their values rather than finished prose, so
+ * a transport renders in its own idiom (Block Kit, MIME) and every locale stays reachable.
+ *
+ * [statement] is already rendered per [renderStatement]; [actions] already reflects its completeness.
+ */
+data class NotificationMessage(
+    val event: NotificationEvent,
+    val taskId: Long,
+    val requester: String,
+    val datasource: String,
+    val roleName: String?,
+    val reason: String?,
+    val statement: RenderedStatement,
+    val decidedBy: String? = null,
+    /** DECIDED only: approved rather than rejected. The two read completely differently to a recipient,
+     *  and the outbox row records only that a decision happened. */
+    val approved: Boolean? = null,
+    val rowCount: Int? = null,
+    val errorCode: String? = null,
+    val deepLink: String,
+    val actions: Set<NotificationAction>,
+)
+
+/** The outcome of one delivery attempt. Only the transport knows which failures are worth another try. */
+sealed interface DeliveryResult {
+    /** Delivered; [externalRef] is the handle a later event edits (Slack `channel:ts`). */
+    data class Sent(val externalRef: String) : DeliveryResult
+
+    /** Transient — try again after backoff (a 429, a socket drop). */
+    data class Retry(val reason: String) : DeliveryResult
+
+    /** Permanent — stop. No address for this principal, a 404, a malformed payload. */
+    data class Drop(val reason: String) : DeliveryResult
+}
+
+/**
+ * A delivery channel. Slack today; email is the second adapter and the reason this seam exists.
+ *
+ * An unconfigured transport is ABSENT, never degraded — the same posture as an unset `PM_SCIM_TOKEN`
+ * disabling SCIM. With no transport configured the whole layer is inert and the workflow is unchanged.
+ */
+interface NotificationTransport {
+    val name: String
+
+    /** The transport's own per-message statement ceiling, 0 when it has none. */
+    val statementHardLimit: Int get() = 0
+
+    /** False for a transport with no edit primitive (email); an update then sends a fresh message. */
+    val supportsUpdate: Boolean get() = false
+
+    /**
+     * This principal's address on this transport, or null when they have none — a null DROPS the row, since no
+     * number of attempts will conjure an address. A TRANSIENT failure (a network blip, a rate limit) THROWS
+     * instead, so delivery retries rather than dead-lettering the recipient over a passing condition.
+     */
+    suspend fun addressOf(principal: String, email: String?): String?
+
+    suspend fun deliver(to: String, message: NotificationMessage, locale: String): DeliveryResult
+
+    /** Edit a previously delivered message in place. Only called when [supportsUpdate]. */
+    suspend fun update(externalRef: String, message: NotificationMessage, locale: String): DeliveryResult
+}

--- a/control-plane/src/main/resources/db/migration/V17__notifications.sql
+++ b/control-plane/src/main/resources/db/migration/V17__notifications.sql
@@ -1,0 +1,55 @@
+-- Out-of-band task notifications: a durable outbox the delivery loop drains, the external handle a later
+-- event edits in place, and the recipient's own language.
+--
+-- The outbox row is written in the SAME transaction as the task state change it describes, so a crash can
+-- never leave a request approved with nobody told. Delivery itself is best-effort and never touches the
+-- task: the console is the system of record and a notification is a courtesy.
+
+-- The recipient's language, set from the console's own locale toggle and on login. A display preference,
+-- never an authorization input -- no policy reads it and nothing fails closed on it. NULL means the user has
+-- never expressed one, so delivery falls back to the instance default and then to English.
+ALTER TABLE app_user ADD COLUMN locale TEXT;
+
+CREATE TABLE notification_outbox (
+    id           BIGSERIAL PRIMARY KEY,
+    task_id      BIGINT NOT NULL REFERENCES access_request(id) ON DELETE CASCADE,
+    -- task.requested | task.decided | task.executed | task.failed | task.cancelled
+    event        TEXT NOT NULL,
+    transport    TEXT NOT NULL,
+    -- The principal to reach. Free text, matching app_user.principal, which is itself not an FK target
+    -- (V1) -- a principal_role-only identity holds roles without ever having a directory row.
+    recipient    TEXT NOT NULL,
+    status       TEXT NOT NULL DEFAULT 'PENDING',
+    attempts     INT  NOT NULL DEFAULT 0,
+    -- When the drainer may next claim this row: now for a first attempt, later for a backed-off retry.
+    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_error   TEXT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT notification_outbox_status_check
+        CHECK (status IN ('PENDING', 'SENT', 'DEAD')),
+    -- One row per (task, event, transport, recipient). An event emitted twice for one recipient -- a retried
+    -- request creation, a redelivery after a partial failure -- collapses onto the same row instead of
+    -- sending twice.
+    CONSTRAINT notification_outbox_unique UNIQUE (task_id, event, transport, recipient)
+);
+
+-- The drainer's claim query: due PENDING rows in insertion order. Partial, so SENT/DEAD rows (the bulk over
+-- time) cost nothing to skip.
+CREATE INDEX idx_notification_outbox_due
+    ON notification_outbox (next_attempt_at, id) WHERE status = 'PENDING';
+
+-- Where a delivered message landed, so a later event edits it rather than piling on. For Slack that is
+-- "channel:ts"; for a transport with no edit primitive the ref is still recorded and the update sends a new
+-- message. One row per (task, transport, recipient) -- the whole point is that every event about one task
+-- rewrites the SAME message for that person.
+CREATE TABLE notification_message (
+    id           BIGSERIAL PRIMARY KEY,
+    task_id      BIGINT NOT NULL REFERENCES access_request(id) ON DELETE CASCADE,
+    transport    TEXT NOT NULL,
+    recipient    TEXT NOT NULL,
+    external_ref TEXT NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT notification_message_unique UNIQUE (task_id, transport, recipient)
+);

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStoreTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStoreTest.kt
@@ -1,0 +1,193 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The durable outbox on real PostgreSQL. The load-bearing cases are the ones a unit test with an in-memory
+ * queue cannot reach: `FOR UPDATE SKIP LOCKED` so a second drainer never double-sends, the backoff that keeps
+ * a retried row out of the claim until it is due, and the earlier-pending check that stops a "decided" edit
+ * from overtaking the "requested" message it edits.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class NotificationStoreTest {
+    private lateinit var fx: EnforcementFixture
+    private lateinit var store: NotificationStore
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        fx = EnforcementFixture.postgres()
+        store = NotificationStore(fx.dataSource)
+    }
+
+    // claimDue's LIMIT is global, so a leftover row from another test would pollute a claim. Start each test
+    // with an empty outbox; the access_request rows the FKs need are left in place.
+    @BeforeEach
+    fun clean() {
+        fx.dataSource.connection.use { c ->
+            c.createStatement().use {
+                it.executeUpdate("DELETE FROM notification_message")
+                it.executeUpdate("DELETE FROM notification_outbox")
+            }
+        }
+    }
+
+    /** A fresh access_request the outbox rows can FK to. */
+    private fun newTask(principal: String = "req@example.com"): Long =
+        fx.accessStore.createQueryRequest(
+            principal = principal, datasourceId = fx.datasource.id, sql = "SELECT 1",
+            denyReason = null, sourceDecisionId = null, reason = "r", title = "t", evaluatedDecision = "ALLOW",
+        ).id
+
+    private fun attemptsOf(id: Long): Int = fx.dataSource.connection.use { c ->
+        c.prepareStatement("SELECT attempts FROM notification_outbox WHERE id = ?").use { ps ->
+            ps.setLong(1, id); ps.executeQuery().use { it.next(); it.getInt(1) }
+        }
+    }
+
+    private fun statusOf(id: Long): String = fx.dataSource.connection.use { c ->
+        c.prepareStatement("SELECT status FROM notification_outbox WHERE id = ?").use { ps ->
+            ps.setLong(1, id); ps.executeQuery().use { it.next(); it.getString(1) }
+        }
+    }
+
+    @Test
+    fun `enqueue is idempotent per task-event-transport-recipient`() {
+        val task = newTask()
+        fx.dataSource.connection.use { c ->
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "a@x")
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "a@x")
+        }
+        assertEquals(1, store.claimDue(10).count { it.taskId == task }, "the second enqueue collapsed onto the first")
+    }
+
+    @Test
+    fun `claimDue returns due pending rows in id order up to the limit`() {
+        val task = newTask()
+        fx.dataSource.connection.use { c ->
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "one@x")
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "two@x")
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "three@x")
+        }
+        val claimed = store.claimDue(2).filter { it.taskId == task }
+        assertEquals(2, claimed.size, "the limit is honored")
+        assertEquals(claimed.map { it.id }.sorted(), claimed.map { it.id }, "returned in id (insertion) order")
+    }
+
+    /**
+     * The claim a second drainer would run must skip a row the first is holding, not block on it or return it.
+     * Hold a row's lock in one open transaction, then claim from the pool: the locked row is invisible.
+     */
+    @Test
+    fun `claimDue skips a row another transaction holds locked`() {
+        val task = newTask()
+        fx.dataSource.connection.use { c ->
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "locked@x")
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "free@x")
+        }
+        val rows = store.claimDue(10).filter { it.taskId == task }.sortedBy { it.id }
+        val lockedId = rows.first().id
+        val freeId = rows.last().id
+
+        val holder = fx.dataSource.connection
+        try {
+            holder.autoCommit = false
+            holder.prepareStatement("SELECT id FROM notification_outbox WHERE id = ? FOR UPDATE").use { ps ->
+                ps.setLong(1, lockedId); ps.executeQuery().use { it.next() }
+            }
+            // Another claimant runs now, while the lock above is held.
+            val claimedIds = store.claimDue(10).map { it.id }
+            assertFalse(lockedId in claimedIds, "the locked row must be skipped, never double-claimed")
+            assertTrue(freeId in claimedIds, "the unlocked sibling is still claimable")
+        } finally {
+            holder.rollback(); holder.autoCommit = true; holder.close()
+        }
+    }
+
+    @Test
+    fun `markSent is terminal and increments attempts`() {
+        val task = newTask()
+        fx.dataSource.connection.use { c -> store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "s@x") }
+        val row = store.claimDue(10).first { it.taskId == task }
+        store.markSent(row.id)
+        assertEquals("SENT", statusOf(row.id))
+        assertEquals(1, attemptsOf(row.id))
+        assertTrue(store.claimDue(10).none { it.id == row.id }, "a SENT row is never claimed again")
+    }
+
+    @Test
+    fun `markRetry keeps the row pending but out of the claim until it is due`() {
+        val task = newTask()
+        fx.dataSource.connection.use { c -> store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "r@x") }
+        val row = store.claimDue(10).first { it.taskId == task }
+
+        store.markRetry(row.id, "ratelimited", Duration.ofHours(1))
+        assertEquals("PENDING", statusOf(row.id))
+        assertTrue(store.claimDue(10).none { it.id == row.id }, "a backed-off row is not due yet")
+
+        // A backoff already in the past makes it claimable again — the retry actually happens.
+        store.markRetry(row.id, "ratelimited", Duration.ofSeconds(-1))
+        assertTrue(store.claimDue(10).any { it.id == row.id }, "once due, the row is reclaimable")
+    }
+
+    @Test
+    fun `markDead is terminal`() {
+        val task = newTask()
+        fx.dataSource.connection.use { c -> store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "d@x") }
+        val row = store.claimDue(10).first { it.taskId == task }
+        store.markDead(row.id, "channel_not_found")
+        assertEquals("DEAD", statusOf(row.id))
+        assertTrue(store.claimDue(10).none { it.id == row.id })
+    }
+
+    @Test
+    fun `an update waits while an earlier event for the same recipient is still pending`() {
+        val task = newTask()
+        fx.dataSource.connection.use { c ->
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "u@x")
+            store.enqueue(c, task, NotificationEvent.TASK_DECIDED, "slack", "u@x")
+        }
+        val rows = store.claimDue(10).filter { it.taskId == task }.sortedBy { it.id }
+        val requested = rows.first { it.event == NotificationEvent.TASK_REQUESTED }
+        val decided = rows.first { it.event == NotificationEvent.TASK_DECIDED }
+
+        assertTrue(store.hasEarlierPending(decided), "the decided edit must wait for the requested message")
+        store.markSent(requested.id)
+        assertFalse(store.hasEarlierPending(decided), "once the requested is delivered, the edit may go")
+    }
+
+    @Test
+    fun `rememberMessage upserts the external ref`() {
+        val task = newTask()
+        assertNull(store.externalRef(task, "slack", "m@x"), "nothing delivered yet")
+        store.rememberMessage(task, "slack", "m@x", "C1:100")
+        assertEquals("C1:100", store.externalRef(task, "slack", "m@x"))
+        store.rememberMessage(task, "slack", "m@x", "C1:200")
+        assertEquals("C1:200", store.externalRef(task, "slack", "m@x"), "a later delivery overwrites the handle")
+    }
+
+    @Test
+    fun `locale and email round-trip for a directory user, and setLocale reports a missing one`() {
+        assertFalse(store.setLocale("nobody@example.com", "ko"), "no directory row to set a preference on")
+
+        fx.dataSource.connection.use { c ->
+            c.prepareStatement("INSERT INTO app_user (principal, email) VALUES (?, ?)").use { ps ->
+                ps.setString(1, "dir@example.com"); ps.setString(2, "dir-mail@example.com"); ps.executeUpdate()
+            }
+        }
+        assertNull(store.localeOf("dir@example.com"), "no preference expressed yet")
+        assertEquals("dir-mail@example.com", store.emailOf("dir@example.com"))
+        assertTrue(store.setLocale("dir@example.com", "ko"))
+        assertEquals("ko", store.localeOf("dir@example.com"))
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationsTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationsTest.kt
@@ -1,0 +1,72 @@
+package com.ridi.oss.proxymonster.controlplane.notify
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What the recipient can actually read, and therefore whether they may approve from the message
+ * (docs/notifications.md, "Never approve what you cannot see").
+ *
+ * The rule is deliberately about the RENDERED text, not the configured mode: a short statement under
+ * TRUNCATED was never truncated, and a long one under FULL is still elided by a transport's own ceiling.
+ * Writing the gate against the mode gets both edges backwards, which is what these cases pin.
+ */
+class NotificationsTest {
+
+    private val short = "SELECT id FROM users"
+    private val long = "SELECT " + "x".repeat(500) + " FROM users"
+
+    @Test
+    fun `a statement shorter than the limit is complete under truncated`() {
+        val r = renderStatement(short, StatementDisclosure.TRUNCATED, maxChars = 200)
+        assertEquals(short, r.text)
+        assertTrue(r.complete, "nothing was cut, so the approver has read the whole statement")
+    }
+
+    @Test
+    fun `a statement longer than the limit is cut and incomplete`() {
+        val r = renderStatement(long, StatementDisclosure.TRUNCATED, maxChars = 200)
+        assertFalse(r.complete)
+        assertTrue(r.text!!.length <= 200, "the ellipsis must fit INSIDE the ceiling, not overrun it")
+        assertTrue(r.text!!.endsWith("…"))
+    }
+
+    @Test
+    fun `full carries the whole statement when the transport can hold it`() {
+        val r = renderStatement(long, StatementDisclosure.FULL, maxChars = 200, hardLimit = 2800)
+        assertEquals(long, r.text)
+        assertTrue(r.complete, "the configured truncation limit does not apply under FULL")
+    }
+
+    /** The edge the mode-based rule got wrong: FULL still loses the button when the transport elides. */
+    @Test
+    fun `full is incomplete when the transport ceiling cuts it`() {
+        val huge = "SELECT " + "y".repeat(4000) + " FROM users"
+        val r = renderStatement(huge, StatementDisclosure.FULL, maxChars = 200, hardLimit = 2800)
+        assertFalse(r.complete, "elided is elided, whoever did it")
+        assertTrue(r.text!!.length <= 2800)
+    }
+
+    @Test
+    fun `omit carries no statement and is never complete`() {
+        val r = renderStatement(short, StatementDisclosure.OMIT, maxChars = 200)
+        assertEquals(null, r.text)
+        assertFalse(r.complete)
+    }
+
+    @Test
+    fun `a task with no statement is never complete`() {
+        val r = renderStatement(null, StatementDisclosure.FULL, maxChars = 200)
+        assertEquals(null, r.text)
+        assertFalse(r.complete)
+    }
+
+    @Test
+    fun `parse rejects an unrecognized disclosure mode`() {
+        assertEquals(StatementDisclosure.TRUNCATED, StatementDisclosure.parse("truncated"))
+        assertEquals(StatementDisclosure.FULL, StatementDisclosure.parse("FULL"))
+        assertEquals(null, StatementDisclosure.parse("sometimes"))
+    }
+}


### PR DESCRIPTION
The durable data layer for out-of-band task notifications, split out to land on its own (reviewed as commit 1 of the notification stack): the transport-neutral message model (events, actions, statement disclosure, the `NotificationTransport` seam) and the `notification_outbox` table with its claim / retry / dead-letter store — an unknown event on the wire is dead-lettered, not skipped, so a poison row cannot loop.

Inert until the service and transport wire it (following PR), so it is safe to merge alone. Self-contained: compiles standalone; `NotificationStoreTest` + `NotificationsTest` green.