### PR TITLE
feat(goproxy): abort the target-DB open when a run is closed or drained during it

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -558,9 +558,9 @@ path and `POST /api/datasources/{id}/query`, not the interactive editor.
   approval-execute path and `POST /api/datasources/{id}/query` — requests
   max(900s, `PM_QUERY_TIMEOUT` + 180s), so at the default 600s timeout it is
   900s, the floor. The floor covers a full-length dial plus a full-length
-  exchange, so a short `PM_QUERY_TIMEOUT` cannot leave a cold session's token
-  expiring mid-statement. `TokenStore.issue` then clamps every request into
-  [60s, 24h], which is the real ceiling on both. A run-stream timeout or
+  exchange, so a short `PM_QUERY_TIMEOUT` cannot leave an opening session's
+  token expiring mid-statement. `TokenStore.issue` then clamps every request
+  into [60s, 24h], which is the real ceiling on both. A run-stream timeout or
   canceled HTTP query does not itself revoke it. It is barred from the
   wire-session handshake (`TokenStore.validate` rejects `kind='EDITOR'`), so a
   leak can't open a native session; within its TTL it could still drive extra

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RunExec.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RunExec.kt
@@ -23,15 +23,15 @@ import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
 // Floor for a one-shot run token's TTL; the effective TTL grows to cover PM_QUERY_TIMEOUT (see
-// RunExecService.runTokenTtlSeconds). The floor alone must outlast a full-length dial-back + cold-open +
-// exchange, so a short PM_QUERY_TIMEOUT cannot leave a cold session's token expiring mid-statement.
+// RunExecService.runTokenTtlSeconds). The floor alone must outlast a full-length dial-back + target-DB open +
+// exchange, so a short PM_QUERY_TIMEOUT cannot leave an opening session's token expiring mid-statement.
 private const val RUN_TOKEN_TTL_FLOOR_SECONDS = 900L
 // A persistent editor SESSION token outlives many queries; give it a generous absolute TTL (sliding
 // refresh-on-activity is a follow-up) and bound the session with idle-sweep + explicit close. Per-session
 // and revoked on close, so a long TTL is not a standing credential.
 private const val EDITOR_SESSION_TTL_SECONDS = 8 * 3600L
 // Headroom over PM_QUERY_TIMEOUT for a one-shot run token's TTL. The token must outlive the WHOLE run it
-// authorizes — the stream dial-back (RUN_DIALBACK_TIMEOUT_MS) + the hard-capped backend cold-open
+// authorizes — the stream dial-back (RUN_DIALBACK_TIMEOUT_MS) + the hard-capped target-DB open
 // (RUN_OPEN_TIMEOUT_MS) + the query exchange (PM_QUERY_TIMEOUT + QUERY_EXCHANGE_GRACE_MS) — so this grace
 // must exceed dial-back + open + the exchange grace (15 + 120 + 150 = 285s), the remainder being a
 // revalidation buffer. The open being HARD-capped (not merely liveness-bounded) keeps that sum finite;
@@ -41,7 +41,7 @@ private const val TOKEN_TTL_GRACE_SECONDS = 300L
 // proxy opens that stream it sends the run's session id as the first frame, so the control-plane can tell WHICH
 // pending run the new stream is for. This bounds only that — the proxy opening the stream and sending the id —
 // which is near-instant when the proxy is alive. A proxy that got the dispatch but cannot open the stream
-// (dead/wedged, or drained between dispatch and dial) fails here rather than hanging; the cold-open that
+// (dead/wedged, or drained between dispatch and dial) fails here rather than hanging; the target-DB open that
 // follows is bounded by RUN_NO_PROGRESS_TIMEOUT_MS + RUN_OPEN_TIMEOUT_MS.
 internal const val RUN_DIALBACK_TIMEOUT_MS = 15_000L
 // Once the control-plane knows which run the stream is for, the proxy heartbeats RunProgress while it dials +
@@ -50,13 +50,13 @@ internal const val RUN_DIALBACK_TIMEOUT_MS = 15_000L
 // AND the absolute ceiling below. A heartbeat proves the PROXY is alive, NOT that the backend is advancing, so
 // a proxy blocked on a wedged backend read keeps ticking; RUN_OPEN_TIMEOUT_MS is what bounds that.
 internal const val RUN_NO_PROGRESS_TIMEOUT_MS = 15_000L
-// Absolute ceiling on the whole cold-open (the dial-back above excluded): even while heartbeats keep the
+// Absolute ceiling on the whole target-DB open (the dial-back above excluded): even while heartbeats keep the
 // no-progress bound reset, the open cannot exceed this. Sized at the old blind dial budget so a legitimately
 // slow open is not regressed, while a stalled-but-heartbeating one fails here instead of riding the backend
 // read-idle timeout — and, being finite, it keeps the run token's TTL grace (which must outlast the open)
 // sufficient.
 internal const val RUN_OPEN_TIMEOUT_MS = 120_000L
-// The table-detail channel keeps a single fixed dial bound (metadata-only introspection, no cold backend
+// The table-detail channel keeps a single fixed dial bound (metadata-only introspection, no slow backend
 // open with liveness heartbeats), so it is unaffected by the run-channel's dial-back/no-progress split.
 internal const val DIAL_TIMEOUT_MS = 120_000L
 // Fallback only: every production path passes Config.queryExchangeTimeoutMs, which tracks
