### PR TITLE
test(control-plane): fix a BindException race in DaemonSessionLivenessIdpTest

### DIFF
--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DaemonSessionLivenessIdpTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DaemonSessionLivenessIdpTest.kt
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.slf4j.LoggerFactory
-import java.net.ServerSocket
 import java.time.Instant
 import java.util.Date
 import java.util.concurrent.atomic.AtomicInteger
@@ -74,8 +73,10 @@ class DaemonSessionLivenessIdpTest {
         roleResolver = RoleResolver(ds, userGroupStore, accessStore)
         rsaKey = RSAKeyGenerator(2048).keyID("session-liveness").generate()
 
-        idpPort = ServerSocket(0).use { it.localPort }
-        idp = embeddedServer(Netty, port = idpPort, host = "127.0.0.1") {
+        // Bind an OS-assigned ephemeral port and read it back after start, rather than probing a free
+        // port with a throwaway ServerSocket: the gap between closing the probe and Netty binding is a
+        // window a parallel test worker can steal the port through, which surfaces as a BindException.
+        idp = embeddedServer(Netty, port = 0, host = "127.0.0.1") {
             routing {
                 get("/.well-known/openid-configuration") {
                     call.respondText(discoveryJson(), ContentType.Application.Json)
@@ -91,6 +92,7 @@ class DaemonSessionLivenessIdpTest {
                 }
             }
         }.start(wait = false)
+        idpPort = runBlocking { idp.engine.resolvedConnectors().first().port }
     }
 
     @AfterAll


### PR DESCRIPTION
The mock IdP probed a free port with `ServerSocket(0)`, closed it, then had Netty bind that same number afterward. Under parallel test workers a sibling could claim the port in the gap, surfacing as an intermittent `BindException` (`initializationError`) — seen while landing #136.

Bind Netty on port `0` (OS-assigned) and read the resolved connector back, so there is no close-then-rebind reuse window.

Verification: `:control-plane:test --tests "*DaemonSessionLivenessIdpTest"` → 8/8 pass; `mise run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)