@@ -335,7 +335,7 @@ class RunExecService(
 
             val channel = attached
             // The stream is matched to this run the moment the proxy opens it (its first frame carries the
-            // run's id); the backend cold-open is still in flight. Wait for RunServing, bounding the wait by
+            // run's id); the target-DB open is still in flight. Wait for RunServing, bounding the wait by
             // lack of progress (each RunProgress heartbeat resets it) so a stalled or broken open fails fast
             // instead of riding a blind dial budget.
             awaitServing(channel.inbound, noProgressMs, openTimeoutMs)
@@ -368,11 +368,11 @@ class RunExecService(
             }
             try {
                 attached?.outbound?.trySend(controlRunMsg { close = runClose {} })
-                // Also close inbound so the gRPC handler tears down promptly. RunClose alone is not enough when
-                // the proxy is still cold-opening (it isn't reading control messages yet): closing inbound makes
-                // the handler's next forward-send fail, ending its collect — so the handler and its buffered
-                // frames aren't retained until the proxy's own backend timeout. Idempotent with the handler's
-                // own close on the normal path.
+                // Also close inbound so the gRPC handler tears down promptly. The RunClose above aborts the
+                // proxy's target-DB open (it reads its inbound throughout); closing inbound here makes the handler's
+                // next forward-send fail and end its collect, so the handler and its buffered frames aren't
+                // retained until the proxy's stream close propagates back. Idempotent with the handler's own
+                // close on the normal path.
                 attached?.inbound?.close()
             } finally {
                 try {
@@ -430,7 +430,7 @@ class RunExecService(
             } catch (e: TimeoutCancellationException) {
                 throw ProxyRunTimeoutException(e)
             }
-            // Wait for the backend cold-open to finish (RunServing), bounded by lack of progress — see run().
+            // Wait for the target-DB open to finish (RunServing), bounded by lack of progress — see run().
             awaitServing(attached.inbound, RUN_NO_PROGRESS_TIMEOUT_MS, RUN_OPEN_TIMEOUT_MS)
             openSessions[sessionId] = OpenEditorSession(
                 sessionId, principal, issued.id, ds.name, attached, opened.connectionId,
@@ -444,8 +444,9 @@ class RunExecService(
                 attached = withContext(NonCancellable) { pending.ready.await() }
             }
             attached?.outbound?.trySend(controlRunMsg { close = runClose {} })
-            // Close inbound too, so the gRPC handler tears down even when the proxy is still cold-opening and
-            // isn't reading the RunClose yet (see run()'s finally). On success the held session keeps the stream.
+            // Close inbound too, so the gRPC handler tears down promptly (see run()'s finally). The RunClose
+            // above aborts the proxy's target-DB open; closing inbound ends the handler without waiting for the
+            // proxy's stream close to propagate. On success the held session keeps the stream.
             attached?.inbound?.close()
             runCatching { core.tokenStore.revoke(issued.id, principal) }
             closeConnectionCatalog(opened.connectionId, ds.name)
@@ -584,10 +585,10 @@ class RunExecService(
     }
 
     /**
-     * Wait for the proxy to finish its backend cold-open and announce RunServing, under two bounds. A stream
+     * Wait for the proxy to finish its target-DB open and announce RunServing, under two bounds. A stream
      * closed before serving (a redeploy cutting the run) fails at once; a proxy that stops heartbeating fails
      * within [noProgressMs]; and — because a RunProgress heartbeat proves the proxy is alive but NOT that its
-     * backend open is advancing — a proxy that keeps ticking while its open is wedged fails at the absolute
+     * target-DB open is advancing — a proxy that keeps ticking while its open is wedged fails at the absolute
      * [openTimeoutMs] ceiling rather than riding the backend read-idle timeout. A terminal RunError during the
      * open (backend unreachable, catalog init failed) is surfaced as-is. The stream is already matched to
      * this run (attached), so every one of these is attributable — there is no blind wait, unlike the old

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ConfigGuardTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ConfigGuardTest.kt
@@ -64,8 +64,8 @@ class ConfigGuardTest {
 
     @Test fun `run token TTL outlives the whole run, session TTL outlives the query window`() {
         // The one-shot run token must stay valid for the ENTIRE run it authorizes — the dial-back + the
-        // cold-open + the exchange (PM_QUERY_TIMEOUT + exchange grace) — not merely the query window, else a
-        // long query on a slow cold-open fails UNAUTHENTICATED mid-run when the proxy revalidates the token.
+        // target-DB open + the exchange (PM_QUERY_TIMEOUT + exchange grace) — not merely the query window, else a
+        // long query on a slow target-DB open fails UNAUTHENTICATED mid-run when the proxy revalidates the token.
         // The editor-session token's 8h floor spans many queries, so it need only clear one window.
         val runOverheadSeconds =
             (RUN_DIALBACK_TIMEOUT_MS + RUN_OPEN_TIMEOUT_MS) / 1000 + Config.QUERY_EXCHANGE_GRACE_MS / 1000
@@ -73,7 +73,7 @@ class ConfigGuardTest {
         for (timeout in listOf(1L, 600L, 616L, 3600L, 36_000L, Config.MAX_QUERY_TIMEOUT_SECONDS)) {
             assertTrue(
                 RunExecService.runTokenTtlSeconds(timeout) >= timeout + runOverheadSeconds,
-                "run token TTL must cover dial-back + cold-open + exchange for timeout=$timeout",
+                "run token TTL must cover dial-back + target-DB open + exchange for timeout=$timeout",
             )
             assertTrue(
                 RunExecService.editorSessionTtlSeconds(timeout) > timeout,

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/GrpcRunExecDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/GrpcRunExecDbTest.kt
@@ -157,7 +157,7 @@ class GrpcRunExecDbTest {
                 sessionReady = runReady { sessionId = open.sessionId }
             },
         )
-        // RunReady (the run id) is sent first; the CP then waits for RunServing (the backend cold-open
+        // RunReady (the run id) is sent first; the CP then waits for RunServing (the target-DB open
         // finishing) before it sends the query. A real proxy heartbeats RunProgress; a fast fake just serves.
         proxyRequests.send(proxyRunMsg { serving = runServing {} })
 
@@ -331,7 +331,7 @@ class GrpcRunExecDbTest {
         supervisorScope {
             val event = async { stub.events(eventsRequest { datasourceName = datasource.name }).first() }
             awaitUntil("Events stream attached") { datasource.name in core.proxyEventsHub.attached() }
-            // Inject a short dial bound: the production one is sized for a cold session against a remote
+            // Inject a short dial bound: the production one is sized for a slow open against a remote
             // backend, and waiting it out here would buy nothing but a two-minute test.
             val result = async {
                 runCatching { service.run("timeout-user", datasource, "select 1", 500, dialTimeoutMs = 1_000) }
@@ -355,7 +355,7 @@ class GrpcRunExecDbTest {
             val result = async { runCatching { service.run("cut-user", datasource, "select 1", 500) } }
             val open = withTimeout(5_000) { event.await() }.openRunChannel
 
-            // The proxy sends RunReady (its run id), then dies mid-cold-open: it closes the stream WITHOUT ever
+            // The proxy sends RunReady (its run id), then dies mid target-DB open: it closes the stream WITHOUT ever
             // sending RunServing (the redeploy-cut scenario). Because the stream was already matched to the run,
             // the CP sees the broken stream at once and fails the run — it does not ride out the dial budget.
             val proxyRequests = Channel<ProxyRunMsg>(Channel.UNLIMITED)
@@ -365,7 +365,7 @@ class GrpcRunExecDbTest {
 
             val failure = withTimeout(5_000) { result.await() }.exceptionOrNull()
             assertIs<ProxyRunException>(failure)
-            assertEquals(0, activeEditorTokens("cut-user"), "a cold-open cut before serving must revoke its token")
+            assertEquals(0, activeEditorTokens("cut-user"), "a target-DB open cut before serving must revoke its token")
             withTimeout(5_000) { proxy.await() }
         }
     }
@@ -375,7 +375,7 @@ class GrpcRunExecDbTest {
         supervisorScope {
             val event = async { stub.events(eventsRequest { datasourceName = datasource.name }).first() }
             awaitUntil("Events stream attached") { datasource.name in core.proxyEventsHub.attached() }
-            // The persistent editor path (openSession) must fail-close on a cold-open cut exactly like the
+            // The persistent editor path (openSession) must fail-close on a target-DB open cut exactly like the
             // one-shot run() path above: the proxy sends RunReady then dies before RunServing, and openSession
             // must fail fast and revoke its per-session token instead of returning a session id whose stream is
             // already dead. Exercises openSession's own cleanup path, not just run()'s.
@@ -391,14 +391,14 @@ class GrpcRunExecDbTest {
             assertIs<ProxyRunException>(failure)
             assertEquals(
                 0, activeEditorTokens("cut-session-user"),
-                "a cut openSession cold-open must revoke its session token",
+                "a cut openSession target-DB open must revoke its session token",
             )
             withTimeout(5_000) { proxy.await() }
         }
     }
 
     @Test
-    fun `a cold-open that stops heartbeating after RunReady fails at the no-progress bound`() = runBlocking {
+    fun `a target-DB open that stops heartbeating after RunReady fails at the no-progress bound`() = runBlocking {
         supervisorScope {
             val event = async { stub.events(eventsRequest { datasourceName = datasource.name }).first() }
             awaitUntil("Events stream attached") { datasource.name in core.proxyEventsHub.attached() }
@@ -416,7 +416,7 @@ class GrpcRunExecDbTest {
 
             val failure = withTimeout(5_000) { result.await() }.exceptionOrNull()
             assertIs<ProxyRunTimeoutException>(failure)
-            assertEquals(0, activeEditorTokens("stall-user"), "a stalled cold-open must revoke its token")
+            assertEquals(0, activeEditorTokens("stall-user"), "a stalled target-DB open must revoke its token")
             proxyRequests.close()
             withTimeout(5_000) { proxy.await() }
         }
@@ -462,7 +462,7 @@ class GrpcRunExecDbTest {
     }
 
     @Test
-    fun `a RunError during the cold-open surfaces as-is instead of waiting to serve`() = runBlocking {
+    fun `a RunError during the target-DB open surfaces as-is instead of waiting to serve`() = runBlocking {
         supervisorScope {
             val event = async { stub.events(eventsRequest { datasourceName = datasource.name }).first() }
             awaitUntil("Events stream attached") { datasource.name in core.proxyEventsHub.attached() }
@@ -472,20 +472,20 @@ class GrpcRunExecDbTest {
             val proxyRequests = Channel<ProxyRunMsg>(Channel.UNLIMITED)
             val proxy = async { stub.runExec(proxyRequests.receiveAsFlow()).collect {} }
             proxyRequests.send(proxyRunMsg { sessionReady = runReady { sessionId = open.sessionId } })
-            // The backend open fails mid-flight, before serving.
+            // The target-DB open fails mid-flight, before serving.
             proxyRequests.send(proxyRunMsg { error = runError { message = "backend connection failed: connection refused" } })
 
             val failure = withTimeout(5_000) { result.await() }.exceptionOrNull()
             assertIs<ProxyRunException>(failure)
             assertEquals("backend connection failed: connection refused", failure.message)
-            assertEquals(0, activeEditorTokens("open-err-user"), "a failed cold-open must revoke its token")
+            assertEquals(0, activeEditorTokens("open-err-user"), "a failed target-DB open must revoke its token")
             proxyRequests.close()
             withTimeout(5_000) { proxy.await() }
         }
     }
 
     @Test
-    fun `a cold-open that heartbeats but never serves fails at the absolute ceiling`() = runBlocking {
+    fun `a target-DB open that heartbeats but never serves fails at the absolute ceiling`() = runBlocking {
         supervisorScope {
             val event = async { stub.events(eventsRequest { datasourceName = datasource.name }).first() }
             awaitUntil("Events stream attached") { datasource.name in core.proxyEventsHub.attached() }

--- a/goproxy/config/config_test.go
+++ b/goproxy/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -37,7 +38,7 @@ func (configTestProvider) ReadTableDetail(*sql.Conn, string, string) (*spi.Table
 func (configTestProvider) NewWireServer(int, spi.BackendTarget, spi.EnforcementClient, engine.Db, func() (*tls.Config, error)) spi.WireServer {
 	return nil
 }
-func (configTestProvider) NewRunSession(spi.BackendTarget, engine.Db, spi.SessionClient, string, []byte, engine.ExecGuard, time.Duration) (spi.BackendSession, error) {
+func (configTestProvider) NewRunSession(context.Context, spi.BackendTarget, engine.Db, spi.SessionClient, string, []byte, engine.ExecGuard, time.Duration) (spi.BackendSession, error) {
 	return nil, nil
 }
 

--- a/goproxy/dialects/dialects.go
+++ b/goproxy/dialects/dialects.go
@@ -2,6 +2,7 @@
 package dialects
 
 import (
+	"context"
 	"crypto/tls"
 	"database/sql"
 	"time"
@@ -38,8 +39,8 @@ func (p mysqlProvider) ReadTableDetail(conn *sql.Conn, schema, table string) (*s
 func (mysqlProvider) NewWireServer(port int, backend spi.BackendTarget, client spi.EnforcementClient, dbImpl engine.Db, tlsProvider func() (*tls.Config, error)) spi.WireServer {
 	return mysqlproxy.New(port, backend, client, dbImpl, tlsProvider)
 }
-func (mysqlProvider) NewRunSession(target spi.BackendTarget, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.BackendSession, error) {
-	return mysqlproxy.NewRunSession(target, dbImpl, client, token, connectionID, guard, readTimeout)
+func (mysqlProvider) NewRunSession(ctx context.Context, target spi.BackendTarget, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.BackendSession, error) {
+	return mysqlproxy.NewRunSession(ctx, target, dbImpl, client, token, connectionID, guard, readTimeout)
 }
 
 func (pgProvider) Dialect() engine.Dialect { return engine.Postgres }
@@ -63,8 +64,8 @@ func (p pgProvider) ReadTableDetail(conn *sql.Conn, schema, table string) (*spi.
 func (pgProvider) NewWireServer(port int, backend spi.BackendTarget, client spi.EnforcementClient, dbImpl engine.Db, tlsProvider func() (*tls.Config, error)) spi.WireServer {
 	return pgproxy.New(port, backend, client, dbImpl, tlsProvider)
 }
-func (pgProvider) NewRunSession(target spi.BackendTarget, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.BackendSession, error) {
-	return pgproxy.NewRunSession(target, dbImpl, client, token, connectionID, guard, readTimeout)
+func (pgProvider) NewRunSession(ctx context.Context, target spi.BackendTarget, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.BackendSession, error) {
+	return pgproxy.NewRunSession(ctx, target, dbImpl, client, token, connectionID, guard, readTimeout)
 }
 
 var registry = spi.MustRegistry(mysqlProvider{}, pgProvider{})

--- a/goproxy/internal/pb/controlplane.pb.go
+++ b/goproxy/internal/pb/controlplane.pb.go
@@ -2055,7 +2055,7 @@ type ProxyRunMsg_SessionReady struct {
 
 type ProxyRunMsg_Decision struct {
 	// plane which pending run this stream serves (the OpenRunChannel it
-	// dispatched) — BEFORE the backend cold-open begins
+	// dispatched) — BEFORE the target-DB open begins
 	Decision *RunDecision `protobuf:"bytes,2,opt,name=decision,proto3,oneof"` // the enforcement verdict + UX metadata (before any rows)
 }
 
@@ -2072,7 +2072,7 @@ type ProxyRunMsg_Error struct {
 }
 
 type ProxyRunMsg_Progress struct {
-	Progress *RunProgress `protobuf:"bytes,6,opt,name=progress,proto3,oneof"` // liveness heartbeat during the cold-open; resets the CP's no-progress bound
+	Progress *RunProgress `protobuf:"bytes,6,opt,name=progress,proto3,oneof"` // liveness heartbeat during the target-DB open; resets the CP's no-progress bound
 }
 
 type ProxyRunMsg_Serving struct {
@@ -2231,7 +2231,7 @@ func (x *RunReady) GetSessionId() string {
 	return ""
 }
 
-// A cold-open liveness heartbeat: the proxy emits these while dialing + authenticating the backend and
+// A target-DB open liveness heartbeat: the proxy emits these while dialing + authenticating the backend and
 // running its on-open catalog commands, so the control-plane can bound the open by lack of progress rather
 // than by a blind dial budget. It carries no payload — the control-plane treats every RunProgress purely as
 // "the proxy is still alive".
@@ -2271,7 +2271,7 @@ func (*RunProgress) Descriptor() ([]byte, []int) {
 	return file_controlplane_proto_rawDescGZIP(), []int{29}
 }
 
-// The backend cold-open finished and the proxy is ready to accept the query. Sent once, after the last
+// The target-DB open finished and the proxy is ready to accept the query. Sent once, after the last
 // RunProgress and before any RunDecision.
 type RunServing struct {
 	state         protoimpl.MessageState

--- a/goproxy/mysqlproxy/backend.go
+++ b/goproxy/mysqlproxy/backend.go
@@ -1,6 +1,7 @@
 package mysqlproxy
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -39,12 +40,17 @@ var testHookCachingSHA2FullAuth func(viaPublicKey bool)
 // CLIENT_SESSION_TRACK is required so text-protocol database changes arrive as protocol signals instead
 // of requiring an interposed SELECT DATABASE() that would corrupt ROW_COUNT/FOUND_ROWS diagnostics.
 func dialBackendAuth(target spi.BackendTarget, mirrorDeprecateEOF bool) (net.Conn, error) {
-	conn, _, err := dialBackendAuthID(target, mirrorDeprecateEOF)
+	conn, _, err := dialBackendAuthID(context.Background(), target, mirrorDeprecateEOF)
 	return conn, err
 }
 
-func dialBackendAuthID(target spi.BackendTarget, mirrorDeprecateEOF bool) (net.Conn, uint32, error) {
-	conn, err := net.DialTimeout("tcp", net.JoinHostPort(target.Host, strconv.Itoa(target.Port)), backendHandshakeTimeout)
+// dialBackendAuthID honors ctx for the whole handshake: DialContext aborts the connect, and while the
+// (deadline-bounded) auth exchange runs, an AfterFunc closes the conn on cancel so a blocked read unwinds at
+// once. On the run path ctx is the target-DB open context, so a run the control-plane already closed does not
+// finish a backend handshake nobody is waiting for; the wire path passes a background ctx (never cancelled).
+func dialBackendAuthID(ctx context.Context, target spi.BackendTarget, mirrorDeprecateEOF bool) (net.Conn, uint32, error) {
+	dialer := net.Dialer{Timeout: backendHandshakeTimeout}
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(target.Host, strconv.Itoa(target.Port)))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -54,6 +60,7 @@ func dialBackendAuthID(target spi.BackendTarget, mirrorDeprecateEOF bool) (net.C
 			_ = conn.Close()
 		}
 	}()
+	defer context.AfterFunc(ctx, func() { _ = conn.Close() })()
 	if err := conn.SetDeadline(time.Now().Add(backendHandshakeTimeout)); err != nil {
 		return nil, 0, fmt.Errorf("set backend auth deadline: %w", err)
 	}

--- a/goproxy/mysqlproxy/backend_cancel_test.go
+++ b/goproxy/mysqlproxy/backend_cancel_test.go
@@ -1,0 +1,73 @@
+package mysqlproxy
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/ridi-oss/proxy-monster/goproxy/spi"
+)
+
+// TestDialBackendAuthIDAbortsOnContextCancel proves the real MySQL dial honors the target-DB open context: a
+// backend that accepts the TCP connection but never sends its greeting stalls the auth read, and cancelling
+// the context must close the conn and return at once — not block until backendHandshakeTimeout. This is the
+// mechanism the run target-DB open relies on; the runner-level tests exercise only the fake provider, so a
+// regression that dropped DialContext or the auth AfterFunc would not surface there.
+func TestDialBackendAuthIDAbortsOnContextCancel(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen stalling backend: %v", err)
+	}
+	defer listener.Close()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		accepted <- conn // hold it open; never write the greeting
+	}()
+
+	host, portStr, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split listener addr: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse listener port: %v", err)
+	}
+	target := spi.BackendTarget{Host: host, Port: port, User: "u", Password: "p", Db: "d"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	dialErr := make(chan error, 1)
+	go func() {
+		_, _, err := dialBackendAuthID(ctx, target, true)
+		dialErr <- err
+	}()
+
+	// The dial must connect and block reading the greeting before we cancel, so the return is attributable to
+	// the cancel unwinding the read rather than a failed connect.
+	select {
+	case conn := <-accepted:
+		defer conn.Close()
+	case <-time.After(5 * time.Second):
+		t.Fatal("dial did not connect to the stalling backend")
+	}
+
+	start := time.Now()
+	cancel()
+	select {
+	case err := <-dialErr:
+		if err == nil {
+			t.Fatal("dial returned nil error after context cancel; want the aborted handshake to fail")
+		}
+		if elapsed := time.Since(start); elapsed > 3*time.Second {
+			t.Fatalf("dial returned %s after cancel; want a prompt abort, not the %s handshake timeout", elapsed, backendHandshakeTimeout)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("dial did not abort promptly on context cancel")
+	}
+}

--- a/goproxy/mysqlproxy/mysqlproxy_test.go
+++ b/goproxy/mysqlproxy/mysqlproxy_test.go
@@ -2,6 +2,7 @@ package mysqlproxy
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -159,7 +160,7 @@ func TestDialBackendCachingSHA2FullAuth(t *testing.T) {
 		User:     user,
 		Password: password,
 	}
-	conn, connID, err := dialBackendAuthID(target, true)
+	conn, connID, err := dialBackendAuthID(context.Background(), target, true)
 	if err != nil {
 		t.Fatalf("dialBackendAuthID against caching_sha2 backend: %v", err)
 	}

--- a/goproxy/mysqlproxy/run_session.go
+++ b/goproxy/mysqlproxy/run_session.go
@@ -1,6 +1,7 @@
 package mysqlproxy
 
 import (
+	"context"
 	"errors"
 	"math"
 	"net"
@@ -25,8 +26,8 @@ type RunSession struct {
 	guard        engine.ExecGuard
 }
 
-func NewRunSession(target spi.BackendTarget, db engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (*RunSession, error) {
-	conn, connID, err := dialBackendAuthID(target, true)
+func NewRunSession(ctx context.Context, target spi.BackendTarget, db engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (*RunSession, error) {
+	conn, connID, err := dialBackendAuthID(ctx, target, true)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +52,13 @@ func NewRunSession(target spi.BackendTarget, db engine.Db, client spi.SessionCli
 	return s, nil
 }
 
-func (s *RunSession) OnOpen(cmds []*pb.Refetch) error { return s.ref.RunAll(cmds) }
+// OnOpen runs the on-open catalog fetch over the backend conn. A cancel of ctx (the control-plane closed the
+// run, or the proxy is draining, during the target-DB open) closes the conn, which unwinds an in-flight fetch read
+// at once instead of holding the backend until readTimeout.
+func (s *RunSession) OnOpen(ctx context.Context, cmds []*pb.Refetch) error {
+	defer context.AfterFunc(ctx, func() { _ = s.conn.Close() })()
+	return s.ref.RunAll(cmds)
+}
 
 func (s *RunSession) ServeStatement(sql string, maxRows int) (result engine.StatementResult, err error) {
 	result.Decision, result.Denied, err = engine.ServeStatement(s.qe, engine.AuthzInput{
@@ -107,7 +114,7 @@ func (s *RunSession) ServeStatement(sql string, maxRows int) (result engine.Stat
 }
 
 func (s *RunSession) Cancel() error {
-	conn, _, err := dialBackendAuthID(s.target, true)
+	conn, _, err := dialBackendAuthID(context.Background(), s.target, true)
 	if err != nil {
 		_ = s.conn.Close()
 		return err

--- a/goproxy/pgproxy/backend.go
+++ b/goproxy/pgproxy/backend.go
@@ -1,6 +1,7 @@
 package pgproxy
 
 import (
+	"context"
 	"crypto/md5"
 	"encoding/hex"
 	"errors"
@@ -20,8 +21,13 @@ import (
 
 const backendHandshakeTimeout = 10 * time.Second
 
-func dialBackendAuth(target spi.BackendTarget) (net.Conn, []pgproto3.ParameterStatus, pgproto3.BackendKeyData, byte, error) {
-	conn, err := net.DialTimeout("tcp", net.JoinHostPort(target.Host, strconv.Itoa(target.Port)), backendHandshakeTimeout)
+// dialBackendAuth honors ctx for the whole handshake: DialContext aborts the connect, and while the
+// (deadline-bounded) auth exchange runs, an AfterFunc closes the conn on cancel so a blocked read unwinds at
+// once. On the run path ctx is the target-DB open context, so a run the control-plane already closed does not
+// finish a backend handshake nobody is waiting for; the wire path passes a background ctx (never cancelled).
+func dialBackendAuth(ctx context.Context, target spi.BackendTarget) (net.Conn, []pgproto3.ParameterStatus, pgproto3.BackendKeyData, byte, error) {
+	dialer := net.Dialer{Timeout: backendHandshakeTimeout}
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(target.Host, strconv.Itoa(target.Port)))
 	if err != nil {
 		return nil, nil, pgproto3.BackendKeyData{}, 0, err
 	}
@@ -31,6 +37,7 @@ func dialBackendAuth(target spi.BackendTarget) (net.Conn, []pgproto3.ParameterSt
 			_ = conn.Close()
 		}
 	}()
+	defer context.AfterFunc(ctx, func() { _ = conn.Close() })()
 	if err := conn.SetDeadline(time.Now().Add(backendHandshakeTimeout)); err != nil {
 		return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("set backend auth deadline: %w", err)
 	}

--- a/goproxy/pgproxy/backend_cancel_test.go
+++ b/goproxy/pgproxy/backend_cancel_test.go
@@ -1,0 +1,72 @@
+package pgproxy
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/ridi-oss/proxy-monster/goproxy/spi"
+)
+
+// TestDialBackendAuthAbortsOnContextCancel proves the real PostgreSQL dial honors the target-DB open context: a
+// backend that accepts the TCP connection but never answers the startup exchange stalls the auth read, and
+// cancelling the context must close the conn and return at once — not block until backendHandshakeTimeout.
+// This is the mechanism the run target-DB open relies on; the runner-level tests exercise only the fake provider.
+func TestDialBackendAuthAbortsOnContextCancel(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen stalling backend: %v", err)
+	}
+	defer listener.Close()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		accepted <- conn // hold it open; never answer the startup message
+	}()
+
+	host, portStr, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split listener addr: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse listener port: %v", err)
+	}
+	target := spi.BackendTarget{Host: host, Port: port, User: "u", Password: "p", Db: "d"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	dialErr := make(chan error, 1)
+	go func() {
+		_, _, _, _, err := dialBackendAuth(ctx, target)
+		dialErr <- err
+	}()
+
+	// The dial must connect and block reading the auth response before we cancel, so the return is
+	// attributable to the cancel unwinding the read rather than a failed connect.
+	select {
+	case conn := <-accepted:
+		defer conn.Close()
+	case <-time.After(5 * time.Second):
+		t.Fatal("dial did not connect to the stalling backend")
+	}
+
+	start := time.Now()
+	cancel()
+	select {
+	case err := <-dialErr:
+		if err == nil {
+			t.Fatal("dial returned nil error after context cancel; want the aborted handshake to fail")
+		}
+		if elapsed := time.Since(start); elapsed > 3*time.Second {
+			t.Fatalf("dial returned %s after cancel; want a prompt abort, not the %s handshake timeout", elapsed, backendHandshakeTimeout)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("dial did not abort promptly on context cancel")
+	}
+}

--- a/goproxy/pgproxy/conn.go
+++ b/goproxy/pgproxy/conn.go
@@ -1,6 +1,7 @@
 package pgproxy
 
 import (
+	"context"
 	"crypto/tls"
 	"log/slog"
 	"net"
@@ -161,7 +162,7 @@ startupComplete:
 	defer func() { _ = s.client.CloseConnection(identity.ConnectionID) }()
 	slog.Info("authenticated postgres client", "client", rawClientConn.RemoteAddr().String(), "principal", identity.Principal, "roles", identity.Roles)
 
-	backendConn, parameters, keyData, txStatus, err := dialBackendAuth(s.backend)
+	backendConn, parameters, keyData, txStatus, err := dialBackendAuth(context.Background(), s.backend)
 	if err != nil {
 		slog.Warn("postgres backend unavailable", "host", s.backend.Host, "port", s.backend.Port, "error", err)
 		_ = sendError(client, "FATAL", "08004", "proxy-monster: backend unavailable", false, 0)

--- a/goproxy/pgproxy/run_session.go
+++ b/goproxy/pgproxy/run_session.go
@@ -1,6 +1,7 @@
 package pgproxy
 
 import (
+	"context"
 	"errors"
 	"net"
 	"time"
@@ -24,8 +25,8 @@ type RunSession struct {
 	poisoned     bool
 }
 
-func NewRunSession(target spi.BackendTarget, db engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (*RunSession, error) {
-	conn, _, keyData, txStatus, err := dialBackendAuth(target)
+func NewRunSession(ctx context.Context, target spi.BackendTarget, db engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (*RunSession, error) {
+	conn, _, keyData, txStatus, err := dialBackendAuth(ctx, target)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +56,13 @@ func NewRunSession(target spi.BackendTarget, db engine.Db, client spi.SessionCli
 	return s, nil
 }
 
-func (s *RunSession) OnOpen(cmds []*pb.Refetch) error { return s.ref.RunAll(cmds) }
+// OnOpen runs the on-open catalog fetch over the backend conn. A cancel of ctx (the control-plane closed the
+// run, or the proxy is draining, during the target-DB open) closes the conn, which unwinds an in-flight fetch read
+// at once instead of holding the backend until readTimeout.
+func (s *RunSession) OnOpen(ctx context.Context, cmds []*pb.Refetch) error {
+	defer context.AfterFunc(ctx, func() { _ = s.conn.Close() })()
+	return s.ref.RunAll(cmds)
+}
 
 func (s *RunSession) ServeStatement(sql string, maxRows int) (result engine.StatementResult, err error) {
 	if s.poisoned {

--- a/goproxy/run/runner.go
+++ b/goproxy/run/runner.go
@@ -19,7 +19,7 @@ const (
 	defaultQueryTimeout                         = 600 * time.Second
 	runSocketTimeoutGrace                       = 30 * time.Second
 	streamCloseDrainTimeout                     = 5 * time.Second
-	// How often the proxy heartbeats RunProgress while the backend cold-open is in flight. Must stay well
+	// How often the proxy heartbeats RunProgress while the target-DB open is in flight. Must stay well
 	// under the control-plane's no-progress bound (RunExec.RUN_NO_PROGRESS_TIMEOUT_MS) so ordinary jitter
 	// never trips it — several missed beats still leave margin.
 	progressInterval = 3 * time.Second
@@ -36,7 +36,7 @@ var errQueryTimeout = errors.New(QueryTimeoutMessage)
 
 type runStream = spi.RunStream
 
-type backendFactory func(token string, connectionID []byte, guard engine.ExecGuard) (spi.BackendSession, error)
+type backendFactory func(ctx context.Context, token string, connectionID []byte, guard engine.ExecGuard) (spi.BackendSession, error)
 
 type Runner struct {
 	client       spi.RunClient
@@ -49,8 +49,8 @@ func NewRunner(client spi.RunClient, dbImpl engine.Db, backend spi.BackendTarget
 		queryTimeout = defaultQueryTimeout
 	}
 	readTimeout := queryTimeout + runSocketTimeoutGrace
-	factory := func(token string, connectionID []byte, guard engine.ExecGuard) (spi.BackendSession, error) {
-		return provider.NewRunSession(backend, dbImpl, client, token, connectionID, guard, readTimeout)
+	factory := func(ctx context.Context, token string, connectionID []byte, guard engine.ExecGuard) (spi.BackendSession, error) {
+		return provider.NewRunSession(ctx, backend, dbImpl, client, token, connectionID, guard, readTimeout)
 	}
 	return &Runner{client: client, factory: factory, queryTimeout: queryTimeout}
 }
@@ -70,7 +70,7 @@ func (r *Runner) Run(open spi.RunOpen, draining <-chan struct{}) {
 	var messages <-chan *pb.ControlRunMsg
 	defer func() { gracefulCloseStream(ctx, stream, messages) }()
 	// Tell the control-plane which run this stream serves immediately — before validating the open or the
-	// (cold, ~26s) backend open. The session id is the stream's first frame, so the control-plane attaches at
+	// (~26s) target-DB open. The session id is the stream's first frame, so the control-plane attaches at
 	// once and EVERY failure below is attributable to this run rather than an unmatched stream it must wait
 	// out. RunProgress heartbeats keep its no-progress bound alive through the open; RunServing (below) then
 	// tells it the backend is ready for the query.
@@ -113,25 +113,23 @@ func (r *Runner) Run(open spi.RunOpen, draining <-chan struct{}) {
 		}
 		return err
 	}
-	if err := heartbeatDuring(stream, func() (openErr error) {
-		sess, openErr = r.factory(open.Token, open.ConnectionID, guard)
-		return
-	}); err != nil {
-		_ = sendError(stream, "backend connection failed: "+err.Error())
-		r.closeConnection(open.SessionID, open.ConnectionID)
+	// Read the inbound before the (~26s) target-DB open — not after RunServing — so a RunClose the
+	// control-plane sends during the open, or a drain, aborts it instead of finishing a backend handshake for
+	// a run nobody is waiting for.
+	messages = receiveRunMessages(ctx, stream)
+	sess = r.openTargetDb(ctx, stream, messages, draining, open, guard)
+	if sess == nil {
+		// The open failed (RunError already sent) or was aborted by an early RunClose / drain. openTargetDb owns
+		// the cleanup: a failure releases the connection before returning, while an abort reaps the cancelled
+		// open and releases the connection in the background (see abort) so the drain/close returns at once.
 		return
 	}
 	defer sess.Close()
 	defer r.closeConnection(open.SessionID, open.ConnectionID)
-	if err := heartbeatDuring(stream, func() error { return sess.OnOpen(open.OnOpen) }); err != nil {
-		_ = sendError(stream, "run catalog initialization failed: "+err.Error())
-		return
-	}
 	if stream.Send(&pb.ProxyRunMsg{Kind: &pb.ProxyRunMsg_Serving{Serving: &pb.RunServing{}}}) != nil {
 		return
 	}
 
-	messages = receiveRunMessages(ctx, stream)
 	for {
 		var message *pb.ControlRunMsg
 		var ok bool
@@ -187,34 +185,119 @@ func (r *Runner) Run(open spi.RunOpen, draining <-chan struct{}) {
 	}
 }
 
-// heartbeatDuring runs work while emitting a RunProgress heartbeat on the stream every progressInterval, so a
-// slow backend cold-open keeps the control-plane's no-progress bound alive. The heartbeat carries no payload —
-// it only attests the PROXY is alive, not that the backend open advances, so the control-plane bounds a
-// stalled-but-heartbeating open with an absolute ceiling, not this signal. For the span of work it is the ONLY
-// sender on the stream — RunReady precedes it; RunServing/RunError follow only after it returns — and it JOINS
-// its ticker before returning via defer, so even a panic in work stops the ticker before Run's deferred stream
-// teardown runs (the gRPC stream is not safe for concurrent Send). A Send error from the ticker just stops the
-// heartbeat; the caller's next Send surfaces the broken stream.
-func heartbeatDuring(stream runStream, work func() error) error {
-	stop := make(chan struct{})
-	done := make(chan struct{})
+// openTargetDb dials + authenticates the backend and runs the on-open catalog fetch, while keeping the run stream
+// alive with RunProgress heartbeats and concurrently watching the inbound and the drain. It returns the ready
+// session, or nil if the open failed or was aborted; on every nil return it has already released the reserved
+// connection (and, for a genuine backend failure, sent the RunError), so the caller only sends RunServing.
+//
+// The open runs in its own goroutine under a cancellable child context — the ONLY writer to that context —
+// while this loop is the ONLY sender on the stream (the heartbeat), so neither the gRPC stream nor the open
+// contends. An early RunClose (the browser navigated away before the backend was ready), a closed or broken
+// stream, or a drain cancels the child context and returns at once; the in-flight backend dial / auth /
+// catalog reads unwind on the cancel rather than finishing a handshake for a run nobody is waiting for, and
+// the open is reaped in the background (see abort). A close or drain that lands just as the open completes
+// still fails the open (the post-completion re-check) so a live session is never installed on an abandoned
+// run or a departing proxy — the editor re-homes to the replacement rather than onto a stream about to die.
+func (r *Runner) openTargetDb(ctx context.Context, stream runStream, messages <-chan *pb.ControlRunMsg, draining <-chan struct{}, open spi.RunOpen, guard engine.ExecGuard) spi.BackendSession {
+	openCtx, cancelOpen := context.WithCancel(ctx)
+	defer cancelOpen()
+
+	type openResult struct {
+		sess    spi.BackendSession
+		err     error
+		errWhat string
+	}
+	done := make(chan openResult, 1)
 	go func() {
-		defer close(done)
-		ticker := time.NewTicker(progressInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-stop:
-				return
-			case <-ticker.C:
-				if stream.Send(&pb.ProxyRunMsg{Kind: &pb.ProxyRunMsg_Progress{Progress: &pb.RunProgress{}}}) != nil {
-					return
-				}
-			}
+		sess, err := r.factory(openCtx, open.Token, open.ConnectionID, guard)
+		if err != nil {
+			done <- openResult{err: err, errWhat: "backend connection failed: "}
+			return
 		}
+		if err := sess.OnOpen(openCtx, open.OnOpen); err != nil {
+			done <- openResult{sess: sess, err: err, errWhat: "run catalog initialization failed: "}
+			return
+		}
+		done <- openResult{sess: sess}
 	}()
-	defer func() { close(stop); <-done }()
-	return work()
+
+	// abort cancels the in-flight open and, in the background, reaps it and releases the reserved connection.
+	// The cancel unwinds the backend dial/auth/catalog reads at once; a catalog push RPC to the control-plane
+	// is not cancellable here and runs to its own deadline, so the reap runs off the hot path rather than
+	// making the drain/close wait out that deadline (and the follow-on connection-release RPC).
+	abort := func() spi.BackendSession {
+		cancelOpen()
+		go func() {
+			res := <-done
+			if res.sess != nil {
+				_ = res.sess.Close()
+			}
+			r.closeConnection(open.SessionID, open.ConnectionID)
+		}()
+		return nil
+	}
+
+	ticker := time.NewTicker(progressInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case res := <-done:
+			if res.err != nil {
+				_ = sendError(stream, res.errWhat+res.err.Error())
+				if res.sess != nil {
+					_ = res.sess.Close()
+				}
+				r.closeConnection(open.SessionID, open.ConnectionID)
+				return nil
+			}
+			// The open finished, but a close or drain that landed during it must not put a live session on an
+			// abandoned run or a departing proxy: re-check both before serving. The open is complete here (no
+			// push in flight), so this cleanup is synchronous.
+			if abandonedDuringOpen(messages, draining) {
+				_ = res.sess.Close()
+				r.closeConnection(open.SessionID, open.ConnectionID)
+				return nil
+			}
+			return res.sess
+		case <-ticker.C:
+			// The heartbeat carries no payload — it attests the PROXY is alive, not that the open advances,
+			// so the control-plane bounds a stalled-but-heartbeating open with an absolute ceiling. A Send
+			// error means the stream is gone: abort the open rather than heartbeat into a dead stream.
+			if stream.Send(&pb.ProxyRunMsg{Kind: &pb.ProxyRunMsg_Progress{Progress: &pb.RunProgress{}}}) != nil {
+				return abort()
+			}
+		case message, ok := <-messages:
+			if !ok || message.GetClose() != nil {
+				return abort()
+			}
+			// A Query or Cancel before RunServing is outside the protocol during a target-DB open (the CP sends a
+			// query only after it observes RunServing); log it so a CP regression is visible, and ignore it.
+			slog.Warn("run received a control message before RunServing; ignoring", "session_id", open.SessionID)
+		case <-draining:
+			return abort()
+		}
+	}
+}
+
+// abandonedDuringOpen reports, without blocking, whether the run was closed or the proxy drained during the
+// target-DB open — checked once the open completes, before serving, so a live session is never installed on an
+// abandoned run or a departing proxy. A pending RunClose, a closed stream, or a closed drain all count. A
+// pre-serving Query/Cancel cannot occur (the CP sends a query only after RunServing), so any other message is
+// dropped rather than carried into the serving loop. The drain is checked first in its own select: a single
+// select over both would let the message arm win by chance while the drain is also ready, and Go's fairness
+// would then serve onto a departing proxy.
+func abandonedDuringOpen(messages <-chan *pb.ControlRunMsg, draining <-chan struct{}) bool {
+	select {
+	case <-draining:
+		return true
+	default:
+	}
+	select {
+	case message, ok := <-messages:
+		return !ok || message.GetClose() != nil
+	default:
+		return false
+	}
 }
 
 func receiveRunMessages(ctx context.Context, stream runStream) <-chan *pb.ControlRunMsg {

--- a/goproxy/run/runner_internal_test.go
+++ b/goproxy/run/runner_internal_test.go
@@ -1,0 +1,71 @@
+package run
+
+import (
+	"testing"
+
+	pb "github.com/ridi-oss/proxy-monster/goproxy/internal/pb"
+)
+
+// TestAbandonedDuringOpen pins the post-completion re-check directly: a completed target-DB open must be failed
+// (not served) when a RunClose is queued, the stream has closed, or the drain is set — and served otherwise.
+// The runner's integration tests can only observe the aborted OUTCOME, which the outer abort path produces
+// too, so this is where the success-branch re-check itself is proven.
+func TestAbandonedDuringOpen(t *testing.T) {
+	closeMsg := &pb.ControlRunMsg{Kind: &pb.ControlRunMsg_Close{Close: &pb.RunClose{}}}
+	queryMsg := &pb.ControlRunMsg{Kind: &pb.ControlRunMsg_Query{Query: &pb.RunQuery{Sql: "SELECT 1"}}}
+
+	t.Run("a queued RunClose abandons the open", func(t *testing.T) {
+		messages := make(chan *pb.ControlRunMsg, 1)
+		messages <- closeMsg
+		if !abandonedDuringOpen(messages, nil) {
+			t.Fatal("a queued RunClose must abandon a completed open")
+		}
+	})
+
+	t.Run("a closed stream abandons the open", func(t *testing.T) {
+		messages := make(chan *pb.ControlRunMsg)
+		close(messages)
+		if !abandonedDuringOpen(messages, nil) {
+			t.Fatal("a closed inbound stream must abandon a completed open")
+		}
+	})
+
+	t.Run("a set drain abandons the open", func(t *testing.T) {
+		draining := make(chan struct{})
+		close(draining)
+		if !abandonedDuringOpen(make(chan *pb.ControlRunMsg), draining) {
+			t.Fatal("a set drain must abandon a completed open")
+		}
+	})
+
+	t.Run("no signal serves the open", func(t *testing.T) {
+		if abandonedDuringOpen(make(chan *pb.ControlRunMsg), make(chan struct{})) {
+			t.Fatal("a completed open with no close/drain must be served")
+		}
+		if abandonedDuringOpen(make(chan *pb.ControlRunMsg), nil) {
+			t.Fatal("a nil drain with no pending message must be served")
+		}
+	})
+
+	t.Run("a pre-serving non-close message does not abandon the open", func(t *testing.T) {
+		messages := make(chan *pb.ControlRunMsg, 1)
+		messages <- queryMsg
+		if abandonedDuringOpen(messages, nil) {
+			t.Fatal("a pre-serving Query (protocol violation) must not be treated as an abandon")
+		}
+	})
+
+	// A set drain must win even when a non-close message is also ready — otherwise a single select over both
+	// would, by Go's fairness, sometimes pick the message arm and serve onto a departing proxy.
+	t.Run("a set drain wins over a ready non-close message", func(t *testing.T) {
+		draining := make(chan struct{})
+		close(draining)
+		messages := make(chan *pb.ControlRunMsg, 1)
+		messages <- queryMsg
+		for i := 0; i < 100; i++ {
+			if !abandonedDuringOpen(messages, draining) {
+				t.Fatal("a set drain must abandon the open even when a non-close message is queued")
+			}
+		}
+	})
+}

--- a/goproxy/run/runner_test.go
+++ b/goproxy/run/runner_test.go
@@ -130,7 +130,7 @@ func (f *runFakeCP) RunExec(stream grpc.BidiStreamingServer[pb.ProxyRunMsg, pb.C
 			}
 			switch {
 			case message.GetProgress() != nil:
-				// Cold-open liveness heartbeat — not part of the result transcript.
+				// Target-DB-open liveness heartbeat — not part of the result transcript.
 				f.mu.Lock()
 				f.progressCount++
 				f.mu.Unlock()
@@ -229,22 +229,40 @@ type runCapturingProvider struct {
 	readTimeout chan time.Duration
 }
 
-func (p *runCapturingProvider) NewRunSession(target spi.BackendTarget, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.BackendSession, error) {
+func (p *runCapturingProvider) NewRunSession(ctx context.Context, target spi.BackendTarget, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.BackendSession, error) {
 	p.readTimeout <- readTimeout
-	return p.Provider.NewRunSession(target, dbImpl, client, token, connectionID, guard, readTimeout)
+	return p.Provider.NewRunSession(ctx, target, dbImpl, client, token, connectionID, guard, readTimeout)
 }
 
-// runSlowOpenProvider blocks the backend dial until release is closed, modeling a cold open against a large
+// runSlowOpenProvider blocks the backend dial until release is closed, modeling a slow open against a large
 // remote backend. A test uses it to observe SessionReady landing before the open finishes and heartbeats
-// being sent while it is in flight — without depending on wall-clock timing.
+// being sent while it is in flight — without depending on wall-clock timing. It honors the target-DB open context:
+// if that is cancelled (the control-plane closed the run, or the proxy drained, during the open) it returns
+// at once, standing in for a real dialect whose dial/auth aborts on cancel. entered, when non-nil, is closed
+// the first time the dial is reached so a test can wait until the open is genuinely in flight before cutting it.
 type runSlowOpenProvider struct {
 	spi.Provider
-	release chan struct{}
+	release   chan struct{}
+	entered   chan struct{}
+	enterOnce sync.Once
+	// beforeDelegate, when non-nil, runs after release but before the real dial. A test uses it to close the
+	// drain exactly as the open is about to complete, forcing the "open finished onto a draining proxy" race.
+	beforeDelegate func()
 }
 
-func (p *runSlowOpenProvider) NewRunSession(target spi.BackendTarget, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.BackendSession, error) {
-	<-p.release
-	return p.Provider.NewRunSession(target, dbImpl, client, token, connectionID, guard, readTimeout)
+func (p *runSlowOpenProvider) NewRunSession(ctx context.Context, target spi.BackendTarget, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.BackendSession, error) {
+	if p.entered != nil {
+		p.enterOnce.Do(func() { close(p.entered) })
+	}
+	select {
+	case <-p.release:
+		if p.beforeDelegate != nil {
+			p.beforeDelegate()
+		}
+		return p.Provider.NewRunSession(ctx, target, dbImpl, client, token, connectionID, guard, readTimeout)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 func TestRunnerMySQL(t *testing.T) {
@@ -1104,14 +1122,7 @@ func TestRunnerDrainReturnsWhenIdle(t *testing.T) {
 		close(done)
 	}()
 
-	select {
-	case <-fake.runReady:
-	case <-time.After(10 * time.Second):
-		t.Fatal("timed out waiting for the runner to start")
-	}
-	if first := runRecv(t, fake); first.GetSessionReady() == nil {
-		t.Fatalf("expected SessionReady, got %v", first)
-	}
+	runAwaitServing(t, fake)
 
 	// The runner is idle between statements. A drain must return it without a Close from the control plane,
 	// so the session ends and the editor re-homes to the replacement.
@@ -1133,14 +1144,7 @@ func TestRunnerDrainLetsInFlightStatementFinish(t *testing.T) {
 		close(done)
 	}()
 
-	select {
-	case <-fake.runReady:
-	case <-time.After(10 * time.Second):
-		t.Fatal("timed out waiting for the runner to start")
-	}
-	if first := runRecv(t, fake); first.GetSessionReady() == nil {
-		t.Fatalf("expected SessionReady, got %v", first)
-	}
+	runAwaitServing(t, fake)
 
 	// Put a statement in flight, then drain mid-statement. The drain is observed only between statements, so
 	// the running SLEEP must complete and return its row (0 == slept the full duration, not interrupted)
@@ -1172,14 +1176,7 @@ func TestRunnerDrainDoesNotStartAQueuedQuery(t *testing.T) {
 		close(done)
 	}()
 
-	select {
-	case <-fake.runReady:
-	case <-time.After(10 * time.Second):
-		t.Fatal("timed out waiting for the runner to start")
-	}
-	if first := runRecv(t, fake); first.GetSessionReady() == nil {
-		t.Fatalf("expected SessionReady, got %v", first)
-	}
+	runAwaitServing(t, fake)
 
 	// Drain, then hand the runner a query. A query racing in with the drain must not start a new statement on
 	// a departing proxy: the runner returns without a decision or rows, and the editor re-homes.
@@ -1194,11 +1191,11 @@ func TestRunnerDrainDoesNotStartAQueuedQuery(t *testing.T) {
 	}
 }
 
-// TestRunnerSendsRunReadyBeforeColdOpenAndHeartbeats proves the run stream sends its id (RunReady) up front
+// TestRunnerSendsRunReadyBeforeTargetDbOpenAndHeartbeats proves the run stream sends its id (RunReady) up front
 // and is kept alive through a slow open: SessionReady arrives before the (delayed) backend dial finishes — so
 // the CP can react to a stall or break during the open instead of waiting a blind budget — and RunProgress
 // heartbeats are emitted while the open runs, then RunServing once it completes.
-func TestRunnerSendsRunReadyBeforeColdOpenAndHeartbeats(t *testing.T) {
+func TestRunnerSendsRunReadyBeforeTargetDbOpenAndHeartbeats(t *testing.T) {
 	fixture := runSeedMySQL(t)
 	release := make(chan struct{})
 	fixture.runProvider = &runSlowOpenProvider{Provider: fixture.runProvider, release: release}
@@ -1209,12 +1206,12 @@ func TestRunnerSendsRunReadyBeforeColdOpenAndHeartbeats(t *testing.T) {
 		close(done)
 	}()
 
-	// SessionReady must arrive while the backend open is still blocked — proving the run id is sent up front,
+	// SessionReady must arrive while the target-DB open is still blocked — proving the run id is sent up front,
 	// not deferred until the backend is ready.
 	select {
 	case <-fake.runReady:
 	case <-time.After(5 * time.Second):
-		t.Fatal("SessionReady did not arrive while the cold open was still blocked")
+		t.Fatal("SessionReady did not arrive while the target-DB open was still blocked")
 	}
 	if first := runRecv(t, fake); first.GetSessionReady() == nil {
 		t.Fatalf("first frame = %v, want SessionReady", first)
@@ -1225,7 +1222,7 @@ func TestRunnerSendsRunReadyBeforeColdOpenAndHeartbeats(t *testing.T) {
 	deadline := time.Now().Add(15 * time.Second)
 	for fake.runRecordedProgress() == 0 {
 		if time.Now().After(deadline) {
-			t.Fatal("no RunProgress heartbeat was sent while the cold open was blocked")
+			t.Fatal("no RunProgress heartbeat was sent while the target-DB open was blocked")
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
@@ -1235,7 +1232,7 @@ func TestRunnerSendsRunReadyBeforeColdOpenAndHeartbeats(t *testing.T) {
 	select {
 	case <-fake.runServing:
 	case <-time.After(15 * time.Second):
-		t.Fatal("timed out waiting for RunServing after releasing the cold open")
+		t.Fatal("timed out waiting for RunServing after releasing the target-DB open")
 	}
 	runSendQuery(fake, "SELECT 1", 20)
 	runExpectDecision(t, runRecv(t, fake), pb.EnfAction_ALLOW, nil, "")
@@ -1248,6 +1245,162 @@ func TestRunnerSendsRunReadyBeforeColdOpenAndHeartbeats(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("runner did not exit after RunClose")
 	}
+}
+
+// TestRunnerCloseDuringTargetDbOpenAbortsBackend proves the proxy reads the inbound during the target-DB open: a
+// RunClose the control-plane sends while the target-DB open is still in flight aborts the open at once and
+// releases the reserved connection, instead of finishing a backend handshake for a run nobody is waiting for.
+// The open is never released — the runner can only return by cancelling it — so a return is the abort.
+func TestRunnerCloseDuringTargetDbOpenAbortsBackend(t *testing.T) {
+	fixture := runSeedMySQL(t)
+	entered := make(chan struct{})
+	fixture.runProvider = &runSlowOpenProvider{Provider: fixture.runProvider, release: make(chan struct{}), entered: entered}
+	fake, client := runStartFakeCP(t, runSessionID)
+	done := make(chan struct{})
+	go func() {
+		run.NewRunner(client, fixture.runDB, fixture.runTarget, fixture.runProvider, 0).Run(runOpen(fixture), nil)
+		close(done)
+	}()
+
+	runAwaitTargetDbOpenInFlight(t, fake, entered)
+
+	runSendClose(fake)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runner did not abort the target-DB open on RunClose (still holding the backend handshake)")
+	}
+	runWaitForCloses(t, fake, 1)
+	runExpectSingleClose(t, fake)
+	runExpectNoServing(t, fake)
+}
+
+// TestRunnerDrainDuringTargetDbOpenAbortsBackend is the redeploy analogue: a drain that lands while the backend
+// open is in flight aborts it and releases the connection, so the proxy does not keep dialing for a run that
+// will re-home to the replacement.
+func TestRunnerDrainDuringTargetDbOpenAbortsBackend(t *testing.T) {
+	fixture := runSeedMySQL(t)
+	entered := make(chan struct{})
+	fixture.runProvider = &runSlowOpenProvider{Provider: fixture.runProvider, release: make(chan struct{}), entered: entered}
+	fake, client := runStartFakeCP(t, runSessionID)
+	draining := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		run.NewRunner(client, fixture.runDB, fixture.runTarget, fixture.runProvider, 0).Run(runOpen(fixture), draining)
+		close(done)
+	}()
+
+	runAwaitTargetDbOpenInFlight(t, fake, entered)
+
+	close(draining)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runner did not abort the target-DB open on drain (still holding the backend handshake)")
+	}
+	runWaitForCloses(t, fake, 1)
+	runExpectSingleClose(t, fake)
+	runExpectNoServing(t, fake)
+}
+
+// TestRunnerDrainAsTargetDbOpenCompletesInstallsNoSession is the open-then-instant-drain case end to end: the
+// target-DB open runs to completion against the real backend with the drain closing during it, and the runner
+// must NOT send RunServing — no live editor session on a departing proxy — while still releasing the
+// connection. It reaches the aborted outcome by whichever path the scheduler picks (the outer drain-abort or
+// the post-completion re-check); the re-check branch itself is pinned deterministically by
+// TestAbandonedDuringOpen in runner_internal_test.go, which no scheduler race can reach through this surface.
+func TestRunnerDrainAsTargetDbOpenCompletesInstallsNoSession(t *testing.T) {
+	fixture := runSeedMySQL(t)
+	release := make(chan struct{})
+	draining := make(chan struct{})
+	var drainOnce sync.Once
+	fixture.runProvider = &runSlowOpenProvider{
+		Provider:       fixture.runProvider,
+		release:        release,
+		beforeDelegate: func() { drainOnce.Do(func() { close(draining) }) },
+	}
+	fake, client := runStartFakeCP(t, runSessionID)
+	done := make(chan struct{})
+	go func() {
+		run.NewRunner(client, fixture.runDB, fixture.runTarget, fixture.runProvider, 0).Run(runOpen(fixture), draining)
+		close(done)
+	}()
+
+	select {
+	case <-fake.runReady:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the runner to start")
+	}
+	if first := runRecv(t, fake); first.GetSessionReady() == nil {
+		t.Fatalf("first frame = %v, want SessionReady", first)
+	}
+
+	// Release the open; the provider closes the drain as it hands back the real session, so the completed open
+	// is observed against a draining proxy. The runner must fail the open rather than serve it.
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("runner did not return after a drain landed as the target-DB open completed")
+	}
+	runWaitForCloses(t, fake, 1)
+	runExpectSingleClose(t, fake)
+	runExpectNoServing(t, fake)
+}
+
+// TestRunnerCloseDuringRealDialAbortsIt drives the abort end to end through the REAL MySQL dial: a RunClose
+// sent while the dial is mid-handshake against a target that accepts TCP but never sends its greeting must
+// abort the dial and release the connection fast — exercising the real runner, the real gRPC control stream,
+// and the real provider.NewRunSession -> dialBackendAuthID (DialContext + AfterFunc), not a fake provider.
+// The release is asserted well under the dial's handshake timeout: a dial that ignored the cancel would leak
+// the connection until that timeout instead.
+func TestRunnerCloseDuringRealDialAbortsIt(t *testing.T) {
+	stall := runStartStallingTarget(t)
+	fake, client := runStartFakeCP(t, runSessionID)
+	done := make(chan struct{})
+	go func() {
+		run.NewRunner(client, db.MySqlDb{}, stall.target, mustProvider(t, engine.MySQL), 0).Run(runStallOpen(), nil)
+		close(done)
+	}()
+
+	runAwaitRealDialInFlight(t, fake, stall)
+
+	runSendClose(fake)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runner did not return on RunClose while the real dial was in flight")
+	}
+	// The reserved connection must be released well before the dial's handshake timeout — proving the real
+	// dial actually aborted on the cancel rather than running out its deadline.
+	runWaitForClosesWithin(t, fake, 1, 4*time.Second)
+	runExpectSingleClose(t, fake)
+	runExpectNoServing(t, fake)
+}
+
+// TestRunnerDrainDuringRealDialAbortsIt is the redeploy analogue of the above, driven through the real dial:
+// a drain that lands while the real MySQL handshake is stalled aborts it and releases the connection fast.
+func TestRunnerDrainDuringRealDialAbortsIt(t *testing.T) {
+	stall := runStartStallingTarget(t)
+	fake, client := runStartFakeCP(t, runSessionID)
+	draining := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		run.NewRunner(client, db.MySqlDb{}, stall.target, mustProvider(t, engine.MySQL), 0).Run(runStallOpen(), draining)
+		close(done)
+	}()
+
+	runAwaitRealDialInFlight(t, fake, stall)
+
+	close(draining)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runner did not return on drain while the real dial was in flight")
+	}
+	runWaitForClosesWithin(t, fake, 1, 4*time.Second)
+	runExpectSingleClose(t, fake)
+	runExpectNoServing(t, fake)
 }
 
 func TestRunnerCloseInFlightCancelsBackend(t *testing.T) {
@@ -1335,12 +1488,12 @@ func runLaunchOpenConfigured(t *testing.T, fake *runFakeCP, client *cp.Client, f
 	if ready.GetSessionId() != open.SessionID {
 		t.Fatalf("SessionReady = %v, want session %q", ready, open.SessionID)
 	}
-	// SessionReady tells the CP which run the stream is for immediately; the backend cold-open (and its on-open
+	// SessionReady tells the CP which run the stream is for immediately; the target-DB open (and its on-open
 	// catalog push) runs after it and completes at RunServing. Wait for serving, then assert the push landed first.
 	select {
 	case <-fake.runServing:
 	case <-time.After(15 * time.Second):
-		t.Fatal("timed out waiting for RunServing after the cold-open")
+		t.Fatal("timed out waiting for RunServing after the target-DB open")
 	}
 	fragments := fake.runRecordedFragments()
 	if len(fragments) != 1 || fragments[0].GetSchema() != fixture.runNamespaceForTable() {
@@ -1516,6 +1669,108 @@ func runWaitForRequests(t *testing.T, fake *runFakeCP, count int) {
 	t.Fatalf("timed out waiting for %d decision requests", count)
 }
 
+// runWaitForCloses waits until at least count CloseConnection requests have been recorded. An aborted
+// target-DB open releases its connection off the hot path (see openTargetDb's abort), so a test cannot read the count
+// synchronously right after the runner returns.
+func runWaitForCloses(t *testing.T, fake *runFakeCP, count int) {
+	t.Helper()
+	runWaitForClosesWithin(t, fake, count, 10*time.Second)
+}
+
+func runWaitForClosesWithin(t *testing.T, fake *runFakeCP, count int, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if len(fake.runRecordedCloses()) >= count {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %s waiting for %d CloseConnection requests", within, count)
+}
+
+// runStallingTarget is a TCP endpoint that accepts connections and holds them open without ever writing, so a
+// backend handshake read against it stalls. accepted fires on the first accepted connection.
+type runStallingTarget struct {
+	target   spi.BackendTarget
+	accepted <-chan struct{}
+}
+
+// runStartStallingTarget stands up a runStallingTarget on a loopback port and closes every accepted connection
+// (and the listener) on cleanup. It stands in for a target DB that is reachable but slow to answer, so a test
+// can dial it for real and cut the run while the handshake is still blocked.
+func runStartStallingTarget(t *testing.T) runStallingTarget {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen stalling target: %v", err)
+	}
+	accepted := make(chan struct{}, 1)
+	var mu sync.Mutex
+	var held []net.Conn
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			select {
+			case accepted <- struct{}{}:
+			default:
+			}
+			mu.Lock()
+			held = append(held, conn)
+			mu.Unlock()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		mu.Lock()
+		for _, conn := range held {
+			_ = conn.Close()
+		}
+		mu.Unlock()
+	})
+	addr := listener.Addr().(*net.TCPAddr)
+	return runStallingTarget{
+		target: spi.BackendTarget{
+			Host: addr.IP.String(), Port: addr.Port, Db: runMySQLSchema,
+			User: runMySQLService, Password: runMySQLServicePwd,
+		},
+		accepted: accepted,
+	}
+}
+
+// runStallOpen is a valid run open whose on-open catalog work is never reached (the dial to a stalling target
+// blocks first), so any schema will do.
+func runStallOpen() spi.RunOpen {
+	return spi.RunOpen{
+		SessionID:    runSessionID,
+		Token:        runToken,
+		ConnectionID: []byte(runConnectionID),
+		OnOpen:       []*pb.Refetch{{Schema: runMySQLSchema}},
+	}
+}
+
+// runAwaitRealDialInFlight consumes SessionReady and then blocks until the real dial has connected to the
+// stalling target, so a test cuts the run while the handshake is genuinely stalled — not before the dial began.
+func runAwaitRealDialInFlight(t *testing.T, fake *runFakeCP, stall runStallingTarget) {
+	t.Helper()
+	select {
+	case <-fake.runReady:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the runner to start")
+	}
+	if first := runRecv(t, fake); first.GetSessionReady() == nil {
+		t.Fatalf("first frame = %v, want SessionReady", first)
+	}
+	select {
+	case <-stall.accepted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the real dial did not connect to the stalling target")
+	}
+}
+
 func runWaitForMySQLSleep(t *testing.T, fixture runEngineFixture, sleepSQL string) {
 	t.Helper()
 	direct := runOpenMySQLInspector(t, fixture)
@@ -1651,5 +1906,56 @@ func runExpectSilence(t *testing.T, fake *runFakeCP, duration time.Duration) {
 	case message := <-fake.runTranscript:
 		t.Fatalf("unexpected run message during silence window: %v", message)
 	case <-time.After(duration):
+	}
+}
+
+// runAwaitTargetDbOpenInFlight consumes SessionReady and then blocks until the target-DB open is genuinely in
+// flight (the slow-open provider's entered signal), so a test can cut the run knowing the abort must unwind
+// an open that is actually running, not race the runner before it reaches the open.
+func runAwaitTargetDbOpenInFlight(t *testing.T, fake *runFakeCP, entered <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-fake.runReady:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the runner to start")
+	}
+	if first := runRecv(t, fake); first.GetSessionReady() == nil {
+		t.Fatalf("first frame = %v, want SessionReady", first)
+	}
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the target-DB open to start")
+	}
+}
+
+// runAwaitServing waits until the runner has completed its target-DB open and sent RunServing, so a test that
+// exercises a post-serving path (an idle drain, an in-flight statement, a queued query) starts from a ready
+// session — matching the control-plane, which sends a query only after it observes RunServing.
+func runAwaitServing(t *testing.T, fake *runFakeCP) {
+	t.Helper()
+	select {
+	case <-fake.runReady:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the runner to start")
+	}
+	if first := runRecv(t, fake); first.GetSessionReady() == nil {
+		t.Fatalf("expected SessionReady, got %v", first)
+	}
+	select {
+	case <-fake.runServing:
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for RunServing after the target-DB open")
+	}
+}
+
+// runExpectNoServing asserts the run never reached RunServing — the open was aborted or failed, so the
+// control-plane never installed a live editor session for it.
+func runExpectNoServing(t *testing.T, fake *runFakeCP) {
+	t.Helper()
+	select {
+	case <-fake.runServing:
+		t.Fatal("RunServing was sent for a run that should have been aborted before it was ready to serve")
+	default:
 	}
 }

--- a/goproxy/spi/spi.go
+++ b/goproxy/spi/spi.go
@@ -96,7 +96,10 @@ type WireServer interface {
 // BackendSession is one dedicated run backend session.
 type BackendSession interface {
 	ServeStatement(sql string, maxRows int) (engine.StatementResult, error)
-	OnOpen([]*pb.Refetch) error
+	// OnOpen runs the on-open catalog fetch. ctx is the target-DB open context: if the control-plane closes the
+	// run (or the proxy drains) while the fetch is in flight, ctx is cancelled and the in-flight backend read
+	// unwinds at once (a catalog push RPC to the control-plane still runs to its own deadline).
+	OnOpen(ctx context.Context, cmds []*pb.Refetch) error
 	Cancel() error
 	Close() error
 }
@@ -190,7 +193,9 @@ type Provider interface {
 	ProbeNamespace(conn *sql.Conn, targetDb string) (defaultSchemas []string, mysqlLowerCaseTableNames *int32, err error)
 	ReadTableDetail(conn *sql.Conn, schema, table string) (*TableDetail, error)
 	NewWireServer(port int, backend BackendTarget, client EnforcementClient, db engine.Db, tlsProvider func() (*tls.Config, error)) WireServer
-	NewRunSession(target BackendTarget, db engine.Db, client SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (BackendSession, error)
+	// NewRunSession dials and authenticates the backend. ctx is the target-DB open context: cancelling it aborts
+	// an in-flight dial/auth so a run the control-plane already closed does not finish a backend handshake.
+	NewRunSession(ctx context.Context, target BackendTarget, db engine.Db, client SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (BackendSession, error)
 }
 
 // Registry resolves the canonical PM_ENGINE name to its Provider. Consumers depend on this interface and

--- a/proto/src/main/proto/controlplane.proto
+++ b/proto/src/main/proto/controlplane.proto
@@ -306,12 +306,12 @@ message ProxyRunMsg {
   oneof kind {
     RunReady session_ready = 1;       // first message, sent the instant the stream opens: tells the control-
                                       // plane which pending run this stream serves (the OpenRunChannel it
-                                      // dispatched) — BEFORE the backend cold-open begins
+                                      // dispatched) — BEFORE the target-DB open begins
     RunDecision decision = 2;         // the enforcement verdict + UX metadata (before any rows)
     RunResultRows result_rows = 3;    // masked rows (ALLOW/MASK only)
     RunDone done = 4;                 // terminal success (rows_affected for a write)
     RunError error = 5;               // terminal failure (backend error, unsupported, ...)
-    RunProgress progress = 6;         // liveness heartbeat during the cold-open; resets the CP's no-progress bound
+    RunProgress progress = 6;         // liveness heartbeat during the target-DB open; resets the CP's no-progress bound
     RunServing serving = 7;           // the backend is connected and its on-open catalog work is done —
                                       // the control-plane may now send the query
   }
@@ -324,12 +324,12 @@ message ControlRunMsg {
   }
 }
 message RunReady { string session_id = 1; }
-// A cold-open liveness heartbeat: the proxy emits these while dialing + authenticating the backend and
+// A target-DB open liveness heartbeat: the proxy emits these while dialing + authenticating the backend and
 // running its on-open catalog commands, so the control-plane can bound the open by lack of progress rather
 // than by a blind dial budget. It carries no payload — the control-plane treats every RunProgress purely as
 // "the proxy is still alive".
 message RunProgress {}
-// The backend cold-open finished and the proxy is ready to accept the query. Sent once, after the last
+// The target-DB open finished and the proxy is ready to accept the query. Sent once, after the last
 // RunProgress and before any RunDecision.
 message RunServing {}
 message RunQuery {


### PR DESCRIPTION
## What

Abort the target-DB open when the control-plane closes the run — or the proxy drains — while it is still in flight. Closes #159.

While the proxy opens the target-DB connection for an editor run (dial + auth + on-open catalog fetch, up to ~25–30s when the DB is slow to answer), the run stream previously only **sent** `RunProgress` heartbeats; it did not **read** the inbound or watch the drain until after `RunServing`. So a `RunClose` the control-plane sent mid-open (the browser navigated away), or a redeploy drain, was seen only once the open finished — the proxy built a target-DB connection for a run nobody was waiting for.

The open now runs in its own goroutine under a cancellable context while the runner reads the inbound and watches `draining` concurrently:

- a `RunClose`, a closed/broken stream, or a drain cancels the open, so the in-flight dial/auth/catalog **read** unwinds at once (`DialContext` for the connect; an `AfterFunc` that closes the conn to unwind a blocked read) and the reserved connection is released;
- a close or drain that lands as the open completes **fails** the open rather than serving, so a live editor session is never installed on an abandoned run or a departing proxy.

## Where it could bite

- `Provider.NewRunSession` and `BackendSession.OnOpen` now take a `context.Context`. The native-wire path passes `context.Background()` (never cancelled) — only the run open is cancellable, so wire behavior is unchanged.
- On an abort, the cancelled open is **reaped in the background** (session close + connection release). This is deliberate: a catalog schema-push RPC to the control-plane is not cancellable here and runs to its own 30s deadline, so blocking the drain/close on it would blow the drain bound. The target-DB socket still closes immediately on the cancel; only the CP-side release lags.
- A `Query`/`Cancel` that arrives during the open is logged and ignored: the control-plane sends a query only after it observes `RunServing`, so this cannot occur in production. The existing drain tests were updated to establish serving before sending a query, matching that protocol.
- Terminology: the run path calls this operation the **target-DB open** throughout (proto + control-plane + proxy). The word **backend** stays elsewhere as the codebase's existing name for the target DB (`BackendSession`, `dialBackendAuth`, wire error strings, …); a full rename of that is out of scope here.

## Verification

`gofmt`, `go vet`, full Go suite (`mise run test-go`, incl. `-race`), the GOWORK=off image build, `proto-check`, and a control-plane Kotlin compile all green. New coverage: close-during-open, drain-during-open, open-completes-as-a-drain-lands, a unit pin of the post-completion re-check (`TestAbandonedDuringOpen`, incl. the drain-vs-message fairness case), and real-dialect MySQL/PG tests that cancel a stalled auth handshake and prove the dial aborts in ~0ms rather than at the 10s timeout. Reviewed by three independent reviewers; findings folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
