### PR TITLE
refactor: rename the "backend" target-DB vocabulary to target-DB

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -148,11 +148,11 @@ body:
       label: Environment
       description: >-
         How you are running it — the local `mise run dev` stack or your own
-        deployment — plus the OS, the backend database version, and the client
+        deployment — plus the OS, the target database version, and the client
         you connected with (`mysql`, `psql`, JDBC, the console editor).
       placeholder: |
         Local `mise run dev` stack on macOS 15 (Apple Silicon)
-        Backend: MySQL 8.4 (sample compose backend)
+        Target DB: MySQL 8.4 (sample compose target DB)
         Client: mysql 8.4 CLI through pmon
     validations:
       required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ weighing review findings, and weight MySQL accordingly.
 Modules:
 
 - `goproxy/` — Go data-plane wire proxy: MySQL/PostgreSQL codecs, token auth,
-  the per-statement `Decide` call, inline result masking, and the backend
+  the per-statement `Decide` call, inline result masking, and the target-DB
   broker.
 - `control-plane/` — Kotlin control plane: identity and roles, Cedar
   authorization, the catalog, the per-statement decision, and the admin +
@@ -51,7 +51,7 @@ Modules:
 - `proto/` — protobuf contracts: the proxy↔control-plane gRPC surface and the
   analyzer FFM boundary.
 - `web/` — the Next.js console (editor, policies, access, audit, admin).
-- `deploy/` — sample seed SQL for the compose backends.
+- `deploy/` — sample seed SQL for the compose target DBs.
 - `docs/` — per-workstream design docs.
 
 Key docs:
@@ -102,7 +102,7 @@ Key docs:
   (see [DESIGN.md](./DESIGN.md#jit-elevation-and-approval)).
 - Planes: the Kotlin control-plane owns a Postgres store (identity, policy,
   catalog, grants, audit); the Go data-plane proxy holds no store — it connects
-  only to its target backend and reads each decision from the control-plane over
+  only to its target DB and reads each decision from the control-plane over
   gRPC.
 - Web console (`web/`): a SQL editor plus admin for datasources, policies,
   access, and audit, in Next.js.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,7 +31,7 @@ flowchart LR
   proxy["Proxy · per datasource"]
   audit["auditmon"]
   pg[("Control-plane store · PostgreSQL only")]
-  backend[("Target DB · MySQL/PG")]
+  targetdb[("Target DB · MySQL/PG")]
   s3[("WORM object store")]
   kms{{"KMS"}}
   op -->|HTTPS| alb
@@ -43,7 +43,7 @@ flowchart LR
   nlb -->|wire| proxy
   web -->|"/api /auth · HTTP"| cp
   proxy -->|"gRPC · decide / register"| cp
-  proxy -->|"MySQL / PG"| backend
+  proxy -->|"MySQL / PG"| targetdb
   cp -->|"SQL r/w"| pg
   cp -.->|"OIDC · HTTPS"| idp
   audit -->|"SQL · read-only"| pg
@@ -55,7 +55,7 @@ flowchart LR
   classDef audit fill:#dff2e8,stroke:#2f8f5b,color:#124430;
   classDef store fill:#e6eaf4,stroke:#4a5a86,color:#26304d;
   class proxy proxy; class cp cp; class web web; class audit audit;
-  class pg,backend,s3 store;
+  class pg,targetdb,s3 store;
 ```
 
 ## Components
@@ -71,7 +71,7 @@ only.
 <!-- prettier-ignore -->
 | Component | Kind | Role |
 | --- | --- | --- |
-| Proxy | data plane · Go | Terminates SQL wire connections in front of one target database (MySQL or PostgreSQL). Authenticates the client to a principal (a minted token as the wire password), asks the control plane to authorize each statement, applies masking, relays to the backend. Introspects the backend catalog and pushes it up. Fails closed. One proxy per datasource. |
+| Proxy | data plane · Go | Terminates SQL wire connections in front of one target database (MySQL or PostgreSQL). Authenticates the client to a principal (a minted token as the wire password), asks the control plane to authorize each statement, applies masking, relays to the target DB. Introspects the target-DB catalog and pushes it up. Fails closed. One proxy per datasource. |
 | Control plane (CP) | brain · Kotlin/Ktor | Owns identity (OIDC login, sessions, roles and groups), policy (Cedar), the catalog, and the per-statement decision. Exposes HTTP (web API, auth and OIDC, an OAuth 2.1 server + MCP resource) and gRPC (proxies register and fetch decisions). Persists to its own PostgreSQL store; never touches a target database directly. |
 | Web console | UI · Next.js | User-facing UI: query editor, policy/role/grant management, approvals, audit view. Thin, and holds no state. Rewrites `/api` and `/auth` to the CP so the browser talks same-origin — the browser's paths, not the CP's whole surface: `/mcp`, `/oauth`, and `/.well-known` are not rewritten, so a deployment using MCP routes those to the CP at the edge (see [How users reach it](#how-users-reach-it)). |
 | auditmon | watcher · Go | Independent audit monitor: reads the committed trail, re-verifies the tamper-evident hash chain, exports redacted batches to a WORM object store, signs off-box anchors, runs anomaly rules to alerts. Separate from the CP by design. Its access to the control-plane store is read-only. |
@@ -102,8 +102,8 @@ decide but never opens a connection to a target database.
    there are no hardcoded allow/deny one-offs.
 5. The proxy enforces the returned decision — forward, refuse, or rewrite the
    result stream, masking flagged output columns by ordinal.
-6. The backend is reached with a per-datasource service account, so users never
-   hold database credentials.
+6. The target DB is reached with a per-datasource service account, so users
+   never hold database credentials.
 7. Every decision, plus a post-execution completion event carrying result
    volume, is written to the hash-chained `audit_event` log in the control-plane
    store. auditmon verifies that chain independently — when it is deployed and

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -180,7 +180,7 @@ wire** (auth mechanism). Authoritative: `docs/auth-model.md`.
     `KNOWN_LIMITATIONS.md`; registrar-identity hardening is backlogged). A
     rotated leaf re-advertises on the next register/reconnect resync (immediate
     rotation-refresh is a follow-up).
-- **Broker:** goproxy reaches the backend with a per-datasource **service
+- **Broker:** goproxy reaches the target DB with a per-datasource **service
   account**; the token only proves _who you are_, never _what you can see_ —
   enforcement (§5) and JIT (§7) are independent of how it was obtained.
 
@@ -218,9 +218,9 @@ mechanism). Authoritative: [docs/auth-model.md](docs/auth-model.md).
     [INSTALL.md](INSTALL.md#proxy--one-set-per-datasource). Where pinning does
     and does not cover this hop:
     [KNOWN_LIMITATIONS.md](KNOWN_LIMITATIONS.md#wire-cert-pinning-pmon--proxy).
-- Broker: goproxy reaches the backend with a per-datasource service account; the
-  token only proves _who you are_, never _what you can see_ — enforcement and
-  JIT elevation are independent of how it was obtained.
+- Broker: goproxy reaches the target DB with a per-datasource service account;
+  the token only proves _who you are_, never _what you can see_ — enforcement
+  and JIT elevation are independent of how it was obtained.
 
 Web session lifetime, IdP revalidation, and device-binding:
 [docs/session-lifetime.md](docs/session-lifetime.md).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -150,19 +150,19 @@ configured per proxy under `PM_TARGET_*`.
   `6033` (MySQL) · `6432` (PG).
 - `PM_TARGET_HOST` / `_PORT` / `_DB` / `_USER` / `_PASSWORD` — _optional with
   local defaults_ (`localhost` · engine default port · `acme` · `acme` ·
-  `acme`). In production set all five to the backend this proxy fronts (VPC
+  `acme`). In production set all five to the target DB this proxy fronts (VPC
   peering in the AWS layout below). Example: `prod-db.prod-vpc.internal` ·
   `5432` · `appdb` · `pmproxy`
 - `PM_CONTROL_PLANE_GRPC` — _optional_. CP gRPC address `host:port`. Default
   `localhost:9090`. Production example: `pm-cp.pm.internal:9090`
 - `PM_ADVERTISE_ADDR` — _optional, no default_. The client-facing `host:port` a
   wire client dials to reach _this_ proxy — distinct from `PM_TARGET_*` (the
-  upstream backend). The proxy registers it with the CP, which hands it to pmon
-  as each datasource's connect address. The proxy cannot guess it, so there is
-  no default: leave it unset and pmon discovers the datasource but cannot broker
-  it (`pmon status` lists it with the reason "no advertised proxy address"). It
-  must parse as `host:port` with a port in 1-65535 or the proxy refuses to
-  start. Example: `127.0.0.1:6033` locally ·
+  upstream target DB). The proxy registers it with the CP, which hands it to
+  pmon as each datasource's connect address. The proxy cannot guess it, so there
+  is no default: leave it unset and pmon discovers the datasource but cannot
+  broker it (`pmon status` lists it with the reason "no advertised proxy
+  address"). It must parse as `host:port` with a port in 1-65535 or the proxy
+  refuses to start. Example: `127.0.0.1:6033` locally ·
   `analytics-prod.pm.example.com:6432` in production
 - `PM_TLS_CERT` / `PM_TLS_KEY` — _optional (both or neither; one alone ⇒ refuses
   to start)_. TLS cert+key file paths for the wire listener. Wire TLS is
@@ -501,17 +501,17 @@ server. Set `PM_MCP_RESOURCE="https://<host>/mcp"` to that public origin. With
 32+ character `PM_SESSION_SECRET`, all `PM_OIDC_*` values, and an OIDC redirect
 URI exactly equal to `https://<host>/auth/oidc/callback`. If a reverse proxy
 terminates TLS in front of control-plane (as any real deployment's will), the
-host the backend sees must equal the host `PM_MCP_RESOURCE` declares:
+host the target DB sees must equal the host `PM_MCP_RESOURCE` declares:
 control-plane's `/mcp` guard compares that host strictly, and only the host. The
-port is never compared — behind a TLS-terminating edge the backend is reached on
-its own cleartext port, and a client's `Host` omits the port whenever it is the
-scheme default, so requiring one would reject every such request. It reads the
-literal `Host` (or HTTP/2 `:authority`) the backend receives, plus
+port is never compared — behind a TLS-terminating edge the target DB is reached
+on its own cleartext port, and a client's `Host` omits the port whenever it is
+the scheme default, so requiring one would reject every such request. It reads
+the literal `Host` (or HTTP/2 `:authority`) the target DB receives, plus
 `X-Forwarded-Host` when the socket peer is listed in `PM_TRUSTED_PROXIES`; there
 is no `ForwardedHeaders`/`XForwardedHeaders` plugin, so nothing else is derived
 from `X-Forwarded-*`. A proxy that forwards the original client-facing hostname
 satisfies this already, whether or not it keeps the port. One that substitutes
-its own backend address in `Host` — an AWS ALB does this unless
+its own target-DB address in `Host` — an AWS ALB does this unless
 `preserve_host_header` is enabled — must either be fixed to preserve it or send
 `X-Forwarded-Host` from a trusted peer, or every `/mcp` call gets a fail-closed
 `403 mcp.invalid_host` instead of the expected `401` OAuth challenge. Configure
@@ -631,8 +631,8 @@ for the store; S3 Object Lock for the WORM trail.
 - pm-vpc (e.g. `10.20.0.0/16`): all ECS services, the ALB (public subnets), the
   NLB, and the Aurora cluster.
 - Peering to `prod-db-vpc` and `dev-db-vpc`: a peering connection to each, a
-  route for `PM_TARGET_HOST` traffic, and the backend DB security group opened
-  to the _proxy_ subnets' CIDRs only. CIDR blocks must not overlap.
+  route for `PM_TARGET_HOST` traffic, and the target-DB security group opened to
+  the _proxy_ subnets' CIDRs only. CIDR blocks must not overlap.
 - A `system:production`-tagged proxy targets a DB in `prod-db-vpc`; a
   `system:development` proxy targets `dev-db-vpc` — same image, different
   `PM_TARGET_*` + peering route + tag.
@@ -997,7 +997,7 @@ aws acm request-certificate --domain-name console.example.com --validation-metho
 aws acm-pca issue-certificate --certificate-authority-arn <pca> --csr fileb://wire.csr \
   --signing-algorithm SHA256WITHRSA --validity Value=365,Type=DAYS   # export → pm/wire-tls-*
 
-# --- VPC peering to a backend-DB VPC + route ---
+# --- VPC peering to a target-DB VPC + route ---
 aws ec2 create-vpc-peering-connection --vpc-id vpc-pm --peer-vpc-id vpc-proddb
 aws ec2 create-route --route-table-id rtb-pm-private \
   --destination-cidr-block 10.30.0.0/16 --vpc-peering-connection-id pcx-xxxx
@@ -1026,4 +1026,4 @@ aws elbv2 create-listener --load-balancer-arn <nlb> --protocol TCP --port 6432 \
   audit window.
 - Non-default `PM_SESSION_SECRET` (≥32) + strong `PM_RESULT_KEY`; all secrets
   via Secrets Manager; task IAM roles over static `AWS_*` keys.
-- Backend-DB security groups admit only the proxy subnets over the VPC peering.
+- Target-DB security groups admit only the proxy subnets over the VPC peering.

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -128,7 +128,7 @@ analog of MySQL's Prepare-time freeze. No control-plane decision is ever stored.
   column in its own charset for client-side decoding — and rewrites it to
   `utf8mb4`, so those clients connect and results stay maskable. The client's
   original statement is authorized and audited; only the bytes sent to the
-  backend are pinned. (A prepared-statement form is pinned too, but its
+  target DB are pinned. (A prepared-statement form is pinned too, but its
   execute-time audit records the pinned statement.) Any other results charset —
   an explicit non-UTF-8 one — is not rewritten and fails the session closed, and
   returning results in a non-UTF-8 charset is not supported.
@@ -148,7 +148,7 @@ analog of MySQL's Prepare-time freeze. No control-plane decision is ever stored.
   isolation level should use `BEGIN ISOLATION LEVEL …` instead of a separate
   `SET TRANSACTION`.
 - 🟡 `client_encoding` must remain UTF8. The engine and control plane read the
-  client's SQL bytes as UTF-8 to resolve identifiers. A backend session that
+  client's SQL bytes as UTF-8 to resolve identifiers. A target-DB session that
   switches `client_encoding` to another encoding would let the same bytes bind
   different objects on each side (a non-ASCII identifier could dodge its
   mask/deny — verified against real PostgreSQL). `client_encoding` is
@@ -171,8 +171,8 @@ analog of MySQL's Prepare-time freeze. No control-plane decision is ever stored.
   never saw, and the `Execute` re-decide authorizes under the stale snapshot (a
   wrong-ALLOW). Reproduced against PG16 by
   `pgproxy.TestExtendedBindCoercionSetConfigLeaksAcrossSchema` (the proxy
-  decides under the primary path yet the backend returns the secondary schema's
-  row). The offending domain must already exist, which needs a
+  decides under the primary path yet the target DB returns the secondary
+  schema's row). The offending domain must already exist, which needs a
   `CREATE DOMAIN`/`CREATE FUNCTION` grant the masking policy denies read-only
   principals. A fail-safe close (re-probe _after_ Bind, or bind under a pinned
   `search_path`) is a follow-up. Tracked:
@@ -181,9 +181,9 @@ analog of MySQL's Prepare-time freeze. No control-plane decision is ever stored.
 ## Catalog freshness
 
 Enforcement decides against a per-connection catalog captured on the
-connection's own held backend connection (design:
+connection's own held target-DB connection (design:
 [`docs/per-connection-catalog.md`](./docs/per-connection-catalog.md)) — the
-control plane always decides against exactly what that connection's backend
+control plane always decides against exactly what that connection's target DB
 binds. The datasource-global catalog is now config-only (catalog browser,
 tagging, table detail) and never feeds an enforcement decision.
 
@@ -231,7 +231,7 @@ tagging, table detail) and never feeds an enforcement decision.
   the column's kind; a masked column in a row-shaping position
   (predicate/join/order/group/distinct) still DENYs. So none of these paths
   leak. The residual gap is a function body that reads a masked/PII column
-  internally, on the backend service-account connection unseen by the proxy,
+  internally, on the target DB service-account connection unseen by the proxy,
   when that column never appears as an argument: `SELECT my_udf(id) FROM t`,
   where `id` is not sensitive and `my_udf` internally reads `ssn`, returns `ssn`
   in the clear. Operational rule: a UDF on a masking datasource must not read
@@ -286,7 +286,7 @@ tagging, table detail) and never feeds an enforcement decision.
   that classify as passthrough and take a table target — e.g. `ANALYZE <table>`
   (PostgreSQL, `SESSION` → wire/editor passthrough, gated only by
   `datasource.connect`, not a table grant) — still disclose an ungranted table's
-  existence via a backend error. They return no rows. The fix routes each
+  existence via a target-DB error. They return no rows. The fix routes each
   resource-bearing utility to a Cedar gate instead of the blanket passthrough
   ([`docs/facts-emission.md`](./docs/facts-emission.md)).
 
@@ -504,7 +504,7 @@ The web SQL editor executes over the proxy-dialed `RunExec` channel (the
 control-plane never dials the target); its query runs through the proxy's normal
 `Decide`, same as a native-wire client. The interactive editor drives a
 persistent per-session stream (`RunExecService.openSession`/`runOnSession`, the
-`editorSessionRoutes` behind `POST /api/editor/sessions`), holding one backend
+`editorSessionRoutes` behind `POST /api/editor/sessions`), holding one target-DB
 connection so `SET`/`USE`/temp/`BEGIN` persist across queries. The one-shot
 `RunExecService.run` (open → one statement → `Close`) backs the approval-execute
 path and `POST /api/datasources/{id}/query`, not the interactive editor.
@@ -513,7 +513,7 @@ path and `POST /api/datasources/{id}/query`, not the interactive editor.
   passthrough-ALLOW. Benign `SET`, `BEGIN`, `USE`, and `ANALYZE` are allowed on
   the editor channel; classified privileged `SET` forms still pass their Utility
   gate, and session statements stay denied on the workflow executor/viewer
-  channels. Because a persistent session holds ONE backend connection across
+  channels. Because a persistent session holds ONE target-DB connection across
   MANY statements, a session mutation can affect a later query on the same
   connection; its safety rests on per-statement re-decide — every statement
   round-trips to the proxy's `Decide` against that connection's live
@@ -522,23 +522,24 @@ path and `POST /api/datasources/{id}/query`, not the interactive editor.
   admission so passthrough only ever sees a pure session statement. Hard gate:
   per-statement re-decide (or an explicit session-mutation refusal) must remain
   the standing mitigation.
-- 🟡 Catalog adoption assumes one backend behind a datasource. On MySQL a new
+- 🟡 Catalog adoption assumes one target DB behind a datasource. On MySQL a new
   connection may start from catalog content the control plane already holds
-  rather than measuring the backend itself, so its first statement decides
-  without a round-trip. That is sound because every backend session for a
+  rather than measuring the target DB itself, so its first statement decides
+  without a round-trip. That is sound because every target-DB session for a
   datasource is opened by one proxy process against one target with one service
   account, which is what makes a catalog scan the same for every connection —
   MySQL temporary tables never appear in `information_schema` and reach a
   decision through the per-request overlay instead. Two changes would break it
-  silently: running several proxies for one datasource against backends that can
-  disagree (a replica behind a load balancer, mid-failover), or varying backend
-  credentials per session, since `information_schema` is privilege-filtered and
-  two accounts legitimately see different columns. An adopting connection would
-  then decide against structure its own backend never had. PostgreSQL never
-  adopts: its `pg_temp_*` schemas are per-session and catalog-visible, so a
-  fragment there is only true for the connection that measured it.
+  silently: running several proxies for one datasource against target DBs that
+  can disagree (a replica behind a load balancer, mid-failover), or varying
+  target DB credentials per session, since `information_schema` is
+  privilege-filtered and two accounts legitimately see different columns. An
+  adopting connection would then decide against structure its own target DB
+  never had. PostgreSQL never adopts: its `pg_temp_*` schemas are per-session
+  and catalog-visible, so a fragment there is only true for the connection that
+  measured it.
 - 🟡 No concurrent-editor-session cap (auth'd DoS surface). Each open session
-  pins ONE unpooled backend connection on the proxy for the life of its run
+  pins ONE unpooled target-DB connection on the proxy for the life of its run
   stream. That stream has no fixed lifetime cap — so an active editor is never
   cut mid-session — which means the connection is held until the stream closes:
   by an explicit close, a subsequent failed query, or the idle sweep. That sweep

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ tamper-evident audit trail.
 - **Transparent proxy.** Speaks the native MySQL and PostgreSQL wire protocols,
   so `psql`, `mysql`, JDBC, and application drivers connect unchanged. It
   authenticates the client to a principal, authorizes each statement, applies
-  masking, and brokers to the backend with a per-datasource service account —
+  masking, and brokers to the target DB with a per-datasource service account —
   users never hold database credentials.
 - **Column-level access control.** Deterministic, role-based masking and deny,
   driven by [Cedar](https://www.cedarpolicy.com/) policy over per-column tags.
@@ -34,7 +34,7 @@ A split control plane (Kotlin/JVM) and data plane (Go), talking over gRPC:
 
 - **`goproxy`** (Go) — the data-plane wire proxy: protocol codecs, token auth, a
   per-statement `Decide` call to the control plane, inline result masking, and
-  the backend broker.
+  the target-DB broker.
 - **`control-plane`** (Kotlin) — identity and roles (OIDC), Cedar policy, the
   catalog, the per-statement decision, and the admin/console API.
 - **`analyzer`** (Go, reached from the JVM through a Foreign Function & Memory

--- a/analyzer/probe/engine.go
+++ b/analyzer/probe/engine.go
@@ -35,7 +35,7 @@ type engine interface {
 	// are marked by the TEMPORARY keyword).
 	IsTempSchema(schema exp.Expression) bool
 	// RewriteStatement optionally rewrites a parsed statement into the SQL the proxy should relay to the
-	// backend, returning "" to leave it unchanged.
+	// target DB, returning "" to leave it unchanged.
 	RewriteStatement(root exp.Expression) string
 }
 
@@ -80,7 +80,7 @@ func newMySQLEngine(config *pb.EngineConfig) (*mysqlEngine, error) {
 	// conditional mysql_ansi_quotes into a single settings string resolved by GetOrRaise. ansi_quotes MUST
 	// go through settings resolution rather than a direct field-set: it rewrites the tokenizer config
 	// (applyMySQLAnsiQuotes — `"` becomes a quoted-identifier delimiter, not a string), which only runs at
-	// resolution time. When the backend's live sql_mode carries ANSI_QUOTES, the analyzer then reads a
+	// resolution time. When the target DB's live sql_mode carries ANSI_QUOTES, the analyzer then reads a
 	// masked column quoted with `"` as the real column and still masks it (instead of the proxy having to
 	// fail the connection closed). mysqlNormalizationDialect only ever sets the strategy, so its
 	// SettingsString round-trips losslessly as the base.
@@ -113,7 +113,7 @@ func (e *mysqlEngine) FoldColumn(column string) string {
 func (e *mysqlEngine) IsTempSchema(exp.Expression) bool { return false }
 
 // RewriteStatement pins a single, session-scoped `SET character_set_results = NULL` — the default MySQL
-// Connector/J (and so DBeaver) session-init, which asks the backend to return each column in its own charset
+// Connector/J (and so DBeaver) session-init, which asks the target DB to return each column in its own charset
 // for client-side decoding — to utf8mb4, so the wire masker keeps decoding results as UTF-8. Only that exact
 // form is rewritten; a compound SET, GLOBAL/PERSIST scope, a same-named user variable, a qualified or
 // bogus-scoped target, or any non-NULL value is left untouched (and still fails closed at the wire session

--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -149,7 +149,7 @@ func EmitFacts(sql string, engineConfig *pb.EngineConfig, sch *schema.Mapping, n
 			facts = unanalyzableFacts("PARSE", fmt.Sprintf("unsupported root %s", exp.ClassName(root.Kind())))
 		}
 	}
-	// The engine may rewrite the statement into what the proxy relays to the backend — MySQL pins
+	// The engine may rewrite the statement into what the proxy relays to the target DB — MySQL pins
 	// `character_set_results = NULL` to utf8mb4 so results stay UTF-8 for the wire masker. Emitted as
 	// rewritten_sql: the data plane relays it while authorization and audit keep the client's original. A
 	// lineage-driven rewrite (the `*`-expansion) already set on an analyzed statement takes precedence.
@@ -292,10 +292,10 @@ func isTemporaryDDL(root exp.Expression, eng engine) bool {
 
 func factsFromProbe(report ProbeResult) *pb.StatementFacts {
 	facts := &pb.StatementFacts{
-		Resolved:       report.Resolved,
-		Detail:         report.Detail,
-		RewrittenSql:   report.RewrittenSQL,
-		Functions:      append([]string(nil), report.Functions...),
+		Resolved:     report.Resolved,
+		Detail:       report.Detail,
+		RewrittenSql: report.RewrittenSQL,
+		Functions:    append([]string(nil), report.Functions...),
 	}
 	if !report.Resolved {
 		facts.FailureClass = pb.FailureClass_FAILURE_CLASS_UNANALYZABLE
@@ -374,7 +374,7 @@ func sessionUtilityFacts(command string) *pb.StatementFacts {
 }
 
 // sessionIdentitySetCommand returns the system-classified Utility command for a structured Set that
-// changes, or persistently reconfigures, session/user identity on a shared backend session, or "" if it
+// changes, or persistently reconfigures, session/user identity on a shared target-DB session, or "" if it
 // does not. It catches every spelling that means such an escalation — keying on only one leaves a
 // privilege-escalation bypass:
 //   - the keyword forms SET ROLE / SET DEFAULT ROLE / SET SESSION AUTHORIZATION, which sqlglot-go models as
@@ -418,7 +418,7 @@ func sessionIdentitySetCommand(root exp.Expression) string {
 }
 
 // lexerModeGucs name the session variables whose value changes how the SQL lexer parses SUBSEQUENT
-// statements on the connection. The analyzer parses under a fixed per-engine dialect, so if the backend's
+// statements on the connection. The analyzer parses under a fixed per-engine dialect, so if the target DB's
 // effective mode diverges (ANSI_QUOTES makes "x" an identifier, NO_BACKSLASH_ESCAPES/standard_conforming_
 // strings change string escaping) a later statement means something different on the wire than the
 // analyzer saw. Their assignment is therefore only allowed with a value the analyzer can read at parse
@@ -451,7 +451,7 @@ func emitSetFacts(root exp.Expression, eng engine) *pb.StatementFacts {
 // passthrough). Substring-matching the rendered SQL is not enough: MySQL evaluates the RHS, so
 // `SET sql_mode = @m`, `SET sql_mode = CONCAT('AN','SI_QUOTES')`, or any function/subquery can resolve to
 // ANSI_QUOTES while the rendered text carries no such token — the analyzer would keep parsing the old
-// dialect while the backend flips the lexer. So an unreadable RHS (and DEFAULT, a server value the
+// dialect while the target DB flips the lexer. So an unreadable RHS (and DEFAULT, a server value the
 // analyzer cannot see) is gated too. Denial then lives in Cedar via the command's system:critical tag.
 func lexerModeUtilityCommand(root exp.Expression) string {
 	for _, item := range root.FindAll(exp.KindSetItem) {
@@ -526,7 +526,7 @@ func emitCommandFacts(root exp.Expression, eng engine) *pb.StatementFacts {
 		// TRANSACTION / CONSTRAINTS / TIME ZONE, the identity forms (SET [SESSION|LOCAL] ROLE / DEFAULT ROLE /
 		// SESSION AUTHORIZATION and the GUC-alias `SET role = x`), the lexer-mode gucs, and the credential.
 		// What degrades to Command is a genuinely-unanalyzable spelling or a form the analyzer cannot vouch
-		// for — a quoted-keyword laundering attempt (`SET "ROLE" admin`, which the backend also rejects), a
+		// for — a quoted-keyword laundering attempt (`SET "ROLE" admin`, which the target DB also rejects), a
 		// value the analyzer cannot read, or an engine construct not yet modeled. Fail closed UNIFORMLY on
 		// both engines: an unstructured SET the analyzer never classified must never relay via an
 		// engine-specific passthrough.
@@ -867,19 +867,19 @@ func passthroughFacts() *pb.StatementFacts {
 // gets its computed kind there instead (so an unanalyzable ALTER still reports ALTER_TABLE).
 func inadmissibleFacts(stage, detail string) *pb.StatementFacts {
 	return &pb.StatementFacts{
-		Resolved:       false,
-		FailureClass:   pb.FailureClass_FAILURE_CLASS_INADMISSIBLE,
-		FailedStage:    strPtr(stage),
-		Detail:         truncateDetail(detail),
+		Resolved:     false,
+		FailureClass: pb.FailureClass_FAILURE_CLASS_INADMISSIBLE,
+		FailedStage:  strPtr(stage),
+		Detail:       truncateDetail(detail),
 	}
 }
 
 func unanalyzableFacts(stage, detail string) *pb.StatementFacts {
 	return &pb.StatementFacts{
-		Resolved:       false,
-		FailureClass:   pb.FailureClass_FAILURE_CLASS_UNANALYZABLE,
-		FailedStage:    strPtr(stage),
-		Detail:         truncateDetail(detail),
+		Resolved:     false,
+		FailureClass: pb.FailureClass_FAILURE_CLASS_UNANALYZABLE,
+		FailedStage:  strPtr(stage),
+		Detail:       truncateDetail(detail),
 	}
 }
 
@@ -892,8 +892,8 @@ func unanalyzableFacts(stage, detail string) *pb.StatementFacts {
 // authorized only by the escape hatch built for statements nobody can prove safe, and denied elsewhere.
 func ddlFacts(root exp.Expression, eng engine) *pb.StatementFacts {
 	return &pb.StatementFacts{
-		Resolved:       true,
-		FailureClass:   pb.FailureClass_FAILURE_CLASS_UNSPECIFIED,
+		Resolved:     true,
+		FailureClass: pb.FailureClass_FAILURE_CLASS_UNSPECIFIED,
 		// A temp-scoped DDL target is session-local, so it changes no shared catalog and must not force
 		// every other connection to re-measure.
 		CatalogChanging: !isTemporaryDDL(root, eng),

--- a/analyzer/probe/mysql_statement_coverage_test.go
+++ b/analyzer/probe/mysql_statement_coverage_test.go
@@ -351,8 +351,8 @@ var mysqlStatements = []mysqlStatement{
 	{"SHOW ENGINE INNODB STATUS", "SHOW ENGINE INNODB STATUS", "stmt.kind.show_engine_status + utility:SHOW_ENGINE_STATUS", pb.StatementKind_STATEMENT_KIND_SHOW_ENGINE_STATUS},
 	{"SHOW BINLOG EVENTS", "SHOW BINLOG EVENTS", "stmt.kind.show_binlog_events + utility:SHOW_BINLOG_EVENTS", pb.StatementKind_STATEMENT_KIND_SHOW_BINLOG_EVENTS},
 	{"SHOW RELAYLOG EVENTS", "SHOW RELAYLOG EVENTS", "stmt.kind.show_relaylog_events + utility:SHOW_RELAYLOG_EVENTS", pb.StatementKind_STATEMENT_KIND_SHOW_RELAYLOG_EVENTS},
-	{"SHOW BINARY LOGS", "SHOW BINARY LOGS", "stmt.kind.show_binary_logs", pb.StatementKind_STATEMENT_KIND_SHOW_BINARY_LOGS},            // GAP: needs REPLICATION CLIENT
-	{"SHOW MASTER STATUS", "SHOW MASTER STATUS", "stmt.kind.show_master_status", pb.StatementKind_STATEMENT_KIND_SHOW_MASTER_STATUS},    // GAP: needs REPLICATION CLIENT
+	{"SHOW BINARY LOGS", "SHOW BINARY LOGS", "stmt.kind.show_binary_logs", pb.StatementKind_STATEMENT_KIND_SHOW_BINARY_LOGS},                  // GAP: needs REPLICATION CLIENT
+	{"SHOW MASTER STATUS", "SHOW MASTER STATUS", "stmt.kind.show_master_status", pb.StatementKind_STATEMENT_KIND_SHOW_MASTER_STATUS},          // GAP: needs REPLICATION CLIENT
 	{"SHOW BINARY LOG STATUS", "SHOW BINARY LOG STATUS", "unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_STMT_UNKNOWN}, // 8.4 rename; degrades to Command, fails closed (unlike SHOW MASTER STATUS)
 	{"SHOW REPLICA STATUS", "SHOW REPLICA STATUS", "stmt.kind.show_replica_status + utility:SHOW_REPLICA_STATUS", pb.StatementKind_STATEMENT_KIND_SHOW_REPLICA_STATUS},
 	{"SHOW SLAVE STATUS", "SHOW SLAVE STATUS", "stmt.kind.show_replica_status + utility:SHOW_REPLICA_STATUS", pb.StatementKind_STATEMENT_KIND_SHOW_REPLICA_STATUS},

--- a/analyzer/probe/mysql_version_gate_test.go
+++ b/analyzer/probe/mysql_version_gate_test.go
@@ -3,8 +3,8 @@ package probe
 import (
 	"testing"
 
-	"github.com/ridi-oss/sqlglot-go/schema"
 	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
+	"github.com/ridi-oss/sqlglot-go/schema"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/analyzer/probe/newly_parseable_conservation_test.go
+++ b/analyzer/probe/newly_parseable_conservation_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
 	sqlglot "github.com/ridi-oss/sqlglot-go"
 	exp "github.com/ridi-oss/sqlglot-go/expressions"
-	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/analyzer/probe/pb/analyzer.pb.go
+++ b/analyzer/probe/pb/analyzer.pb.go
@@ -842,7 +842,7 @@ type EngineConfig struct {
 	// MySQL's server-level lower_case_table_names setting (0..2), required for MySQL. Absent for
 	// PostgreSQL, which has no equivalent setting.
 	MysqlLowerCaseTableNames *int32 `protobuf:"varint,3,opt,name=mysql_lower_case_table_names,json=mysqlLowerCaseTableNames,proto3,oneof" json:"mysql_lower_case_table_names,omitempty"`
-	// Whether the backend's live MySQL session sql_mode has ANSI_QUOTES active. When true the analyzer
+	// Whether the target DB's live MySQL session sql_mode has ANSI_QUOTES active. When true the analyzer
 	// builds the MySQL dialect with the mysql_ansi_quotes tokenizer state, so `"col"` parses as a quoted
 	// IDENTIFIER (a masked column read) rather than a string literal — matching the server, so a masked
 	// column quoted with `"` is still masked instead of leaking cleartext. sql_mode is mutable per
@@ -978,7 +978,7 @@ func (x *AnalyzeRequest) GetEngineConfig() *EngineConfig {
 	return nil
 }
 
-// One physical backend relation the statement scans (docs/facts-emission.md). catalog/schema/table
+// One physical target-DB relation the statement scans (docs/facts-emission.md). catalog/schema/table
 // is the resolved identity; covered is true once at least one traced column fact names this table
 // (see probe.go's SourceInfo doc comment for the full per-table coverage rationale).
 type SourceInfo struct {
@@ -1512,7 +1512,7 @@ type StatementFacts struct {
 	FailedStage *string `protobuf:"bytes,3,opt,name=failed_stage,json=failedStage,proto3,oneof" json:"failed_stage,omitempty"`
 	// Stable diagnostic detail for audit. Empty failure detail is still a denial, never an allow.
 	Detail string `protobuf:"bytes,4,opt,name=detail,proto3" json:"detail,omitempty"`
-	// Ordered backend output names; RequireResultReadGrant.output_ordinals indexes this exact list.
+	// Ordered target-DB output names; RequireResultReadGrant.output_ordinals indexes this exact list.
 	OutputColumns []string `protobuf:"bytes,7,rep,name=output_columns,json=outputColumns,proto3" json:"output_columns,omitempty"`
 	// Safe analyzer rewrite (currently faithful star expansion); absent means relay the client's SQL.
 	RewrittenSql *string `protobuf:"bytes,9,opt,name=rewritten_sql,json=rewrittenSql,proto3,oneof" json:"rewritten_sql,omitempty"`

--- a/analyzer/probe/probe.go
+++ b/analyzer/probe/probe.go
@@ -37,7 +37,7 @@ type OriginInfo struct {
 	Derived bool `json:"derived,omitempty"`
 }
 
-// SourceInfo is one physical backend relation the statement scans (docs/facts-emission.md).
+// SourceInfo is one physical target-DB relation the statement scans (docs/facts-emission.md).
 // `Table` is the fully-qualified `catalog.schema.table` identity. `Covered` is true when at least one
 // traced column fact (an origin base or a reference) names this table — meaning the existing column
 // authorization already gates the scan. An UNCOVERED table (Covered=false) is a scan that reads the
@@ -774,7 +774,7 @@ func generateExecutableSQL(root exp.Expression, dialect *dialects.Dialect) (stri
 	executable := root.Copy()
 	// Catalog is part of the analyzer's identity, but neither PostgreSQL nor MySQL accepts it as an
 	// executable third table-name component. Keep the real schema/database qualification and remove only
-	// the analyzer-only catalog from the copy rendered for backend execution.
+	// the analyzer-only catalog from the copy rendered for target-DB execution.
 	for _, table := range executable.FindAll(exp.KindTable) {
 		table.Set("catalog", nil)
 	}

--- a/analyzer/probe/probe_test.go
+++ b/analyzer/probe/probe_test.go
@@ -4,9 +4,9 @@ import (
 	"reflect"
 	"testing"
 
+	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
 	sqlglot "github.com/ridi-oss/sqlglot-go"
 	exp "github.com/ridi-oss/sqlglot-go/expressions"
-	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/analyzer/probe/schema_threading_test.go
+++ b/analyzer/probe/schema_threading_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
 	sqlglot "github.com/ridi-oss/sqlglot-go"
 	exp "github.com/ridi-oss/sqlglot-go/expressions"
-	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -83,7 +83,7 @@ func requireResolvedKeys(t *testing.T, result *ProbeResult, expected ...string) 
 }
 
 // PostgreSQL quoted and unquoted cases are part of the byte-identity oracle: the emitted
-// catalog.schema.table.column spelling must match the backend's identifier identity exactly.
+// catalog.schema.table.column spelling must match the target DB's identifier identity exactly.
 func TestSchemaThreadingPostgresResolution(t *testing.T) {
 	cases := []struct {
 		name string
@@ -159,7 +159,7 @@ func TestSchemaThreadingOrderedSearchPath(t *testing.T) {
 }
 
 // Together with the PostgreSQL quoted-identifier cases above, these case-mode assertions form the
-// Byte-identity oracle: emitted catalog.schema.table.column keys must match backend folding exactly.
+// Byte-identity oracle: emitted catalog.schema.table.column keys must match target DB folding exactly.
 func TestSchemaThreadingMySQLCaseModes(t *testing.T) {
 	cols := []*pb.ColumnSpec{
 		columnSpec("def", "App", "Users", "ID", "BIGINT"),
@@ -376,7 +376,7 @@ func TestSchemaThreadingWriteSourceResolution(t *testing.T) {
 }
 
 // A mixed-case CTE in a write binds case-insensitively on PostgreSQL
-// (the backend folds `Orders` ≡ `orders`), so its masked source column MUST reach the write's lineage.
+// (the target-DB folds `Orders` ≡ `orders`), so its masked source column MUST reach the write's lineage.
 // public.orders deliberately HAS an `amount` column, so a CTE ref misclassified as the physical
 // public.orders would RESOLVE to the unmasked public.orders.amount and silently ALLOW — the exact
 // fail-open. Before folding identifiers ahead of write-scope classification, that is what happened.
@@ -411,7 +411,7 @@ func TestSchemaThreadingWriteCTECaseFold(t *testing.T) {
 
 // PG folds UNQUOTED identifiers ASCII-only (`CAFÉ` → `cafÉ`,
 // the É preserved), not full-Unicode. A distinct column `café` (e.g. quoted-created, ordinary) can
-// coexist with `cafÉ` (PII). An unquoted `CAFÉ` MUST resolve to `cafÉ` — matching the backend — not
+// coexist with `cafÉ` (PII). An unquoted `CAFÉ` MUST resolve to `cafÉ` — matching the target DB — not
 // over-fold to `café` and pick up the wrong column's policy. Requires sqlglot-go >= v0.2.0 (which folds
 // PG identifiers ASCII-only instead of strings.ToLower).
 func TestSchemaThreadingPostgresAsciiOnlyFold(t *testing.T) {

--- a/analyzer/probe/statement_facts_test.go
+++ b/analyzer/probe/statement_facts_test.go
@@ -185,7 +185,7 @@ func TestStatementFactsNoFromUnknownFunctionGrant(t *testing.T) {
 
 func TestStatementFactsUserTypeCastGated(t *testing.T) {
 	// A cast or typed literal to a user (non-built-in) type runs that type's coercion / DOMAIN CHECK — a
-	// user function — on the shared backend session: code execution + an error-channel leak. It resolves
+	// user function — on the shared target-DB session: code execution + an error-channel leak. It resolves
 	// carrying a USER_TYPE_CAST Utility grant (system:critical), gated in every position: no-FROM CAST/::,
 	// a qualified target, and a with-FROM read (the domain code runs regardless of the FROM).
 	for _, sql := range []string{
@@ -322,7 +322,7 @@ func TestStatementFactsStructuredSessionForms(t *testing.T) {
 func TestStatementFactsLexerModeAssignmentGated(t *testing.T) {
 	// A lexer-mode GUC must only be assigned a value the analyzer can read at parse time. MySQL evaluates
 	// the RHS, so a session variable, CONCAT, or DEFAULT can resolve to ANSI_QUOTES while the rendered
-	// text carries no such token — the analyzer would keep parsing the old dialect while the backend
+	// text carries no such token — the analyzer would keep parsing the old dialect while the target DB
 	// flipped the lexer, so a later `SELECT "ssn" FROM users` returns the protected identifier's value.
 	// A value that flips the lexer, or one the analyzer cannot read at parse time, resolves carrying a
 	// system:critical Utility grant (the control-plane floor forbids it) — not a hard admission deny.

--- a/analyzer/probe/testdata/oracle/probe.py
+++ b/analyzer/probe/testdata/oracle/probe.py
@@ -313,7 +313,7 @@ def _leaf_selects(setop):
 
 
 def _from_source_order(sel):
-    """Alias order of FROM/JOIN sources, left-to-right — the order the backend expands a bare `SELECT *`
+    """Alias order of FROM/JOIN sources, left-to-right — the order the target DB expands a bare `SELECT *`
     into (and thus the wire column order the mask ordinals must match). sqlglot's expand_stars instead
     orders physical tables before derived tables, so bare-`*` origins must be re-sorted to this order."""
     order = []
@@ -371,7 +371,7 @@ def _expandable_sources(sel):
 
 def _resort_bare_star_inplace(osel, qsel):
     """Mutate qsel's projections: re-sort the bare `*`'s expanded BLOCK into FROM-source order, so the
-    serialized query's column order (which the backend echoes verbatim, since we send explicit columns)
+    serialized query's column order (which the target DB echoes verbatim, since we send explicit columns)
     equals the order origins index — and matches native `SELECT *` for the client. sqlglot expands physical
     tables before derived tables; the DB uses FROM order. `osel` (pre-qualify) locates the bare Star and
     the explicit projections around it (each a single column, since a bare `*` mixed with ANOTHER star is
@@ -533,7 +533,7 @@ def probe(sql, dialect, schema):
     # and PG folds unquoted identifiers to lowercase, but sqlglot preserves spelling — so a MySQL
     # `SELECT * FROM Users` never matches the lowercase catalog, silently leaving `*` unexpanded (a full
     # bypass), and `Users.Ssn` resolves to an origin string that misses the policy key. Normalize UNQUOTED
-    # identifiers on this analysis copy (the query the backend runs is untouched) and match a lowercased
+    # identifiers on this analysis copy (the query the target DB runs is untouched) and match a lowercased
     # schema, so resolution + policy matching are case-insensitive. For MySQL, also fold QUOTED identifiers:
     # MySQL column names are always case-insensitive and `` `Users`.`SSN` `` otherwise skips the policy key
     # (a leak) or fails the column-existence check as unknown (an over-deny). PG quoted idents ARE
@@ -636,7 +636,7 @@ def probe(sql, dialect, schema):
         qroot.set("tables", None)
 
     # Drop DEAD (unreferenced) CTEs before analysis. Postgres/MySQL don't execute an unreferenced CTE, so
-    # its clauses never touch the backend — but the reference sweeps below would still scan them, so a
+    # its clauses never touch the target DB — but the reference sweeps below would still scan them, so a
     # throwaway `WITH dead AS (SELECT id FROM users WHERE ssn='x') SELECT … FROM orders` would over-deny
     # an unrelated live query. Iterate to a fixpoint: dropping one dead CTE can orphan another that only
     # it referenced. (Safe: a CTE referenced anywhere outside its own body is kept, so this can never drop
@@ -839,7 +839,7 @@ def probe(sql, dialect, schema):
             # Like add_clause, but for ORDER BY / GROUP BY, which can reference an output ALIAS or a
             # positional ORDINAL. sqlglot leaves those as a bare, unbindable ref (or an int literal), so
             # resolve them back to that projection's base columns — else a masked column used as a sort/
-            # dedup key (the backend sorts/dedups on CLEARTEXT before masking) leaks and is missed.
+            # dedup key (the target DB sorts/dedups on CLEARTEXT before masking) leaks and is missed.
             projs = sel.selects
             for t in terms:
                 if t is None or _enclosing_opaque(t, opaque_selects) is not None:
@@ -1035,11 +1035,11 @@ def probe(sql, dialect, schema):
                 if src is not None:
                     references[OTHER] |= _src_all_cols(src)
 
-        # ---- proxy-side `*` expansion (reads only): the mask binds by ORDINAL, so the backend's wire
-        # column order MUST equal the order origins index. Rather than PREDICT the backend's native `*`
+        # ---- proxy-side `*` expansion (reads only): the mask binds by ORDINAL, so the target DB's wire
+        # column order MUST equal the order origins index. Rather than PREDICT the target DB's native `*`
         # order — fragile: it assumes the catalog's column order matches the live DB, and needs every
         # FROM source type enumerated (the whack-a-mole that leaked LATERAL/VALUES/unnest) — we EXPAND `*`
-        # here and hand the proxy explicit columns to send: the backend then echoes OUR order, so
+        # here and hand the proxy explicit columns to send: the target DB then echoes OUR order, so
         # origins-ordinal == wire-position BY CONSTRUCTION (and stays correct even if the catalog drifts
         # from the DB's physical column order). Every starred select must sit inside the proven-faithful
         # envelope (verified byte-identical vs live PG+MySQL) else fail closed; a sole bare `*` is re-sorted
@@ -1092,7 +1092,7 @@ def probe(sql, dialect, schema):
                 #  2. `*` expands to the CATALOG's columns, so `SELECT *` returns catalog columns, not
                 #     necessarily the live table's — a column the DB has but the catalog lacks is silently
                 #     dropped from the result (protected columns are still masked at their ordinal; nothing
-                #     unknown is ever revealed). Keep the catalog in sync with the backend schema.
+                #     unknown is ever revealed). Keep the catalog in sync with the target-DB schema.
                 rewritten_sql = qroot.sql(dialect=dialect)
 
         # ---- origins: a top-level output is maskable ONLY if it is the value-preserving IDENTITY of a
@@ -1301,7 +1301,7 @@ def probe(sql, dialect, schema):
         return {"resolved": True, "failedStage": None, "detail": "ok",
                 "outputColumns": len(origins), "tracedColumns": traced,
                 "origins": origins, "references": refs_out, "isWrite": is_write,
-                # the expanded query the proxy must send so the backend echoes the order origins index
+                # the expanded query the proxy must send so the target DB echoes the order origins index
                 # (null = no `*` on a read root; send the original verbatim). See the expansion block above.
                 "rewrittenSql": rewritten_sql}
     except Exception as e:

--- a/analyzer/probe/wire.go
+++ b/analyzer/probe/wire.go
@@ -8,8 +8,8 @@ package probe
 import (
 	"fmt"
 
-	"github.com/ridi-oss/sqlglot-go/schema"
 	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
+	"github.com/ridi-oss/sqlglot-go/schema"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -71,7 +71,7 @@ import kotlin.time.Duration.Companion.seconds
 /** How often the background sweep deletes expired result rows. */
 private const val RESULT_PURGE_INTERVAL_MS = 15 * 60 * 1000L
 
-/** An editor session idle longer than this is reaped (its proxy stream + backend connection freed).
+/** An editor session idle longer than this is reaped (its proxy stream + target-DB connection freed).
  *  Swept on the same timer as RESULT_PURGE_INTERVAL_MS. */
 private const val EDITOR_SESSION_MAX_IDLE_MS = 30 * 60 * 1000L
 
@@ -443,7 +443,7 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
                 runCatching { queryResultStore.purgeExpired() }
                     .onFailure { environment.log.warn("result purge failed", it) }
             }
-            // Reap editor sessions idle past the cutoff — releases the held proxy stream + backend
+            // Reap editor sessions idle past the cutoff — releases the held proxy stream + target DB
             // connection + revokes the per-session token, so an abandoned editor tab doesn't pin resources.
             runCatching { runExecService.sweepIdleSessions(EDITOR_SESSION_MAX_IDLE_MS) }
                 .onFailure { environment.log.warn("editor session idle sweep failed", it) }
@@ -694,7 +694,7 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
 
         // Enforcing SQL query endpoint (deny + result masking; effective roles come from RoleResolver).
         queryRoutes(config, datasourceStore, queryHistoryStore, runExecService)
-        // Persistent editor sessions (one held proxy stream / backend connection per session)
+        // Persistent editor sessions (one held proxy stream / target-DB connection per session)
         // whose submits run async as auto-approved EDITOR tasks with saved, task.assume-gated results.
         editorSessionRoutes(
             config, datasourceStore, accessStore, queryResultStore, policyStore, userGroupStore,

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Config.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Config.kt
@@ -150,10 +150,10 @@ data class Config(
         const val MAX_QUERY_TIMEOUT_SECONDS = 9_223_372_006L
 
         // The control-plane's per-statement exchange budget sits this far above the configured query
-        // timeout so the proxy's PM_QUERY_TIMEOUT watchdog — which starts later, at backend exec — fires
+        // timeout so the proxy's PM_QUERY_TIMEOUT watchdog — which starts later, at target-DB exec — fires
         // first and cancels the statement in-band, rather than the CP exchange pre-empting it.
         // Headroom the exchange budget adds over the proxy's own statement watchdog. It has to absorb
-        // everything the proxy does around the guarded execution — the watchdog wraps only the backend
+        // everything the proxy does around the guarded execution — the watchdog wraps only the target DB
         // statement, while authorization and the catalog probes before it run outside that guard and have
         // been measured in the tens of seconds against a large remote catalog. Too small and the control
         // plane calls a timeout on a statement whose watchdog has not fired, blaming the query for time

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ConnectionCatalog.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ConnectionCatalog.kt
@@ -15,10 +15,10 @@ private const val CONNECTION_ID_BYTES = 16
 
 /**
  * How long a connection may hold a schema fragment before re-measuring it. This is the backstop for drift the
- * control plane never learned about — DDL run straight against the backend, which no push reports — so it
+ * control plane never learned about — DDL run straight against the target DB, which no push reports — so it
  * bounds how long such a change can go unnoticed.
  *
- * Set above the proxy's ambient refresh interval, which re-reads the whole backend catalog and, through
+ * Set above the proxy's ambient refresh interval, which re-reads the whole target-DB catalog and, through
  * [ConnectionCatalogRegistry.recordAmbientMeasurement], re-measures the pooled fragments it still agrees
  * with. That cycle is what detects out-of-band DDL; this bound is the ceiling for a connection whose
  * schemas the refresh did not confirm, so it only has to sit far enough above the interval that an ordinary
@@ -45,10 +45,10 @@ data class SchemaFragment(val key: PoolKey, val hash: ContentHash, val columns: 
 data class PooledFragment(val fragment: SchemaFragment, val refCount: Int)
 
 /**
- * [measuredNanos] is when THIS datasource's backend was last read and found to hold this content — the
+ * [measuredNanos] is when THIS datasource's target DB was last read and found to hold this content — the
  * evidence a connection inherits when it adopts. It lives here rather than on [PooledFragment] because
  * identical content is pooled once and shared across datasources, while a reading only ever speaks for the
- * backend it came from.
+ * target DB it came from.
  */
 data class Authoritative(
     val hash: ContentHash,
@@ -100,7 +100,7 @@ sealed interface CatalogMutationResult {
 /**
  * Ephemeral, fail-closed enforcement catalog state. The wire exposes datasource/principal/token-kind but no
  * proxy-instance identifier, so [Binding] binds exactly those authoritative fields; backend_generation binds
- * the first backend-connection instance that successfully pushes and thereafter advances monotonically.
+ * the first target-DB-connection instance that successfully pushes and thereafter advances monotonically.
  */
 class ConnectionCatalogRegistry(
     private val clockNanos: () -> Long = System::nanoTime,
@@ -160,9 +160,9 @@ class ConnectionCatalogRegistry(
                 val auth = authoritative[connection.binding.datasourceName to schema]
                 val pooled = auth?.let { pool[it.pooledRef] }
                 // Where a scan cannot vary by connection, content another connection already measured is
-                // this connection's answer too, so it starts from that instead of putting a backend fetch in
+                // this connection's answer too, so it starts from that instead of putting a target-DB fetch in
                 // front of the first query. lastVerifiedNanos carries the original measurement time rather
-                // than now: the staleness gate must keep counting from when the backend was actually read, or
+                // than now: the staleness gate must keep counting from when the target DB was actually read, or
                 // a stream of new connections would refresh the clock forever and the bound would never fire.
                 if (adoptHeldContent && auth != null && pooled != null) {
                     retain(pooled.fragment, 1)
@@ -299,7 +299,7 @@ class ConnectionCatalogRegistry(
             // Authoritative is ACCEPT-ordered (last accepted push wins, via a monotonic epoch), NOT
             // content-monotonic: an accepted push from a lagging read-replica may legitimately set an older
             // content hash. This is a liveness hint, never a correctness input — every connection decides
-            // against exactly what ITS OWN backend binds (freshnessGate re-verifies per connection). Under a
+            // against exactly what ITS OWN target DB binds (freshnessGate re-verifies per connection). Under a
             // primary+replica pool a lagging push can regress this and cause bounded before_decide churn on
             // siblings (each self-heals in one round-trip); damping that is a deferred liveness optimization.
             authoritative[authKey] = Authoritative(pushedHash, key, authoritativeEpoch.incrementAndGet(), now)
@@ -417,7 +417,7 @@ class ConnectionCatalogRegistry(
      * Fold a whole-catalog measurement from the proxy's ambient refresh into this datasource's authoritative
      * entries.
      *
-     * The refresh reads every schema from the backend with the same six fields a fragment holds, so for a
+     * The refresh reads every schema from the target DB with the same six fields a fragment holds, so for a
      * schema whose columns are byte-identical it is a genuine re-measurement of exactly that content — the
      * same evidence a connection's own hash probe produces. Recording it advances the authoritative entry's
      * measurement time, so the staleness gate counts from this reading rather than from the first time the
@@ -426,11 +426,11 @@ class ConnectionCatalogRegistry(
      * Recorded on the authoritative entry, NOT on the pooled fragment: identical system-schema content is
      * pooled once per engine version and shared by every datasource on it ([poolKey]), so writing the time
      * there would let one datasource's refresh vouch for another's schema that nobody read. Freshness is
-     * evidence about one backend; only the content itself is shareable.
+     * evidence about one target DB; only the content itself is shareable.
      *
      * Deliberately narrow: a schema whose columns differ is left untouched, so this can only ever confirm
      * content, never install it. Divergence stays the job of the connection's own probe, which alone knows
-     * what that connection's backend binds.
+     * what that connection's target DB binds.
      *
      * Returns the schemas confirmed, for logging.
      */
@@ -462,7 +462,7 @@ class ConnectionCatalogRegistry(
      * The persisted catalog is already cleared on a retarget, because keeping it would authorize the new
      * target against the old schema. This state is the same hazard: a connection opening afterwards would
      * otherwise adopt structure measured from the database that is no longer there, and decide against a
-     * catalog its backend never had. Dropping the entries makes the next connection measure for itself.
+     * catalog its target DB never had. Dropping the entries makes the next connection measure for itself.
      *
      * Live connections are left alone — each already holds its own reference and re-verifies on its own
      * clock, and tearing their content out mid-session would empty structuralRows under an in-flight

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Engines.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Engines.kt
@@ -136,7 +136,7 @@ fun Engine.isSystemSchema(schema: String): Boolean = when (this) {
  * it.
  *
  * Where this is true, a connection may start from catalog content the control plane already holds rather than
- * measuring the backend itself.
+ * measuring the target DB itself.
  */
 val Engine.catalogIsConnectionIndependent: Boolean
     get() = when (this) {

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ProxyEventsHub.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ProxyEventsHub.kt
@@ -97,7 +97,7 @@ class ProxyEventsHub {
 
     /**
      * Hand [event] to exactly one attached replica. The first non-blocking send that succeeds wins;
-     * broadcasting would make every replica open a backend connection for the same request.
+     * broadcasting would make every replica open a target-DB connection for the same request.
      *
      * A channel that refuses the event is deregistered here rather than left in place. It cannot serve a
      * later request either, and leaving it registered means `attached()` keeps reporting a proxy that
@@ -132,7 +132,7 @@ class ProxyEventsHub {
 
     /**
      * Ask exactly one attached proxy replica to dial a run stream. The first successful non-blocking
-     * send wins; broadcasting would make every replica open a backend connection for the same CP request.
+     * send wins; broadcasting would make every replica open a target-DB connection for the same CP request.
      */
     fun requestOpenRun(
         name: String,

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -145,7 +145,7 @@ data class DecisionContext(
     val passthrough: Boolean,
     val structural: Boolean = false,
     /** ALLOW/MASK only: the `*`-expanded query the wire proxy must send instead of the client's original
-     * so backend column order matches the mask ordinals. Null = send verbatim. */
+     * so target-DB column order matches the mask ordinals. Null = send verbatim. */
     val rewrittenSql: String? = null,
     /** The analyzer's ordered output column names for this decision (an empty list for a passthrough /
      * unanalyzed statement). APPROVAL live result viewing compares this against the stored execute-enforced
@@ -162,7 +162,7 @@ data class DecisionContext(
     /** MASK-only capability grant. A proxy may relay an unmaskable binary result unmasked iff this is true
      * AND the proxy's local feature capability says that relay path is supported. */
     val unmaskablePermitted: Boolean = false,
-    /** Whether the proxy must strip this statement's backend diagnostics to code + severity — set
+    /** Whether the proxy must strip this statement's target-DB diagnostics to code + severity — set
      * when the principal is not a full-cleartext reader of this datasource AND the diagnostic could carry a
      * protected value (engine leaks on ALLOW, or the verdict touches protected data). See redactsDiagnostics
      * and docs/diagnostic-redaction.md. */
@@ -178,7 +178,7 @@ data class DecisionContext(
 )
 
 /**
- * Whether a decision's backend diagnostics must be stripped to code + severity. Redact iff the
+ * Whether a decision's target-DB diagnostics must be stripped to code + severity. Redact iff the
  * diagnostic could carry a protected value — the verdict touches protected data (MASK/DENY), or the engine
  * leaks even on an ALLOW ([leaksDiagnosticsOnAllow]) — AND the principal is NOT a full-cleartext reader
  * of the datasource ([mayReadUnmasked], the Cedar `result.read.unmasked`-on-datasource authorization: ALLOW
@@ -397,7 +397,7 @@ fun decideQuery(
     // Keyed off ds.engineVersion, path-agnostic (CP-introspect + proxy PushCatalog).
     systemClassification: SystemClassificationService? = null,
     // The connection's session/temp columns (proxy-introspected off its held connection), overlaid
-    // onto the base catalog so a bare name resolves to the temp the backend binds. Empty for one-shot/wire.
+    // onto the base catalog so a bare name resolves to the temp the target DB binds. Empty for one-shot/wire.
     tempColumns: List<CatalogColumn> = emptyList(),
     // TEST-ONLY seam. When non-null, the grant walk runs over these StatementFacts instead of analyzing
     // [sql] — the ONLY way to exercise the fail-closed contract branches (an UNSPECIFIED disposition, a
@@ -986,7 +986,7 @@ data class EditorTaskStatus(val taskId: Long, val status: String, val result: Qu
 
 /**
  * Persistent editor SESSION + async task routes (connection-model.md; editor-as-task). Open
- * ONE proxy-dialed stream — one backend connection — per editor session, then submit queries that run
+ * ONE proxy-dialed stream — one target-DB connection — per editor session, then submit queries that run
  * ASYNC as auto-approved EDITOR tasks: each submit creates a born-APPROVED task with one query_result child,
  * launches the run on [appScope] over the held session, and saves the enforced result. The client polls the
  * task/result endpoints — the editor never blocks and each tab polls independently. Enforcement stays

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RequesterIp.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RequesterIp.kt
@@ -127,7 +127,7 @@ internal fun resolveHttpRequesterIp(peerAddress: String?, xff: String?, trustedP
  * The HOST the CLIENT addressed, for the checks that compare a request's target against a configured
  * public identity — today the `/mcp` host check (McpServer.kt).
  *
- * Host only, never a port. Behind a TLS-terminating edge the backend is reached on its own cleartext
+ * Host only, never a port. Behind a TLS-terminating edge the target DB is reached on its own cleartext
  * port, and a client's `Host` omits the port whenever it is the scheme default, so a port comparison
  * rejects every request in the deployment shape the check exists to serve. It also buys nothing — an
  * attacker who controls the host names any port they like. (The port of a browser-facing request is

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RunExec.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/RunExec.kt
@@ -45,18 +45,18 @@ private const val TOKEN_TTL_GRACE_SECONDS = 300L
 // follows is bounded by RUN_NO_PROGRESS_TIMEOUT_MS + RUN_OPEN_TIMEOUT_MS.
 internal const val RUN_DIALBACK_TIMEOUT_MS = 15_000L
 // Once the control-plane knows which run the stream is for, the proxy heartbeats RunProgress while it dials +
-// authenticates the backend and runs its on-open catalog commands, then sends RunServing. The CP waits for
+// authenticates the target DB and runs its on-open catalog commands, then sends RunServing. The CP waits for
 // RunServing under TWO bounds: this no-progress gap — a dead or cut proxy stops heartbeating and fails fast —
-// AND the absolute ceiling below. A heartbeat proves the PROXY is alive, NOT that the backend is advancing, so
-// a proxy blocked on a wedged backend read keeps ticking; RUN_OPEN_TIMEOUT_MS is what bounds that.
+// AND the absolute ceiling below. A heartbeat proves the PROXY is alive, NOT that the target DB is advancing, so
+// a proxy blocked on a wedged target-DB read keeps ticking; RUN_OPEN_TIMEOUT_MS is what bounds that.
 internal const val RUN_NO_PROGRESS_TIMEOUT_MS = 15_000L
 // Absolute ceiling on the whole target-DB open (the dial-back above excluded): even while heartbeats keep the
 // no-progress bound reset, the open cannot exceed this. Sized at the old blind dial budget so a legitimately
-// slow open is not regressed, while a stalled-but-heartbeating one fails here instead of riding the backend
+// slow open is not regressed, while a stalled-but-heartbeating one fails here instead of riding the target DB
 // read-idle timeout — and, being finite, it keeps the run token's TTL grace (which must outlast the open)
 // sufficient.
 internal const val RUN_OPEN_TIMEOUT_MS = 120_000L
-// The table-detail channel keeps a single fixed dial bound (metadata-only introspection, no slow backend
+// The table-detail channel keeps a single fixed dial bound (metadata-only introspection, no slow target DB
 // open with liveness heartbeats), so it is unaffected by the run-channel's dial-back/no-progress split.
 internal const val DIAL_TIMEOUT_MS = 120_000L
 // Fallback only: every production path passes Config.queryExchangeTimeoutMs, which tracks
@@ -219,7 +219,7 @@ class RunExecService(
 
     /**
      * Cancel the in-flight run for [taskId] if one is registered. Under the run's [ActiveRun.gate]: if the
-     * query was already dispatched, a `RunCancel` is sent down its stream (the proxy cancels the backend
+     * query was already dispatched, a `RunCancel` is sent down its stream (the proxy cancels the target DB
      * statement); if it has NOT been dispatched yet, the pending send is vetoed (the run coroutine throws
      * [RunCanceledBeforeStartException]) so the query never leaves the CP. Returns whether a run was found.
      */
@@ -388,7 +388,7 @@ class RunExecService(
 
     // ---- Persistent per-editor-session streams (stateful editor, connection-model.md) ----
     // Unlike run() (one-shot: open→query→close, backing the approval-execute path and /api/query), an editor
-    // SESSION holds ONE proxy-dialed stream — hence one dedicated backend connection — across MANY queries, so
+    // SESSION holds ONE proxy-dialed stream — hence one dedicated target-DB connection — across MANY queries, so
     // SET/USE, temp objects, and BEGIN…COMMIT persist across the session, exactly like a native wire client.
     // This is the path the web SQL editor drives. Enforcement stays PER-STATEMENT (each query re-decides
     // against the connection's live namespace/catalog); a persistent connection is a data-plane fact, not an
@@ -398,7 +398,7 @@ class RunExecService(
 
     /**
      * Open a persistent editor session: mint a per-session EDITOR token, dial one proxy stream, and hold it.
-     * The proxy keeps its dedicated backend connection alive for the life of the session. On any failure to
+     * The proxy keeps its dedicated target-DB connection alive for the life of the session. On any failure to
      * establish, the pending registration, token, and any half-open stream are cleaned up before throwing.
      *
      * [requesterIp] is the requester-IP carrier (see [run]'s doc) — recorded under the session token's hash
@@ -511,7 +511,7 @@ class RunExecService(
                         closeSession(sessionId)
                         throw ProxyRunTimeoutException(e)
                     } catch (e: ProxyRunException) {
-                        // A query-level error — a canceled statement, a backend error — ends the persistent proxy
+                        // A query-level error — a canceled statement, a target-DB error — ends the persistent proxy
                         // session (the run loop returns on any query error), so drop the CP-side session too. The
                         // next submit then reopens a fresh one cleanly instead of failing on a since-dead stream.
                         closeSession(sessionId)
@@ -571,7 +571,7 @@ class RunExecService(
         }
     }
 
-    /** Reap sessions idle longer than [maxIdleMs] (called on a timer) — releases the backend connection. */
+    /** Reap sessions idle longer than [maxIdleMs] (called on a timer) — releases the target-DB connection. */
     fun sweepIdleSessions(maxIdleMs: Long) {
         val cutoffNanos = System.nanoTime() - maxIdleMs * 1_000_000
         openSessions.values.filter { it.lastUsedNanos < cutoffNanos }.forEach { closeSession(it.sessionId) }
@@ -589,8 +589,8 @@ class RunExecService(
      * closed before serving (a redeploy cutting the run) fails at once; a proxy that stops heartbeating fails
      * within [noProgressMs]; and — because a RunProgress heartbeat proves the proxy is alive but NOT that its
      * target-DB open is advancing — a proxy that keeps ticking while its open is wedged fails at the absolute
-     * [openTimeoutMs] ceiling rather than riding the backend read-idle timeout. A terminal RunError during the
-     * open (backend unreachable, catalog init failed) is surfaced as-is. The stream is already matched to
+     * [openTimeoutMs] ceiling rather than riding the target DB read-idle timeout. A terminal RunError during the
+     * open (target DB unreachable, catalog init failed) is surfaced as-is. The stream is already matched to
      * this run (attached), so every one of these is attributable — there is no blind wait, unlike the old
      * pre-RunReady gap.
      */

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/ControlPlaneGrpcService.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/ControlPlaneGrpcService.kt
@@ -82,7 +82,7 @@ private const val TABLE_DETAIL_STREAM_TIMEOUT_MS = 60_000L
 // a server-v* release always ships both at the same value.
 internal const val CONTROL_PROTOCOL_VERSION = 1
 
-// The completion-event terminal statuses the proxy reports: a clean finish, a backend/relay error carrying
+// The completion-event terminal statuses the proxy reports: a clean finish, a target DB/relay error carrying
 // partial counts, or a canceled statement. Any other value is rejected fail-closed so a malformed report
 // can't write an uninterpretable outcome into the audit trail.
 private val COMPLETION_STATUSES = setOf("ok", "error", "canceled")
@@ -92,7 +92,7 @@ private val COMPLETION_STATUSES = setOf("ok", "error", "canceled")
  * trust gates before any column can be read UNMASKED (an overlay column is read without a Cedar grant and
  * skips the uncovered-scan gate, so it is load-bearing that only genuine session temps reach it):
  *  - **channel gate** — temps are only legitimate on the [Channel.EDITOR] path (a persistent editor session
- *    holds the backend connection whose temps these are). A wire / approver-exec decision carrying
+ *    holds the target-DB connection whose temps these are). A wire / approver-exec decision carrying
  *    temp_columns is a buggy or compromised proxy: drop them all rather than grant the unmask on a channel
  *    that was never analyzed for it (the native-wire/one-shot proxies never send temps).
  *  - **pg_temp\* filter** — a temp overlay entry names a schema read unmasked, so it must be an actual
@@ -465,7 +465,7 @@ class ControlPlaneGrpcService(
             engineVersion = request.engineVersion,
             columns = pushedColumns,
         )
-        // This push is a fresh whole-catalog read of the backend, so where it agrees with content the
+        // This push is a fresh whole-catalog read of the target DB, so where it agrees with content the
         // enforcement pool already holds it re-measures that content — the ambient refresh keeps held
         // fragments verified instead of only feeding the config catalog, and a connection is not made to
         // re-probe a schema the proxy just confirmed.

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementAudit.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementAudit.kt
@@ -65,7 +65,7 @@ class ManagementAuditRecorder(private val auditStore: AuditStore) {
         const val KIND_ADMIN = "admin"
         const val OUTCOME_ALLOW = "ALLOW"
 
-        /** Admin events are instance-scoped, not tied to a target backend; the query-decision `datasource`
+        /** Admin events are instance-scoped, not tied to a target DB; the query-decision `datasource`
          *  slot carries the control plane itself, matching the existing SYSTEM-policy-toggle event. */
         private const val DATASOURCE = "control-plane"
     }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementServices.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/management/ManagementServices.kt
@@ -161,7 +161,7 @@ class DatasourceManagementService(
             // Drop the name-keyed in-memory enforcement catalog for this datasource. A soft-deleted name is
             // free for a new datasource to reuse, and the authoritative catalog is keyed by name, not id — so
             // without this a connection to the reused name could adopt structure measured from the deleted
-            // predecessor's backend and mask the wrong result columns. Same hazard a retarget already
+            // predecessor's target DB and mask the wrong result columns. Same hazard a retarget already
             // invalidates; idempotent and fail-safe (an over-drop only forces the next connection to
             // re-measure).
             connectionCatalog.invalidateDatasource(current.name)

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/BaselineDangerousFunctionEnforcementDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/BaselineDangerousFunctionEnforcementDbTest.kt
@@ -124,9 +124,9 @@ class BaselineDangerousFunctionEnforcementDbTest {
 
     // Dangerous PG functions the shipped manifest classifies (exact + `functionFamilies` prefixes) but the
     // hand-curated 15-name baseline floor MISSED — the cleartext-PII leak class. Each is a
-    // whole-table/page/large-object/backend reader that reads data INVISIBLE to lineage (its data source is a
+    // whole-table/page/large-object/target DB reader that reads data INVISIBLE to lineage (its data source is a
     // string/regclass/oid arg, not a scanned column), so on a no-manifest datasource a flat 15-name baseline
-    // would return null → ALLOW → the backend would stream e.g. the entire `users` table as XML incl. cleartext ssn.
+    // would return null → ALLOW → the target DB would stream e.g. the entire `users` table as XML incl. cleartext ssn.
     private val pgManifestOnlyDangerousCalls = listOf(
         "table_to_xml('public.users'::regclass, true, false, '')", // table_to_xml* family (the canonical dump)
         "query_to_xmlschema('SELECT ssn FROM users', true, false, '')", // query_to_xml* family (NOT the baseline's two exact names)
@@ -204,7 +204,7 @@ class BaselineDangerousFunctionEnforcementDbTest {
         assertEquals(EnfAction.DENY, decide(pg, "select dblink_exec('c','s') from users natural join users").action, "resolved=false critical denies on the floor")
         // BOUNDARY (explicit, not a gap this closes): the backfill only fires on a POST-PARSE failure — a
         // statement that sqlglot cannot PARSE (p.root == nil) emits no function facts, so a critical builtin in
-        // a parse-failing statement the backend still accepts takes the exception.unanalyzable verbatim relay on a
+        // a parse-failing statement the target DB still accepts takes the exception.unanalyzable verbatim relay on a
         // system:development datasource (it DENIES on the floor). That is the accepted `exception.unanalyzable ⊇ exec`
         // posture an operator opts into with system:development — pre-existing, unclosable via function facts,
         // and the multi-statement route into it is already shut (admission rejects >1-statement batches).

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ChannelDecideAuditDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ChannelDecideAuditDbTest.kt
@@ -135,7 +135,7 @@ class ChannelDecideAuditDbTest {
     @Test
     fun `a session temp resolves and reads unmasked via the overlay, unresolvable without it`() {
         // The proxy sends the connection's temp columns; the CP overlays them so a bare name resolves to
-        // the temp (what the backend binds). A temp is unclassified + owned by the user → read UNMASKED.
+        // the temp (what the target DB binds). A temp is unclassified + owned by the user → read UNMASKED.
         val tempSchema = "pg_temp_9"
         val tempCol = CatalogColumn(
             catalog = fx.datasource.dbName, schema = tempSchema, table = "scratch", column = "secret",

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DatasourceSoftDeleteDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DatasourceSoftDeleteDbTest.kt
@@ -194,7 +194,7 @@ class DatasourceSoftDeleteDbTest {
             core.connectionCatalog.authoritativeFor(name, "app"),
             "delete drops the name-keyed authoritative catalog",
         )
-        // A new connection on the freed name must therefore re-measure its own backend, not adopt the drop.
+        // A new connection on the freed name must therefore re-measure its own target DB, not adopt the drop.
         val reused = core.connectionCatalog.open(Binding(name, "after", "USER"), listOf("app"), adoptHeldContent = true)
         assertEquals(
             listOf("app"),

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/EnforcementDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/EnforcementDbTest.kt
@@ -258,7 +258,7 @@ class EnforcementPostgresDbTest {
 
     @Test
     fun `a provably-total transform of a masked column redacts in full and the rest of the row returns`() {
-        // The headline behavior end-to-end against a real backend: upper(ssn) is a provably-total transform
+        // The headline behavior end-to-end against a real target DB: upper(ssn) is a provably-total transform
         // → the derived cell is blanked to NULL, but the statement is ALLOWed (MASK) and the non-sensitive
         // columns still return — unlike a DENY. Exercises the harness NULL-redaction path for a derived cell.
         val r = fx.run("select id, upper(ssn) from users")
@@ -312,7 +312,7 @@ class EnforcementMysqlDbTest {
     fun `error-based extraction via extractvalue over a masked column is denied end-to-end`() {
         // A MySQL error-based exfiltration technique: extractvalue() puts a stored value into a 1105 XPATH error
         // message. ssn (masked pii) is read in a NON-OUTPUT position — a function-argument subquery, and the
-        // ORDER BY oracle predicate — so admission must DENY before the statement reaches the backend to
+        // ORDER BY oracle predicate — so admission must DENY before the statement reaches the target DB to
         // produce that error. This is the primary defense, ahead of the proxy's DIAG error-message strip
         // (which is the backstop if enforcement ever had a gap).
         val viaArg = fx.run("select extractvalue(1, concat(0x7e, (select ssn from users limit 1)))")
@@ -324,7 +324,7 @@ class EnforcementMysqlDbTest {
         // redacted (docs/derived-masking.md): only PROVABLY-TOTAL string transforms (upper/substr/…) are
         // redactable; a cast or arithmetic can fault (or warn) on the value, so executing it would leak the
         // raw value through the error-presence / SQLSTATE / warning-count channel that output redaction can't
-        // touch. So these stay denied and never reach the backend.
+        // touch. So these stay denied and never reach the target DB.
         val cast = fx.run("select cast(ssn as unsigned) from users")
         assertEquals(EnfAction.DENY, cast.decision, "cast(ssn) is a value-dependent-fault-capable transform → denied; reason=${cast.denyReason}")
         assertTrue(cast.rows.isEmpty(), "a DENY must not return rows")
@@ -382,7 +382,7 @@ class EnforcementMysqlDbTest {
         // MySQL parity for the passthrough-bypass regression: `SELECT .. INTO OUTFILE` writes a server
         // file with no FROM, and was READONLY_META-classified (ALLOW) ahead of the gates. Its kind is
         // select_into_outfile (stmt.cat.admin.file, a server-side FILE write), so analyst — read + metadata
-        // + session, no admin — is DENIED at the kind gate before it can ever reach the backend. A ddl grant
+        // + session, no admin — is DENIED at the kind gate before it can ever reach the target DB. A ddl grant
         // alone would not authorize it either: file export is admin.file, not plain ddl.
         val r = fx.run("select 1 into outfile '/tmp/pm_stmt_gate_bypass'")
         assertEquals(EnfAction.DENY, r.decision, "SELECT INTO OUTFILE must be gated; reason=${r.denyReason}")
@@ -393,7 +393,7 @@ class EnforcementMysqlDbTest {
     fun `a no-FROM SELECT reading a table via UNION TABLE cannot exfiltrate cleartext ssn`() {
         // MySQL parity for the UNION TABLE red-team regression (a live cleartext leak):
         // `SELECT … UNION TABLE users` reads users.ssn with no FROM word and must be denied at admission,
-        // never reaching the backend.
+        // never reaching the target DB.
         val r = fx.run("select 0,'x','x','x' union table users")
         assertEquals(EnfAction.DENY, r.decision, "UNION TABLE read must be denied; reason=${r.denyReason}")
         assertTrue(r.rows.isEmpty(), "a DENY must not return rows")
@@ -406,7 +406,7 @@ class EnforcementMysqlDbTest {
         // UNION SELECT 1 INTO @a` mutates @a (a write) but was READONLY_META-classified and passthrough-
         // ALLOW'd ahead of the gates — the leading paren branch hid the INTO. The analyzer finds the INTO
         // recursively and classifies it select_into (stmt.cat.ddl); analyst (connect + read, NO ddl) must
-        // be denied at the kind gate, before it can ever reach the backend.
+        // be denied at the kind gate, before it can ever reach the target DB.
         val r = fx.run("(select 1) union select 1 into @pm_p3_branch")
         assertEquals(EnfAction.DENY, r.decision, "branch SELECT INTO must be gated; reason=${r.denyReason}")
         assertEquals("statement kind 'select_into' is not permitted", r.denyReason, "deny reason: ${r.denyReason}")

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/GateSqlglotRegressionTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/GateSqlglotRegressionTest.kt
@@ -63,7 +63,7 @@ class GateSqlglotRegressionTest {
 
     @Test
     fun `cast or typed literal to a user type denies through the production walk`() {
-        // A user DOMAIN/type coercion runs its check function on the shared backend session (code exec +
+        // A user DOMAIN/type coercion runs its check function on the shared target-DB session (code exec +
         // error-oracle leak). The Go analyzer marks it INADMISSIBLE; prove the control-plane walk denies.
         for (sql in listOf(
             "SELECT CAST('x' AS public.pm_leak_domain)",
@@ -93,7 +93,7 @@ class GateSqlglotRegressionTest {
 
     @Test
     fun `MySQL ANSI_QUOTES masks a double-quoted pii column, default mode leaves it a string literal`() {
-        // Under sql_mode=ANSI_QUOTES the backend reads `"ssn"` as
+        // Under sql_mode=ANSI_QUOTES the target DB reads `"ssn"` as
         // the pii column ssn, not a string. Told liveAnsiQuotes=true, the analyzer parses it the same way, so
         // the CP must MASK it instead of skipping it as a literal — this is the whole reason the proxy can now
         // forward an ANSI_QUOTES session instead of failing it closed. Without the flag (default mode) `"ssn"`

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/KnownGapsTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/KnownGapsTest.kt
@@ -67,7 +67,7 @@ class KnownGapsTest {
 
     @Test
     fun `a CTE that shadows a real ungranted table name is allowed - the physical table is not read`() {
-        // The `orders` in the outer query binds to the CTE (SELECT 1), NOT the backend table, so nothing
+        // The `orders` in the outer query binds to the CTE (SELECT 1), NOT the target-DB table, so nothing
         // physical is scanned — ALLOW (analyst holds datasource.connect + sql.select). A naive
         // global-CTE-name fix would either leak the real table or wrongly deny this.
         val r = fx.run("with orders as (select 1) select count(*) from orders")

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ManifestCommandCoverageDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ManifestCommandCoverageDbTest.kt
@@ -72,7 +72,7 @@ class ManifestCommandCoverageDbTest {
     // One representative statement per dangerous command id + the engine to decide it on. The completeness
     // assertion below proves this map ∪ INTENTIONAL_PASSTHROUGH covers every manifest dangerous command, so a
     // missing entry is a test failure, not a silent relay. Statements need only ADMIT + decide (they are
-    // never executed — a dangerous command denies before it reaches the backend).
+    // never executed — a dangerous command denies before it reaches the target DB).
     private val samples: Map<String, Pair<Eng, String>> = mapOf(
         // MySQL — account / privilege administration.
         "SET_PASSWORD" to (Eng.MY to "SET PASSWORD = 'x'"),

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PerConnectionCatalogStateTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PerConnectionCatalogStateTest.kt
@@ -144,14 +144,14 @@ class PerConnectionCatalogStateTest {
         val connection = registry.find(second.connectionId)!!
         assertEquals("h1", connection.held.getValue("app").hash.bytes.toStringUtf8())
         assertTrue(connection.pending.isEmpty())
-        // The point of adopting: the first statement decides without waiting on the backend.
+        // The point of adopting: the first statement decides without waiting on the target DB.
         assertTrue(registry.freshnessGate(connection, listOf("app")).isEmpty())
     }
 
     @Test
     fun `adoption inherits the original measurement time so staleness still fires`() = runBlocking {
         // Adopting must not restart the staleness clock. If it did, a stream of new connections would keep
-        // content alive indefinitely without anyone re-reading the backend, and the bound could never fire.
+        // content alive indefinitely without anyone re-reading the target DB, and the bound could never fire.
         var now = 0L
         val registry = ConnectionCatalogRegistry(clockNanos = { now }, stalenessNanos = 10)
         val first = registry.open(Binding(ds.name, "first", "USER"), listOf("app"))
@@ -174,7 +174,7 @@ class PerConnectionCatalogStateTest {
     fun `an ambient refresh re-measures pooled content so adopters stay fresh`() = runBlocking {
         // The staleness ceiling sits above the ambient refresh interval on the premise that the refresh
         // itself keeps pooled content verified. Without that, content pooled once would age out no matter
-        // how recently the backend was read, and every new session would refetch.
+        // how recently the target DB was read, and every new session would refetch.
         var now = 0L
         val registry = ConnectionCatalogRegistry(clockNanos = { now }, stalenessNanos = 10)
         val first = registry.open(Binding(ds.name, "first", "USER"), listOf("app"))
@@ -199,7 +199,7 @@ class PerConnectionCatalogStateTest {
     @Test
     fun `an ambient refresh whose columns differ never overwrites pooled content`() = runBlocking {
         // Confirmation only. Divergence belongs to the connection's own probe, which alone knows what that
-        // connection's backend binds; installing a differing ambient read here would decide against a
+        // connection's target DB binds; installing a differing ambient read here would decide against a
         // catalog no connection measured.
         var now = 0L
         val registry = ConnectionCatalogRegistry(clockNanos = { now }, stalenessNanos = 10)
@@ -303,7 +303,7 @@ class PerConnectionCatalogStateTest {
     fun `invalidating a datasource forces the next connection to measure for itself`() = runBlocking {
         // Repointing a datasource at another database makes held structure describe a database that is no
         // longer there. Adoption would otherwise hand that structure to the next connection, which would
-        // decide against a catalog its backend never had.
+        // decide against a catalog its target DB never had.
         val registry = ConnectionCatalogRegistry()
         val first = registry.open(Binding(ds.name, "first", "USER"), listOf("app"))
         registry.applyPush(push(first, "app", "h1"), ds)
@@ -330,7 +330,7 @@ class PerConnectionCatalogStateTest {
     fun `one datasource's ambient refresh cannot vouch for another's schema`() = runBlocking {
         // System-schema content is pooled once per engine version and shared by every datasource on it, so a
         // measurement recorded against the shared content would let a datasource nobody read look freshly
-        // verified. Freshness is evidence about one backend; only the content is shareable.
+        // verified. Freshness is evidence about one target DB; only the content is shareable.
         var now = 0L
         val registry = ConnectionCatalogRegistry(clockNanos = { now }, stalenessNanos = 10)
         val dsA = ds.copy(id = 1, name = "dsA")
@@ -361,7 +361,7 @@ class PerConnectionCatalogStateTest {
         assertEquals(
             setOf("information_schema"),
             registry.freshnessGate(registry.find(onB.connectionId)!!, listOf("information_schema")),
-            "dsB's backend was never re-read; dsA's refresh must not make it look fresh",
+            "dsB's target DB was never re-read; dsA's refresh must not make it look fresh",
         )
     }
 

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SchemaThreadingDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SchemaThreadingDbTest.kt
@@ -117,8 +117,8 @@ data class SchemaThreadingFixture(
             c.autoCommit = false
             try {
                 val count = c.createStatement().use { it.executeUpdate(sql) }
-                assertTrue(count > 0, "expected a row-affecting backend UPDATE, count=$count: $sql")
-                assertEquals(after, readSsn(c, table), "the backend did not execute the claimed mutation: $sql")
+                assertTrue(count > 0, "expected a row-affecting target DB UPDATE, count=$count: $sql")
+                assertEquals(after, readSsn(c, table), "the target DB did not execute the claimed mutation: $sql")
             } finally {
                 c.rollback()
             }
@@ -352,7 +352,7 @@ object SchemaThreadingFixtures {
     }
 }
 
-/** Shared live-backend contract, run once against PostgreSQL and once against MySQL. */
+/** Shared live-target DB contract, run once against PostgreSQL and once against MySQL. */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class SchemaThreadingDbContract {
     protected lateinit var fx: SchemaThreadingFixture
@@ -440,7 +440,7 @@ abstract class SchemaThreadingDbContract {
     }
 
     @Test
-    fun `protected bare-target update is valid and mutating on the backend but enforcement denies it`() {
+    fun `protected bare-target update is valid and mutating on the target DB but enforcement denies it`() {
         val sql = fx.protectedUpdateSql()
         fx.executeRolledBack(sql, fx.defaultTable, fx.defaultSsn, "${fx.defaultSsn}-blocked")
 
@@ -581,7 +581,7 @@ class SchemaThreadingPostgresDbTest : SchemaThreadingDbContract() {
                     }
                     st.executeQuery("select ssn from ${fx.analyticsTable} where id = 1").use { rs ->
                         assertTrue(rs.next(), "missing seeded row in ${fx.analyticsTable}")
-                        assertEquals(fx.defaultSsn, rs.getString(1), "the backend did not persist the protected value in the transaction")
+                        assertEquals(fx.defaultSsn, rs.getString(1), "the target DB did not persist the protected value in the transaction")
                     }
                 }
             } finally {
@@ -605,7 +605,7 @@ class SchemaThreadingPostgresDbTest : SchemaThreadingDbContract() {
     @Test
     fun `system catalogs are introspected as first-class resources, not shadowed`() {
         // pg_catalog is on the effective search path, so excluding it from the
-        // mapping makes a bare name the backend binds there fall through to a user schema (shadow
+        // mapping makes a bare name the target DB binds there fall through to a user schema (shadow
         // leak). System schemas must be introspected — this assertion fails if the NOT IN (...)
         // exclusion is re-added.
         val schemas = fx.datasourceStore.catalog(fx.datasource.id).map { it.schema }.toSet()

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ShowWarningsExfilDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ShowWarningsExfilDbTest.kt
@@ -21,8 +21,8 @@ import kotlin.test.assertTrue
  * the `system:data-leak` tag (resource `session-diagnostics`), so the shipped floor forbid denies them on the
  * production floor — relaxed only on `system:development`, where there is no PII.
  *
- * This is an end-to-end enforcement test on a real MySQL backend: it first proves the leak is REAL (the
- * backend does echo the value into the warning buffer), then proves the control-plane decision denies the
+ * This is an end-to-end enforcement test on a real MySQL target DB: it first proves the leak is REAL (the
+ * target DB does echo the value into the warning buffer), then proves the control-plane decision denies the
  * retrieval, and that the deny is the data-leak forbid — it overrides even a broad any-action grant.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -53,10 +53,10 @@ class ShowWarningsExfilDbTest {
     ).action
 
     @Test
-    fun `SHOW WARNINGS cannot exfiltrate a value the backend leaked into the warning buffer`() {
+    fun `SHOW WARNINGS cannot exfiltrate a value the target DB leaked into the warning buffer`() {
         val secret = fx.cleartextSsn[0]
 
-        // (1) The vector is REAL — on ONE backend session, the failing CAST echoes the value into the warning
+        // (1) The vector is REAL — on ONE target-DB session, the failing CAST echoes the value into the warning
         // buffer and SHOW WARNINGS reads it back verbatim. If this precondition ever stops holding the test
         // proves nothing, so it is asserted, not assumed.
         DriverManager.getConnection(fx.targetJdbcUrl, fx.targetUser, fx.targetPassword).use { c ->
@@ -67,7 +67,7 @@ class ShowWarningsExfilDbTest {
                     while (rs.next()) {
                         if (rs.getString("Message")?.contains(secret) == true) leaked = true
                     }
-                    assertTrue(leaked, "precondition: the backend must echo the raw value into the warning buffer")
+                    assertTrue(leaked, "precondition: the target DB must echo the raw value into the warning buffer")
                 }
             }
         }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/StatementFactsGrantLoopTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/StatementFactsGrantLoopTest.kt
@@ -357,7 +357,7 @@ class StatementFactsGrantLoopTest {
     @Test
     fun `session rewrite rides the passthrough on persistent-connection channels`() {
         // The analyzer's results-charset pin (issue #81) is emitted as a rewrite on a session SET; it must
-        // survive the session passthrough so the data plane relays utf8mb4 to the backend. Denied channels
+        // survive the session passthrough so the data plane relays utf8mb4 to the target DB. Denied channels
         // (MCP/workflow) never execute the SET, so no rewrite reaches them.
         val pinned = statementFacts {
             resolved = true

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TableDetailDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TableDetailDbTest.kt
@@ -212,13 +212,13 @@ class TableDetailDbTest {
                 dbName = "unreachable",
             ),
         )
-        fakeProxies += FakeTableDetailProxy(core, failing.name) { _, _ -> ProxyReply.Error("backend connection failed") }
+        fakeProxies += FakeTableDetailProxy(core, failing.name) { _, _ -> ProxyReply.Error("target-DB connection failed") }
         val failedResponse = client.get("/api/datasources/${failing.id}/table-detail") {
             parameter("schema", "public")
             parameter("table", "anything")
         }
         assertEquals(HttpStatusCode.BadGateway, failedResponse.status)
-        assertContains(failedResponse.bodyAsText(), "backend connection failed")
+        assertContains(failedResponse.bodyAsText(), "target-DB connection failed")
 
         val detached = datasourceStore.create(
             DatasourceInput(

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/GrpcRunExecDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/GrpcRunExecDbTest.kt
@@ -305,11 +305,11 @@ class GrpcRunExecDbTest {
                 },
             )
             requests.send(rowsChunk(listOf("email"), listOf(listOf("must-not-escape@example.com"))))
-            requests.send(proxyRunMsg { error = runError { message = "backend disconnected" } })
+            requests.send(proxyRunMsg { error = runError { message = "target DB disconnected" } })
         }.exceptionOrNull()
 
         assertIs<ProxyRunException>(failure)
-        assertEquals("backend disconnected", failure.message)
+        assertEquals("target DB disconnected", failure.message)
     }
 
     @Test
@@ -332,7 +332,7 @@ class GrpcRunExecDbTest {
             val event = async { stub.events(eventsRequest { datasourceName = datasource.name; protocolVersion = CONTROL_PROTOCOL_VERSION }).first() }
             awaitUntil("Events stream attached") { datasource.name in core.proxyEventsHub.attached() }
             // Inject a short dial bound: the production one is sized for a slow open against a remote
-            // backend, and waiting it out here would buy nothing but a two-minute test.
+            // target DB, and waiting it out here would buy nothing but a two-minute test.
             val result = async {
                 runCatching { service.run("timeout-user", datasource, "select 1", 500, dialTimeoutMs = 1_000) }
             }
@@ -473,11 +473,11 @@ class GrpcRunExecDbTest {
             val proxy = async { stub.runExec(proxyRequests.receiveAsFlow()).collect {} }
             proxyRequests.send(proxyRunMsg { sessionReady = runReady { sessionId = open.sessionId } })
             // The target-DB open fails mid-flight, before serving.
-            proxyRequests.send(proxyRunMsg { error = runError { message = "backend connection failed: connection refused" } })
+            proxyRequests.send(proxyRunMsg { error = runError { message = "target-DB connection failed: connection refused" } })
 
             val failure = withTimeout(5_000) { result.await() }.exceptionOrNull()
             assertIs<ProxyRunException>(failure)
-            assertEquals("backend connection failed: connection refused", failure.message)
+            assertEquals("target-DB connection failed: connection refused", failure.message)
             assertEquals(0, activeEditorTokens("open-err-user"), "a failed target-DB open must revoke its token")
             proxyRequests.close()
             withTimeout(5_000) { proxy.await() }
@@ -489,9 +489,9 @@ class GrpcRunExecDbTest {
         supervisorScope {
             val event = async { stub.events(eventsRequest { datasourceName = datasource.name; protocolVersion = CONTROL_PROTOCOL_VERSION }).first() }
             awaitUntil("Events stream attached") { datasource.name in core.proxyEventsHub.attached() }
-            // The proxy heartbeats faster than the no-progress bound but never serves (its backend read is
+            // The proxy heartbeats faster than the no-progress bound but never serves (its target-DB read is
             // wedged though the proxy is alive). Only the absolute open ceiling can end this — a heartbeat is
-            // liveness, not backend progress. Short ceiling so the test is fast.
+            // liveness, not target DB progress. Short ceiling so the test is fast.
             val result = async {
                 runCatching { service.run("wedged-user", datasource, "select 1", 500, noProgressMs = 5_000, openTimeoutMs = 800) }
             }
@@ -689,7 +689,7 @@ class GrpcRunExecDbTest {
             assertEquals("203.0.113.42", core.runRequesterIps.get(tokenHash(ephemeralToken)))
 
             // ONE fake-proxy stream that services N queries then a close — the proof the CP reuses one stream
-            // (one backend connection) across queries rather than dialing fresh per statement.
+            // (one target-DB connection) across queries rather than dialing fresh per statement.
             val proxyRequests = Channel<ProxyRunMsg>(Channel.UNLIMITED)
             val queriesSeen = java.util.Collections.synchronizedList(ArrayList<String>())
             val proxy = async {

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackNotificationE2eDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackNotificationE2eDbTest.kt
@@ -82,7 +82,7 @@ import kotlin.test.fail
  * [ControlPlaneGrpcService], so the run plays back over the true execute-under-R wire path, as in
  * `ApprovalExecuteRouteDbTest`).
  *
- * Only Slack and the target backend are mocked; the compose route, `decideQuery` + the disclosure hint,
+ * Only Slack and the target DB are mocked; the compose route, `decideQuery` + the disclosure hint,
  * the notification drain, the Socket Mode click, the Cedar `task.approve`, and the production run path
  * (`claimAndStartRun` → `runApprovedTask` → `runExecService.run`) are the real classes.
  */

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/PerConnectionCatalogFixture.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/PerConnectionCatalogFixture.kt
@@ -36,7 +36,7 @@ class PerConnectionCatalogFixture(val enforcement: EnforcementFixture) {
     }
 
     /**
-     * Scan one schema through the caller-owned backend connection. This intentionally observes that
+     * Scan one schema through the caller-owned target-DB connection. This intentionally observes that
      * connection's transaction-local DDL rather than opening a fresh connection or copying metadata rows.
      */
     suspend fun pushFromTarget(

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,7 +6,7 @@ local, ECS Fargate, and EKS run steps — lives in [INSTALL.md](../INSTALL.md).
 
 ## Contents
 
-- `seed/target-seed-mysql.sql`, `seed/target-seed.sql` — sample backend schema
+- `seed/target-seed-mysql.sql`, `seed/target-seed.sql` — sample target-DB schema
   and seed data: a small OLTP schema (`users`, `orders`, `payments`,
   `addresses`, ...) with realistic PII columns (`email`, `phone`, `name`, `ssn`,
   `card_number`, ...) to classify and mask against. The local compose stack

--- a/deploy/seed/target-seed-mysql.sql
+++ b/deploy/seed/target-seed-mysql.sql
@@ -1,4 +1,4 @@
--- Sample OLTP schema for the target (brokered) MySQL backend —
+-- Sample OLTP schema for the target (brokered) MySQL database —
 -- MySQL is the primary target engine (Postgres is the add-on). Mirrors
 -- deploy/seed/target-seed.sql so the same queries exercise the engine + enforcement
 -- on MySQL. PII columns (email, phone, name, ssn, card_number, line1,
@@ -6,7 +6,7 @@
 -- free-text column the content backstop covers. DATETIME (not TIMESTAMP) to
 -- avoid TZ conversion + the 2038 range limit.
 
--- The proxy brokers to the backend with a native-password handshake (8.4 has it disabled by
+-- The proxy brokers to the target DB with a native-password handshake (8.4 has it disabled by
 -- default; the container is started with --mysql-native-password=ON). caching_sha2 is a follow-up.
 ALTER USER 'acme'@'%' IDENTIFIED WITH mysql_native_password BY 'acme';
 

--- a/deploy/seed/target-seed.sql
+++ b/deploy/seed/target-seed.sql
@@ -1,4 +1,4 @@
--- Sample OLTP schema for the target (brokered) Postgres backend.
+-- Sample OLTP schema for the target (brokered) Postgres database.
 -- Mirrors the catalog the analyzer's parse+lineage tests use, so the same queries run
 -- against a real database here.
 -- PII columns (email, phone, name, ssn, card_number, line1, postal_code) are what the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Local dev infra for proxy-monster (DESIGN.md).
 #   pm-postgres     — the control-plane's own metadata store (catalog/policy/grants/audit).
-#   target-mysql    — the PRIMARY sample backend the proxy brokers to (MySQL is the main target).
-#   target-postgres — the add-on sample backend (Postgres is secondary).
+#   target-mysql    — the PRIMARY sample target DB the proxy brokers to (MySQL is the main target).
+#   target-postgres — the add-on sample target DB (Postgres is secondary).
 services:
   pm-postgres:
     image: postgres:17.6
@@ -24,7 +24,7 @@ services:
   target-mysql:
     image: mysql:8.4
     # Enable mysql_native_password (disabled by default in 8.4) so the proxy's broker can do a
-    # simple native-password handshake to the backend. (caching_sha2 backend auth is a follow-up.)
+    # simple native-password handshake to the target DB. (caching_sha2 target-DB auth is a follow-up.)
     command: ["--mysql-native-password=ON"]
     environment:
       MYSQL_DATABASE: acme

--- a/docs/access-model.md
+++ b/docs/access-model.md
@@ -197,7 +197,7 @@ Three things never become Cedar, correctly:
 - Connection / namespace / catalog plumbing — the per-connection model
   enforcement resolves against ([connection-model.md](./connection-model.md)) is
   a data-plane mechanism. Cedar decides over the resolved key; the connection
-  model only makes that key match what the backend binds.
+  model only makes that key match what the target DB binds.
 - Data-plane capability — Cedar can _permit_ an unmaskable feature (COPY,
   fast-path) on a development datasource, but the proxy must be _able_ to relay
   it verbatim. Where it can't, the feature stays denied regardless of policy
@@ -233,9 +233,9 @@ Three things never become Cedar, correctly:
   output passes unmasked ([KNOWN_LIMITATIONS.md](../KNOWN_LIMITATIONS.md);
   backlogged).
 - Shared service account. Permitting `SET PASSWORD`/`SET GLOBAL`
-  (`system:critical`) mutates the _shared_ backend account for everyone; it is
-  fully isolated only once the proxy brokers a per-user backend login. The admin
-  owns the call until then.
+  (`system:critical`) mutates the _shared_ target DB account for everyone; it is
+  fully isolated only once the proxy brokers a per-user target DB login. The
+  admin owns the call until then.
 - Data-plane passthrough for unmaskable features (COPY / fast-path) must be
   built for a Cedar permit to take effect; until then capability denial wins
   regardless of policy.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -37,8 +37,8 @@ forward work. MySQL leads PostgreSQL in priority.
   in between, the update matches nothing and the follow-up read dereferences a
   group that is gone, so the request fails with a 500. Fall through to an insert
   (a true upsert) or return a clean 404/409. Availability, not authorization.
-- MySQL `caching_sha2_password` backend auth. PostgreSQL SCRAM-SHA-256 is done;
-  the MySQL service user still uses `mysql_native_password`.
+- MySQL `caching_sha2_password` target-DB auth. PostgreSQL SCRAM-SHA-256 is
+  done; the MySQL service user still uses `mysql_native_password`.
 - pmon HTTP API auth: today the CLI presents its wire token as a bearer to the
   read-only datasource discovery routes only. Make it a first-class client —
   either an OAuth bearer client of its own, or a reuse of the web session — so
@@ -109,7 +109,7 @@ forward work. MySQL leads PostgreSQL in priority.
 
 ## Task execution
 
-- Retry a task whose execution never reached the backend. A definite refusal
+- Retry a task whose execution never reached the target DB. A definite refusal
   marks the task failed, which is correct, but a transient pre-dial transport
   failure does the same and permanently burns the approval, forcing a fresh
   request and approval. Add a retry affordance, or restore the approved state on
@@ -224,8 +224,8 @@ Fixes for gaps documented in
   authorize a principal's later requests.
 - Canonicalize introspected schema names on the proxy side (case-fold-aware),
   removing the interim MySQL lowercase fold in the control plane.
-- Broker a per-user backend login so `SET PASSWORD` / `SET GLOBAL` stop mutating
-  a shared service account.
+- Broker a per-user target DB login so `SET PASSWORD` / `SET GLOBAL` stop
+  mutating a shared service account.
 - UDF-output vouching: gate a data-reading UDF's output on a masking datasource
   behind an admin assertion, auto-clearing declared-pure functions (low
   priority).
@@ -252,7 +252,7 @@ Fixes for gaps documented in
   portal when its transaction ends; the proxy prunes only on an explicit close
   or a name reuse, so a long-lived connection cycling unique portal names grows
   proxy memory. There is no data path — a stale entry re-decides and then hits
-  the backend's own error. Clearing on transaction end needs either SQL
+  the target DB's own error. Clearing on transaction end needs either SQL
   classification in the proxy, which the stateless-relay contract forbids, or it
   breaks `WITH HOLD` cursors.
 - Validate that the extended protocol's temp-table overlay comes from the
@@ -316,7 +316,7 @@ Fixes for gaps documented in
   and MySQL does not accept a prepared generic `SET` — but the fail-closed
   invariant should hold on this path too: live-probe before EXECUTE for the
   invariant check while keeping the frozen snapshot for authorization.
-- Proxy-side cancel brokering: issue synthetic `BackendKeyData` and broker
+- Proxy-side cancel brokering: issue synthetic `TargetDbKeyData` and broker
   cancels proxy-side, so `CancelRequest` can require TLS without breaking psql's
   Ctrl-C.
 - Wire-cert rotation refresh: a rotated proxy leaf cert only re-advertises its
@@ -330,7 +330,7 @@ Fixes for gaps documented in
   and keeps a fixed socket-inactivity cap, so a direct statement through `pmon`
   is not bounded by it. The relay is a streaming passthrough with no discrete
   per-statement execution to guard, so this needs a per-statement watchdog plus
-  a backend cancel wired into the relay loop, not a value threaded through.
+  a target DB cancel wired into the relay loop, not a value threaded through.
 - Surface a contended daemon lock distinctly. `EnsureDaemon` connects first and
   spawns only on failure, and a daemon that loses the lock exits silently, so
   the caller sees a generic "did not come up" timeout. A caller in a loop

--- a/docs/connection-model.md
+++ b/docs/connection-model.md
@@ -1,16 +1,16 @@
 # The connection model — live namespace-aware enforcement
 
-The connection is the unit of enforcement state. A backend query resolves names
-against _its connection's_ live session — the current `search_path` / database,
-the temp objects it created, and the catalog as it stands right now — never
-against "the datasource" in the abstract. So the proxy's decision must resolve
-against that same per-connection state, or it authorizes a different table than
-the backend binds, which is a cleartext leak.
+The connection is the unit of enforcement state. A target DB query resolves
+names against _its connection's_ live session — the current `search_path` /
+database, the temp objects it created, and the catalog as it stands right now —
+never against "the datasource" in the abstract. So the proxy's decision must
+resolve against that same per-connection state, or it authorizes a different
+table than the target DB binds, which is a cleartext leak.
 
 Three things are therefore per-connection, not per-datasource:
 
 - The connection — each editor session and each wire client holds its own
-  persistent backend connection (not a fresh pooled connection per statement),
+  persistent target-DB connection (not a fresh pooled connection per statement),
   exactly as psql/JDBC/TablePlus already behave.
 - The namespace — the connection's live effective `search_path` (PG) / current
   database (MySQL), tracked as `SET search_path` / `USE` change it.
@@ -19,7 +19,7 @@ Three things are therefore per-connection, not per-datasource:
   ([per-connection-catalog.md](./per-connection-catalog.md)).
 
 Enforcement resolves each statement against the connection's namespace +
-catalog, matching the backend exactly. It stays per-statement: a persistent
+catalog, matching the target DB exactly. It stays per-statement: a persistent
 connection is a data-plane fact, not an authz relaxation. Every statement still
 goes through `decideQuery` → Cedar independently against the connection's
 current namespace/catalog. Session continuity is not trust continuity — a
@@ -27,32 +27,32 @@ statement touching a masked column still `DENY`s mid-session.
 
 ## Per-connection connection (editor + wire, unified)
 
-- Wire clients already hold a persistent backend connection through the proxy.
+- Wire clients already hold a persistent target-DB connection through the proxy.
   The decision path reads _that connection's_ namespace + catalog, not a
   datasource-global snapshot.
 - The editor holds one persistent connection per editor session.
   `BEGIN…COMMIT`/`ROLLBACK`, `SET`/`USE`, and temp tables persist across the
   session like a wire client. Selecting N statements runs them in order on that
   session's connection; each is still independently gated by the shared query
-  engine. The control plane holds one proxy stream (one backend connection) per
-  editor session across many queries (`RunExecService.openSession` /
+  engine. The control plane holds one proxy stream (one target-DB connection)
+  per editor session across many queries (`RunExecService.openSession` /
   `runOnSession` / `closeSession` / `sweepIdleSessions`); the web editor opens,
   reuses, and closes one session per datasource (`useResultTabs`).
 - The session-close route is ownership-checked (`closeSessionOwnedBy`), so a
   leaked session id cannot tear down another principal's connection.
-- Idle-bounded. The backend connection is held for the session and released on
+- Idle-bounded. The target-DB connection is held for the session and released on
   disconnect / idle timeout.
 
 ## Per-connection namespace (`SET search_path` / `USE`)
 
-The backend resolves a bare name against the connection's live effective path;
+The target DB resolves a bare name against the connection's live effective path;
 the proxy must resolve against the same path or it authorizes the wrong table:
 
 `SET search_path = restricted, public; SELECT ssn FROM users` — a
 datasource-global default (`public`) authorizes `public.users` (ALLOW), while
-the backend binds `restricted.users` (PII). Same via MySQL `USE otherdb`.
+the target DB binds `restricted.users` (PII). Same via MySQL `USE otherdb`.
 
-- Track the effective path by probing the backend. `current_schemas(true)` /
+- Track the effective path by probing the target DB. `current_schemas(true)` /
   `current_database()` on the connection already reflect every `SET`/`USE`, the
   `pg_catalog`-implicit-first rule, and `$user` expansion — more robust than
   re-parsing every `SET` form. The engine caches the probe and re-runs it when
@@ -77,18 +77,18 @@ a lone `SET` changes the path and the next query decides and binds against it.
 
 The connection's enforcement catalog is kept transactionally current by
 [per-connection-catalog.md](./per-connection-catalog.md): the proxy introspects
-each referenced schema on the connection's own held backend connection, so a
+each referenced schema on the connection's own held target-DB connection, so a
 decision sees uncommitted in-transaction DDL.
 
 Temp objects need care because a session temp shadowing a real table is
 invisible to a datasource-global catalog — the analyzer would resolve the real
-table while the backend binds the temp. For PostgreSQL the proxy introspects the
-held connection's visible `pg_temp` columns (`probeTempColumns`, goproxy) and
-sends them with each decide; the control plane overlays only `pg_temp*` entries
-onto the base catalog (`editorTempOverlay`, EDITOR-channel-gated). The temp is
-searched first, so the analyzer resolves the same relation the backend binds. A
-session temp reads unmasked (the user owns it) and a zero-column temp scan skips
-the uncovered-scan gate.
+table while the target DB binds the temp. For PostgreSQL the proxy introspects
+the held connection's visible `pg_temp` columns (`probeTempColumns`, goproxy)
+and sends them with each decide; the control plane overlays only `pg_temp*`
+entries onto the base catalog (`editorTempOverlay`, EDITOR-channel-gated). The
+temp is searched first, so the analyzer resolves the same relation the target DB
+binds. A session temp reads unmasked (the user owns it) and a zero-column temp
+scan skips the uncovered-scan gate.
 
 Reading a temp back plain is safe: `CREATE TEMP … AS SELECT` is a write, so the
 write-references-masked deny (`Query.kt`) blocks copying a masked/denied source
@@ -101,7 +101,7 @@ limitations).
 
 [schema-threading-problem.md](./schema-threading-problem.md) fixes the _static_
 keys (names → fully-qualified keys, fail-closed on unresolvable) but resolves
-against a _snapshot_ namespace/catalog. On the wire the backend binds against
+against a _snapshot_ namespace/catalog. On the wire the target DB binds against
 the _live_ connection session, and every divergence — `search_path`/`USE`,
 freshly-created or temp tables — is a leak. This model removes the divergence:
 same connection, same live namespace, same fresh catalog on both sides.

--- a/docs/datasource-registration.md
+++ b/docs/datasource-registration.md
@@ -13,7 +13,7 @@ set up policy ahead of time), not a required gate.
 
 A proxy needs only `PM_DATASOURCE_NAME` — already what Cedar policies key on
 (`Datasource::"<name>"`, `authz/Authz.kt`) — plus `PM_TARGET_*` for its own
-backend connection. No numeric id crosses the wire; the control-plane keeps a
+target-DB connection. No numeric id crosses the wire; the control-plane keeps a
 `BIGSERIAL` surrogate internally and resolves `name` → `id` on every call.
 
 ## The gRPC surface
@@ -73,7 +73,7 @@ admin UI and incident triage — which physical instance a datasource points at.
 The three `advertise_*` fields are the opposite — client-facing and consumed.
 `advertise_addr` is the `host:port` a wire client dials to reach this
 datasource's proxy (`PM_ADVERTISE_ADDR`, [`../INSTALL.md`](../INSTALL.md)), not
-the upstream backend `host`/`port` above.
+the upstream target DB `host`/`port` above.
 
 `advertise_cert_chain` is the certificate chain a client should trust to reach
 this proxy: PEM, leaf first, then any intermediates and the root. A self-signed
@@ -141,7 +141,7 @@ message CatalogRequest {
 `default_schemas` and `mysql_lower_case_table_names` are load-bearing, not
 advisory: schema-threading resolves every bare table reference to catalog+schema
 via exactly these values, and getting them wrong authorizes a different table
-than the backend binds (see [`connection-model.md`](./connection-model.md)).
+than the target DB binds (see [`connection-model.md`](./connection-model.md)).
 Both come from live server/session state the proxy holds and cannot be
 hand-configured reliably. `engine_version` feeds
 [`system-classification.md`](./system-classification.md), whose
@@ -235,7 +235,7 @@ target:
 - `POST /api/datasources/{id}/test` is a proxy-attachment check, not a database
   connection test: `ok` is true when a proxy `Events` stream is currently
   attached to this datasource, and `message` adds the catalog-sync and last-seen
-  state. It reaches neither the backend nor the proxy.
+  state. It reaches neither the target DB nor the proxy.
 - `GET /api/datasources/live` is the same signal as a list of attached
   datasource names. `Datasource.lastSeenAt` is weaker — it records only that a
   proxy was seen at some point, and never clears.
@@ -278,10 +278,10 @@ short-lived ephemeral token minted for the requester), and the proxy dials back
 with `RunExec`. Data then flows both ways over a connection the control-plane
 never opened.
 
-One stream serves one session (session ↔ `RunExec` stream ↔ its own backend
+One stream serves one session (session ↔ `RunExec` stream ↔ its own target-DB
 connection), so a slow query in one session cannot head-of-line-block another,
 the stream's lifecycle is the session's lifecycle, and each session gets a
-dedicated backend connection where transactions, `SET`, and temp tables behave
+dedicated target-DB connection where transactions, `SET`, and temp tables behave
 like a real session.
 
 ```protobuf

--- a/docs/diagnostic-redaction.md
+++ b/docs/diagnostic-redaction.md
@@ -45,11 +45,11 @@ message:
   `RAISE`-based vectors are not reachable through the principal's own statement,
   and for an ordinary error the structural / `q` / `W` fields hold object names
   or are empty, not row values. Those fields are kept; the only reachable
-  value-carriers are stripped — the backend's own `M` (conversion) and `D` (the
-  whole-row `DETAIL` dump).
-- The editor/HTTP path also surfaces raw backend errors (`goproxy/run/runner.go`
-  returns the backend error to the control plane), so native-wire handling alone
-  does not cover it.
+  value-carriers are stripped — the target DB's own `M` (conversion) and `D`
+  (the whole-row `DETAIL` dump).
+- The editor/HTTP path also surfaces raw target-DB errors
+  (`goproxy/run/runner.go` returns the target-DB error to the control plane), so
+  native-wire handling alone does not cover it.
 
 ## Why an enumerated denylist is unsafe
 
@@ -98,7 +98,7 @@ keeps the rest:
   (`23514` → `check_violation`), falling back to the 2-char class name (`23` →
   `integrity_constraint_violation`) then a generic string; MySQL to the essno
   symbol (`1146` → `ER_NO_SUCH_TABLE`), generic fallback. It is looked up only
-  by the numeric code, never reconstructed from the backend's echoed text
+  by the numeric code, never reconstructed from the target DB's echoed text
   (truncating at `: '`, stripping quotes) — that would re-open the leak, since a
   crafted value can contain the delimiters. A free-message catch-all code (MySQL
   `1105` `ER_UNKNOWN_ERROR`, which `extractvalue`/`updatexml` abuse) keeps only
@@ -110,13 +110,13 @@ keeps the rest:
   class/generic message — a fail-safe UX default, not the boundary (the strip
   is).
 
-Everything else is kept. For an ordinary backend error the remaining PostgreSQL
-fields hold object names, not row values — the structural `s`/`t`/`c`/`d`/`n`
-(schema/table/column/type/constraint), and the PL/pgSQL context `W`/`q` which
-are simply empty. The only way to put an arbitrary value in any of them is
-`RAISE … USING` or dynamic PL/pgSQL, which needs a `DO`/`CALL`/function and is
-denied for a restricted principal. Keeping them gives a developer the real
-diagnostic —
+Everything else is kept. For an ordinary target-DB error the remaining
+PostgreSQL fields hold object names, not row values — the structural
+`s`/`t`/`c`/`d`/`n` (schema/table/column/type/constraint), and the PL/pgSQL
+context `W`/`q` which are simply empty. The only way to put an arbitrary value
+in any of them is `RAISE … USING` or dynamic PL/pgSQL, which needs a
+`DO`/`CALL`/function and is denied for a restricted principal. Keeping them
+gives a developer the real diagnostic —
 `[23514] check_violation on orders.amount, constraint amount_positive` — instead
 of a bare code. The accepted residual: a pre-existing trigger or vouched
 function that RAISEs a value into one of those fields, fired by an allowed
@@ -145,7 +145,7 @@ restricted-principal threat model.
 MySQL ERR packets keep essno + SQLSTATE and replace the message with the essno
 symbol; MySQL has no structured error fields.
 
-The strip runs where the backend wire is decoded — the native relay
+The strip runs where the target DB wire is decoded — the native relay
 (`goproxy/pgproxy/relay.go`, `goproxy/mysqlproxy/relay.go`, and the PostgreSQL
 extended-protocol `forwardError`/`forwardNotice` in
 `goproxy/pgproxy/diagnostics.go`) and the editor path.

--- a/docs/facts-emission.md
+++ b/docs/facts-emission.md
@@ -140,7 +140,7 @@ each read `orders` and expose at least its existence and cardinality, so
 `orders` must be a Table resource even when no Column fact covers it.
 
 The analyzer walks each resolved scope's source map and emits a Table fact only
-when the source resolves to a physical backend relation. A CTE, derived table,
+when the source resolves to a physical target-DB relation. A CTE, derived table,
 table-valued expression, or alias is not a physical Table; the walk recurses
 into its scope and emits the physical relations it reads. This reuses the
 analyzer's scope resolution (`analyzer/probe/relation.go`) rather than
@@ -148,10 +148,10 @@ collecting SQL names and subtracting a CTE-name set — that distinction is the
 safety property:
 
 ```sql
--- The outer orders is a CTE; the backend table is not read → no Table fact.
+-- The outer orders is a CTE; the target-DB table is not read → no Table fact.
 WITH orders AS (SELECT 1) SELECT count(*) FROM orders;
 
--- The CTE body resolves orders against the backend table → it is emitted.
+-- The CTE body resolves orders against the target-DB table → it is emitted.
 WITH orders AS (SELECT count(*) AS c FROM orders) SELECT c FROM orders;
 ```
 
@@ -278,8 +278,8 @@ action; apply the dangerous-function and `exception.unanalyzable` gates for an
 unresolved statement; then authorize classified functions, Columns, and
 uncovered Tables. An EXPLAIN that would MASK is denied. For any remaining MASK
 verdict, the control-plane checks `exception.unmaskable` and carries the result
-as a capability flag for the proxy. Every gate runs before the backend receives
-the statement.
+as a capability flag for the proxy. Every gate runs before the target DB
+receives the statement.
 
 Assuming `datasource.connect` and the `stmt.kind.select` gate pass:
 

--- a/docs/mcp-access-control.md
+++ b/docs/mcp-access-control.md
@@ -266,7 +266,7 @@ REST's session-only `requireApi` on some list routes).
   `DELETE /api/datasources/{id}/classification`.
 
 MCP exposes column tags only. There is no table-level tag store; tagging a whole
-table is out of scope until/unless the backend grows one (a separate design).
+table is out of scope until/unless the target DB grows one (a separate design).
 Datasource tags are set only by the proxy's gRPC `Register`/`PushCatalog` —
 there is no REST field to edit them (`DatasourceInput` has no `tags`) — so MCP
 reports datasource tags but has no `set_datasource_tags` tool.

--- a/docs/per-connection-catalog.md
+++ b/docs/per-connection-catalog.md
@@ -5,9 +5,9 @@ Two catalogs with opposite freshness contracts run on separate gRPC channels:
 - The **enforcement catalog** is per-connection, control-plane-commanded, and
   transactionally current. Every wire/editor connection resolves decisions
   against catalog fragments the proxy introspected on that connection's own held
-  backend connection, so they reflect uncommitted in-transaction DDL. The
-  control plane always decides against exactly what _that_ connection's backend
-  will bind.
+  target-DB connection, so they reflect uncommitted in-transaction DDL. The
+  control plane always decides against exactly what _that_ connection's target
+  DB will bind.
 - The **config catalog** is datasource-global and SWR-refreshed (~12 min), on
   its own channel. It feeds the config/admin surfaces — catalog browsing,
   tagging/classification, table detail, the system-classification manifest, the
@@ -66,7 +66,7 @@ the DB-side hash (`goproxy/db/db.go`), and the config-channel split (a second
 | Scope | one wire/editor connection (per-schema fragments) | the datasource |
 | Freshness | transactionally current for the issuing connection | SWR, ambient ~12 min + admin refresh |
 | Kept current by | control-plane `REFETCH` commands, DB-hash-gated | proxy timer + Events `RefreshCatalog` |
-| Introspected on | the connection's held backend connection | a dedicated short-lived connection (`introspect.Run`) |
+| Introspected on | the connection's held target-DB connection | a dedicated short-lived connection (`introspect.Run`) |
 | Channel | enforcement (`ValidateToken`/`Decide`/`PushSchemaFragment`/`CloseConnection`/`RunExec`/`ReportCompletion`) | config (`Register`/`PushCatalog`/`Events`/`TableDetailExec`) |
 | Control-plane storage | in-memory content-addressed fragments + per-connection held-hash map | `catalog_column` + `datasource` rows |
 | Read by | `decideConnection` → `decideQuery` (wire/editor/`RunExec`) | catalog browser, classification writes/reads, MCP `browse_catalog`, table detail, approval dry-run previews, manifest logging, liveness UI |
@@ -96,7 +96,7 @@ keyed by a stable content hash of its enforcement-relevant fields:
   (refcount).
 
 So "reuse instead of refetch" falls out for free: two connections that see the
-same `s1` share `(datasource, s1, H)`; a connection whose backend already
+same `s1` share `(datasource, s1, H)`; a connection whose target DB already
 matches the held hash for a schema skips the fetch (a no-op `REFETCH`). It also
 makes the after-DDL refresh a content event, not a timing event.
 
@@ -106,7 +106,7 @@ One generic, extensible command carries the whole mechanism; `REFETCH` is its
 only value today.
 
 `REFETCH(schema S, if_hash_differs H)` — the proxy runs a DB-side hash query for
-`S` on the held backend connection. If the live hash equals `H` it is a no-op
+`S` on the held target-DB connection. If the live hash equals `H` it is a no-op
 (the connection already holds the right fragment) and the proxy acks
 "unchanged". If it differs (or no trustworthy hash can be produced), the proxy
 full-introspects `S` on the held connection and pushes the fragment plus its
@@ -144,11 +144,11 @@ own statement:
    statement of its own. On its next `Decide` the control plane sees the held
    `S`-hash ≠ the datasource-authoritative `S`-hash →
    `before_decide REFETCH(S, H = held)` → retry. The proxy re-hashes `S` on its
-   own backend: if that backend also has the change it pushes the new fragment;
-   if it legitimately does not (replica lag), the `REFETCH` is a no-op and the
-   control plane records the connection as revalidated so it does not loop. The
-   control plane always decides against what _this_ connection's backend binds,
-   never a sibling's.
+   own target DB: if that target DB also has the change it pushes the new
+   fragment; if it legitimately does not (replica lag), the `REFETCH` is a no-op
+   and the control plane records the connection as revalidated so it does not
+   loop. The control plane always decides against what _this_ connection's
+   target DB binds, never a sibling's.
 2. Control-plane restart. The control plane lost its in-memory per-connection
    catalogs; the next `Decide` for an unknown `connection_id` → `before_decide`
    (re-push the needed schemas) → retry. A mid-transaction connection
@@ -177,7 +177,7 @@ own statement:
    decides admit/reject; on admit it mints a 128-bit CSPRNG `connection_id`,
    creates the per-connection state, and returns `connection_id` + `on_open`
    (`REFETCH`s for the default + system schemas).
-3. Fetch-on-open (hash-gated). The proxy dials its backend, then runs each
+3. Fetch-on-open (hash-gated). The proxy dials its target DB, then runs each
    `on_open REFETCH` on that held connection: hash the schema, push the fragment
    only if it differs. Matching schemas are no-ops (shared fragment reuse). Only
    after every `on_open` push is acknowledged does the proxy serve client
@@ -186,7 +186,7 @@ own statement:
 4. Decide, refresh-on-command. Every client statement → `Decide` (carrying
    `connection_id` + the live `search_path`). The response is a `oneof`: a
    verdict (with any `after_statement` commands) or a `before_decide` (run
-   commands, re-send). On a verdict the proxy relays, observes the backend's
+   commands, re-send). On a verdict the proxy relays, observes the target DB's
    mechanical success signal, and runs any `after_statement REFETCH` on the held
    connection before the next statement.
 5. Close. On connection close the proxy sends `CloseConnection(connection_id)`;
@@ -195,15 +195,15 @@ own statement:
 
 ### The correctness property
 
-The hash query and the full introspection both run on the held backend
+The hash query and the full introspection both run on the held target-DB
 connection, inside the client's current transaction, so they see uncommitted
 DDL. After `BEGIN; DROP TABLE s1.accounts;` the `after_statement REFETCH(s1, …)`
 hashes `s1` on the held connection (now differs) → full-introspects `s1` inside
 the transaction (sees the drop) → pushes a fragment without `accounts` → the
 connection's held `s1`-hash updates. The next decision for
 `SELECT … FROM accounts` (search_path `s1, s2`) resolves the bare name to what
-the backend will actually bind — `s2.accounts` — and denies it if the principal
-lacks access.
+the target DB will actually bind — `s2.accounts` — and denies it if the
+principal lacks access.
 
 This eliminates, for the enforcing session: datasource-global staleness (no
 shared snapshot to be stale against), the committed-DDL wrong-ALLOW gate
@@ -215,12 +215,12 @@ go directly: the refresh runs inside the transaction right after the DDL;
 so there is no idle gate to miss; a disconnect takes the connection's fragments
 with it and no sibling's catalog ever depended on that session.
 
-Scope (MySQL temporary tables). The "decides against exactly what the backend
+Scope (MySQL temporary tables). The "decides against exactly what the target DB
 binds" property is scoped to objects visible in `information_schema`. A MySQL
 `CREATE TEMPORARY TABLE` is invisible to `information_schema` even within its
 own session, so the held-connection hash/introspection cannot see a session temp
 that shadows a base-table name — `decideQuery` resolves the bare name to the
-base table while the backend binds the temp. This is mostly fail-closed in
+base table while the target DB binds the temp. This is mostly fail-closed in
 practice (a temp `CREATE … AS SELECT` is a write gated by the
 write-references-masked deny; a shape-mismatched read tends to error) but the
 property does not cover it. PostgreSQL's `pg_temp` is handled by the per-query
@@ -232,10 +232,10 @@ residual is MySQL-specific (see known limitations).
 The proxy is inside the trusted computing base. Correctness depends on it (a)
 calling the control plane for every statement, (b) enforcing the verdict
 (mask/deny), and (c) honestly executing a forced `REFETCH` (running the hash
-query on its backend and reporting the result truthfully). A proxy that bypasses
-`Decide`, forwards raw SQL, or fabricates a hash / `unchanged` reply defeats
-enforcement — no protocol mechanism here prevents that; removing the proxy from
-the TCB would require DB-enforced, control-plane-signed per-statement
+query on its target DB and reporting the result truthfully). A proxy that
+bypasses `Decide`, forwards raw SQL, or fabricates a hash / `unchanged` reply
+defeats enforcement — no protocol mechanism here prevents that; removing the
+proxy from the TCB would require DB-enforced, control-plane-signed per-statement
 capabilities, a different architecture out of scope. What this design avoids is
 depending on the proxy's proactive, voluntary freshness bookkeeping:
 `before_decide` + the pending mark let the control plane demand freshness at
@@ -279,7 +279,7 @@ message SchemaFragmentPush {
   bool   unchanged          = 5;  // true = live hash matched H; columns omitted (no-op ack)
   repeated Column columns   = 6;  // enforcement-relevant fields only (schema/table/column/
                                   // data_type/ordinal/nullable) — the same Column message as PushCatalog
-  uint64 backend_generation = 7;  // which backend-connection instance measured this
+  uint64 backend_generation = 7;  // which target-DB-connection instance measured this
 }
 message SchemaFragmentAck { uint64 generation = 1; }  // per-connection generation after applying
 
@@ -360,8 +360,8 @@ catalog).
 
 - State. Per `(datasource, schema)`: the authoritative
   `{ hash, immutable fragment, epoch }` (last accepted push; a liveness hint,
-  never a correctness input — each connection re-verifies against its own
-  backend), plus a content-addressed fragment pool (dedup + refcount). Per
+  never a correctness input — each connection re-verifies against its own target
+  DB), plus a content-addressed fragment pool (dedup + refcount). Per
   `connection_id`:
   `{ held schema→hash map, per-schema pending mark, generation, binding tuple, backend_generation }`.
   All in-memory — session-scoped ephemeral state; persisting it would be
@@ -403,7 +403,7 @@ catalog).
   `probeNamespace`/`probeTempColumns`: the DB-side hash query for a schema, and
   the per-schema full introspection (the `columnsSQL` column scan filtered to
   the schema — all schemas including system, never excluded). Both run on the
-  wire session's backend connection so they see its transaction.
+  wire session's target-DB connection so they see its transaction.
   `introspect.Run` (dedicated connection) stays for the config catalog only.
 - PG extended-protocol capture uses the extended probe. When a PG connection is
   mid extended-query batch (Parse/Bind/Execute), the held-connection hash and
@@ -412,7 +412,7 @@ catalog).
   would trigger an implicit commit/sync of the pending extended batch and
   corrupt normal operation.
 - Fetch-on-open / refresh-on-command. Run `on_open` before the serve loop; run
-  `after_statement` immediately after the backend's mechanical success signal
+  `after_statement` immediately after the target DB's mechanical success signal
   (PG simple: no `ErrorResponse` before `ReadyForQuery`; PG extended:
   `CommandComplete` for the flagged `Execute`; MySQL: the tracked OK/EOF
   terminator, `relayQueryResponseTracked`, for both `COM_QUERY` and
@@ -421,7 +421,7 @@ catalog).
   (bounded retries; repeated failure → fail closed).
 - Refresh failure is fail-closed, per-connection. A failed `after_statement`
   refetch would leave this connection's fragment provably wrong for the open
-  transaction → close both connections (forcing backend rollback). The
+  transaction → close both connections (forcing target DB rollback). The
   control-plane pending mark makes this belt-and-suspenders.
 
 ## The catalog hash
@@ -509,7 +509,7 @@ endpoint, same `x-pm-secret-token`), owned by a config-side client in
 
 ## Editor, table-detail, temp overlay
 
-- The editor session is just another connection. It already holds one backend
+- The editor session is just another connection. It already holds one target-DB
   connection per session (`RunExecService.openSession` / one `RunExec` stream).
   `OpenRunChannel` carries `connection_id` + `on_open`; the proxy fetches the
   session's schemas before the first `RunQuery`; editor DDL/CALL gets the same
@@ -552,7 +552,7 @@ endpoint, same `x-pm-secret-token`), owned by a config-side client in
   both holding `accounts`; an in-tx `DROP app.accounts` is captured, then
   `COMMIT` / `Sync` / `ROLLBACK TO` reverts it; the held fragment still shows
   `app.accounts` gone, so `decideQuery` resolves bare `accounts` to
-  `public.accounts` (allowed) while the reverted backend binds the restored
+  `public.accounts` (allowed) while the reverted target DB binds the restored
   `app.accounts` → cleartext of `app.accounts`. Fail-closed stopgap: on any
   observed rollback / `Sync`-abort / savepoint-revert, force a `before_decide`
   re-check of the transaction-dirty schemas instead of trusting the held
@@ -560,10 +560,10 @@ endpoint, same `x-pm-secret-token`), owned by a config-side client in
 - MySQL temporary-table shadowing (mostly fail-closed). A
   `CREATE TEMPORARY TABLE` is invisible to `information_schema`, so a session
   temp shadowing a base-table name is not captured in the held fragment;
-  `decideQuery` resolves the bare name to the base table while the backend binds
-  the temp. Mostly fail-closed in practice (temp creation is a write gated by
-  the write-references-masked deny; shape-mismatched reads against the temp tend
-  to error). MySQL has no `pg_temp`-style overlay
+  `decideQuery` resolves the bare name to the base table while the target DB
+  binds the temp. Mostly fail-closed in practice (temp creation is a write gated
+  by the write-references-masked deny; shape-mismatched reads against the temp
+  tend to error). MySQL has no `pg_temp`-style overlay
   (`SupportsTempOverlay() == false`).
 - PostgreSQL without `pgcrypto` (weakened schema-hash collision-resistance).
   Where `pgcrypto` is absent the schema hash falls back to core `md5()` rather
@@ -587,7 +587,7 @@ endpoint, same `x-pm-secret-token`), owned by a config-side client in
   (row-limited Execute) defers its `after_statement` refetch to the next
   `CommandComplete` — niche for DDL (returns no rows) and backstopped by the
   pending mark. A held-connection probe that draws an `ErrorResponse` mid
-  extended-batch leaves the backend awaiting `Sync`, so the next probe blocks
+  extended-batch leaves the target DB awaiting `Sync`, so the next probe blocks
   until the read-idle timeout before failing closed — a latency amplification,
   not a leak; a `Sync`-to-resync removes it.
 

--- a/docs/policy-store.md
+++ b/docs/policy-store.md
@@ -26,7 +26,7 @@ System rows are immutable through the API except for `enabled`:
 - an upgrade UPSERT updates the shipped source but deliberately preserves the
   row's current `enabled` value;
 - user rows remain full CRUD; and
-- the backend enforces the distinction. The console is a matching read-only
+- the target DB enforces the distinction. The console is a matching read-only
   presentation, not the security boundary.
 
 A clean database runs the whole migration chain and therefore starts with the
@@ -538,7 +538,7 @@ DTO:
 CedarPolicy(id, systemKey?, origin /* SYSTEM | USER */, name, cedarSrc, enabled, updatedBy, updatedAt)
 ```
 
-Backend invariants:
+Target DB invariants:
 
 - `POST /api/policies` creates USER only and rejects a `system:`-prefixed name
   with a 400;
@@ -564,7 +564,7 @@ The policy list shows one surface, grouped or filterable by origin
   for copy/review; the enable switch stays available to `admin.policies`;
   disabling shows the concrete consequence (for example, "Disabling the critical
   guard allows a later permit to expose credentials or privileged mutation");
-  and the UI handles backend immutability errors rather than assuming its own
+  and the UI handles target DB immutability errors rather than assuming its own
   controls suffice.
 - User rows: normal Edit/Delete/enable controls.
 

--- a/docs/schema-threading-problem.md
+++ b/docs/schema-threading-problem.md
@@ -66,7 +66,7 @@ an `EngineConfig` (engine identity, version, and — for MySQL —
 carries structured `catalog`, `schema`, `table`, `column`, and SQL-type fields.
 The namespace descriptor is the namespace observed at introspection (or the
 connection's live path on the wire), not a claim about an arbitrary long-lived
-backend session.
+target-DB session.
 
 ### Go resolves physical tables once
 

--- a/docs/system-classification.md
+++ b/docs/system-classification.md
@@ -13,7 +13,7 @@ Aurora deployments of those series — Aurora PostgreSQL 16 and 17, Aurora MySQL
 3.x (MySQL 8.0-compatible) and Aurora MySQL 8.4. (The repo's
 `docker-compose.yml` vanilla PostgreSQL 17 / MySQL 8.4 are the offline CI
 substrate; the manifests are keyed by engine major series, so the same manifest
-serves a vanilla and an Aurora backend of that series.) The format supports
+serves a vanilla and an Aurora target DB of that series.) The format supports
 additional release series without code changes.
 
 Aurora is not vanilla, so each manifest also classifies the Aurora-proprietary
@@ -345,7 +345,7 @@ server-file/program forms of `COPY`, which are also `exception.unmaskable`,
 since policy cannot make an unimplemented relay work.
 
 `SET_ROLE` and `SET_SESSION_AUTHORIZATION` are `system:critical` because they
-change which backend identity and namespace future statements bind under
+change which target DB identity and namespace future statements bind under
 ([statement-facts-contract.md](./statement-facts-contract.md)).
 `SET_STANDARD_CONFORMING_STRINGS` joins them: it changes how the server lexes
 string literals, which changes what a later statement means. `USER_TYPE_CAST`
@@ -584,7 +584,7 @@ Utility::"acme-mysql/SHOW_PROCESSLIST"
 
 The key is datasource / canonical command id, outside the SQL catalog/schema
 namespace, so a quoted user schema or function cannot collide with it. The
-resource is logical only and is never passed to the backend as an object name.
+resource is logical only and is never passed to the target DB as an object name.
 Transaction control and connection plumbing stay in their own structural path.
 Ordinary metadata SHOWs (`SHOW TABLES`, `SHOW CREATE TABLE`, …) carry no utility
 grant; their kind (a metadata kind Cedar maps to `stmt.cat.metadata`) is
@@ -616,8 +616,9 @@ at runtime.
 
 ### Version selection
 
-Catalog introspection records the backend's parsed engine release. Selection is
-by release series: PostgreSQL major (`17`) and MySQL LTS/release family (`8.4`).
+Catalog introspection records the target DB's parsed engine release. Selection
+is by release series: PostgreSQL major (`17`) and MySQL LTS/release family
+(`8.4`).
 
 - exact supported series → select its manifest;
 - newer patch/minor within the series → use the series manifest; unmatched new
@@ -633,7 +634,7 @@ that an untested engine major is certified.
 
 ### Introspection
 
-The proxy introspects every schema the backend reports — a plain
+The proxy introspects every schema the target DB reports — a plain
 `information_schema.columns` scan with no exclusions, system schemas included —
 and pushes the columns over gRPC `PushCatalog` into
 `DatasourceStore.storePushedCatalog`, which persists the real
@@ -641,7 +642,7 @@ catalog/schema/table/column identities the MappingSchema needs. Excluding a
 system schema here would be the shadowing leak
 [schema-threading-problem.md](./schema-threading-problem.md) describes: a system
 table absent from the mapping resolves to a user table of the same name while
-the backend binds the system one. Refresh follows the connection-model
+the target DB binds the system one. Refresh follows the connection-model
 snapshot/SWR path; system-schema breadth never adds a synchronous per-query
 catalog scan or blocks existing connections on a full refresh. The manifest does
 not write system tags into `column_classification`; the object identity is
@@ -694,7 +695,7 @@ listed under [Verification](#verification) — nothing more. In particular:
 - there is no committed inventory of any engine version's system objects;
 - no test enumerates a live server's catalog and compares it against a manifest;
   the DB-backed tests exercise specific statements against a Testcontainers
-  backend, they do not sweep the engine's system surface; and
+  target DB, they do not sweep the engine's system surface; and
 - no CI job diffs a manifest against a new engine release. The only
   classification-related CI is `mise run verify`, which runs those same tests.
 
@@ -770,8 +771,8 @@ means rather than which statements pass.
 - immutable JSON manifest files per engine release series;
 - a validated in-process `SystemClassifier` per series, and a combined checksum
   over the bundle;
-- `datasource.engine_version`, the raw backend version string the proxy pushed,
-  which is what manifest resolution keys off;
+- `datasource.engine_version`, the raw target DB version string the proxy
+  pushed, which is what manifest resolution keys off;
 - canonical Utility grants and manifest command/tag mappings;
 - `catalog_column` as the physical column inventory, including the system
   schemas; and

--- a/docs/task-execution.md
+++ b/docs/task-execution.md
@@ -75,7 +75,7 @@ request lifecycle, a human approver, and the encrypted result store.
 3. Run. Per statement, the proxy round-trips `Decide` → sfacts + Cedar under the
    relevant role set, against the live per-connection catalog → verdict + mask
    plan — then runs the statement and applies the masks.
-   - Wire: the native session's own backend connection; roles = caller's own;
+   - Wire: the native session's own target-DB connection; roles = caller's own;
      channel `wire`.
    - Editor: CP-driven `RunExec` on an editor session connection (or one-shot
      `/api/datasources/{id}/query`); roles = caller's own; channel `editor`.
@@ -108,7 +108,7 @@ by the per-statement `Decide`.
 | Create | — | — | `POST /api/approvals` → `PENDING` (requires `roleId`) |
 | Approval | — | — | the chosen approver approves or rejects (`task.approve`) |
 | `execute-as R` | the connecting principal's own roles | the caller's own roles (no elevation) | the elevation role set R |
-| Connection | the wire session's own backend connection | the editor session's held connection (or one-shot dial) | a new connection, dialed at run |
+| Connection | the wire session's own target-DB connection | the editor session's held connection (or one-shot dial) | a new connection, dialed at run |
 | Executor (runs it) | the connecting client (caller) | the caller | the approver of record |
 | Run | per-statement `Decide` → apply masks (streams to socket) | per-statement `Decide` via `RunExec` → apply masks | per-statement `Decide` via `RunExec` under `{R}` → apply masks |
 | Result | streams back on the socket | HTTP response rows | `save → query_result` ciphertext; view via `/api/approvals/{id}/result` |
@@ -184,7 +184,7 @@ connection is opened, under the relevant roles:
 - editor — when the editor session opens / one-shot query dials;
 - workflow — when the new connection is dialed at run.
 
-On DENY the connection is refused with no backend dial. `decideQuery` also
+On DENY the connection is refused with no target DB dial. `decideQuery` also
 re-checks `datasource.connect` ahead of each statement as a mid-session
 revocation guard, but the authoritative connect gate is at connection open.
 
@@ -204,7 +204,7 @@ revocation guard, but the authoritative connect gate is at connection open.
 - Cancel / abort. There is no `RunCancel` control message on the run channel
   today (`ControlRunMsg` is only `RunQuery` | `RunClose`). In-flight aborts use
   the proxy timeout watchdog: PostgreSQL `CancelRequest` (via the session's
-  `BackendKeyData`), MySQL `KILL QUERY <conn-id>`, without dropping the
+  `TargetDbKeyData`), MySQL `KILL QUERY <conn-id>`, without dropping the
   connection for a clean timeout path. A cancel is a control-plane-side
   terminalization: `POST /api/approvals/{id}/cancel` and
   `POST /api/editor/tasks/{taskId}/cancel` are `task.cancel`-gated, accept only

--- a/docs/web-console.md
+++ b/docs/web-console.md
@@ -44,7 +44,7 @@ every admin API. The client learns the viewer's coarse capabilities from
 - A logs tab (`query-logs` in `result-tabs`): a SQL-console-style log of
   statements run this session — statement text, ALLOW/MASK/DENY with deny
   reason, rows, latency, errors, timestamp.
-- The editor runs on a per-session backend connection (see
+- The editor runs on a per-session target-DB connection (see
   [`connection-model.md`](./connection-model.md)), so `BEGIN…COMMIT`/`ROLLBACK`,
   `SET`/`USE`, and temp tables persist across statements. Enforcement stays
   per-statement: a statement referencing a masked column still denies

--- a/engine/src/main/kotlin/com/ridi/oss/proxymonster/classification/SystemClassificationStore.kt
+++ b/engine/src/main/kotlin/com/ridi/oss/proxymonster/classification/SystemClassificationStore.kt
@@ -31,7 +31,7 @@ class SystemClassificationStore private constructor(
     val checksum: String,
 ) {
     /**
-     * Resolve the manifest for a datasource. [serverVersion] is the parsed backend release (e.g. `17.9`,
+     * Resolve the manifest for a datasource. [serverVersion] is the parsed target DB release (e.g. `17.9`,
      * `8.0.44`, `8.4.7`). [allowFallback] is the operator opt-in: when false (the safe default), an
      * uncertified major returns null (system schemas stay unavailable); when true, it falls back to the
      * nearest supported major of the same engine.

--- a/goproxy/boot/boot.go
+++ b/goproxy/boot/boot.go
@@ -66,7 +66,7 @@ func Run(registry spi.Registry) error {
 
 	provider := cfg.Provider
 	dbImpl := provider.NewDb()
-	backend := spi.BackendTarget{
+	targetDb := spi.TargetDb{
 		Host:     cfg.TargetHost,
 		Port:     cfg.TargetPort,
 		Db:       cfg.TargetDb,
@@ -147,7 +147,7 @@ func Run(registry spi.Registry) error {
 	defer eventsCancel() // covers the early serve-error return; the drain path cancels explicitly (idempotent)
 	eventsDone := make(chan struct{})
 	// A wire-protocol version skew is fatal: refuse to start rather than attach and stall the run channel.
-	if err := registerAndPushCatalog(configClient, cfg, backend, provider, certChain); err != nil {
+	if err := registerAndPushCatalog(configClient, cfg, targetDb, provider, certChain); err != nil {
 		slog.Error("refusing to start — deploy the proxy and control-plane from the same server-v* release", "error", err)
 		return err
 	}
@@ -158,21 +158,21 @@ func Run(registry spi.Registry) error {
 			func() {
 				// A re-register (reconnect) that finds a now-incompatible control-plane is equally fatal:
 				// exit so the supervisor replaces this proxy rather than run against a version it cannot speak.
-				if err := registerAndPushCatalog(configClient, cfg, backend, provider, certChain); err != nil {
+				if err := registerAndPushCatalog(configClient, cfg, targetDb, provider, certChain); err != nil {
 					slog.Error("control-plane became version-incompatible on reconnect — exiting", "error", err)
 					os.Exit(1)
 				}
 			},
-			func() { refreshCatalog(configClient, provider, backend) },
+			func() { refreshCatalog(configClient, provider, targetDb) },
 			func(open spi.RunOpen) {
 				runs.Add()
 				go func() {
 					defer runs.Done()
-					run.NewRunner(enforcementClient, dbImpl, backend, provider, cfg.QueryTimeout).Run(open, runs.Signal())
+					run.NewRunner(enforcementClient, dbImpl, targetDb, provider, cfg.QueryTimeout).Run(open, runs.Signal())
 				}()
 			},
 			func(sessionID, schema, table string) {
-				go run.NewTableDetailRunner(configClient, backend, provider).Run(sessionID, schema, table)
+				go run.NewTableDetailRunner(configClient, targetDb, provider).Run(sessionID, schema, table)
 			},
 		)
 		// A version rejection on the events stream is fatal even when a resync Register races to a still-
@@ -186,11 +186,11 @@ func Run(registry spi.Registry) error {
 	go func() {
 		for {
 			time.Sleep(ambientRefreshInterval)
-			refreshCatalog(configClient, provider, backend)
+			refreshCatalog(configClient, provider, targetDb)
 		}
 	}()
 
-	server := provider.NewWireServer(cfg.ProxyPort, backend, enforcementClient, dbImpl, tlsProvider)
+	server := provider.NewWireServer(cfg.ProxyPort, targetDb, enforcementClient, dbImpl, tlsProvider)
 	slog.Info("starting proxy-monster data plane", "engine", cfg.Engine, "control_plane", cfg.ControlPlaneGrpcTarget)
 
 	serveErr := make(chan error, 1)
@@ -261,17 +261,17 @@ func gracefulDrain(
 // stays non-fatal (returns nil after the attempts): the proxy starts and fails decisions closed until the
 // control plane has the catalog, so a briefly-unreachable control plane self-heals on reconnect.
 func registerAndPushCatalog(
-	configClient *cp.Client, cfg *config.Config, backend spi.BackendTarget, provider spi.Provider,
+	configClient *cp.Client, cfg *config.Config, targetDb spi.TargetDb, provider spi.Provider,
 	certChain func() *string,
 ) error {
 	for attempt := 0; attempt < bootRegisterAttempts; attempt++ {
-		err := configClient.Register(provider.Dialect().Proto(), backend.Host, backend.Port, backend.Db, cfg.DatasourceTags, cfg.AdvertiseAddr, certChain(), cfg.TLSEnabled())
+		err := configClient.Register(provider.Dialect().Proto(), targetDb.Host, targetDb.Port, targetDb.Db, cfg.DatasourceTags, cfg.AdvertiseAddr, certChain(), cfg.TLSEnabled())
 		if errors.Is(err, cp.ErrIncompatibleControlPlane) {
 			return err
 		}
 		if err != nil {
 			slog.Warn("datasource registration failed", "attempt", attempt+1, "of", bootRegisterAttempts, "error", err)
-		} else if refreshCatalog(configClient, provider, backend) {
+		} else if refreshCatalog(configClient, provider, targetDb) {
 			slog.Info("datasource registered + catalog pushed", "datasource", cfg.DatasourceName)
 			return nil
 		}
@@ -285,10 +285,10 @@ func registerAndPushCatalog(
 	return nil
 }
 
-func refreshCatalog(configClient *cp.Client, provider spi.Provider, backend spi.BackendTarget) bool {
+func refreshCatalog(configClient *cp.Client, provider spi.Provider, targetDb spi.TargetDb) bool {
 	refreshMu.Lock()
 	defer refreshMu.Unlock()
-	catalog, err := introspect.Run(provider, backend)
+	catalog, err := introspect.Run(provider, targetDb)
 	if err != nil {
 		slog.Warn("catalog refresh failed", "error", err)
 		return false

--- a/goproxy/config/config_test.go
+++ b/goproxy/config/config_test.go
@@ -26,19 +26,19 @@ type configTestProvider struct {
 	dialect engine.Dialect
 }
 
-func (p configTestProvider) Dialect() engine.Dialect                     { return p.dialect }
-func (configTestProvider) NewDb() engine.Db                              { return nil }
-func (configTestProvider) OpenTarget(spi.BackendTarget) (*sql.DB, error) { return nil, nil }
+func (p configTestProvider) Dialect() engine.Dialect                { return p.dialect }
+func (configTestProvider) NewDb() engine.Db                         { return nil }
+func (configTestProvider) OpenTarget(spi.TargetDb) (*sql.DB, error) { return nil, nil }
 func (configTestProvider) ProbeNamespace(*sql.Conn, string) ([]string, *int32, error) {
 	return nil, nil, nil
 }
 func (configTestProvider) ReadTableDetail(*sql.Conn, string, string) (*spi.TableDetail, error) {
 	return nil, nil
 }
-func (configTestProvider) NewWireServer(int, spi.BackendTarget, spi.EnforcementClient, engine.Db, func() (*tls.Config, error)) spi.WireServer {
+func (configTestProvider) NewWireServer(int, spi.TargetDb, spi.EnforcementClient, engine.Db, func() (*tls.Config, error)) spi.WireServer {
 	return nil
 }
-func (configTestProvider) NewRunSession(context.Context, spi.BackendTarget, engine.Db, spi.SessionClient, string, []byte, engine.ExecGuard, time.Duration) (spi.BackendSession, error) {
+func (configTestProvider) NewRunSession(context.Context, spi.TargetDb, engine.Db, spi.SessionClient, string, []byte, engine.ExecGuard, time.Duration) (spi.TargetDbSession, error) {
 	return nil, nil
 }
 

--- a/goproxy/cp/client.go
+++ b/goproxy/cp/client.go
@@ -1,7 +1,7 @@
 // Package cp is the proxy's gRPC client to the control plane.
 //
 // The proxy fronts ONE datasource (identified by datasourceName, its stable wire identity) and brokers
-// to the backend itself, so it only needs the verdict + mask spec — it never sends rows to the control
+// to the target DB itself, so it only needs the verdict + mask spec — it never sends rows to the control
 // plane. Per-query enforcement re-sends the RAW token to Decide, which the control plane re-validates
 // every call (closing the mid-session revocation gap): an authN failure (bad/revoked/expired token,
 // deprovisioned principal) comes back as an error the caller fails closed on, distinct from a policy
@@ -71,7 +71,7 @@ const (
 	eventsDrainReconnect = 500 * time.Millisecond
 	// eventsStreamMaxAge bounds how long one Events stream is used before it is replaced. HTTP/2 keepalive
 	// proves the CONNECTION is alive, not that the stream on it still reaches a live control plane: a
-	// load balancer that keeps a connection open toward a replaced backend leaves the proxy holding a
+	// load balancer that keeps a connection open toward a replaced target DB leaves the proxy holding a
 	// stream nothing will ever answer, and because the proxy's other calls are unary they open their own
 	// connections and keep succeeding — so the catalog stays fresh while the control plane reports this
 	// datasource as having no proxy attached, and every query against it is refused. Ending the stream on
@@ -397,7 +397,7 @@ func (c *Client) PushCatalog(catalog *pb.CatalogRequest) error {
 		return fmt.Errorf("cp: push catalog for %q: %w", c.datasourceName, err)
 	}
 	// Paired with introspect.Run's phase breakdown, this closes the refresh cycle: a slow refresh is
-	// either the backend scan or this push, and the two logs together say which.
+	// either the target DB scan or this push, and the two logs together say which.
 	slog.Info("pushed catalog", "datasource", c.datasourceName, "columns", ack.GetColumns(),
 		"push_ms", time.Since(started).Milliseconds())
 	return nil

--- a/goproxy/cp/client_test.go
+++ b/goproxy/cp/client_test.go
@@ -460,7 +460,7 @@ func TestRegisterAndPushCatalog(t *testing.T) {
 	fake := &fakeControlPlane{}
 	c := startFakeControlPlane(t, fake)
 	chain := "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
-	if err := c.Register(enginepb.Engine_MYSQL, "backend", 3306, "app", []string{"tag"}, "127.0.0.1:6033", &chain, true); err != nil {
+	if err := c.Register(enginepb.Engine_MYSQL, "target DB", 3306, "app", []string{"tag"}, "127.0.0.1:6033", &chain, true); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 	catalog := &pb.CatalogRequest{Columns: []*pb.Column{{Schema: "s", Table: "t", Column: "c"}}}
@@ -505,7 +505,7 @@ func TestRegisterRejectsIncompatibleControlPlaneVersion(t *testing.T) {
 	bad := ProtocolVersion + 1
 	fake := &fakeControlPlane{registerRespVersion: &bad}
 	c := startFakeControlPlane(t, fake)
-	err := c.Register(enginepb.Engine_MYSQL, "backend", 3306, "app", nil, "", nil, false)
+	err := c.Register(enginepb.Engine_MYSQL, "target DB", 3306, "app", nil, "", nil, false)
 	if !errors.Is(err, ErrIncompatibleControlPlane) {
 		t.Fatalf("Register against a version-skewed control plane must return ErrIncompatibleControlPlane: %v", err)
 	}
@@ -522,7 +522,7 @@ func TestRegisterTreatsControlPlaneRejectionAsIncompatible(t *testing.T) {
 		"proxy wire-protocol version 1 is incompatible with this control-plane's version 2 — deploy the proxy and control-plane from the same server-v* release",
 	)}
 	c := startFakeControlPlane(t, fake)
-	err := c.Register(enginepb.Engine_MYSQL, "backend", 3306, "app", nil, "", nil, false)
+	err := c.Register(enginepb.Engine_MYSQL, "target DB", 3306, "app", nil, "", nil, false)
 	if !errors.Is(err, ErrIncompatibleControlPlane) {
 		t.Fatalf("a control-plane version rejection must surface as ErrIncompatibleControlPlane: %v", err)
 	}
@@ -690,7 +690,7 @@ func TestEventsLoopReconnectsFastOnDrain(t *testing.T) {
 }
 
 // holdOpenControlPlane never returns from Events, standing in for a control plane the proxy can reach but
-// which will never send anything — the shape a stream left pointing at a replaced backend takes.
+// which will never send anything — the shape a stream left pointing at a replaced target DB takes.
 type holdOpenControlPlane struct {
 	pb.UnimplementedControlPlaneServer
 	mu    sync.Mutex

--- a/goproxy/db/hash_integration_test.go
+++ b/goproxy/db/hash_integration_test.go
@@ -206,7 +206,7 @@ func TestMySqlSchemaHashIntegration(t *testing.T) {
 }
 
 func TestPostgresSchemaHashIntegration(t *testing.T) {
-	backend := dbtest.Postgres(t)
+	targetDb := dbtest.Postgres(t)
 	admin := dbtest.OpenPostgres(t, "")
 
 	createDatabase := func(t *testing.T, name string) *sql.DB {
@@ -220,7 +220,7 @@ func TestPostgresSchemaHashIntegration(t *testing.T) {
 		t.Cleanup(func() {
 			_, _ = admin.Exec(`DROP DATABASE IF EXISTS "` + name + `" WITH (FORCE)`)
 		})
-		return openPostgresDatabase(t, backend, name)
+		return openPostgresDatabase(t, targetDb, name)
 	}
 
 	t.Run("pgcrypto in public", func(t *testing.T) {
@@ -359,9 +359,9 @@ func verifyPostgresHashAndFragment(t *testing.T, database *sql.DB, wantCrypto bo
 	mutate("drop table", "DROP TABLE "+quote(matrixSchema)+".renamed_table")
 }
 
-func openPostgresDatabase(t *testing.T, backend dbtest.Backend, name string) *sql.DB {
+func openPostgresDatabase(t *testing.T, targetDb dbtest.TargetDb, name string) *sql.DB {
 	t.Helper()
-	database, err := sql.Open("pgx", backend.PostgresDSN(name))
+	database, err := sql.Open("pgx", targetDb.PostgresDSN(name))
 	if err != nil {
 		t.Fatalf("open Postgres database %s: %v", name, err)
 	}

--- a/goproxy/db/refetch_integration_test.go
+++ b/goproxy/db/refetch_integration_test.go
@@ -131,7 +131,7 @@ func TestMySqlRefetcherIntegration(t *testing.T) {
 }
 
 func TestPostgresRefetcherIntegration(t *testing.T) {
-	backend := dbtest.Postgres(t)
+	targetDb := dbtest.Postgres(t)
 	admin := dbtest.OpenPostgres(t, "")
 
 	modes := []struct {
@@ -144,7 +144,7 @@ func TestPostgresRefetcherIntegration(t *testing.T) {
 	for _, mode := range modes {
 		t.Run(mode.name, func(t *testing.T) {
 			databaseName := uniqueFixtureName("pm_refetch_pg")
-			database := createPostgresRefetchDatabase(t, admin, backend, databaseName)
+			database := createPostgresRefetchDatabase(t, admin, targetDb, databaseName)
 			if mode.crypto {
 				if _, err := database.Exec("CREATE EXTENSION pgcrypto"); err != nil {
 					t.Fatalf("CREATE EXTENSION pgcrypto: %v", err)
@@ -441,7 +441,7 @@ func execRefetchSQL(t *testing.T, conn *sql.Conn, statement string) {
 	}
 }
 
-func createPostgresRefetchDatabase(t *testing.T, admin *sql.DB, backend dbtest.Backend, name string) *sql.DB {
+func createPostgresRefetchDatabase(t *testing.T, admin *sql.DB, targetDb dbtest.TargetDb, name string) *sql.DB {
 	t.Helper()
 	if _, err := admin.Exec(`DROP DATABASE IF EXISTS "` + name + `" WITH (FORCE)`); err != nil {
 		t.Fatalf("drop database %s: %v", name, err)
@@ -452,5 +452,5 @@ func createPostgresRefetchDatabase(t *testing.T, admin *sql.DB, backend dbtest.B
 	t.Cleanup(func() {
 		_, _ = admin.Exec(`DROP DATABASE IF EXISTS "` + name + `" WITH (FORCE)`)
 	})
-	return openPostgresDatabase(t, backend, name)
+	return openPostgresDatabase(t, targetDb, name)
 }

--- a/goproxy/dialects/dialects.go
+++ b/goproxy/dialects/dialects.go
@@ -20,7 +20,7 @@ type pgProvider struct{}
 
 func (mysqlProvider) Dialect() engine.Dialect { return engine.MySQL }
 func (mysqlProvider) NewDb() engine.Db        { return db.MySqlDb{} }
-func (mysqlProvider) OpenTarget(target spi.BackendTarget) (*sql.DB, error) {
+func (mysqlProvider) OpenTarget(target spi.TargetDb) (*sql.DB, error) {
 	return introspect.OpenMySQLTarget(target)
 }
 func (mysqlProvider) ProbeNamespace(conn *sql.Conn, targetDb string) ([]string, *int32, error) {
@@ -36,16 +36,16 @@ func (p mysqlProvider) ReadTableDetail(conn *sql.Conn, schema, table string) (*s
 	}
 	return readMySQLTableDetail(conn, schema, table)
 }
-func (mysqlProvider) NewWireServer(port int, backend spi.BackendTarget, client spi.EnforcementClient, dbImpl engine.Db, tlsProvider func() (*tls.Config, error)) spi.WireServer {
-	return mysqlproxy.New(port, backend, client, dbImpl, tlsProvider)
+func (mysqlProvider) NewWireServer(port int, targetDb spi.TargetDb, client spi.EnforcementClient, dbImpl engine.Db, tlsProvider func() (*tls.Config, error)) spi.WireServer {
+	return mysqlproxy.New(port, targetDb, client, dbImpl, tlsProvider)
 }
-func (mysqlProvider) NewRunSession(ctx context.Context, target spi.BackendTarget, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.BackendSession, error) {
+func (mysqlProvider) NewRunSession(ctx context.Context, target spi.TargetDb, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.TargetDbSession, error) {
 	return mysqlproxy.NewRunSession(ctx, target, dbImpl, client, token, connectionID, guard, readTimeout)
 }
 
 func (pgProvider) Dialect() engine.Dialect { return engine.Postgres }
 func (pgProvider) NewDb() engine.Db        { return db.PgDb{} }
-func (pgProvider) OpenTarget(target spi.BackendTarget) (*sql.DB, error) {
+func (pgProvider) OpenTarget(target spi.TargetDb) (*sql.DB, error) {
 	return introspect.OpenPostgresTarget(target)
 }
 func (pgProvider) ProbeNamespace(conn *sql.Conn, targetDb string) ([]string, *int32, error) {
@@ -61,10 +61,10 @@ func (p pgProvider) ReadTableDetail(conn *sql.Conn, schema, table string) (*spi.
 	}
 	return readPostgresTableDetail(conn, schema, table)
 }
-func (pgProvider) NewWireServer(port int, backend spi.BackendTarget, client spi.EnforcementClient, dbImpl engine.Db, tlsProvider func() (*tls.Config, error)) spi.WireServer {
-	return pgproxy.New(port, backend, client, dbImpl, tlsProvider)
+func (pgProvider) NewWireServer(port int, targetDb spi.TargetDb, client spi.EnforcementClient, dbImpl engine.Db, tlsProvider func() (*tls.Config, error)) spi.WireServer {
+	return pgproxy.New(port, targetDb, client, dbImpl, tlsProvider)
 }
-func (pgProvider) NewRunSession(ctx context.Context, target spi.BackendTarget, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.BackendSession, error) {
+func (pgProvider) NewRunSession(ctx context.Context, target spi.TargetDb, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.TargetDbSession, error) {
 	return pgproxy.NewRunSession(ctx, target, dbImpl, client, token, connectionID, guard, readTimeout)
 }
 
@@ -77,10 +77,10 @@ func Registry() spi.Registry { return registry }
 func For(dialect engine.Dialect) (spi.Provider, error) { return registry.For(dialect) }
 
 var (
-	_ spi.Provider       = mysqlProvider{}
-	_ spi.Provider       = pgProvider{}
-	_ spi.BackendSession = (*mysqlproxy.RunSession)(nil)
-	_ spi.BackendSession = (*pgproxy.RunSession)(nil)
-	_ spi.WireServer     = (*mysqlproxy.Server)(nil)
-	_ spi.WireServer     = (*pgproxy.Server)(nil)
+	_ spi.Provider        = mysqlProvider{}
+	_ spi.Provider        = pgProvider{}
+	_ spi.TargetDbSession = (*mysqlproxy.RunSession)(nil)
+	_ spi.TargetDbSession = (*pgproxy.RunSession)(nil)
+	_ spi.WireServer      = (*mysqlproxy.Server)(nil)
+	_ spi.WireServer      = (*pgproxy.Server)(nil)
 )

--- a/goproxy/dialects/dialects_test.go
+++ b/goproxy/dialects/dialects_test.go
@@ -38,7 +38,7 @@ func TestRegistryProviderContracts(t *testing.T) {
 			if got := provider.NewDb(); got != test.wantDb {
 				t.Errorf("NewDb() = %#v, want %#v", got, test.wantDb)
 			}
-			server := provider.NewWireServer(0, spi.BackendTarget{}, nil, provider.NewDb(), nil)
+			server := provider.NewWireServer(0, spi.TargetDb{}, nil, provider.NewDb(), nil)
 			switch test.dialect {
 			case engine.MySQL:
 				if reflect.TypeOf(server).String() != "*mysqlproxy.Server" {
@@ -107,7 +107,7 @@ func TestNewWireServerStartsExpectedProtocol(t *testing.T) {
 	for _, dialect := range []engine.Dialect{engine.MySQL, engine.Postgres} {
 		t.Run(dialect.WireName(), func(t *testing.T) {
 			provider, _ := dialects.For(dialect)
-			server := provider.NewWireServer(0, spi.BackendTarget{}, nil, provider.NewDb(), nil)
+			server := provider.NewWireServer(0, spi.TargetDb{}, nil, provider.NewDb(), nil)
 			starter, ok := server.(interface {
 				Listen() error
 				Serve() error

--- a/goproxy/engine/completion.go
+++ b/goproxy/engine/completion.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Completion statuses reported after a statement's result is relayed. A clean result is StatusOK; a
-// backend error or a relay/transport fault carrying only the rows relayed before it is StatusError.
+// target-DB error or a relay/transport fault carrying only the rows relayed before it is StatusError.
 // StatusCanceled is accepted by the control plane and reserved for a future explicit-cancel signal — the
 // blocking wire relay has no distinct cancel event today, so a canceled query surfaces as StatusError.
 const (
@@ -41,7 +41,7 @@ type CompletionReporter interface {
 }
 
 // RelayStatus reduces a relay's terminal condition to the completion status vocabulary. clean reports
-// whether the result set terminated normally (a backend OK/EOF, not a backend error); err is any transport
+// whether the result set terminated normally (a target-DB OK/EOF, not a target-DB error); err is any transport
 // or protocol fault that tore the relay down. Anything that is not a clean, error-free completion is an
 // error — the partial counts gathered before the fault still travel with it.
 func RelayStatus(clean bool, err error) string {

--- a/goproxy/engine/engine.go
+++ b/goproxy/engine/engine.go
@@ -22,7 +22,7 @@ import (
 	pb "github.com/ridi-oss/proxy-monster/goproxy/internal/pb"
 )
 
-// Dialect is the typed datasource engine — the backend SQL dialect and the registration identity are the
+// Dialect is the typed datasource engine — the target-DB SQL dialect and the registration identity are the
 // same fact. It is the single home for every "is this MySQL or Postgres?" decision, so nothing else
 // compares an engine string literal. MySQL is the priority engine (iota 0, listed first everywhere).
 type Dialect int
@@ -138,7 +138,7 @@ func (d Dialect) DefaultProxyPort() int {
 	}
 }
 
-// DefaultTargetPort is the proxy's default backend port for this dialect when PM_TARGET_PORT is unset —
+// DefaultTargetPort is the proxy's default target DB port for this dialect when PM_TARGET_PORT is unset —
 // MySQL 3307, Postgres 5433 (an unrecognized dialect falls back to the MySQL default; boot rejects it
 // before the port is used).
 func (d Dialect) DefaultTargetPort() int {
@@ -212,15 +212,15 @@ type Decision struct {
 	AfterStatement      []*pb.Refetch
 	Generation          uint64
 	// SanitizeDiagnostics is the control plane's per-decision diagnostic-redaction flag. When set,
-	// the proxy strips this statement's backend error/notice messages down to code + severity. See
+	// the proxy strips this statement's target-DB error/notice messages down to code + severity. See
 	// docs/diagnostic-redaction.md.
 	SanitizeDiagnostics bool
 }
 
-// RedactedDiagnosticMessage is the single generic string that replaces every backend diagnostic message on
+// RedactedDiagnosticMessage is the single generic string that replaces every target-DB diagnostic message on
 // a diagnostic-redacted connection. It carries no stored value; the proxy keeps only the
 // machine-readable code + severity beside it. See docs/diagnostic-redaction.md.
-const RedactedDiagnosticMessage = "backend diagnostic details are redacted on this connection (proxy-monster)"
+const RedactedDiagnosticMessage = "target-DB diagnostic details are redacted on this connection (proxy-monster)"
 
 // EnfActionName reduces a proto EnfAction to Decision.Action's string vocabulary, fail-closed: any
 // value that is not ALLOW or MASK — including ENF_ACTION_UNSPECIFIED and the generated UNRECOGNIZED —
@@ -269,7 +269,7 @@ type TempColumn struct {
 }
 
 // DecideRequest is the complete per-query control-plane request plus the callback used to satisfy
-// before_decide commands on the held backend connection.
+// before_decide commands on the held target-DB connection.
 type DecideRequest struct {
 	Token      string
 	SQL        string
@@ -423,17 +423,17 @@ func NewQueryEngine(db Db, decider Decider) *QueryEngine {
 }
 
 // MarkNamespaceDirty invalidates the cached namespace. The protocol calls this when an authoritative
-// backend signal says the namespace may have changed but does not include its new value, never by
+// target DB signal says the namespace may have changed but does not include its new value, never by
 // classifying SQL text.
 func (e *QueryEngine) MarkNamespaceDirty() { e.nsDirty = true }
 
-// SanitizeDiagnostics reports whether the CURRENT statement's backend diagnostics must be redacted
-// — the value from the most recent decision, so the protocol can gate each backend error/notice forward on
+// SanitizeDiagnostics reports whether the CURRENT statement's target-DB diagnostics must be redacted
+// — the value from the most recent decision, so the protocol can gate each target-DB error/notice forward on
 // it. Per-decision, not latched (the control plane decides it fresh each Decide). See
 // docs/diagnostic-redaction.md.
 func (e *QueryEngine) SanitizeDiagnostics() bool { return e.sanitizeDiag }
 
-// SetNamespace replaces the cached namespace from an authoritative backend protocol signal. It copies
+// SetNamespace replaces the cached namespace from an authoritative target DB protocol signal. It copies
 // namespace so a caller cannot mutate the authorization context after the signal is consumed.
 func (e *QueryEngine) SetNamespace(namespace []string) {
 	e.namespace = append([]string{}, namespace...)
@@ -452,7 +452,7 @@ type NamespaceProbe struct {
 }
 
 // AuthzInput is one statement to authorize plus the probe callbacks the protocol wires up. The Db
-// supplies the probe SQL; the protocol runs it on the backend and parses the result. The engine calls
+// supplies the probe SQL; the protocol runs it on the target DB and parses the result. The engine calls
 // ProbeNamespace only when its cache is dirty, and ProbeTempColumns only when the Db supports the overlay.
 type AuthzInput struct {
 	SQL              string
@@ -500,7 +500,7 @@ func (e *QueryEngine) Authorize(in AuthzInput) Verdict {
 	if out.IsErr() {
 		return Fail{Message: out.Err}
 	}
-	// The control plane decides per statement whether this statement's backend diagnostics are
+	// The control plane decides per statement whether this statement's target-DB diagnostics are
 	// redacted (production posture + engine leak-on-ALLOW capability + the verdict action). Applied
 	// per-decision, NOT latched: a MySQL ALLOW after a MASK is intentionally left un-redacted, because an
 	// ALLOW MySQL query cannot leak a protected value through a diagnostic (docs/diagnostic-redaction.md).

--- a/goproxy/engine/refetch.go
+++ b/goproxy/engine/refetch.go
@@ -10,7 +10,7 @@ import (
 	pb "github.com/ridi-oss/proxy-monster/goproxy/internal/pb"
 )
 
-// Refetcher executes connection-local catalog commands through callback-injected held-backend I/O.
+// Refetcher executes connection-local catalog commands through callback-injected held-target DB I/O.
 type Refetcher struct {
 	Db                Db
 	ConnectionID      []byte

--- a/goproxy/engine/serve.go
+++ b/goproxy/engine/serve.go
@@ -15,7 +15,7 @@ type StatementResult struct {
 	RowsAffected int
 }
 
-// ExecGuard optionally wraps only backend execution. Authorization and catalog probes run outside it.
+// ExecGuard optionally wraps only target-DB execution. Authorization and catalog probes run outside it.
 type ExecGuard func(exec func() error) error
 
 // FailError is a mechanical authorization failure that has no control-plane decision to report.

--- a/goproxy/engine/serve_test.go
+++ b/goproxy/engine/serve_test.go
@@ -38,7 +38,7 @@ func TestServeStatementDenySkipsRun(t *testing.T) {
 
 func TestServeStatementRunErrorRetainsDecision(t *testing.T) {
 	want := &Decision{Action: "ALLOW"}
-	runErr := errors.New("backend failed")
+	runErr := errors.New("target DB failed")
 	qe := NewQueryEngine(mysqlDb, &fakeDecider{outcome: DecisionOutcome{Decision: want}})
 	dec, denied, err := ServeStatement(qe, serveInput(), nil, nil, func(string, []*pb.ColumnMask) (bool, error) {
 		return false, runErr
@@ -67,7 +67,7 @@ func TestServeStatementRefetchesOnlyAfterCleanCompletion(t *testing.T) {
 		name  string
 		clean bool
 		want  int
-	}{{"clean", true, 3}, {"backend error response", false, 0}} {
+	}{{"clean", true, 3}, {"target-DB error response", false, 0}} {
 		t.Run(tc.name, func(t *testing.T) {
 			calls := 0
 			decision := &Decision{Action: "ALLOW", AfterStatement: []*pb.Refetch{{Schema: "app"}}}

--- a/goproxy/go.mod
+++ b/goproxy/go.mod
@@ -20,6 +20,10 @@ require (
 // duplicating the fold rules.
 replace github.com/ridi-oss/proxy-monster/analyzer => ../analyzer
 
+// mysqlwire is a sibling module in this repo; resolve it from source so a renamed/added symbol is
+// picked up by the GOWORK=off image build (goproxy/Dockerfile copies ../mysqlwire in), not just go.work.
+replace github.com/ridi-oss/proxy-monster/mysqlwire => ../mysqlwire
+
 require (
 	dario.cat/mergo v1.0.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect

--- a/goproxy/internal/dbtest/dbtest.go
+++ b/goproxy/internal/dbtest/dbtest.go
@@ -1,4 +1,4 @@
-// Package dbtest provides the ONE shared MySQL and PostgreSQL backend that every DB-backed test in the
+// Package dbtest provides the ONE shared MySQL and PostgreSQL target DB that every DB-backed test in the
 // goproxy module uses. Each engine's container is started once and REUSED for the entire suite
 // (testcontainers Reuse by fixed Name — the first test to need it starts it, every other test and
 // package reuses the same running container). DB-backed tests are MANDATORY: if no Docker provider is
@@ -24,8 +24,8 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-// Backend is the connection info for a shared test database.
-type Backend struct {
+// Target DB is the connection info for a shared test database.
+type TargetDb struct {
 	Host     string
 	Port     int
 	User     string
@@ -33,16 +33,16 @@ type Backend struct {
 	DB       string
 }
 
-// MySQLDSN is a go-sql-driver/mysql DSN for this backend (for the given database, blank = the default).
-func (b Backend) MySQLDSN(db string) string {
+// MySQLDSN is a go-sql-driver/mysql DSN for this target DB (for the given database, blank = the default).
+func (b TargetDb) MySQLDSN(db string) string {
 	if db == "" {
 		db = b.DB
 	}
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true&multiStatements=true", b.User, b.Password, b.Host, b.Port, db)
 }
 
-// PostgresDSN is a pgx-stdlib DSN for this backend.
-func (b Backend) PostgresDSN(db string) string {
+// PostgresDSN is a pgx-stdlib DSN for this target DB.
+func (b TargetDb) PostgresDSN(db string) string {
 	if db == "" {
 		db = b.DB
 	}
@@ -51,17 +51,17 @@ func (b Backend) PostgresDSN(db string) string {
 
 var (
 	mysqlOnce sync.Once
-	mysqlB    Backend
+	mysqlB    TargetDb
 	mysqlErr  error
 
 	pgOnce sync.Once
-	pgB    Backend
+	pgB    TargetDb
 	pgErr  error
 )
 
-// MySQL returns the shared MySQL 8 backend, starting it once and reusing it across the whole suite. It
+// MySQL returns the shared MySQL 8 target DB, starting it once and reusing it across the whole suite. It
 // fails the test if no Docker provider is available.
-func MySQL(t testing.TB) Backend {
+func MySQL(t testing.TB) TargetDb {
 	t.Helper()
 	mysqlOnce.Do(func() { mysqlB, mysqlErr = startMySQL() })
 	if mysqlErr != nil {
@@ -70,9 +70,9 @@ func MySQL(t testing.TB) Backend {
 	return mysqlB
 }
 
-// Postgres returns the shared PostgreSQL 16 backend, starting it once and reusing it across the whole
+// Postgres returns the shared PostgreSQL 16 target DB, starting it once and reusing it across the whole
 // suite. It fails the test if no Docker provider is available.
-func Postgres(t testing.TB) Backend {
+func Postgres(t testing.TB) TargetDb {
 	t.Helper()
 	pgOnce.Do(func() { pgB, pgErr = startPostgres() })
 	if pgErr != nil {
@@ -81,10 +81,10 @@ func Postgres(t testing.TB) Backend {
 	return pgB
 }
 
-// OpenMySQL opens (and pings) a *sql.DB against the shared MySQL backend for database db (blank = default).
+// OpenMySQL opens (and pings) a *sql.DB against the shared MySQL target DB for database db (blank = default).
 func OpenMySQL(t testing.TB, db string) *sql.DB { return open(t, "mysql", MySQL(t).MySQLDSN(db)) }
 
-// OpenPostgres opens (and pings) a *sql.DB against the shared Postgres backend for database db (blank = default).
+// OpenPostgres opens (and pings) a *sql.DB against the shared Postgres target DB for database db (blank = default).
 func OpenPostgres(t testing.TB, db string) *sql.DB {
 	return open(t, "pgx", Postgres(t).PostgresDSN(db))
 }
@@ -148,7 +148,7 @@ func containerName(prefix, img string) string {
 	return name
 }
 
-func startMySQL() (Backend, error) {
+func startMySQL() (TargetDb, error) {
 	const user, pass, db = "root", "rootpw", "app"
 	img := image("PM_TEST_MYSQL_IMAGE", defaultMySQLImage)
 	req := testcontainers.ContainerRequest{
@@ -163,7 +163,7 @@ func startMySQL() (Backend, error) {
 	return start(req, "3306/tcp", user, pass, db)
 }
 
-func startPostgres() (Backend, error) {
+func startPostgres() (TargetDb, error) {
 	const user, pass, db = "postgres", "pgpw", "app"
 	img := image("PM_TEST_POSTGRES_IMAGE", defaultPostgresImage)
 	req := testcontainers.ContainerRequest{
@@ -219,7 +219,7 @@ func imageSeries(img string) string {
 // assertSeries fails the test unless the live server is in the series its configured image names. A
 // container reused from another image, or a tag that resolved elsewhere, would otherwise let a leg
 // report a pass for a version it never ran — indistinguishable from real coverage. Called from the
-// shared fixtures below, so every consumer gets a verified backend rather than having to opt in.
+// shared fixtures below, so every consumer gets a verified target DB rather than having to opt in.
 func assertSeries(t testing.TB, db *sql.DB, query, img string) {
 	t.Helper()
 	want := imageSeries(img)
@@ -265,10 +265,10 @@ func lockShared(name string) (func(), error) {
 
 // start creates or reuses (by Name) the container and returns its live host:port. Reuse means the
 // container persists after the run and is shared across every test package/process.
-func start(req testcontainers.ContainerRequest, port nat.Port, user, pass, db string) (Backend, error) {
+func start(req testcontainers.ContainerRequest, port nat.Port, user, pass, db string) (TargetDb, error) {
 	unlock, err := lockShared(req.Name)
 	if err != nil {
-		return Backend{}, err
+		return TargetDb{}, err
 	}
 	defer unlock()
 
@@ -279,15 +279,15 @@ func start(req testcontainers.ContainerRequest, port nat.Port, user, pass, db st
 		Reuse:            true,
 	})
 	if err != nil {
-		return Backend{}, err
+		return TargetDb{}, err
 	}
 	host, err := c.Host(ctx)
 	if err != nil {
-		return Backend{}, err
+		return TargetDb{}, err
 	}
 	mapped, err := c.MappedPort(ctx, port)
 	if err != nil {
-		return Backend{}, err
+		return TargetDb{}, err
 	}
-	return Backend{Host: host, Port: mapped.Int(), User: user, Password: pass, DB: db}, nil
+	return TargetDb{Host: host, Port: mapped.Int(), User: user, Password: pass, DB: db}, nil
 }

--- a/goproxy/internal/pb/controlplane.pb.go
+++ b/goproxy/internal/pb/controlplane.pb.go
@@ -836,7 +836,7 @@ type SchemaFragmentPush struct {
 	ContentHash       []byte    `protobuf:"bytes,4,opt,name=content_hash,json=contentHash,proto3" json:"content_hash,omitempty"`                    // the live DB-side hash the proxy just measured for this schema
 	Unchanged         bool      `protobuf:"varint,5,opt,name=unchanged,proto3" json:"unchanged,omitempty"`                                          // true = live hash matched the REFETCH hash; columns omitted (no-op ack)
 	Columns           []*Column `protobuf:"bytes,6,rep,name=columns,proto3" json:"columns,omitempty"`                                               // enforcement-relevant fields; reuses the catalog Column shape
-	BackendGeneration uint64    `protobuf:"varint,7,opt,name=backend_generation,json=backendGeneration,proto3" json:"backend_generation,omitempty"` // backend-connection instance that measured this fragment
+	BackendGeneration uint64    `protobuf:"varint,7,opt,name=backend_generation,json=backendGeneration,proto3" json:"backend_generation,omitempty"` // target-DB-connection instance that measured this fragment
 }
 
 func (x *SchemaFragmentPush) Reset() {
@@ -1065,11 +1065,11 @@ type DecisionRequest struct {
 	ClientAddr     string   `protobuf:"bytes,5,opt,name=client_addr,json=clientAddr,proto3" json:"client_addr,omitempty"` // end-client address, for the audit record
 	// Per-connection catalog freshness: the session/temp tables live on THIS connection, invisible
 	// to the datasource-global catalog. The proxy introspects them off its held connection and sends them so
-	// the control-plane resolves a bare name to the connection's temp (matching what the backend binds) instead
+	// the control-plane resolves a bare name to the connection's temp (matching what the target DB binds) instead
 	// of a shadowed real table. Editor-session only; empty for one-shot/wire paths.
 	TempColumns  []*TempColumn `protobuf:"bytes,6,rep,name=temp_columns,json=tempColumns,proto3" json:"temp_columns,omitempty"`
 	ConnectionId []byte        `protobuf:"bytes,7,opt,name=connection_id,json=connectionId,proto3" json:"connection_id,omitempty"`
-	// Whether the backend's live MySQL session sql_mode has ANSI_QUOTES active, observed by the proxy per
+	// Whether the target DB's live MySQL session sql_mode has ANSI_QUOTES active, observed by the proxy per
 	// statement (sql_mode is mutable per session). The control-plane forwards it to the analyzer's
 	// EngineConfig so `"col"` is parsed as a quoted identifier (a masked column read) rather than a string,
 	// letting the proxy relay an ANSI_QUOTES session under masking instead of failing it closed. Absent/false
@@ -1172,7 +1172,7 @@ type TempColumn struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Schema  string `protobuf:"bytes,1,opt,name=schema,proto3" json:"schema,omitempty"` // the temp namespace as the backend reports it (e.g. a pg_temp_N schema)
+	Schema  string `protobuf:"bytes,1,opt,name=schema,proto3" json:"schema,omitempty"` // the temp namespace as the target DB reports it (e.g. a pg_temp_N schema)
 	Table   string `protobuf:"bytes,2,opt,name=table,proto3" json:"table,omitempty"`
 	Column  string `protobuf:"bytes,3,opt,name=column,proto3" json:"column,omitempty"`
 	SqlType string `protobuf:"bytes,4,opt,name=sql_type,json=sqlType,proto3" json:"sql_type,omitempty"`
@@ -1422,7 +1422,7 @@ type Verdict struct {
 	// rejects it fail-closed).
 	AfterStatement []*ProxyCommand `protobuf:"bytes,8,rep,name=after_statement,json=afterStatement,proto3" json:"after_statement,omitempty"`
 	Generation     uint64          `protobuf:"varint,9,opt,name=generation,proto3" json:"generation,omitempty"` // per-connection generation this verdict was computed under
-	// The diagnostic-redaction flag. When set, the proxy strips backend error/notice messages on
+	// The diagnostic-redaction flag. When set, the proxy strips target-DB error/notice messages on
 	// this connection down to code + severity + a generic message (docs/diagnostic-redaction.md) — DB
 	// diagnostics echo stored values that masking hides, so they are an unmasked side-channel. It is an
 	// imperative command the proxy executes mechanically (not statement meaning), evaluated fresh per
@@ -2080,7 +2080,7 @@ type ProxyRunMsg_Done struct {
 }
 
 type ProxyRunMsg_Error struct {
-	Error *RunError `protobuf:"bytes,5,opt,name=error,proto3,oneof"` // terminal failure (backend error, unsupported, ...)
+	Error *RunError `protobuf:"bytes,5,opt,name=error,proto3,oneof"` // terminal failure (target-DB error, unsupported, ...)
 }
 
 type ProxyRunMsg_Progress struct {
@@ -2088,7 +2088,7 @@ type ProxyRunMsg_Progress struct {
 }
 
 type ProxyRunMsg_Serving struct {
-	Serving *RunServing `protobuf:"bytes,7,opt,name=serving,proto3,oneof"` // the backend is connected and its on-open catalog work is done —
+	Serving *RunServing `protobuf:"bytes,7,opt,name=serving,proto3,oneof"` // the target DB is connected and its on-open catalog work is done —
 }
 
 func (*ProxyRunMsg_SessionReady) isProxyRunMsg_Kind() {}
@@ -2185,7 +2185,7 @@ type ControlRunMsg_Query struct {
 }
 
 type ControlRunMsg_Close struct {
-	Close *RunClose `protobuf:"bytes,2,opt,name=close,proto3,oneof"` // drop the session's backend connection; the proxy closes the stream
+	Close *RunClose `protobuf:"bytes,2,opt,name=close,proto3,oneof"` // drop the session's target-DB connection; the proxy closes the stream
 }
 
 type ControlRunMsg_Cancel struct {
@@ -2243,7 +2243,7 @@ func (x *RunReady) GetSessionId() string {
 	return ""
 }
 
-// A target-DB open liveness heartbeat: the proxy emits these while dialing + authenticating the backend and
+// A target-DB open liveness heartbeat: the proxy emits these while dialing + authenticating the target DB and
 // running its on-open catalog commands, so the control-plane can bound the open by lack of progress rather
 // than by a blind dial budget. It carries no payload — the control-plane treats every RunProgress purely as
 // "the proxy is still alive".

--- a/goproxy/internal/pb/controlplane_grpc.pb.go
+++ b/goproxy/internal/pb/controlplane_grpc.pb.go
@@ -57,7 +57,7 @@ type ControlPlaneClient interface {
 	Events(ctx context.Context, in *EventsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ControlEvent], error)
 	// The CP-driven execution channel. PROXY-DIALED bidi: the control-plane nudges the proxy over Events
 	// (OpenRunChannel) to open this, so data flows both ways without the control-plane ever dialing into the
-	// proxy. It serves web-editor and workflow execution through the same backend + Decide path, streaming
+	// proxy. It serves web-editor and workflow execution through the same target DB + Decide path, streaming
 	// the decision and masked rows back.
 	RunExec(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[ProxyRunMsg, ControlRunMsg], error)
 	// On-demand admin table-browser introspection. Also PROXY-DIALED: request selectors ride the Events
@@ -215,7 +215,7 @@ type ControlPlaneServer interface {
 	Events(*EventsRequest, grpc.ServerStreamingServer[ControlEvent]) error
 	// The CP-driven execution channel. PROXY-DIALED bidi: the control-plane nudges the proxy over Events
 	// (OpenRunChannel) to open this, so data flows both ways without the control-plane ever dialing into the
-	// proxy. It serves web-editor and workflow execution through the same backend + Decide path, streaming
+	// proxy. It serves web-editor and workflow execution through the same target DB + Decide path, streaming
 	// the decision and masked rows back.
 	RunExec(grpc.BidiStreamingServer[ProxyRunMsg, ControlRunMsg]) error
 	// On-demand admin table-browser introspection. Also PROXY-DIALED: request selectors ride the Events

--- a/goproxy/introspect/introspect.go
+++ b/goproxy/introspect/introspect.go
@@ -27,7 +27,7 @@ import (
 )
 
 // queryTimeout bounds every introspection query. A full catalog scan of a large schema on a remote
-// backend has been measured at ~53s, so a bound near that turns an ordinary slow scan into a failed
+// target DB has been measured at ~53s, so a bound near that turns an ordinary slow scan into a failed
 // refresh; this leaves room for one well clear of the observed cost.
 const queryTimeout = 120 * time.Second
 
@@ -38,7 +38,7 @@ const connectTimeout = 5 * time.Second
 //
 // Introspect ALL schemas, including the system catalogs (pg_catalog / information_schema / mysql /
 // performance_schema / sys). We do NOT exclude them: a system schema on the search path that is absent
-// from the mapping makes bare-name resolution diverge from the backend (the backend binds pg_catalog
+// from the mapping makes bare-name resolution diverge from the target DB (the target DB binds pg_catalog
 // first; we would fall through to a user schema shadowing a system-table name) — a fail-open leak.
 // System objects are first-class access-controlled resources: deny-by-default until the access-model
 // `system:` tags open the safe ones. Never re-add a NOT IN (...) exclusion here.
@@ -47,7 +47,7 @@ FROM information_schema.columns
 ORDER BY table_schema, table_name, ordinal_position`
 
 // OpenMySQLTarget opens a database/sql handle to a MySQL target (plaintext link, 5s connect / 30s socket).
-func OpenMySQLTarget(target spi.BackendTarget) (*sql.DB, error) {
+func OpenMySQLTarget(target spi.TargetDb) (*sql.DB, error) {
 	cfg := mysqldriver.NewConfig()
 	cfg.User = target.User
 	cfg.Passwd = target.Password
@@ -73,7 +73,7 @@ func OpenMySQLTarget(target spi.BackendTarget) (*sql.DB, error) {
 }
 
 // OpenPostgresTarget opens a database/sql handle to a Postgres target.
-func OpenPostgresTarget(target spi.BackendTarget) (*sql.DB, error) {
+func OpenPostgresTarget(target spi.TargetDb) (*sql.DB, error) {
 	// pgx has no socket-timeout DSN param; the per-query 30s context below carries that intent.
 	u := url.URL{
 		Scheme:   "postgres",
@@ -93,14 +93,14 @@ func OpenPostgresTarget(target spi.BackendTarget) (*sql.DB, error) {
 // dialect's engine.Db — whose NormalizeColumns is the one place that decides how a dialect folds
 // identifiers, so Run never branches on a dialect name to normalize.
 type TargetOpener interface {
-	OpenTarget(target spi.BackendTarget) (*sql.DB, error)
+	OpenTarget(target spi.TargetDb) (*sql.DB, error)
 	ProbeNamespace(conn *sql.Conn, targetDb string) (defaultSchemas []string, mysqlLowerCaseTableNames *int32, err error)
 	NewDb() engine.Db
 }
 
 // Run introspects the target's information_schema over a live connection and returns the catalog to
 // push to the control plane. DatasourceName is left blank — the caller (cp.PushCatalog) stamps it.
-func Run(opener TargetOpener, target spi.BackendTarget) (*pb.CatalogRequest, error) {
+func Run(opener TargetOpener, target spi.TargetDb) (*pb.CatalogRequest, error) {
 	db, err := opener.OpenTarget(target)
 	if err != nil {
 		return nil, err
@@ -164,7 +164,7 @@ func Run(opener TargetOpener, target spi.BackendTarget) (*pb.CatalogRequest, err
 	for _, c := range columns {
 		distinctTables[c.GetSchema()+"."+c.GetTable()] = struct{}{}
 	}
-	// Per-phase timings, not just the total: introspection against a remote backend has been observed
+	// Per-phase timings, not just the total: introspection against a remote target DB has been observed
 	// taking tens of seconds, and the total alone cannot say whether that is the dial, the catalog scan,
 	// or the fold over every column.
 	slog.Info("introspected catalog",

--- a/goproxy/introspect/introspect_test.go
+++ b/goproxy/introspect/introspect_test.go
@@ -32,7 +32,7 @@ const (
 
 type mysqlTestOpener struct{}
 
-func (mysqlTestOpener) OpenTarget(target spi.BackendTarget) (*sql.DB, error) {
+func (mysqlTestOpener) OpenTarget(target spi.TargetDb) (*sql.DB, error) {
 	return OpenMySQLTarget(target)
 }
 func (mysqlTestOpener) ProbeNamespace(conn *sql.Conn, targetDb string) ([]string, *int32, error) {
@@ -42,7 +42,7 @@ func (mysqlTestOpener) NewDb() engine.Db { return db.MySqlDb{} }
 
 type pgTestOpener struct{}
 
-func (pgTestOpener) OpenTarget(target spi.BackendTarget) (*sql.DB, error) {
+func (pgTestOpener) OpenTarget(target spi.TargetDb) (*sql.DB, error) {
 	return OpenPostgresTarget(target)
 }
 func (pgTestOpener) ProbeNamespace(conn *sql.Conn, targetDb string) ([]string, *int32, error) {
@@ -95,7 +95,7 @@ func TestRunPinsOneConnectionOnDeadTarget(t *testing.T) {
 	}
 
 	addr := ln.Addr().(*net.TCPAddr)
-	target := spi.BackendTarget{Host: "127.0.0.1", Port: addr.Port, Db: "appdb", User: "svc", Password: "pw"}
+	target := spi.TargetDb{Host: "127.0.0.1", Port: addr.Port, Db: "appdb", User: "svc", Password: "pw"}
 
 	// Baseline: the dials a single connection acquisition costs against this dead target.
 	baseDB, err := OpenMySQLTarget(target)
@@ -149,7 +149,7 @@ func hasSchema(cols []*pb.Column, schema string) bool {
 }
 
 func TestIntrospectMySQL(t *testing.T) {
-	backend := dbtest.MySQL(t)
+	targetDb := dbtest.MySQL(t)
 
 	// Seed a user table under a dedicated schema and a delimiter-bearing service account. All statements are
 	// idempotent (IF NOT EXISTS / re-GRANT) because the container is shared and persists across runs. The
@@ -172,7 +172,7 @@ func TestIntrospectMySQL(t *testing.T) {
 	}
 
 	t.Run("root captures seeded + system schemas and load-bearing facts", func(t *testing.T) {
-		cat, err := Run(mysqlTestOpener{}, spi.BackendTarget{Host: backend.Host, Port: backend.Port, Db: itMySQLSchema, User: backend.User, Password: backend.Password})
+		cat, err := Run(mysqlTestOpener{}, spi.TargetDb{Host: targetDb.Host, Port: targetDb.Port, Db: itMySQLSchema, User: targetDb.User, Password: targetDb.Password})
 		if err != nil {
 			t.Fatalf("Run: %v", err)
 		}
@@ -201,7 +201,7 @@ func TestIntrospectMySQL(t *testing.T) {
 	})
 
 	t.Run("delimiter-bearing credentials authenticate (connector path, no DSN round-trip)", func(t *testing.T) {
-		cat, err := Run(mysqlTestOpener{}, spi.BackendTarget{Host: backend.Host, Port: backend.Port, Db: itMySQLSchema, User: "svc:reader", Password: "p@s:s/w@rd"})
+		cat, err := Run(mysqlTestOpener{}, spi.TargetDb{Host: targetDb.Host, Port: targetDb.Port, Db: itMySQLSchema, User: "svc:reader", Password: "p@s:s/w@rd"})
 		if err != nil {
 			t.Fatalf("Run with delimiter-bearing credentials: %v (FormatDSN round-trip would corrupt them)", err)
 		}
@@ -220,7 +220,7 @@ func TestIntrospectMySQL(t *testing.T) {
 		if _, err := seed.Exec(`CREATE TABLE IF NOT EXISTS ` + itMySQLSchema + `.orders (id INT PRIMARY KEY, CustomerID INT NOT NULL)`); err != nil {
 			t.Fatalf("seed mixed-case column: %v", err)
 		}
-		cat, err := Run(mysqlTestOpener{}, spi.BackendTarget{Host: backend.Host, Port: backend.Port, Db: itMySQLSchema, User: backend.User, Password: backend.Password})
+		cat, err := Run(mysqlTestOpener{}, spi.TargetDb{Host: targetDb.Host, Port: targetDb.Port, Db: itMySQLSchema, User: targetDb.User, Password: targetDb.Password})
 		if err != nil {
 			t.Fatalf("Run: %v", err)
 		}
@@ -235,7 +235,7 @@ func TestIntrospectMySQL(t *testing.T) {
 }
 
 func TestIntrospectPostgres(t *testing.T) {
-	backend := dbtest.Postgres(t)
+	targetDb := dbtest.Postgres(t)
 
 	// Seed a user table under a unique name plus a login role whose password carries '@', '/', ':' — the
 	// shape that exercises introspect's url.UserPassword escaping on the PG DSN path. Idempotent because the
@@ -254,7 +254,7 @@ func TestIntrospectPostgres(t *testing.T) {
 	}
 
 	t.Run("captures seeded + system schemas and load-bearing facts", func(t *testing.T) {
-		cat, err := Run(pgTestOpener{}, spi.BackendTarget{Host: backend.Host, Port: backend.Port, Db: backend.DB, User: backend.User, Password: backend.Password})
+		cat, err := Run(pgTestOpener{}, spi.TargetDb{Host: targetDb.Host, Port: targetDb.Port, Db: targetDb.DB, User: targetDb.User, Password: targetDb.Password})
 		if err != nil {
 			t.Fatalf("Run: %v", err)
 		}
@@ -283,7 +283,7 @@ func TestIntrospectPostgres(t *testing.T) {
 
 	t.Run("special-char credentials authenticate (url.UserPassword escaping)", func(t *testing.T) {
 		// Auth failing here would flag broken url.UserPassword escaping of the special-char password.
-		cat, err := Run(pgTestOpener{}, spi.BackendTarget{Host: backend.Host, Port: backend.Port, Db: backend.DB, User: itPGRole, Password: "p@ss/w:rd"})
+		cat, err := Run(pgTestOpener{}, spi.TargetDb{Host: targetDb.Host, Port: targetDb.Port, Db: targetDb.DB, User: itPGRole, Password: "p@ss/w:rd"})
 		if err != nil {
 			t.Fatalf("Run with special-char credentials: %v (a naive DSN would mangle them)", err)
 		}

--- a/goproxy/mysqlproxy/backend.go
+++ b/goproxy/mysqlproxy/backend.go
@@ -18,13 +18,13 @@ import (
 )
 
 const (
-	backendHandshakeTimeout = 10 * time.Second
-	maxBackendAuthPacket    = 64 << 10
+	targetDbHandshakeTimeout = 10 * time.Second
+	maxTargetDbAuthPacket    = 64 << 10
 )
 
 const (
-	backendPluginNative      = "mysql_native_password"
-	backendPluginCachingSHA2 = "caching_sha2_password"
+	targetDbPluginNative      = "mysql_native_password"
+	targetDbPluginCachingSHA2 = "caching_sha2_password"
 )
 
 // testHookCachingSHA2FullAuth, when non-nil, is invoked whenever the caching_sha2_password full-auth
@@ -33,23 +33,23 @@ const (
 // is exercised end-to-end.
 var testHookCachingSHA2FullAuth func(viaPublicKey bool)
 
-// dialBackendAuth connects to the target and performs the service-account handshake. Both
+// dialTargetDbAuth connects to the target and performs the service-account handshake. Both
 // mysql_native_password and caching_sha2_password (mysql:8.0 / Aurora MySQL 3 default) are supported,
 // each on the direct and auth-switch paths; caching_sha2 additionally runs the full-auth exchange
 // (RSA public-key over a plaintext link, cleartext over TLS) when the server's fast-auth cache misses.
 // CLIENT_SESSION_TRACK is required so text-protocol database changes arrive as protocol signals instead
 // of requiring an interposed SELECT DATABASE() that would corrupt ROW_COUNT/FOUND_ROWS diagnostics.
-func dialBackendAuth(target spi.BackendTarget, mirrorDeprecateEOF bool) (net.Conn, error) {
-	conn, _, err := dialBackendAuthID(context.Background(), target, mirrorDeprecateEOF)
+func dialTargetDbAuth(target spi.TargetDb, mirrorDeprecateEOF bool) (net.Conn, error) {
+	conn, _, err := dialTargetDbAuthID(context.Background(), target, mirrorDeprecateEOF)
 	return conn, err
 }
 
-// dialBackendAuthID honors ctx for the whole handshake: DialContext aborts the connect, and while the
+// dialTargetDbAuthID honors ctx for the whole handshake: DialContext aborts the connect, and while the
 // (deadline-bounded) auth exchange runs, an AfterFunc closes the conn on cancel so a blocked read unwinds at
 // once. On the run path ctx is the target-DB open context, so a run the control-plane already closed does not
-// finish a backend handshake nobody is waiting for; the wire path passes a background ctx (never cancelled).
-func dialBackendAuthID(ctx context.Context, target spi.BackendTarget, mirrorDeprecateEOF bool) (net.Conn, uint32, error) {
-	dialer := net.Dialer{Timeout: backendHandshakeTimeout}
+// finish a target-DB handshake nobody is waiting for; the wire path passes a background ctx (never cancelled).
+func dialTargetDbAuthID(ctx context.Context, target spi.TargetDb, mirrorDeprecateEOF bool) (net.Conn, uint32, error) {
+	dialer := net.Dialer{Timeout: targetDbHandshakeTimeout}
 	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(target.Host, strconv.Itoa(target.Port)))
 	if err != nil {
 		return nil, 0, err
@@ -61,20 +61,20 @@ func dialBackendAuthID(ctx context.Context, target spi.BackendTarget, mirrorDepr
 		}
 	}()
 	defer context.AfterFunc(ctx, func() { _ = conn.Close() })()
-	if err := conn.SetDeadline(time.Now().Add(backendHandshakeTimeout)); err != nil {
-		return nil, 0, fmt.Errorf("set backend auth deadline: %w", err)
+	if err := conn.SetDeadline(time.Now().Add(targetDbHandshakeTimeout)); err != nil {
+		return nil, 0, fmt.Errorf("set target-DB auth deadline: %w", err)
 	}
 
-	greetingSeq, payload, err := mysqlwire.ReadPacketLimited(conn, maxBackendAuthPacket)
+	greetingSeq, payload, err := mysqlwire.ReadPacketLimited(conn, maxTargetDbAuthPacket)
 	if err != nil {
-		return nil, 0, fmt.Errorf("read backend greeting: %w", err)
+		return nil, 0, fmt.Errorf("read target-DB greeting: %w", err)
 	}
 	greeting, err := mysqlwire.ParseHandshakeV10(payload)
 	if err != nil {
-		return nil, 0, fmt.Errorf("malformed backend greeting: %w", err)
+		return nil, 0, fmt.Errorf("malformed target-DB greeting: %w", err)
 	}
 	if greeting.Capabilities&mysqlwire.CapSessionTrack == 0 {
-		return nil, 0, errors.New("backend does not support CLIENT_SESSION_TRACK (MySQL 8.0+ required)")
+		return nil, 0, errors.New("target DB does not support CLIENT_SESSION_TRACK (MySQL 8.0+ required)")
 	}
 
 	caps := uint32(mysqlwire.CapLongPassword | mysqlwire.CapProtocol41 | mysqlwire.CapTransactions |
@@ -86,27 +86,27 @@ func dialBackendAuthID(ctx context.Context, target spi.BackendTarget, mirrorDepr
 	// The plugin negotiated in the greeting drives the initial HandshakeResponse. scramble is the auth
 	// challenge for the CURRENT plugin; it is updated on an auth-switch and is the seed the caching_sha2
 	// full-auth path encrypts against.
-	plugin, err := canonicalBackendPlugin(greeting.AuthPlugin)
+	plugin, err := canonicalTargetDbPlugin(greeting.AuthPlugin)
 	if err != nil {
 		return nil, 0, err
 	}
 	scramble := greeting.Scramble
-	authResp, err := backendAuthResponse(plugin, target.Password, scramble)
+	authResp, err := targetDbAuthResponse(plugin, target.Password, scramble)
 	if err != nil {
 		return nil, 0, err
 	}
-	response := mysqlwire.BackendHandshakeResponse(caps, target.User, authResp, target.Db, plugin)
+	response := mysqlwire.TargetDbHandshakeResponse(caps, target.User, authResp, target.Db, plugin)
 	if err := mysqlwire.WritePacket(conn, greetingSeq+1, response); err != nil {
-		return nil, 0, fmt.Errorf("write backend handshake response: %w", err)
+		return nil, 0, fmt.Errorf("write target-DB handshake response: %w", err)
 	}
 
 	for {
-		seq, authPayload, err := mysqlwire.ReadPacketLimited(conn, maxBackendAuthPacket)
+		seq, authPayload, err := mysqlwire.ReadPacketLimited(conn, maxTargetDbAuthPacket)
 		if err != nil {
-			return nil, 0, fmt.Errorf("read backend auth response: %w", err)
+			return nil, 0, fmt.Errorf("read target-DB auth response: %w", err)
 		}
 		if len(authPayload) == 0 {
-			return nil, 0, errors.New("unexpected empty backend auth packet")
+			return nil, 0, errors.New("unexpected empty target-DB auth packet")
 		}
 		switch authPayload[0] {
 		case 0x00:
@@ -114,12 +114,12 @@ func dialBackendAuthID(ctx context.Context, target spi.BackendTarget, mirrorDepr
 				return nil, 0, err
 			}
 			if err := conn.SetDeadline(time.Time{}); err != nil {
-				return nil, 0, fmt.Errorf("clear backend auth deadline: %w", err)
+				return nil, 0, fmt.Errorf("clear target-DB auth deadline: %w", err)
 			}
 			keep = true
 			return conn, greeting.ConnectionID, nil
 		case 0xff:
-			return nil, 0, fmt.Errorf("backend auth failed: %s", mysqlwire.ErrString(authPayload))
+			return nil, 0, fmt.Errorf("target-DB auth failed: %s", mysqlwire.ErrString(authPayload))
 		case 0xfe:
 			switchPlugin, switchScramble, err := parseAuthSwitch(authPayload)
 			if err != nil {
@@ -127,49 +127,49 @@ func dialBackendAuthID(ctx context.Context, target spi.BackendTarget, mirrorDepr
 			}
 			plugin = switchPlugin
 			scramble = switchScramble
-			resp, err := backendAuthResponse(plugin, target.Password, scramble)
+			resp, err := targetDbAuthResponse(plugin, target.Password, scramble)
 			if err != nil {
 				return nil, 0, err
 			}
 			if err := mysqlwire.WritePacket(conn, seq+1, resp); err != nil {
-				return nil, 0, fmt.Errorf("write backend auth switch response: %w", err)
+				return nil, 0, fmt.Errorf("write target-DB auth switch response: %w", err)
 			}
 		case mysqlwire.AuthMoreData:
-			if plugin != backendPluginCachingSHA2 {
+			if plugin != targetDbPluginCachingSHA2 {
 				return nil, 0, fmt.Errorf("unexpected AuthMoreData for plugin %s", plugin)
 			}
 			if err := handleCachingSHA2MoreData(conn, seq, authPayload, target.Password, scramble); err != nil {
 				return nil, 0, err
 			}
 		default:
-			return nil, 0, fmt.Errorf("unexpected backend auth packet 0x%02x", authPayload[0])
+			return nil, 0, fmt.Errorf("unexpected target-DB auth packet 0x%02x", authPayload[0])
 		}
 	}
 }
 
-// canonicalBackendPlugin normalizes the greeting's auth plugin to one the proxy implements, failing
+// canonicalTargetDbPlugin normalizes the greeting's auth plugin to one the proxy implements, failing
 // closed on anything else. An empty plugin name (pre-4.1 greeting without CapPluginAuth) is treated as
 // mysql_native_password, matching ParseHandshakeV10's default.
-func canonicalBackendPlugin(plugin string) (string, error) {
+func canonicalTargetDbPlugin(plugin string) (string, error) {
 	switch {
-	case plugin == "" || strings.EqualFold(plugin, backendPluginNative):
-		return backendPluginNative, nil
-	case strings.EqualFold(plugin, backendPluginCachingSHA2):
-		return backendPluginCachingSHA2, nil
+	case plugin == "" || strings.EqualFold(plugin, targetDbPluginNative):
+		return targetDbPluginNative, nil
+	case strings.EqualFold(plugin, targetDbPluginCachingSHA2):
+		return targetDbPluginCachingSHA2, nil
 	default:
-		return "", fmt.Errorf("backend requested unsupported auth plugin %s", plugin)
+		return "", fmt.Errorf("target DB requested unsupported auth plugin %s", plugin)
 	}
 }
 
-// backendAuthResponse computes the HandshakeResponse (or auth-switch response) auth bytes for plugin.
-func backendAuthResponse(plugin, password string, scramble []byte) ([]byte, error) {
+// targetDbAuthResponse computes the HandshakeResponse (or auth-switch response) auth bytes for plugin.
+func targetDbAuthResponse(plugin, password string, scramble []byte) ([]byte, error) {
 	switch plugin {
-	case backendPluginNative:
+	case targetDbPluginNative:
 		return mysqlwire.NativePassword(password, scramble), nil
-	case backendPluginCachingSHA2:
+	case targetDbPluginCachingSHA2:
 		return mysqlwire.CachingSHA2Password(password, scramble), nil
 	default:
-		return nil, fmt.Errorf("backend requested unsupported auth plugin %s", plugin)
+		return nil, fmt.Errorf("target DB requested unsupported auth plugin %s", plugin)
 	}
 }
 
@@ -179,15 +179,15 @@ func backendAuthResponse(plugin, password string, scramble []byte) ([]byte, erro
 func parseAuthSwitch(payload []byte) (string, []byte, error) {
 	r := mysqlwire.NewReader(payload)
 	if err := r.Skip(1); err != nil {
-		return "", nil, errors.New("unexpected backend auth packet")
+		return "", nil, errors.New("unexpected target-DB auth packet")
 	}
 	plugin, err := r.Cstr()
 	if err != nil {
-		return "", nil, errors.New("unexpected backend auth packet")
+		return "", nil, errors.New("unexpected target-DB auth packet")
 	}
 	start := 1 + len(plugin) + 1
 	if start > len(payload) {
-		return "", nil, errors.New("unexpected backend auth packet")
+		return "", nil, errors.New("unexpected target-DB auth packet")
 	}
 	end := len(payload)
 	if end > start && payload[end-1] == 0 {
@@ -196,7 +196,7 @@ func parseAuthSwitch(payload []byte) (string, []byte, error) {
 	if end > start+20 {
 		end = start + 20
 	}
-	canonical, err := canonicalBackendPlugin(plugin)
+	canonical, err := canonicalTargetDbPlugin(plugin)
 	if err != nil {
 		return "", nil, err
 	}
@@ -232,7 +232,7 @@ func handleCachingSHA2MoreData(conn net.Conn, seq byte, payload []byte, password
 		if err := mysqlwire.WritePacket(conn, seq+1, []byte{mysqlwire.CachingSHA2RequestPublicKey}); err != nil {
 			return fmt.Errorf("request caching_sha2 public key: %w", err)
 		}
-		keySeq, keyPayload, err := mysqlwire.ReadPacketLimited(conn, maxBackendAuthPacket)
+		keySeq, keyPayload, err := mysqlwire.ReadPacketLimited(conn, maxTargetDbAuthPacket)
 		if err != nil {
 			return fmt.Errorf("read caching_sha2 public key: %w", err)
 		}
@@ -255,7 +255,7 @@ func handleCachingSHA2MoreData(conn net.Conn, seq byte, payload []byte, password
 	}
 }
 
-// enableSessionTracking makes the backend report enforcement-critical session state in the OK packet of the
+// enableSessionTracking makes the target DB report enforcement-critical session state in the OK packet of the
 // statement that changed it: session_track_schema=ON emits an authoritative SESSION_TRACK_SCHEMA block after
 // every text USE, and the SESSION_TRACK_SYSTEM_VARIABLES list surfaces a direct change to schema tracking,
 // the tracking list, or the connection charset. This is a fast fail-closed signal for DIRECT tampering; it
@@ -264,22 +264,22 @@ func handleCachingSHA2MoreData(conn net.Conn, seq byte, payload []byte, password
 // but the variables are session-configurable, so the proxy sets them explicitly rather than trusting the
 // server default.
 func enableSessionTracking(conn net.Conn) error {
-	if err := execBackendSet(conn, "SET SESSION session_track_schema = ON"); err != nil {
-		return fmt.Errorf("enable backend schema tracking: %w", err)
+	if err := execTargetDbSet(conn, "SET SESSION session_track_schema = ON"); err != nil {
+		return fmt.Errorf("enable target-DB schema tracking: %w", err)
 	}
-	if err := execBackendSet(conn, "SET SESSION session_track_system_variables = '"+trackedSysVarList()+"'"); err != nil {
-		return fmt.Errorf("enable backend session-variable tracking: %w", err)
+	if err := execTargetDbSet(conn, "SET SESSION session_track_system_variables = '"+trackedSysVarList()+"'"); err != nil {
+		return fmt.Errorf("enable target DB session-variable tracking: %w", err)
 	}
 	return nil
 }
 
-// execBackendSet sends one SET on the service-account connection and consumes its single OK packet, failing
-// on a backend error or a malformed response.
-func execBackendSet(conn net.Conn, sql string) error {
+// execTargetDbSet sends one SET on the service-account connection and consumes its single OK packet, failing
+// on a target-DB error or a malformed response.
+func execTargetDbSet(conn net.Conn, sql string) error {
 	if err := mysqlwire.WritePacket(conn, 0, mysqlwire.ComQueryPayload(sql)); err != nil {
 		return err
 	}
-	_, payload, err := mysqlwire.ReadPacketLimited(conn, maxBackendAuthPacket)
+	_, payload, err := mysqlwire.ReadPacketLimited(conn, maxTargetDbAuthPacket)
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func execBackendSet(conn net.Conn, sql string) error {
 	if payload[0] != 0x00 {
 		return fmt.Errorf("unexpected response 0x%02x", payload[0])
 	}
-	if _, _, _, _, err := normalizeBackendOK(payload); err != nil {
+	if _, _, _, _, err := normalizeTargetDbOK(payload); err != nil {
 		return err
 	}
 	return nil
@@ -306,7 +306,7 @@ func execBackendSet(conn net.Conn, sql string) error {
 // the true current database, charset, and sql_mode regardless of tracker state, so a client cannot silently
 // defeat the proxy's namespace/encoding/lexer-mode observation. Reading sql_mode here (not just at connect)
 // covers BOTH the connect-time and mid-session vectors: ANSI_QUOTES is OBSERVED and forwarded to the analyzer
-// (which parses "…" as the quoted identifier the backend reads, so a masked column stays masked), while any
+// (which parses "…" as the quoted identifier the target DB reads, so a masked column stays masked), while any
 // flag that is not parse-safe — a known parse-affecting one the analyzer cannot model or an unrecognized one
 // — fails the session closed (see classifyMySQLSqlMode's allowlist; mirrors pgproxy's
 // standard_conforming_strings guard). Because the proxy serves one statement at a time and sql_mode changes
@@ -349,7 +349,7 @@ type textResultCollector struct {
 	masks                      []*pb.ColumnMask
 	result                     *engine.StatementResult
 	masker                     *engine.RowMasker
-	backendErr, affectedErr    error
+	targetDbErr, affectedErr   error
 }
 
 func (c *textResultCollector) hooks() resultHooks {
@@ -357,7 +357,7 @@ func (c *textResultCollector) hooks() resultHooks {
 }
 func (c *textResultCollector) sink(_ byte, payload []byte) error {
 	if len(payload) > 0 && payload[0] == 0xff {
-		c.backendErr = errors.New(mysqlwire.ErrString(payload))
+		c.targetDbErr = errors.New(mysqlwire.ErrString(payload))
 	}
 	return c.affectedErr
 }
@@ -418,22 +418,22 @@ func (c *textResultCollector) onOK(affected uint64) {
 	}
 }
 
-// runInternalQuery executes one text query on the held backend and strictly decodes its rows.
-func runInternalQuery(backend net.Conn, deprecateEOF bool, sql string, expectedColumns int) ([][]*string, error) {
+// runInternalQuery executes one text query on the held target DB and strictly decodes its rows.
+func runInternalQuery(targetDb net.Conn, deprecateEOF bool, sql string, expectedColumns int) ([][]*string, error) {
 	if expectedColumns <= 0 {
 		return nil, fmt.Errorf("internal query expected columns = %d, want positive", expectedColumns)
 	}
-	if err := mysqlwire.WritePacket(backend, 0, mysqlwire.ComQueryPayload(sql)); err != nil {
+	if err := mysqlwire.WritePacket(targetDb, 0, mysqlwire.ComQueryPayload(sql)); err != nil {
 		return nil, err
 	}
 	result := engine.StatementResult{Rows: make([][]*string, 0)}
 	collect := textResultCollector{expected: expectedColumns, result: &result}
-	_, err := relayResultSet(backend, deprecateEOF, collect.hooks())
+	_, err := relayResultSet(targetDb, deprecateEOF, collect.hooks())
 	if err != nil {
 		return nil, err
 	}
-	if collect.backendErr != nil {
-		return nil, fmt.Errorf("backend internal query: %w", collect.backendErr)
+	if collect.targetDbErr != nil {
+		return nil, fmt.Errorf("target DB internal query: %w", collect.targetDbErr)
 	}
 	return result.Rows, collect.affectedErr
 }
@@ -441,8 +441,8 @@ func runInternalQuery(backend net.Conn, deprecateEOF bool, sql string, expectedC
 // probeNamespace runs the pre-statement session probe and returns the connection's namespace plus whether
 // its live sql_mode has ANSI_QUOTES active, failing closed on an unsafe charset or a non-modeled
 // lexer-changing sql_mode flag.
-func probeNamespace(backend net.Conn, deprecateEOF bool) (namespace []string, ansiQuotes bool, err error) {
-	rows, err := runInternalQuery(backend, deprecateEOF, mysqlSessionProbeSQL, 5)
+func probeNamespace(targetDb net.Conn, deprecateEOF bool) (namespace []string, ansiQuotes bool, err error) {
+	rows, err := runInternalQuery(targetDb, deprecateEOF, mysqlSessionProbeSQL, 5)
 	if err != nil {
 		return nil, false, err
 	}
@@ -454,8 +454,8 @@ func probeNamespace(backend net.Conn, deprecateEOF bool) (namespace []string, an
 
 // probeNamespaceObservation runs the pre-statement session probe and packages its result as the engine's
 // NamespaceProbe, so every wire/editor call site shares one probe→engine conversion.
-func probeNamespaceObservation(backend net.Conn, deprecateEOF bool) (engine.NamespaceProbe, error) {
-	namespace, ansiQuotes, err := probeNamespace(backend, deprecateEOF)
+func probeNamespaceObservation(targetDb net.Conn, deprecateEOF bool) (engine.NamespaceProbe, error) {
+	namespace, ansiQuotes, err := probeNamespace(targetDb, deprecateEOF)
 	if err != nil {
 		return engine.NamespaceProbe{}, err
 	}

--- a/goproxy/mysqlproxy/backend_cancel_test.go
+++ b/goproxy/mysqlproxy/backend_cancel_test.go
@@ -10,15 +10,15 @@ import (
 	"github.com/ridi-oss/proxy-monster/goproxy/spi"
 )
 
-// TestDialBackendAuthIDAbortsOnContextCancel proves the real MySQL dial honors the target-DB open context: a
-// backend that accepts the TCP connection but never sends its greeting stalls the auth read, and cancelling
-// the context must close the conn and return at once — not block until backendHandshakeTimeout. This is the
+// TestDialTargetDbAuthIDAbortsOnContextCancel proves the real MySQL dial honors the target-DB open context: a
+// target DB that accepts the TCP connection but never sends its greeting stalls the auth read, and cancelling
+// the context must close the conn and return at once — not block until targetDbHandshakeTimeout. This is the
 // mechanism the run target-DB open relies on; the runner-level tests exercise only the fake provider, so a
 // regression that dropped DialContext or the auth AfterFunc would not surface there.
-func TestDialBackendAuthIDAbortsOnContextCancel(t *testing.T) {
+func TestDialTargetDbAuthIDAbortsOnContextCancel(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		t.Fatalf("listen stalling backend: %v", err)
+		t.Fatalf("listen stalling target DB: %v", err)
 	}
 	defer listener.Close()
 
@@ -39,12 +39,12 @@ func TestDialBackendAuthIDAbortsOnContextCancel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse listener port: %v", err)
 	}
-	target := spi.BackendTarget{Host: host, Port: port, User: "u", Password: "p", Db: "d"}
+	target := spi.TargetDb{Host: host, Port: port, User: "u", Password: "p", Db: "d"}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	dialErr := make(chan error, 1)
 	go func() {
-		_, _, err := dialBackendAuthID(ctx, target, true)
+		_, _, err := dialTargetDbAuthID(ctx, target, true)
 		dialErr <- err
 	}()
 
@@ -54,7 +54,7 @@ func TestDialBackendAuthIDAbortsOnContextCancel(t *testing.T) {
 	case conn := <-accepted:
 		defer conn.Close()
 	case <-time.After(5 * time.Second):
-		t.Fatal("dial did not connect to the stalling backend")
+		t.Fatal("dial did not connect to the stalling target DB")
 	}
 
 	start := time.Now()
@@ -65,7 +65,7 @@ func TestDialBackendAuthIDAbortsOnContextCancel(t *testing.T) {
 			t.Fatal("dial returned nil error after context cancel; want the aborted handshake to fail")
 		}
 		if elapsed := time.Since(start); elapsed > 3*time.Second {
-			t.Fatalf("dial returned %s after cancel; want a prompt abort, not the %s handshake timeout", elapsed, backendHandshakeTimeout)
+			t.Fatalf("dial returned %s after cancel; want a prompt abort, not the %s handshake timeout", elapsed, targetDbHandshakeTimeout)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("dial did not abort promptly on context cancel")

--- a/goproxy/mysqlproxy/charset_e2e_test.go
+++ b/goproxy/mysqlproxy/charset_e2e_test.go
@@ -12,7 +12,7 @@ import (
 
 // TestResultsCharsetPinAppliedFromControlPlane proves the wire path applies a control-plane rewrite on a
 // session passthrough: when the CP pins `SET character_set_results = NULL` to utf8mb4 (its rewritten_sql),
-// the proxy relays the pinned statement to the backend, so the SET succeeds and a following masked read
+// the proxy relays the pinned statement to the target DB, so the SET succeeds and a following masked read
 // still returns the mask. Authorization and audit still see the client's original statement. (The
 // recognition — that the real analyzer emits this pin — is covered by the analyzer and control-plane tests.)
 func TestResultsCharsetPinAppliedFromControlPlane(t *testing.T) {
@@ -37,12 +37,12 @@ func TestResultsCharsetPinAppliedFromControlPlane(t *testing.T) {
 	}
 	client := openRawClient(t, h.addr, validToken)
 
-	// The pinned SET reaches the backend as utf8mb4, so it succeeds instead of tripping the charset invariant.
+	// The pinned SET reaches the target DB as utf8mb4, so it succeeds instead of tripping the charset invariant.
 	response := client.firstQueryPacket(t, setNULL)
 	if len(response) == 0 || response[0] != 0x00 {
 		t.Fatalf("SET character_set_results = NULL response = %x, want OK (pinned to utf8mb4)", response)
 	}
-	// Masking still works: had the original NULL reached the backend, the invariant would have closed the
+	// Masking still works: had the original NULL reached the target DB, the invariant would have closed the
 	// session and this read would fail; instead ssn is masked and the NULL row is preserved.
 	rows := client.textRows(t, maskedRead, 3)
 	if len(rows) != 2 {

--- a/goproxy/mysqlproxy/completion_test.go
+++ b/goproxy/mysqlproxy/completion_test.go
@@ -89,15 +89,15 @@ func TestCompletionReportPreparedSelectCountsRows(t *testing.T) {
 	}
 }
 
-// A statement whose backend result is an error still reports a completion, tagged status=error.
+// A statement whose target-DB result is an error still reports a completion, tagged status=error.
 func TestCompletionReportErroredStatement(t *testing.T) {
 	h := startBroker(t)
 	h.fake.decideFn = allowWithDecisionID(completionDecisionID)
 	conn := h.openDB(t, validToken)
 
-	// An allowed statement the backend rejects (unknown table) relays an ERR, not a result set.
+	// An allowed statement the target DB rejects (unknown table) relays an ERR, not a result set.
 	if _, err := conn.Query("SELECT id FROM no_such_table_here"); err == nil {
-		t.Fatal("Query on a missing table succeeded, want a backend error")
+		t.Fatal("Query on a missing table succeeded, want a target-DB error")
 	}
 
 	got := h.waitCompletions(t, 1)

--- a/goproxy/mysqlproxy/conn.go
+++ b/goproxy/mysqlproxy/conn.go
@@ -41,7 +41,7 @@ func writeShutdownNotice(clientConn net.Conn) {
 }
 
 // handleConn performs the frontend clear-password token handshake, authenticates the service-account
-// backend, then runs one blocking command at a time.
+// target DB, then runs one blocking command at a time.
 func (s *Server) handleConn(clientConn net.Conn) {
 	defer clientConn.Close()
 
@@ -59,7 +59,7 @@ func (s *Server) handleConn(clientConn net.Conn) {
 		return
 	}
 	connID := s.connID.Add(1)
-	// true: this handler relays a handshake-supplied database to the backend as COM_INIT_DB below, so
+	// true: this handler relays a handshake-supplied database to the target DB as COM_INIT_DB below, so
 	// it is safe (and, for a real client's self-consistency, necessary) to advertise CapConnectWithDB.
 	greeting := mysqlwire.ServerGreeting(connID, scramble, frontendServerVersion, true)
 	if tlsConfig != nil {
@@ -152,34 +152,34 @@ func (s *Server) handleConn(clientConn net.Conn) {
 	}()
 	slog.Info("authenticated mysql client", "client", clientConn.RemoteAddr().String(), "principal", identity.Principal, "roles", identity.Roles)
 
-	backendConn, err := dialBackendAuth(s.backend, deprecateEOF)
+	targetDbConn, err := dialTargetDbAuth(s.targetDb, deprecateEOF)
 	if err != nil {
-		slog.Warn("mysql backend unavailable", "host", s.backend.Host, "port", s.backend.Port, "error", err)
+		slog.Warn("mysql target DB unavailable", "host", s.targetDb.Host, "port", s.targetDb.Port, "error", err)
 		_ = mysqlwire.WritePacket(clientConn, tokenSeq+1, mysqlwire.ErrPacketState(
 			1045,
 			"08004",
-			"proxy-monster: backend unavailable",
+			"proxy-monster: target DB unavailable",
 		))
 		return
 	}
-	backendConn = s.WrapBackendConn(backendConn)
-	defer backendConn.Close()
+	targetDbConn = s.WrapTargetDbConn(targetDbConn)
+	defer targetDbConn.Close()
 
 	qe := engine.NewQueryEngine(s.db, s.client)
 	preparedStmts := make(map[uint32]preparedStmt)
 	if handshake.Database != "" {
 		// The client selected a database at connect time. Switching the current database is not a gated
-		// action, so relay it mechanically to the backend as COM_INIT_DB rather than synthesizing and
+		// action, so relay it mechanically to the target DB as COM_INIT_DB rather than synthesizing and
 		// authorizing a USE — the control plane enforces subsequent queries under the new namespace. The
-		// backend's response is consumed here (the client is still awaiting the single auth result): only a
+		// target DB's response is consumed here (the client is still awaiting the single auth result): only a
 		// failure is surfaced to the client, and the auth OK written below stands in for success.
 		payload := append([]byte{mysqlwire.ComInitDB}, handshake.Database...)
-		result, err := executeSingleResponse(backendConn, 0, payload)
+		result, err := executeSingleResponse(targetDbConn, 0, payload)
 		if err != nil {
 			_ = mysqlwire.WritePacket(clientConn, tokenSeq+1, mysqlwire.ErrPacketState(
 				1045,
 				"08004",
-				"proxy-monster: backend unavailable",
+				"proxy-monster: target DB unavailable",
 			))
 			return
 		}
@@ -196,7 +196,7 @@ func (s *Server) handleConn(clientConn net.Conn) {
 		return
 	}
 	refetcher := engine.NewRefetcher(s.db, identity.ConnectionID, generation, func(sql string, expectedColumns int) ([][]*string, error) {
-		return runInternalQuery(backendConn, deprecateEOF, sql, expectedColumns)
+		return runInternalQuery(targetDbConn, deprecateEOF, sql, expectedColumns)
 	}, s.client.PushSchemaFragment)
 	if err := refetcher.RunAll(identity.OnOpen); err != nil {
 		slog.Warn("mysql catalog initialization failed", "error", err)
@@ -238,7 +238,7 @@ func (s *Server) handleConn(clientConn net.Conn) {
 		cmd := payload[0]
 		switch cmd {
 		case mysqlwire.ComQuit:
-			_ = mysqlwire.WritePacket(backendConn, seq, payload)
+			_ = mysqlwire.WritePacket(targetDbConn, seq, payload)
 			return
 
 		case mysqlwire.ComQuery:
@@ -251,7 +251,7 @@ func (s *Server) handleConn(clientConn net.Conn) {
 				Token:          token,
 				ClientAddr:     clientAddr,
 				ConnectionID:   identity.ConnectionID,
-				ProbeNamespace: func() (engine.NamespaceProbe, error) { return probeNamespaceObservation(backendConn, deprecateEOF) },
+				ProbeNamespace: func() (engine.NamespaceProbe, error) { return probeNamespaceObservation(targetDbConn, deprecateEOF) },
 				RunCommands:    refetcher.RunAll,
 			}, refetcher, nil, func(toSend string, masks []*pb.ColumnMask) (bool, error) {
 				queryPayload := mysqlwire.ComQueryPayload(toSend)
@@ -265,10 +265,10 @@ func (s *Server) handleConn(clientConn net.Conn) {
 					}
 					return false, nil
 				}
-				if err := mysqlwire.WritePacket(backendConn, 0, queryPayload); err != nil {
+				if err := mysqlwire.WritePacket(targetDbConn, 0, queryPayload); err != nil {
 					return false, err
 				}
-				clean, stats, err := relayQueryResponseTracked(clientConn, backendConn, deprecateEOF, masks, errRedactor(qe))
+				clean, stats, err := relayQueryResponseTracked(clientConn, targetDbConn, deprecateEOF, masks, errRedactor(qe))
 				relayStats = stats
 				relayStatus = engine.RelayStatus(clean, err)
 				if err != nil {
@@ -301,15 +301,15 @@ func (s *Server) handleConn(clientConn net.Conn) {
 
 		case mysqlwire.ComInitDB:
 			// Switching the current database is not a gated action. Relay COM_INIT_DB mechanically to the
-			// backend and forward its OK/ERR verbatim; the control plane enforces subsequent queries under
+			// target DB and forward its OK/ERR verbatim; the control plane enforces subsequent queries under
 			// the new namespace via Decide. The database changed, so re-probe the namespace on the next query.
-			if _, err := relaySingleResponse(clientConn, backendConn, seq, payload, errRedactor(qe)); err != nil {
+			if _, err := relaySingleResponse(clientConn, targetDbConn, seq, payload, errRedactor(qe)); err != nil {
 				return
 			}
 			qe.MarkNamespaceDirty()
 
 		case mysqlwire.ComPing:
-			if _, err := relaySingleResponse(clientConn, backendConn, seq, payload, errRedactor(qe)); err != nil {
+			if _, err := relaySingleResponse(clientConn, targetDbConn, seq, payload, errRedactor(qe)); err != nil {
 				return
 			}
 
@@ -319,7 +319,7 @@ func (s *Server) handleConn(clientConn net.Conn) {
 			var frozen []string
 			var frozenAnsiQuotes bool
 			proceed, allowed, err := s.authorize(qe, clientConn, seq, sql, token, clientAddr, identity.ConnectionID, refetcher.RunAll, func() (engine.NamespaceProbe, error) {
-				obs, err := probeNamespaceObservation(backendConn, deprecateEOF)
+				obs, err := probeNamespaceObservation(targetDbConn, deprecateEOF)
 				if err == nil {
 					frozen = append([]string{}, obs.Namespace...)
 					frozenAnsiQuotes = obs.MySQLAnsiQuotes
@@ -368,10 +368,10 @@ func (s *Server) handleConn(clientConn net.Conn) {
 			}
 			// After-statement commands from PREPARE are deliberately ignored: PREPARE executes no statement effect,
 			// and EXECUTE obtains its own fresh verdict whose commands govern the actual execution.
-			if err := mysqlwire.WritePacket(backendConn, 0, toSend); err != nil {
+			if err := mysqlwire.WritePacket(targetDbConn, 0, toSend); err != nil {
 				return
 			}
-			stmtID, prepared, err := relayStmtPrepareResponse(clientConn, backendConn, deprecateEOF, errRedactor(qe))
+			stmtID, prepared, err := relayStmtPrepareResponse(clientConn, targetDbConn, deprecateEOF, errRedactor(qe))
 			if err != nil {
 				return
 			}
@@ -439,14 +439,14 @@ func (s *Server) handleConn(clientConn net.Conn) {
 				continue
 			}
 
-			// The fresh verdict authorized exactly the SQL already prepared on the backend under exactly its
+			// The fresh verdict authorized exactly the SQL already prepared on the target DB under exactly its
 			// frozen namespace. EXECUTE is forwarded verbatim; a fresh rewrite and masks cannot be applied to
 			// the binary path and are deliberately ignored.
 			start := time.Now()
-			if err := mysqlwire.WritePacket(backendConn, 0, payload); err != nil {
+			if err := mysqlwire.WritePacket(targetDbConn, 0, payload); err != nil {
 				return
 			}
-			ok, stats, err := relayQueryResponseTracked(clientConn, backendConn, deprecateEOF, nil, errRedactor(qe))
+			ok, stats, err := relayQueryResponseTracked(clientConn, targetDbConn, deprecateEOF, nil, errRedactor(qe))
 			// Post-relay, best-effort completion for this binary-protocol EXECUTE (no-op if unaudited).
 			engine.EmitCompletion(s.client, proceed.Decision, stats, engine.RelayStatus(ok, err), start)
 			if err != nil {
@@ -467,7 +467,7 @@ func (s *Server) handleConn(clientConn net.Conn) {
 				continue
 			}
 			delete(preparedStmts, id)
-			if err := mysqlwire.WritePacket(backendConn, seq, payload); err != nil {
+			if err := mysqlwire.WritePacket(targetDbConn, seq, payload); err != nil {
 				return
 			}
 
@@ -476,7 +476,7 @@ func (s *Server) handleConn(clientConn net.Conn) {
 			if _, ok := preparedStmts[id]; err != nil || !ok {
 				continue
 			}
-			if err := mysqlwire.WritePacket(backendConn, seq, payload); err != nil {
+			if err := mysqlwire.WritePacket(targetDbConn, seq, payload); err != nil {
 				return
 			}
 
@@ -488,7 +488,7 @@ func (s *Server) handleConn(clientConn net.Conn) {
 				}
 				continue
 			}
-			if _, err := relaySingleResponse(clientConn, backendConn, seq, payload, errRedactor(qe)); err != nil {
+			if _, err := relaySingleResponse(clientConn, targetDbConn, seq, payload, errRedactor(qe)); err != nil {
 				return
 			}
 
@@ -565,41 +565,41 @@ type singleResponse struct {
 	schema  *string
 }
 
-func executeSingleResponse(backend net.Conn, seq byte, payload []byte) (singleResponse, error) {
-	if err := mysqlwire.WritePacket(backend, seq, payload); err != nil {
+func executeSingleResponse(targetDb net.Conn, seq byte, payload []byte) (singleResponse, error) {
+	if err := mysqlwire.WritePacket(targetDb, seq, payload); err != nil {
 		return singleResponse{}, err
 	}
-	responseSeq, response, err := mysqlwire.ReadPacket(backend)
+	responseSeq, response, err := mysqlwire.ReadPacket(targetDb)
 	if err != nil {
 		return singleResponse{}, err
 	}
 	if len(response) == 0 {
-		return singleResponse{}, errors.New("mysqlproxy: empty single-packet backend response")
+		return singleResponse{}, errors.New("mysqlproxy: empty single-packet target-DB response")
 	}
 	result := singleResponse{seq: responseSeq, payload: response}
 	switch response[0] {
 	case 0x00:
-		result.payload, _, result.schema, _, err = normalizeBackendOK(response)
+		result.payload, _, result.schema, _, err = normalizeTargetDbOK(response)
 		if err != nil {
 			return singleResponse{}, err
 		}
 		result.ok = true
 	case 0xff:
-		// Preserve the backend ERR packet for the frontend.
+		// Preserve the target-DB ERR packet for the frontend.
 	default:
-		return singleResponse{}, fmt.Errorf("mysqlproxy: unexpected single-packet backend response 0x%02x", response[0])
+		return singleResponse{}, fmt.Errorf("mysqlproxy: unexpected single-packet target-DB response 0x%02x", response[0])
 	}
 	return result, nil
 }
 
-// relaySingleResponse forwards a command and exactly one backend packet, translating a session-tracked OK
+// relaySingleResponse forwards a command and exactly one target DB packet, translating a session-tracked OK
 // into the frontend's non-tracking packet shape.
-func relaySingleResponse(client, backend net.Conn, seq byte, payload []byte, redactErr func([]byte) []byte) (singleResponse, error) {
-	result, err := executeSingleResponse(backend, seq, payload)
+func relaySingleResponse(client, targetDb net.Conn, seq byte, payload []byte, redactErr func([]byte) []byte) (singleResponse, error) {
+	result, err := executeSingleResponse(targetDb, seq, payload)
 	if err != nil {
 		return singleResponse{}, err
 	}
-	// A single-response backend ERR (COM_INIT_DB / COM_PING / COM_STMT_RESET) is a mandated redaction site
+	// A single-response target-DB ERR (COM_INIT_DB / COM_PING / COM_STMT_RESET) is a mandated redaction site
 	// (fail-closed): strip it on a redacted decision before forwarding. See docs/diagnostic-redaction.md.
 	if !result.ok && redactErr != nil && len(result.payload) > 0 && result.payload[0] == 0xff {
 		result.payload = redactErr(result.payload)

--- a/goproxy/mysqlproxy/diag_e2e_test.go
+++ b/goproxy/mysqlproxy/diag_e2e_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // End-to-end proof through the real proxy that a diagnostic-redacted connection strips a
-// backend ERR packet to essno + SQLSTATE + the generic message, and relays it verbatim otherwise. MySQL's
+// target-DB ERR packet to essno + SQLSTATE + the generic message, and relays it verbatim otherwise. MySQL's
 // stored-value diagnostic leak is chiefly the SHOW WARNINGS buffer, denied at the control plane;
 // this validates the ERR-packet message strip that closes the inline-error surface. A recognizable
 // token embedded in a nonexistent table name stands in for the echoed content the message must not carry.
@@ -43,7 +43,7 @@ func TestDiagnosticRedactionStripsMysqlErrPacketEndToEnd(t *testing.T) {
 		t.Errorf("the token leaked through the redacted message: %q", myErr.Message)
 	}
 
-	// Control: without redaction the backend message is relayed verbatim (token present), proving the
+	// Control: without redaction the target-DB message is relayed verbatim (token present), proving the
 	// redaction above is what strips it.
 	sanitize.Store(false)
 	plain := h.openDB(t, validToken)
@@ -61,7 +61,7 @@ func TestDiagnosticRedactionStripsMysqlErrPacketEndToEnd(t *testing.T) {
 // query itself with no SHOW WARNINGS / GET DIAGNOSTICS read-back. This is defense-in-depth behind the CP's
 // own lineage enforcement (a masked column in a non-output position is denied before the statement runs);
 // this test isolates the redaction layer with an allow-all fake CP to prove the ERR-packet strip still
-// removes the value if the statement ever reaches the backend.
+// removes the value if the statement ever reaches the target DB.
 func TestDiagnosticRedactionStripsErrorBasedExtractionEndToEnd(t *testing.T) {
 	h := startBroker(t)
 	var sanitize atomic.Bool

--- a/goproxy/mysqlproxy/diagcodes.go
+++ b/goproxy/mysqlproxy/diagcodes.go
@@ -4,7 +4,7 @@ import "github.com/ridi-oss/proxy-monster/goproxy/engine"
 
 // mysqlDiagnosticMessage maps a MySQL essno to its canonical error symbol (ER_*) for a diagnostic-redacted
 // connection — a fixed, value-free identity looked up from the code, never reconstructed from the
-// backend's echoed message text. Unmapped essnos degrade to the generic redacted string rather than leaking
+// target DB's echoed message text. Unmapped essnos degrade to the generic redacted string rather than leaking
 // (fail-safe UX, not a security boundary — that is the strip itself). The symbol preserves the error's
 // identity without any of its interpolated content.
 func mysqlDiagnosticMessage(essno int) string {

--- a/goproxy/mysqlproxy/diagnostics.go
+++ b/goproxy/mysqlproxy/diagnostics.go
@@ -10,9 +10,9 @@ import (
 // meant to hide — a conversion/truncation warning promoted to an error, a duplicate-key value, an
 // invalid-character oracle. On a diagnostic-redacted connection the proxy keeps only the machine-readable
 // essno + SQLSTATE and replaces the message with the essno's canonical symbol (see mysqlDiagnosticMessage),
-// a fixed value-free identity looked up from the code — never reconstructed from the backend's text.
+// a fixed value-free identity looked up from the code — never reconstructed from the target DB's text.
 //
-// A CLIENT_PROTOCOL_41 ERR payload (every backend here negotiates 4.1) is:
+// A CLIENT_PROTOCOL_41 ERR payload (every target DB here negotiates 4.1) is:
 //
 //	[0]    0xff header
 //	[1:3]  essno, little-endian

--- a/goproxy/mysqlproxy/diagnostics_test.go
+++ b/goproxy/mysqlproxy/diagnostics_test.go
@@ -47,14 +47,14 @@ func TestSanitizeErrPacketDefaultsSqlStateWhenAbsent(t *testing.T) {
 	}
 }
 
-// End-to-end: a backend ERR relayed through relayResultSet with the RedactErr hook installed reaches the
+// End-to-end: a target-DB ERR relayed through relayResultSet with the RedactErr hook installed reaches the
 // client sanitized — essno + SQLSTATE preserved, message and any echoed value gone.
-func TestRelayResultSetRedactsBackendError(t *testing.T) {
-	var backend bytes.Buffer
-	writeTestPacket(t, &backend, 1, mysqlwire.ErrPacketState(1146, "42S02", "Table 'db.secret_010_1234_5678' doesn't exist"))
+func TestRelayResultSetRedactsTargetDbError(t *testing.T) {
+	var targetDb bytes.Buffer
+	writeTestPacket(t, &targetDb, 1, mysqlwire.ErrPacketState(1146, "42S02", "Table 'db.secret_010_1234_5678' doesn't exist"))
 
 	var relayed []byte
-	ok, err := relayResultSet(&backend, true, resultHooks{
+	ok, err := relayResultSet(&targetDb, true, resultHooks{
 		Sink: func(_ byte, payload []byte) error {
 			relayed = append([]byte(nil), payload...)
 			return nil
@@ -65,7 +65,7 @@ func TestRelayResultSetRedactsBackendError(t *testing.T) {
 		t.Fatalf("relayResultSet: %v", err)
 	}
 	if ok {
-		t.Fatal("relayResultSet reported success for a backend ERR")
+		t.Fatal("relayResultSet reported success for a target-DB ERR")
 	}
 	if binary.LittleEndian.Uint16(relayed[1:3]) != 1146 {
 		t.Errorf("essno not preserved through relay: %x", relayed[1:3])
@@ -80,12 +80,12 @@ func TestRelayResultSetRedactsBackendError(t *testing.T) {
 
 // Without the RedactErr hook the ERR is relayed verbatim (the system:development / non-latched path), so the
 // redaction is genuinely gated, not unconditional.
-func TestRelayResultSetForwardsBackendErrorVerbatimWhenNotRedacting(t *testing.T) {
-	var backend bytes.Buffer
-	writeTestPacket(t, &backend, 1, mysqlwire.ErrPacketState(1146, "42S02", "Table 'db.t' doesn't exist"))
+func TestRelayResultSetForwardsTargetDbErrorVerbatimWhenNotRedacting(t *testing.T) {
+	var targetDb bytes.Buffer
+	writeTestPacket(t, &targetDb, 1, mysqlwire.ErrPacketState(1146, "42S02", "Table 'db.t' doesn't exist"))
 
 	var relayed []byte
-	if _, err := relayResultSet(&backend, true, resultHooks{
+	if _, err := relayResultSet(&targetDb, true, resultHooks{
 		Sink: func(_ byte, payload []byte) error {
 			relayed = append([]byte(nil), payload...)
 			return nil
@@ -94,18 +94,18 @@ func TestRelayResultSetForwardsBackendErrorVerbatimWhenNotRedacting(t *testing.T
 		t.Fatalf("relayResultSet: %v", err)
 	}
 	if mysqlwire.ErrString(relayed) != "Table 'db.t' doesn't exist" {
-		t.Errorf("relayed message = %q, want verbatim backend message", mysqlwire.ErrString(relayed))
+		t.Errorf("relayed message = %q, want verbatim target-DB message", mysqlwire.ErrString(relayed))
 	}
 }
 
-// A prepare-time backend ERR is one of the three mandated MySQL ERR-forward sites: with the redactor it
+// A prepare-time target-DB ERR is one of the three mandated MySQL ERR-forward sites: with the redactor it
 // must reach the client stripped, closing the fail-closed gap even though PREPARE does not evaluate rows.
-func TestRelayStmtPrepareResponseRedactsBackendError(t *testing.T) {
-	var backend bytes.Buffer
-	writeTestPacket(t, &backend, 1, mysqlwire.ErrPacketState(1146, "42S02", "Table 'db.secret_010_1234_5678' doesn't exist"))
+func TestRelayStmtPrepareResponseRedactsTargetDbError(t *testing.T) {
+	var targetDb bytes.Buffer
+	writeTestPacket(t, &targetDb, 1, mysqlwire.ErrPacketState(1146, "42S02", "Table 'db.secret_010_1234_5678' doesn't exist"))
 
 	var client bytes.Buffer
-	if _, prepared, err := relayStmtPrepareResponse(&client, &backend, true, sanitizeErrPacket); err != nil || prepared {
+	if _, prepared, err := relayStmtPrepareResponse(&client, &targetDb, true, sanitizeErrPacket); err != nil || prepared {
 		t.Fatalf("relayStmtPrepareResponse: prepared=%v err=%v", prepared, err)
 	}
 	_, payload, err := mysqlwire.ReadPacket(&client)

--- a/goproxy/mysqlproxy/drain_test.go
+++ b/goproxy/mysqlproxy/drain_test.go
@@ -81,11 +81,11 @@ func TestDrainLetsInFlightStatementComplete(t *testing.T) {
 	h.fake.decideFn = allowAll
 	client := openRawClient(t, h.addr, validToken)
 
-	// SLEEP holds the handler in the relay (reading the backend) across the Drain call.
+	// SLEEP holds the handler in the relay (reading the target DB) across the Drain call.
 	if err := mysqlwire.WritePacket(client.conn, 0, mysqlwire.ComQueryPayload("SELECT SLEEP(0.5)")); err != nil {
 		t.Fatalf("write slow query: %v", err)
 	}
-	// Let the query reach the backend and begin relaying before draining.
+	// Let the query reach the target DB and begin relaying before draining.
 	time.Sleep(100 * time.Millisecond)
 
 	drained := make(chan struct{})

--- a/goproxy/mysqlproxy/mysqlproxy_test.go
+++ b/goproxy/mysqlproxy/mysqlproxy_test.go
@@ -20,16 +20,16 @@ import (
 	"github.com/ridi-oss/proxy-monster/mysqlwire"
 )
 
-func TestNormalizeBackendOKExtractsSchemaAndStripsTracking(t *testing.T) {
+func TestNormalizeTargetDbOKExtractsSchemaAndStripsTracking(t *testing.T) {
 	block := mysqlwire.AppendLenencStr(nil, "other_db")
 	state := []byte{sessionTrackSchema}
 	state = mysqlwire.AppendLenenc(state, uint64(len(block)))
 	state = append(state, block...)
 
 	payload := trackedOKPacket(0x00, serverStatusSessionStateChanged|0x0002, "rows matched", state)
-	clean, _, schema, _, err := normalizeBackendOK(payload)
+	clean, _, schema, _, err := normalizeTargetDbOK(payload)
 	if err != nil {
-		t.Fatalf("normalizeBackendOK: %v", err)
+		t.Fatalf("normalizeTargetDbOK: %v", err)
 	}
 	if schema == nil || *schema != "other_db" {
 		t.Fatalf("schema = %v, want other_db", schema)
@@ -61,18 +61,18 @@ func TestMaskedRowExpansionAtPacketBoundaryFailsClosed(t *testing.T) {
 }
 
 func TestUnmaskedRowContinuationCannotMasqueradeAsTerminator(t *testing.T) {
-	var backend bytes.Buffer
-	writeTestPacket(t, &backend, 1, []byte{0x01})
-	writeTestPacket(t, &backend, 2, []byte{0x03, 'd', 'e', 'f'})
+	var targetDb bytes.Buffer
+	writeTestPacket(t, &targetDb, 1, []byte{0x01})
+	writeTestPacket(t, &targetDb, 2, []byte{0x03, 'd', 'e', 'f'})
 	firstFragment := make([]byte, maxPacketPayload)
 	firstFragment[0] = 0xfe
 	binary.LittleEndian.PutUint64(firstFragment[1:9], uint64(maxPacketPayload+3))
-	writeTestPacket(t, &backend, 3, firstFragment)
-	writeTestPacket(t, &backend, 4, []byte{0xfe, 0x01, 0x02})
-	writeTestPacket(t, &backend, 5, trackedOKPacket(0xfe, 0x0002, "", nil))
+	writeTestPacket(t, &targetDb, 3, firstFragment)
+	writeTestPacket(t, &targetDb, 4, []byte{0xfe, 0x01, 0x02})
+	writeTestPacket(t, &targetDb, 5, trackedOKPacket(0xfe, 0x0002, "", nil))
 
 	var got [][]byte
-	ok, err := relayResultSet(&backend, true, resultHooks{Sink: func(_ byte, payload []byte) error {
+	ok, err := relayResultSet(&targetDb, true, resultHooks{Sink: func(_ byte, payload []byte) error {
 		got = append(got, append([]byte(nil), payload...))
 		return nil
 	}})
@@ -80,7 +80,7 @@ func TestUnmaskedRowContinuationCannotMasqueradeAsTerminator(t *testing.T) {
 		t.Fatalf("relayResultSet: %v", err)
 	}
 	if !ok {
-		t.Fatal("relayResultSet reported backend failure for a fragmented successful result")
+		t.Fatal("relayResultSet reported target-DB failure for a fragmented successful result")
 	}
 	if len(got) != 5 {
 		t.Fatalf("relayed packets = %d, want 5", len(got))
@@ -90,49 +90,49 @@ func TestUnmaskedRowContinuationCannotMasqueradeAsTerminator(t *testing.T) {
 	}
 }
 
-func TestRelayResultSetReportsBackendError(t *testing.T) {
-	var backend bytes.Buffer
-	writeTestPacket(t, &backend, 1, mysqlwire.ErrPacketState(1146, "42S02", "missing table"))
+func TestRelayResultSetReportsTargetDbError(t *testing.T) {
+	var targetDb bytes.Buffer
+	writeTestPacket(t, &targetDb, 1, mysqlwire.ErrPacketState(1146, "42S02", "missing table"))
 
-	ok, err := relayResultSet(&backend, true, resultHooks{})
+	ok, err := relayResultSet(&targetDb, true, resultHooks{})
 	if err != nil {
 		t.Fatalf("relayResultSet: %v", err)
 	}
 	if ok {
-		t.Fatal("relayResultSet reported success for a backend ERR packet")
+		t.Fatal("relayResultSet reported success for a target-DB ERR packet")
 	}
 }
 
 func TestRelayResultSetReportsAffectedRowsFromFirstOK(t *testing.T) {
 	payload := mysqlwire.OKPacket()
 	payload[1] = 7
-	var backend bytes.Buffer
-	writeTestPacket(t, &backend, 1, payload)
+	var targetDb bytes.Buffer
+	writeTestPacket(t, &targetDb, 1, payload)
 
 	var affected uint64
-	ok, err := relayResultSet(&backend, true, resultHooks{OnOK: func(n uint64) { affected = n }})
+	ok, err := relayResultSet(&targetDb, true, resultHooks{OnOK: func(n uint64) { affected = n }})
 	if err != nil || !ok || affected != 7 {
 		t.Fatalf("ok=%v affected=%d err=%v, want true, 7, nil", ok, affected, err)
 	}
 }
 
 func TestRelayResultSetRejectsFragmentedColumnDefinitionForCollector(t *testing.T) {
-	var backend bytes.Buffer
-	writeTestPacket(t, &backend, 1, []byte{0x01})
-	writeTestPacket(t, &backend, 2, make([]byte, maxPacketPayload))
+	var targetDb bytes.Buffer
+	writeTestPacket(t, &targetDb, 1, []byte{0x01})
+	writeTestPacket(t, &targetDb, 2, make([]byte, maxPacketPayload))
 
-	_, err := relayResultSet(&backend, true, resultHooks{OnColumnDef: func([]byte) error { return nil }})
+	_, err := relayResultSet(&targetDb, true, resultHooks{OnColumnDef: func([]byte) error { return nil }})
 	if err == nil || !strings.Contains(err.Error(), "fragmented MySQL column definitions") {
 		t.Fatalf("err=%v, want fragmented column-definition rejection", err)
 	}
 }
 
-// TestDialBackendCachingSHA2FullAuth proves the service-account dial completes the caching_sha2_password
+// TestDialTargetDbCachingSHA2FullAuth proves the service-account dial completes the caching_sha2_password
 // full-auth exchange over the plaintext link. The user is created fresh (unique name), so the server's
 // fast-auth cache has never seen it and MUST demand full authentication — a successful dial therefore
 // necessarily ran the RSA public-key path, which the test hook confirms directly.
-func TestDialBackendCachingSHA2FullAuth(t *testing.T) {
-	backend := dbtest.MySQL(t)
+func TestDialTargetDbCachingSHA2FullAuth(t *testing.T) {
+	targetDb := dbtest.MySQL(t)
 	seed := dbtest.OpenMySQL(t, "")
 
 	user := fmt.Sprintf("it_csha2_%d", time.Now().UnixNano())
@@ -140,7 +140,7 @@ func TestDialBackendCachingSHA2FullAuth(t *testing.T) {
 	if _, err := seed.Exec("CREATE USER '" + user + "'@'%' IDENTIFIED WITH caching_sha2_password BY '" + password + "'"); err != nil {
 		t.Fatalf("create caching_sha2 user: %v", err)
 	}
-	if _, err := seed.Exec("GRANT SELECT ON " + backend.DB + ".* TO '" + user + "'@'%'"); err != nil {
+	if _, err := seed.Exec("GRANT SELECT ON " + targetDb.DB + ".* TO '" + user + "'@'%'"); err != nil {
 		t.Fatalf("grant caching_sha2 user: %v", err)
 	}
 	t.Cleanup(func() { _, _ = seed.Exec("DROP USER IF EXISTS '" + user + "'@'%'") })
@@ -153,20 +153,20 @@ func TestDialBackendCachingSHA2FullAuth(t *testing.T) {
 	}
 	t.Cleanup(func() { testHookCachingSHA2FullAuth = nil })
 
-	target := spi.BackendTarget{
-		Host:     backend.Host,
-		Port:     backend.Port,
-		Db:       backend.DB,
+	target := spi.TargetDb{
+		Host:     targetDb.Host,
+		Port:     targetDb.Port,
+		Db:       targetDb.DB,
 		User:     user,
 		Password: password,
 	}
-	conn, connID, err := dialBackendAuthID(context.Background(), target, true)
+	conn, connID, err := dialTargetDbAuthID(context.Background(), target, true)
 	if err != nil {
-		t.Fatalf("dialBackendAuthID against caching_sha2 backend: %v", err)
+		t.Fatalf("dialTargetDbAuthID against caching_sha2 target DB: %v", err)
 	}
 	defer conn.Close()
 	if connID == 0 {
-		t.Fatal("backend connection id = 0, want the server-assigned id")
+		t.Fatal("target-DB connection id = 0, want the server-assigned id")
 	}
 	if fullAuthViaPublicKey != 1 {
 		t.Fatalf("caching_sha2 full-auth public-key path ran %d times, want exactly 1", fullAuthViaPublicKey)

--- a/goproxy/mysqlproxy/proxy_test.go
+++ b/goproxy/mysqlproxy/proxy_test.go
@@ -243,9 +243,9 @@ func startFakeCP(t *testing.T) (*fakeControlPlane, *cp.Client) {
 	return fake, client
 }
 
-func seedBackend(t *testing.T) dbtest.Backend {
+func seedTargetDb(t *testing.T) dbtest.TargetDb {
 	t.Helper()
-	backend := dbtest.MySQL(t)
+	targetDb := dbtest.MySQL(t)
 	seed := dbtest.OpenMySQL(t, "")
 	statements := []string{
 		"CREATE DATABASE IF NOT EXISTS " + primarySchema,
@@ -259,9 +259,9 @@ func seedBackend(t *testing.T) dbtest.Backend {
 		"DELETE FROM " + secondarySchema + ".people",
 		"INSERT INTO " + secondarySchema + ".people (id, name, ssn) VALUES (10, 'Secondary', 'secret-2')",
 		// caching_sha2_password is the mysql:8.0 / Aurora MySQL 3 default, so the broker's DB tests run
-		// against it as the regression proof that the caching_sha2 backend handshake works end-to-end.
+		// against it as the regression proof that the caching_sha2 target-DB handshake works end-to-end.
 		// ALTER USER re-salts the stored credential every run, invalidating the server's fast-auth cache,
-		// so the first backend dial each run is forced through the full-auth (RSA public-key) exchange.
+		// so the first target DB dial each run is forced through the full-auth (RSA public-key) exchange.
 		"CREATE USER IF NOT EXISTS '" + serviceUser + "'@'%' IDENTIFIED WITH caching_sha2_password BY '" + servicePassword + "'",
 		"ALTER USER '" + serviceUser + "'@'%' IDENTIFIED WITH caching_sha2_password BY '" + servicePassword + "'",
 		"GRANT ALL ON " + primarySchema + ".* TO '" + serviceUser + "'@'%'",
@@ -273,7 +273,7 @@ func seedBackend(t *testing.T) dbtest.Backend {
 			t.Fatalf("seed statement %q: %v", statement, err)
 		}
 	}
-	return backend
+	return targetDb
 }
 
 type brokerHarness struct {
@@ -298,7 +298,7 @@ func startBrokerTLS(t *testing.T) *brokerHarness {
 	return startBrokerWithTLS(t, reloading.Current)
 }
 
-// startBrokerWithTLS boots a broker against the shared seeded backend. A nil tlsProvider keeps the frontend
+// startBrokerWithTLS boots a broker against the shared seeded target DB. A nil tlsProvider keeps the frontend
 // plaintext (every existing test); a non-nil one advertises CLIENT_SSL and requires TLS.
 func startBrokerWithTLS(t *testing.T, tlsProvider func() (*tls.Config, error)) *brokerHarness {
 	t.Helper()
@@ -307,11 +307,11 @@ func startBrokerWithTLS(t *testing.T, tlsProvider func() (*tls.Config, error)) *
 
 func startBrokerConfigured(t *testing.T, tlsProvider func() (*tls.Config, error), dbImpl engine.Db) *brokerHarness {
 	t.Helper()
-	backend := seedBackend(t)
+	targetDb := seedTargetDb(t)
 	fake, cpClient := startFakeCP(t)
-	target := spi.BackendTarget{
-		Host:     backend.Host,
-		Port:     backend.Port,
+	target := spi.TargetDb{
+		Host:     targetDb.Host,
+		Port:     targetDb.Port,
 		Db:       primarySchema,
 		User:     serviceUser,
 		Password: servicePassword,
@@ -636,14 +636,14 @@ func TestRejectedFlaggedDDLDoesNotRefetch(t *testing.T) {
 
 	response := client.firstQueryPacket(t, "ALTER TABLE "+missing+" ADD COLUMN impossible INT")
 	if len(response) == 0 || response[0] != 0xff {
-		t.Fatalf("rejected DDL response = %x, want backend ERR", response)
+		t.Fatalf("rejected DDL response = %x, want target-DB ERR", response)
 	}
 	if got := len(h.fake.fragmentRequests()); got != 0 {
 		t.Fatalf("PushSchemaFragment calls after rejected DDL = %d, want zero", got)
 	}
 }
 
-func TestFlaggedDMLRefetchFailureClosesFrontendAndBackend(t *testing.T) {
+func TestFlaggedDMLRefetchFailureClosesFrontendAndTargetDb(t *testing.T) {
 	h := startBroker(t)
 	const connectionIDQuery = "SELECT CONNECTION_ID()"
 	h.fake.decideFn = func(req *pb.DecisionRequest) (*pb.WireDecision, error) {
@@ -658,15 +658,15 @@ func TestFlaggedDMLRefetchFailureClosesFrontendAndBackend(t *testing.T) {
 	if len(rows) != 1 || rows[0][0] == nil {
 		t.Fatalf("CONNECTION_ID rows = %v", rows)
 	}
-	var backendID uint64
-	if _, err := fmt.Sscan(*rows[0][0], &backendID); err != nil {
-		t.Fatalf("parse backend id %q: %v", *rows[0][0], err)
+	var targetDbID uint64
+	if _, err := fmt.Sscan(*rows[0][0], &targetDbID); err != nil {
+		t.Fatalf("parse target-DB id %q: %v", *rows[0][0], err)
 	}
 
 	h.fake.setPushError(status.Error(codes.Unavailable, "catalog unavailable"))
 	response := client.firstQueryPacket(t, "UPDATE people SET name = name WHERE id = 1")
 	if len(response) == 0 || response[0] != 0x00 {
-		t.Fatalf("DML response = %x, want backend OK before terminal refetch", response)
+		t.Fatalf("DML response = %x, want target-DB OK before terminal refetch", response)
 	}
 	_ = client.conn.SetReadDeadline(time.Now().Add(2 * time.Second))
 	if _, err := client.conn.Read(make([]byte, 1)); err == nil {
@@ -676,7 +676,7 @@ func TestFlaggedDMLRefetchFailureClosesFrontendAndBackend(t *testing.T) {
 	direct := dbtest.OpenMySQL(t, "")
 	waitFor(t, func() bool {
 		var count int
-		if err := direct.QueryRow("SELECT COUNT(*) FROM information_schema.PROCESSLIST WHERE ID = ?", backendID).Scan(&count); err != nil {
+		if err := direct.QueryRow("SELECT COUNT(*) FROM information_schema.PROCESSLIST WHERE ID = ?", targetDbID).Scan(&count); err != nil {
 			return false
 		}
 		return count == 0
@@ -727,7 +727,7 @@ func TestPreparedDDLRefetchesOnlyAfterSuccessfulExecute(t *testing.T) {
 		prepared := client.prepare(t, "ALTER TABLE "+missing+" ADD COLUMN impossible INT")
 		response := client.command(t, stmtExecuteNoParamsPayload(t, prepared.StmtID))
 		if len(response) == 0 || response[0] != 0xff {
-			t.Fatalf("failed EXECUTE response = %x, want backend ERR", response)
+			t.Fatalf("failed EXECUTE response = %x, want target-DB ERR", response)
 		}
 		if got := len(h.fake.fragmentRequests()); got != 0 {
 			t.Fatalf("PushSchemaFragment calls after failed EXECUTE = %d, want zero", got)
@@ -808,7 +808,7 @@ func assertFragmentColumn(t *testing.T, fragment *pb.SchemaFragmentPush, schema,
 
 func schemaHash(t *testing.T, schema string) []byte {
 	t.Helper()
-	backend := dbtest.OpenMySQL(t, primarySchema)
+	targetDb := dbtest.OpenMySQL(t, primarySchema)
 	dbImpl := db.MySqlDb{}
 	query, _, err := dbImpl.SchemaHashSQL(schema, nil)
 	if err != nil {
@@ -816,7 +816,7 @@ func schemaHash(t *testing.T, schema string) []byte {
 	}
 	var hash string
 	var produced, count uint64
-	if err := backend.QueryRow(query).Scan(&hash, &produced, &count); err != nil {
+	if err := targetDb.QueryRow(query).Scan(&hash, &produced, &count); err != nil {
 		t.Fatalf("schema hash query: %v", err)
 	}
 	rows := [][]*string{{&hash, stringPtr(fmt.Sprint(produced)), stringPtr(fmt.Sprint(count))}}
@@ -1099,7 +1099,7 @@ func TestHandshakeDatabaseIsRelayedAndSelected(t *testing.T) {
 		t.Fatalf("secondary database rows = %v, want [10]", got)
 	}
 
-	// The handshake-selected database is relayed to the backend as COM_INIT_DB, not authorized as a
+	// The handshake-selected database is relayed to the target DB as COM_INIT_DB, not authorized as a
 	// synthesized USE: only the query reaches the control plane, decided under the switched namespace.
 	requests := h.fake.requests()
 	if len(requests) != 1 {
@@ -1221,7 +1221,7 @@ func TestComInitDBRelaysAndReprobesNamespace(t *testing.T) {
 
 // TestTextUseIsReprobedIntoNamespace proves a bare text USE moves the authorization namespace: after USE
 // the next statement is decided under the new schema. The proxy re-probes the current database before
-// every statement (probe-always), so this holds whether or not the backend emits a SESSION_TRACK_SCHEMA
+// every statement (probe-always), so this holds whether or not the target DB emits a SESSION_TRACK_SCHEMA
 // signal for the USE.
 func TestTextUseIsReprobedIntoNamespace(t *testing.T) {
 	h := startBroker(t)
@@ -1248,7 +1248,7 @@ func TestTextUseIsReprobedIntoNamespace(t *testing.T) {
 // TestChainedSessionTrackBypassStillReprobesNamespace is the namespace half of the chained
 // session-track bypass. A client that
 // clears session_track_system_variables (silently defeating the sysvar tracker), then disables
-// session_track_schema (now unreported), then issues a bare text USE, defeats every backend signal the
+// session_track_schema (now unreported), then issues a bare text USE, defeats every target DB signal the
 // proxy could observe the switch through — yet the current database really changed. Probe-always closes
 // the hole: the proxy re-reads DATABASE() before the next statement, so that statement is authorized under
 // the switched schema, never the stale one. The tracker-defeating SETs and the USE all succeed; the guard
@@ -1404,7 +1404,7 @@ func TestLegacyEOFRelayRewriteAndPing(t *testing.T) {
 }
 
 func TestOversizedUnauthenticatedHandshakeIsRejectedWithoutBody(t *testing.T) {
-	server := mysqlproxy.New(0, spi.BackendTarget{}, nil, nil, nil)
+	server := mysqlproxy.New(0, spi.TargetDb{}, nil, nil, nil)
 	if err := server.Listen(); err != nil {
 		t.Fatalf("Listen: %v", err)
 	}
@@ -1924,7 +1924,7 @@ func TestPreparedRewrittenSqlReDecidedAsPrepared(t *testing.T) {
 		t.Fatalf("PREPARE DecisionRequest SQL = %q, want original %q", requests[0].GetSql(), original)
 	}
 	if requests[1].GetSql() != rewritten {
-		t.Fatalf("EXECUTE DecisionRequest SQL = %q, want backend-prepared rewrite %q", requests[1].GetSql(), rewritten)
+		t.Fatalf("EXECUTE DecisionRequest SQL = %q, want target-DB-prepared rewrite %q", requests[1].GetSql(), rewritten)
 	}
 	for i, request := range requests {
 		if got := request.GetSearchPath(); !reflect.DeepEqual(got, []string{primarySchema}) {

--- a/goproxy/mysqlproxy/relay.go
+++ b/goproxy/mysqlproxy/relay.go
@@ -43,17 +43,17 @@ type resultHooks struct {
 	OnOK        func(uint64)
 	OnSchema    func(string)
 	OnSysVars   func([]sysVarChange) error
-	// RedactErr, when non-nil, rewrites a standalone backend ERR packet before it reaches the sink — the one
+	// RedactErr, when non-nil, rewrites a standalone target-DB ERR packet before it reaches the sink — the one
 	// client-facing ERR site for both the wire relay and the run collector, so redaction here covers both.
 	RedactErr func([]byte) []byte
 	// Stats, when non-nil, tallies result volume as rows stream: one row per logical data row and the
-	// backend row-packet payload bytes (including continuation fragments of an oversized row). It measures
-	// backend data volume, not the post-mask relayed size, so a masked result reports the same volume signal.
+	// target DB row-packet payload bytes (including continuation fragments of an oversized row). It measures
+	// target DB data volume, not the post-mask relayed size, so a masked result reports the same volume signal.
 	Stats *engine.RelayStats
 }
 
 // relayResultSet consumes one complete COM_QUERY text result for both wire relay and in-memory collection.
-func relayResultSet(backend io.Reader, deprecateEOF bool, h resultHooks) (bool, error) {
+func relayResultSet(targetDb io.Reader, deprecateEOF bool, h resultHooks) (bool, error) {
 	phase, columnCount, columnsSeen := resultFirst, 0, 0
 	fragmenting, fragmentPhase := false, resultFirst
 	sink := func(seq byte, payload []byte) error {
@@ -74,7 +74,7 @@ func relayResultSet(backend io.Reader, deprecateEOF bool, h resultHooks) (bool, 
 	}
 
 	for {
-		seq, payload, err := mysqlwire.ReadPacket(backend)
+		seq, payload, err := mysqlwire.ReadPacket(targetDb)
 		if err != nil {
 			return false, err
 		}
@@ -119,7 +119,7 @@ func relayResultSet(backend io.Reader, deprecateEOF bool, h resultHooks) (bool, 
 		switch phase {
 		case resultFirst:
 			if payload[0] == 0x00 {
-				clean, affected, schema, sysVars, err := normalizeBackendOK(payload)
+				clean, affected, schema, sysVars, err := normalizeTargetDbOK(payload)
 				if err != nil {
 					return false, &resultSetError{seq, fmt.Errorf("parse result OK: %w", err)}
 				}
@@ -186,7 +186,7 @@ func relayResultSet(backend io.Reader, deprecateEOF bool, h resultHooks) (bool, 
 
 		case resultRows:
 			if deprecateEOF && payload[0] == 0xfe && len(payload) < maxPacketPayload {
-				clean, _, schema, sysVars, err := normalizeBackendOK(payload)
+				clean, _, schema, sysVars, err := normalizeTargetDbOK(payload)
 				if err != nil {
 					return false, &resultSetError{seq, fmt.Errorf("parse result terminator: %w", err)}
 				}
@@ -211,7 +211,7 @@ func relayResultSet(backend io.Reader, deprecateEOF bool, h resultHooks) (bool, 
 			}
 			// A non-terminator packet in the rows phase starts one logical data row (its continuation
 			// fragments, if any, are counted in the fragmenting block above). Tally it before masking so the
-			// volume reflects the backend row, not the rewritten one.
+			// volume reflects the target-DB row, not the rewritten one.
 			if h.Stats != nil {
 				h.Stats.Rows++
 				h.Stats.Bytes += int64(len(payload))
@@ -237,7 +237,7 @@ func relayResultSet(backend io.Reader, deprecateEOF bool, h resultHooks) (bool, 
 
 // errRedactor returns the ERR-packet redactor for the current decision — sanitizeErrPacket when the control
 // plane latched diagnostic redaction for this statement, else nil (relay the ERR verbatim). It is the single
-// gate every backend-ERR relay path passes through. See docs/diagnostic-redaction.md.
+// gate every target-DB-ERR relay path passes through. See docs/diagnostic-redaction.md.
 func errRedactor(qe *engine.QueryEngine) func([]byte) []byte {
 	if qe != nil && qe.SanitizeDiagnostics() {
 		return sanitizeErrPacket
@@ -245,7 +245,7 @@ func errRedactor(qe *engine.QueryEngine) func([]byte) []byte {
 	return nil
 }
 
-// relayQueryResponseTracked streams one backend result to the client and applies engine-selected masks.
+// relayQueryResponseTracked streams one target-DB result to the client and applies engine-selected masks.
 // It also fails closed on a session-state violation reported in the OK packet
 // (schema tracking disabled, tracking list dropped, or a charset that left UTF-8): a client-issued SET that
 // the control plane allowed can still defeat the proxy's observation, so the guard terminates the session
@@ -253,7 +253,7 @@ func errRedactor(qe *engine.QueryEngine) func([]byte) []byte {
 // sends a final ERR and closes both sockets so no unmasked row can leak, no partially-relayed protocol can
 // be reused, and no follow-up query can run under a defeated invariant.
 func relayQueryResponseTracked(
-	client, backend net.Conn,
+	client, targetDb net.Conn,
 	deprecateEOF bool,
 	masks []*pb.ColumnMask,
 	redactErr func([]byte) []byte,
@@ -278,7 +278,7 @@ func relayQueryResponseTracked(
 		}
 	}
 
-	ok, err := relayResultSet(backend, deprecateEOF, resultHooks{
+	ok, err := relayResultSet(targetDb, deprecateEOF, resultHooks{
 		Sink:      func(seq byte, payload []byte) error { return mysqlwire.WritePacket(client, seq, payload) },
 		OnColumns: onFirst,
 		OnRow:     rewrite,
@@ -295,7 +295,7 @@ func relayQueryResponseTracked(
 	if errors.As(err, &resultErr) {
 		code := 1105
 		state := "HY000"
-		message := "proxy-monster: malformed backend result set"
+		message := "proxy-monster: malformed target-DB result set"
 		switch {
 		case errors.Is(resultErr, errMaskUnbound):
 			code = 1235
@@ -312,14 +312,14 @@ func relayQueryResponseTracked(
 			message = "proxy-monster: connection character set must remain utf8mb4/utf8; connection closed"
 		case errors.Is(resultErr, errUnsafeSqlMode):
 			state = "HY000"
-			message = "proxy-monster: backend sql_mode enables a flag that is not parse-safe (only ANSI_QUOTES and known runtime/semantic flags are allowed); connection closed"
+			message = "proxy-monster: target DB sql_mode enables a flag that is not parse-safe (only ANSI_QUOTES and known runtime/semantic flags are allowed); connection closed"
 		case len(masks) > 0:
-			message = "proxy-monster: malformed backend text row"
+			message = "proxy-monster: malformed target-DB text row"
 		}
 		_ = mysqlwire.WritePacket(client, resultErr.seq, mysqlwire.ErrPacketState(code, state, message))
 	}
 	_ = client.Close()
-	_ = backend.Close()
+	_ = targetDb.Close()
 	// The partial volume tallied before the fault still travels with the error completion.
 	return false, stats, err
 }

--- a/goproxy/mysqlproxy/run_session.go
+++ b/goproxy/mysqlproxy/run_session.go
@@ -18,7 +18,7 @@ import (
 type RunSession struct {
 	conn         net.Conn
 	connID       uint32
-	target       spi.BackendTarget
+	target       spi.TargetDb
 	token        string
 	connectionID []byte
 	qe           *engine.QueryEngine
@@ -26,12 +26,12 @@ type RunSession struct {
 	guard        engine.ExecGuard
 }
 
-func NewRunSession(ctx context.Context, target spi.BackendTarget, db engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (*RunSession, error) {
-	conn, connID, err := dialBackendAuthID(ctx, target, true)
+func NewRunSession(ctx context.Context, target spi.TargetDb, db engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (*RunSession, error) {
+	conn, connID, err := dialTargetDbAuthID(ctx, target, true)
 	if err != nil {
 		return nil, err
 	}
-	conn = wire.WithBackendReadTimeout(conn, readTimeout)
+	conn = wire.WithTargetDbReadTimeout(conn, readTimeout)
 	generation, ok := wire.NextBackendGeneration()
 	if !ok {
 		_ = conn.Close()
@@ -52,9 +52,9 @@ func NewRunSession(ctx context.Context, target spi.BackendTarget, db engine.Db, 
 	return s, nil
 }
 
-// OnOpen runs the on-open catalog fetch over the backend conn. A cancel of ctx (the control-plane closed the
+// OnOpen runs the on-open catalog fetch over the target DB conn. A cancel of ctx (the control-plane closed the
 // run, or the proxy is draining, during the target-DB open) closes the conn, which unwinds an in-flight fetch read
-// at once instead of holding the backend until readTimeout.
+// at once instead of holding the target DB until readTimeout.
 func (s *RunSession) OnOpen(ctx context.Context, cmds []*pb.Refetch) error {
 	defer context.AfterFunc(ctx, func() { _ = s.conn.Close() })()
 	return s.ref.RunAll(cmds)
@@ -77,7 +77,7 @@ func (s *RunSession) ServeStatement(sql string, maxRows int) (result engine.Stat
 			if maxRows == math.MaxInt {
 				return false, errors.New("max rows exceeds MySQL SQL_SELECT_LIMIT range")
 			}
-			if err := execBackendSet(s.conn, "SET SQL_SELECT_LIMIT = "+strconv.Itoa(maxRows+1)); err != nil {
+			if err := execTargetDbSet(s.conn, "SET SQL_SELECT_LIMIT = "+strconv.Itoa(maxRows+1)); err != nil {
 				return false, err
 			}
 		}
@@ -85,7 +85,7 @@ func (s *RunSession) ServeStatement(sql string, maxRows int) (result engine.Stat
 			if !capped {
 				return nil
 			}
-			return execBackendSet(s.conn, "SET SQL_SELECT_LIMIT = DEFAULT")
+			return execTargetDbSet(s.conn, "SET SQL_SELECT_LIMIT = DEFAULT")
 		}
 
 		if err := mysqlwire.WritePacket(s.conn, 0, payload); err != nil {
@@ -102,8 +102,8 @@ func (s *RunSession) ServeStatement(sql string, maxRows int) (result engine.Stat
 		if relayErr != nil {
 			return false, relayErr
 		}
-		if collect.backendErr != nil {
-			return false, collect.backendErr
+		if collect.targetDbErr != nil {
+			return false, collect.targetDbErr
 		}
 		if resetErr != nil {
 			return false, resetErr
@@ -114,14 +114,14 @@ func (s *RunSession) ServeStatement(sql string, maxRows int) (result engine.Stat
 }
 
 func (s *RunSession) Cancel() error {
-	conn, _, err := dialBackendAuthID(context.Background(), s.target, true)
+	conn, _, err := dialTargetDbAuthID(context.Background(), s.target, true)
 	if err != nil {
 		_ = s.conn.Close()
 		return err
 	}
 	conn = wire.WithIODeadlines(conn, 5*time.Second, 5*time.Second)
 	defer conn.Close()
-	if err := execBackendSet(conn, "KILL QUERY "+strconv.FormatUint(uint64(s.connID), 10)); err != nil {
+	if err := execTargetDbSet(conn, "KILL QUERY "+strconv.FormatUint(uint64(s.connID), 10)); err != nil {
 		_ = s.conn.Close()
 		return err
 	}

--- a/goproxy/mysqlproxy/serve_statement_test.go
+++ b/goproxy/mysqlproxy/serve_statement_test.go
@@ -106,11 +106,11 @@ func TestRunStatementMySQLUncappedHasNoBracket(t *testing.T) {
 	}
 }
 
-func TestRunStatementMySQLResetsAfterBackendError(t *testing.T) {
+func TestRunStatementMySQLResetsAfterTargetDbError(t *testing.T) {
 	response := mysqlPacket(t, mysqlwire.ErrPacketState(1146, "42S02", "missing"))
 	_, err, writes := runMySQLStatement(t, 2, response)
 	if err == nil || !strings.Contains(err.Error(), "missing") {
-		t.Fatalf("err = %v, want backend error", err)
+		t.Fatalf("err = %v, want target-DB error", err)
 	}
 	if len(writes) != 3 || writes[2] != "SET SQL_SELECT_LIMIT = DEFAULT" {
 		t.Fatalf("writes = %v, want reset after ERR", writes)

--- a/goproxy/mysqlproxy/server.go
+++ b/goproxy/mysqlproxy/server.go
@@ -15,19 +15,19 @@ import (
 )
 
 // Server is the MySQL wire broker: the shared wire.Server lifecycle (accept loop, connection tracking,
-// graceful drain) plus this protocol's per-connection handler and its backend/enforcement dependencies.
+// graceful drain) plus this protocol's per-connection handler and its target DB/enforcement dependencies.
 type Server struct {
 	*wire.Server
-	backend     spi.BackendTarget
+	targetDb    spi.TargetDb
 	client      spi.EnforcementClient
 	db          engine.Db
 	tlsProvider func() (*tls.Config, error)
 	connID      atomic.Uint32
 }
 
-// New constructs a MySQL wire broker for one backend datasource.
-func New(port int, backend spi.BackendTarget, client spi.EnforcementClient, dbImpl engine.Db, tlsProvider func() (*tls.Config, error)) *Server {
-	s := &Server{backend: backend, client: client, db: dbImpl, tlsProvider: tlsProvider}
+// New constructs a MySQL wire broker for one target DB datasource.
+func New(port int, targetDb spi.TargetDb, client spi.EnforcementClient, dbImpl engine.Db, tlsProvider func() (*tls.Config, error)) *Server {
+	s := &Server{targetDb: targetDb, client: client, db: dbImpl, tlsProvider: tlsProvider}
 	s.Server = wire.New(port, "mysqlproxy", s.handleConn)
 	return s
 }

--- a/goproxy/mysqlproxy/session.go
+++ b/goproxy/mysqlproxy/session.go
@@ -23,10 +23,10 @@ type sysVarChange struct {
 }
 
 var (
-	errSchemaTrackingDisabled = errors.New("backend disabled session_track_schema; session state can no longer be tracked")
-	errUnsafeCharset          = errors.New("backend session character set left utf8mb4/utf8; identifier binding can no longer be trusted")
-	errSessionTrackingDropped = errors.New("backend dropped a required member from session_track_system_variables; session-state changes can no longer be observed")
-	errUnsafeSqlMode          = errors.New("backend session sql_mode enabled a flag that is not parse-safe (only ANSI_QUOTES and known runtime/semantic flags are allowed; anything else — NO_BACKSLASH_ESCAPES/PIPES_AS_CONCAT/… or an unrecognized flag — fails closed); analyzer↔backend SQL lexing can no longer be trusted")
+	errSchemaTrackingDisabled = errors.New("target DB disabled session_track_schema; session state can no longer be tracked")
+	errUnsafeCharset          = errors.New("target-DB session character set left utf8mb4/utf8; identifier binding can no longer be trusted")
+	errSessionTrackingDropped = errors.New("target DB dropped a required member from session_track_system_variables; session-state changes can no longer be observed")
+	errUnsafeSqlMode          = errors.New("target-DB session sql_mode enabled a flag that is not parse-safe (only ANSI_QUOTES and known runtime/semantic flags are allowed; anything else — NO_BACKSLASH_ESCAPES/PIPES_AS_CONCAT/… or an unrecognized flag — fails closed); analyzer↔target-DB SQL lexing can no longer be trusted")
 )
 
 // requiredTrackedSysVars are the system variables the proxy pins to SESSION_TRACK_SYSTEM_VARIABLES so a
@@ -40,7 +40,7 @@ var (
 // omits the variable itself — is reported as NOTHING (verified against live MySQL 8.0: no SESSION_TRACK
 // block, and the OK's SESSION_STATE_CHANGED status bit stays clear). Once the list is cleared, a later
 // SET session_track_schema=OFF and SET NAMES latin1 are equally silent. The proxy therefore ALSO re-probes
-// the namespace and charset before every statement (probe-always; see backend.go mysqlSessionProbeSQL),
+// the namespace and charset before every statement (probe-always; see target DB.go mysqlSessionProbeSQL),
 // which observes the true current database and charset regardless of tracker state.
 var requiredTrackedSysVars = []string{
 	"session_track_system_variables",
@@ -56,7 +56,7 @@ func trackedSysVarList() string { return strings.Join(requiredTrackedSysVars, ",
 // checkSysVarInvariants returns a terminal error if a reported system-variable change moved an enforcement
 // invariant to an unsafe value: schema tracking turned off, the tracking list dropped a required member, a
 // session charset left UTF-8, or sql_mode enabled a lexer-changing flag the analyzer cannot model
-// (NO_BACKSLASH_ESCAPES / PIPES_AS_CONCAT / …, which desync the analyzer's lexing from the backend's). It is
+// (NO_BACKSLASH_ESCAPES / PIPES_AS_CONCAT / …, which desync the analyzer's lexing from the target DB's). It is
 // shared by the run session and the wire relay so a client cannot silently defeat the proxy's observation
 // on either path. A change that enables ONLY ANSI_QUOTES is NOT a violation here: the analyzer models it and
 // the pre-statement probe forwards it, so the following statement is decided under the right mode rather than
@@ -121,7 +121,7 @@ func isSafeMySQLCharset(value string) bool {
 // HIGH_NOT_PRECEDENCE / IGNORE_SPACE are parse-affecting and unmodeled). This set is the ALLOWLIST: a flag
 // that is neither ANSI_QUOTES nor a member here fails the session closed — fail-closed conservation, so a
 // flag we do not recognize (a future MySQL version, an Aurora/fork extension) cannot silently desync the
-// analyzer's lexer from the backend's. A denylist would fail OPEN on such an unknown flag. The compound
+// analyzer's lexer from the target DB's. A denylist would fail OPEN on such an unknown flag. The compound
 // modes (ANSI, TRADITIONAL, …) are absent because MySQL stores @@session.sql_mode EXPANDED — only the
 // component flags ever reach this classifier.
 var mysqlParseSafeSqlModes = map[string]bool{
@@ -148,9 +148,9 @@ var mysqlParseSafeSqlModes = map[string]bool{
 // (mysqlParseSafeSqlModes) is ignored. ANY OTHER flag — a known parse-affecting one the analyzer cannot
 // model (NO_BACKSLASH_ESCAPES / PIPES_AS_CONCAT / HIGH_NOT_PRECEDENCE / IGNORE_SPACE) OR one this build does
 // not recognize — fails the session closed (errUnsafeSqlMode), because it could desync the analyzer's lexer
-// from the backend's and leak a masked column. sql_mode is a comma-separated flag list; an unsafe member
+// from the target DB's and leak a masked column. sql_mode is a comma-separated flag list; an unsafe member
 // takes precedence over an observed ANSI_QUOTES (e.g. "ANSI_QUOTES,NO_BACKSLASH_ESCAPES" fails closed).
-// Mirrors the PG standard_conforming_strings guard (pgproxy/backend.go).
+// Mirrors the PG standard_conforming_strings guard (pgproxy/target DB.go).
 func classifyMySQLSqlMode(value string) (ansiQuotes bool, err error) {
 	for _, raw := range strings.Split(value, ",") {
 		mode := strings.ToUpper(strings.TrimSpace(raw))
@@ -168,15 +168,15 @@ func classifyMySQLSqlMode(value string) (ansiQuotes bool, err error) {
 	return ansiQuotes, nil
 }
 
-// normalizeBackendOK removes CLIENT_SESSION_TRACK-only framing before an OK packet is sent to a frontend
+// normalizeTargetDbOK removes CLIENT_SESSION_TRACK-only framing before an OK packet is sent to a frontend
 // that did not negotiate it, and returns affected rows plus its authoritative session-state signals: a
 // schema-change value (SESSION_TRACK_SCHEMA) and any tracked system-variable changes
 // (SESSION_TRACK_SYSTEM_VARIABLES). Tracking these signals avoids interposing SELECT DATABASE() between
 // client statements, which would corrupt MySQL's statement-scoped diagnostics such as ROW_COUNT(),
 // FOUND_ROWS(), and SHOW WARNINGS.
-func normalizeBackendOK(payload []byte) ([]byte, uint64, *string, []sysVarChange, error) {
+func normalizeTargetDbOK(payload []byte) ([]byte, uint64, *string, []sysVarChange, error) {
 	if len(payload) == 0 || (payload[0] != 0x00 && payload[0] != 0xfe) {
-		return nil, 0, nil, nil, fmt.Errorf("mysqlproxy: expected backend OK packet")
+		return nil, 0, nil, nil, fmt.Errorf("mysqlproxy: expected target-DB OK packet")
 	}
 
 	pos := 1
@@ -202,7 +202,7 @@ func normalizeBackendOK(payload []byte) ([]byte, uint64, *string, []sysVarChange
 	// payload in that shape, so the fixed fields are already valid for a non-tracking frontend.
 	if pos == len(payload) {
 		if status&serverStatusSessionStateChanged != 0 {
-			return nil, 0, nil, nil, fmt.Errorf("mysqlproxy: backend OK advertises session state without a state payload")
+			return nil, 0, nil, nil, fmt.Errorf("mysqlproxy: target-DB OK advertises session state without a state payload")
 		}
 		return clean, affected, nil, nil, nil
 	}
@@ -227,7 +227,7 @@ func normalizeBackendOK(payload []byte) ([]byte, uint64, *string, []sysVarChange
 		}
 	}
 	if pos != len(payload) {
-		return nil, 0, nil, nil, fmt.Errorf("mysqlproxy: trailing bytes after backend OK packet")
+		return nil, 0, nil, nil, fmt.Errorf("mysqlproxy: trailing bytes after target-DB OK packet")
 	}
 	return clean, affected, schema, sysVars, nil
 }

--- a/goproxy/mysqlproxy/sqlmode_e2e_test.go
+++ b/goproxy/mysqlproxy/sqlmode_e2e_test.go
@@ -10,13 +10,13 @@ import (
 
 // allowAllDecide is the fake-CP verdict for these sql_mode wire tests. The analyzer is not in the loop here,
 // so every statement is ALLOWed and each assertion rides on the proxy's OWN sql_mode observation/forwarding
-// (the masked-read proof against a real ANSI_QUOTES backend + the live analyzer is a control-plane / pm-demo
+// (the masked-read proof against a real ANSI_QUOTES target DB + the live analyzer is a control-plane / pm-demo
 // check, not a wire-layer one).
 func allowAllDecide(*pb.DecisionRequest) (*pb.WireDecision, error) {
 	return wireVerdict(&pb.Verdict{Decision: pb.EnfAction_ALLOW}), nil
 }
 
-// TestAnsiQuotesObservedAndForwarded is the ANSI_QUOTES wire flip against a real MySQL backend: a session
+// TestAnsiQuotesObservedAndForwarded is the ANSI_QUOTES wire flip against a real MySQL target DB: a session
 // that enters ANSI_QUOTES is NO LONGER failed closed. The SET succeeds and every subsequent statement's
 // DecisionRequest carries MysqlAnsiQuotes=true, so the control plane can mask a `"`-quoted column instead of
 // the proxy killing the session. Because the proxy re-probes sql_mode before every statement, the flip is

--- a/goproxy/mysqlproxy/stmt.go
+++ b/goproxy/mysqlproxy/stmt.go
@@ -10,7 +10,7 @@ import (
 
 const malformedStmtPrepareMessage = "proxy-monster: malformed prepared-statement response"
 
-// preparedStmt binds the SQL actually prepared on the backend to the namespace AND the ANSI_QUOTES
+// preparedStmt binds the SQL actually prepared on the target DB to the namespace AND the ANSI_QUOTES
 // observation frozen at PREPARE. MySQL parses `"…"` as an
 // identifier-or-string at PREPARE time under the then-current sql_mode, fixing it for every EXECUTE, so the
 // prepare-time ansiQuotes is what each EXECUTE re-authorizes under. Every EXECUTE is re-authorized against
@@ -21,11 +21,11 @@ type preparedStmt struct {
 	ansiQuotes bool
 }
 
-// relayStmtPrepareResponse relays one complete COM_STMT_PREPARE response and returns the backend-assigned
+// relayStmtPrepareResponse relays one complete COM_STMT_PREPARE response and returns the target-DB-assigned
 // statement ID. Parameter and column definitions are opaque logical packets; a full-size physical packet
 // therefore consumes the following continuation without advancing the definition count.
-func relayStmtPrepareResponse(client io.Writer, backend io.Reader, deprecateEOF bool, redactErr func([]byte) []byte) (stmtID uint32, prepared bool, err error) {
-	seq, payload, err := mysqlwire.ReadPacket(backend)
+func relayStmtPrepareResponse(client io.Writer, targetDb io.Reader, deprecateEOF bool, redactErr func([]byte) []byte) (stmtID uint32, prepared bool, err error) {
+	seq, payload, err := mysqlwire.ReadPacket(targetDb)
 	if err != nil {
 		return 0, false, err
 	}
@@ -33,7 +33,7 @@ func relayStmtPrepareResponse(client io.Writer, backend io.Reader, deprecateEOF 
 		return 0, false, errors.New("mysqlproxy: empty prepared-statement response")
 	}
 	if payload[0] == 0xff {
-		// A prepare-time backend ERR is a mandated redaction site (fail-closed): strip it on a redacted
+		// A prepare-time target-DB ERR is a mandated redaction site (fail-closed): strip it on a redacted
 		// decision before it reaches the client. See docs/diagnostic-redaction.md.
 		if redactErr != nil {
 			payload = redactErr(payload)
@@ -55,7 +55,7 @@ func relayStmtPrepareResponse(client io.Writer, backend io.Reader, deprecateEOF 
 	relayDefinitions := func(count int) error {
 		for range count {
 			for {
-				seq, payload, err := mysqlwire.ReadPacket(backend)
+				seq, payload, err := mysqlwire.ReadPacket(targetDb)
 				if err != nil {
 					return err
 				}
@@ -70,7 +70,7 @@ func relayStmtPrepareResponse(client io.Writer, backend io.Reader, deprecateEOF 
 		return nil
 	}
 	relayLegacyEOF := func() error {
-		seq, payload, err := mysqlwire.ReadPacket(backend)
+		seq, payload, err := mysqlwire.ReadPacket(targetDb)
 		if err != nil {
 			return err
 		}

--- a/goproxy/mysqlproxy/stmt_test.go
+++ b/goproxy/mysqlproxy/stmt_test.go
@@ -27,17 +27,17 @@ func TestRelayStmtPrepareResponseRelaysMetadata(t *testing.T) {
 				packets = append(packets, stmtTestPacket{seq: byte(len(packets) + 1), payload: stmtTestEOFPacket()})
 			}
 
-			backend := stmtTestPacketBuffer(t, packets)
+			targetDb := stmtTestPacketBuffer(t, packets)
 			var client bytes.Buffer
-			stmtID, prepared, err := relayStmtPrepareResponse(&client, backend, deprecateEOF, nil)
+			stmtID, prepared, err := relayStmtPrepareResponse(&client, targetDb, deprecateEOF, nil)
 			if err != nil {
 				t.Fatalf("relayStmtPrepareResponse: %v", err)
 			}
 			if stmtID != 42 || !prepared {
 				t.Fatalf("result = (%d, %v), want (42, true)", stmtID, prepared)
 			}
-			if backend.Len() != 0 {
-				t.Fatalf("backend has %d unread bytes", backend.Len())
+			if targetDb.Len() != 0 {
+				t.Fatalf("target DB has %d unread bytes", targetDb.Len())
 			}
 			if got := readStmtTestPackets(t, &client); !reflect.DeepEqual(got, packets) {
 				t.Fatalf("relayed packets = %#v, want %#v", got, packets)
@@ -98,17 +98,17 @@ func TestRelayStmtPrepareResponseMetadataShapes(t *testing.T) {
 				[]stmtTestPacket{{seq: 1, payload: stmtPrepareOKPayload(99, test.columns, test.params)}},
 				test.definitions...,
 			)
-			backend := stmtTestPacketBuffer(t, packets)
+			targetDb := stmtTestPacketBuffer(t, packets)
 			var client bytes.Buffer
-			stmtID, prepared, err := relayStmtPrepareResponse(&client, backend, test.deprecate, nil)
+			stmtID, prepared, err := relayStmtPrepareResponse(&client, targetDb, test.deprecate, nil)
 			if err != nil {
 				t.Fatalf("relayStmtPrepareResponse: %v", err)
 			}
 			if stmtID != 99 || !prepared {
 				t.Fatalf("result = (%d, %v), want (99, true)", stmtID, prepared)
 			}
-			if backend.Len() != 0 {
-				t.Fatalf("backend has %d unread bytes", backend.Len())
+			if targetDb.Len() != 0 {
+				t.Fatalf("target DB has %d unread bytes", targetDb.Len())
 			}
 			if got := readStmtTestPackets(t, &client); !reflect.DeepEqual(got, packets) {
 				t.Fatalf("relayed packets = %#v, want %#v", got, packets)
@@ -125,31 +125,31 @@ func TestRelayStmtPrepareResponseCountsLogicalDefinitions(t *testing.T) {
 		{seq: 2, payload: firstFragment},
 		{seq: 3, payload: []byte("definition-continuation")},
 	}
-	backend := stmtTestPacketBuffer(t, packets)
+	targetDb := stmtTestPacketBuffer(t, packets)
 	var client bytes.Buffer
 
-	stmtID, prepared, err := relayStmtPrepareResponse(&client, backend, true, nil)
+	stmtID, prepared, err := relayStmtPrepareResponse(&client, targetDb, true, nil)
 	if err != nil {
 		t.Fatalf("relayStmtPrepareResponse: %v", err)
 	}
 	if stmtID != 77 || !prepared {
 		t.Fatalf("result = (%d, %v), want (77, true)", stmtID, prepared)
 	}
-	if backend.Len() != 0 {
-		t.Fatalf("backend has %d unread bytes", backend.Len())
+	if targetDb.Len() != 0 {
+		t.Fatalf("target DB has %d unread bytes", targetDb.Len())
 	}
 	if got := readStmtTestPackets(t, &client); !reflect.DeepEqual(got, packets) {
 		t.Fatalf("relayed packets = %#v, want %#v", got, packets)
 	}
 }
 
-func TestRelayStmtPrepareResponseRelaysBackendError(t *testing.T) {
-	backendErr := mysqlwire.ErrPacketState(1064, "42000", "backend rejected prepare")
-	packets := []stmtTestPacket{{seq: 1, payload: backendErr}}
-	backend := stmtTestPacketBuffer(t, packets)
+func TestRelayStmtPrepareResponseRelaysTargetDbError(t *testing.T) {
+	targetDbErr := mysqlwire.ErrPacketState(1064, "42000", "target DB rejected prepare")
+	packets := []stmtTestPacket{{seq: 1, payload: targetDbErr}}
+	targetDb := stmtTestPacketBuffer(t, packets)
 	var client bytes.Buffer
 
-	stmtID, prepared, err := relayStmtPrepareResponse(&client, backend, true, nil)
+	stmtID, prepared, err := relayStmtPrepareResponse(&client, targetDb, true, nil)
 	if err != nil {
 		t.Fatalf("relayStmtPrepareResponse: %v", err)
 	}
@@ -164,10 +164,10 @@ func TestRelayStmtPrepareResponseRelaysBackendError(t *testing.T) {
 func TestRelayStmtPrepareResponseRejectsMalformedHeader(t *testing.T) {
 	malformed := stmtPrepareOKPayload(42, 0, 0)
 	malformed[0] = 0x01
-	backend := stmtTestPacketBuffer(t, []stmtTestPacket{{seq: 7, payload: malformed}})
+	targetDb := stmtTestPacketBuffer(t, []stmtTestPacket{{seq: 7, payload: malformed}})
 	var client bytes.Buffer
 
-	if _, prepared, err := relayStmtPrepareResponse(&client, backend, true, nil); err == nil || prepared {
+	if _, prepared, err := relayStmtPrepareResponse(&client, targetDb, true, nil); err == nil || prepared {
 		t.Fatalf("result = (prepared %v, error %v), want false and error", prepared, err)
 	}
 	packets := readStmtTestPackets(t, &client)
@@ -186,10 +186,10 @@ func TestRelayStmtPrepareResponseRequiresLegacyEOF(t *testing.T) {
 		{seq: 2, payload: []byte("param-definition")},
 		{seq: 3, payload: []byte("not-an-eof")},
 	}
-	backend := stmtTestPacketBuffer(t, packets)
+	targetDb := stmtTestPacketBuffer(t, packets)
 	var client bytes.Buffer
 
-	if _, prepared, err := relayStmtPrepareResponse(&client, backend, false, nil); err == nil || prepared {
+	if _, prepared, err := relayStmtPrepareResponse(&client, targetDb, false, nil); err == nil || prepared {
 		t.Fatalf("result = (prepared %v, error %v), want false and error", prepared, err)
 	}
 	got := readStmtTestPackets(t, &client)

--- a/goproxy/pgproxy/backend.go
+++ b/goproxy/pgproxy/backend.go
@@ -19,14 +19,14 @@ import (
 	"github.com/ridi-oss/proxy-monster/goproxy/wire"
 )
 
-const backendHandshakeTimeout = 10 * time.Second
+const targetDbHandshakeTimeout = 10 * time.Second
 
-// dialBackendAuth honors ctx for the whole handshake: DialContext aborts the connect, and while the
+// dialTargetDbAuth honors ctx for the whole handshake: DialContext aborts the connect, and while the
 // (deadline-bounded) auth exchange runs, an AfterFunc closes the conn on cancel so a blocked read unwinds at
 // once. On the run path ctx is the target-DB open context, so a run the control-plane already closed does not
-// finish a backend handshake nobody is waiting for; the wire path passes a background ctx (never cancelled).
-func dialBackendAuth(ctx context.Context, target spi.BackendTarget) (net.Conn, []pgproto3.ParameterStatus, pgproto3.BackendKeyData, byte, error) {
-	dialer := net.Dialer{Timeout: backendHandshakeTimeout}
+// finish a target-DB handshake nobody is waiting for; the wire path passes a background ctx (never cancelled).
+func dialTargetDbAuth(ctx context.Context, target spi.TargetDb) (net.Conn, []pgproto3.ParameterStatus, pgproto3.BackendKeyData, byte, error) {
+	dialer := net.Dialer{Timeout: targetDbHandshakeTimeout}
 	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(target.Host, strconv.Itoa(target.Port)))
 	if err != nil {
 		return nil, nil, pgproto3.BackendKeyData{}, 0, err
@@ -38,8 +38,8 @@ func dialBackendAuth(ctx context.Context, target spi.BackendTarget) (net.Conn, [
 		}
 	}()
 	defer context.AfterFunc(ctx, func() { _ = conn.Close() })()
-	if err := conn.SetDeadline(time.Now().Add(backendHandshakeTimeout)); err != nil {
-		return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("set backend auth deadline: %w", err)
+	if err := conn.SetDeadline(time.Now().Add(targetDbHandshakeTimeout)); err != nil {
+		return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("set target-DB auth deadline: %w", err)
 	}
 
 	wireConn := &switchConn{Conn: conn, strictReads: true}
@@ -53,7 +53,7 @@ func dialBackendAuth(ctx context.Context, target spi.BackendTarget) (net.Conn, [
 		},
 	})
 	if err := frontend.Flush(); err != nil {
-		return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("write backend startup: %w", err)
+		return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("write target-DB startup: %w", err)
 	}
 
 	var scram *scramClient
@@ -63,30 +63,30 @@ func dialBackendAuth(ctx context.Context, target spi.BackendTarget) (net.Conn, [
 	for !authenticated {
 		message, err := frontend.Receive()
 		if err != nil {
-			return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("read backend auth response: %w", err)
+			return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("read target-DB auth response: %w", err)
 		}
 		switch message := message.(type) {
 		case *pgproto3.AuthenticationOk:
 			if scram != nil && !scramVerified {
-				return nil, nil, pgproto3.BackendKeyData{}, 0, errors.New("backend accepted auth without completing the SCRAM exchange")
+				return nil, nil, pgproto3.BackendKeyData{}, 0, errors.New("target DB accepted auth without completing the SCRAM exchange")
 			}
 			authenticated = true
 
 		case *pgproto3.AuthenticationCleartextPassword:
 			frontend.Send(&pgproto3.PasswordMessage{Password: target.Password})
 			if err := frontend.Flush(); err != nil {
-				return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("write backend cleartext password: %w", err)
+				return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("write target DB cleartext password: %w", err)
 			}
 
 		case *pgproto3.AuthenticationMD5Password:
 			frontend.Send(&pgproto3.PasswordMessage{Password: md5Password(target.User, target.Password, message.Salt)})
 			if err := frontend.Flush(); err != nil {
-				return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("write backend md5 password: %w", err)
+				return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("write target DB md5 password: %w", err)
 			}
 
 		case *pgproto3.AuthenticationSASL:
 			if scram != nil || !containsString(message.AuthMechanisms, "SCRAM-SHA-256") {
-				return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("backend offered no usable SCRAM-SHA-256 mechanism: %v", message.AuthMechanisms)
+				return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("target DB offered no usable SCRAM-SHA-256 mechanism: %v", message.AuthMechanisms)
 			}
 			scram, err = newScramClient(target.Password)
 			if err != nil {
@@ -97,12 +97,12 @@ func dialBackendAuth(ctx context.Context, target spi.BackendTarget) (net.Conn, [
 				Data:          scram.clientFirstMessage(),
 			})
 			if err := frontend.Flush(); err != nil {
-				return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("write backend SCRAM initial response: %w", err)
+				return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("write target DB SCRAM initial response: %w", err)
 			}
 
 		case *pgproto3.AuthenticationSASLContinue:
 			if scram == nil || scramFinalSent {
-				return nil, nil, pgproto3.BackendKeyData{}, 0, errors.New("unexpected SASLContinue from backend")
+				return nil, nil, pgproto3.BackendKeyData{}, 0, errors.New("unexpected SASLContinue from target DB")
 			}
 			if err := scram.recvServerFirstMessage(message.Data); err != nil {
 				return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("SCRAM exchange failed: %w", err)
@@ -114,12 +114,12 @@ func dialBackendAuth(ctx context.Context, target spi.BackendTarget) (net.Conn, [
 			scramFinalSent = true
 			frontend.Send(&pgproto3.SASLResponse{Data: final})
 			if err := frontend.Flush(); err != nil {
-				return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("write backend SCRAM final response: %w", err)
+				return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("write target DB SCRAM final response: %w", err)
 			}
 
 		case *pgproto3.AuthenticationSASLFinal:
 			if scram == nil || !scramFinalSent || scramVerified {
-				return nil, nil, pgproto3.BackendKeyData{}, 0, errors.New("unexpected SASLFinal from backend")
+				return nil, nil, pgproto3.BackendKeyData{}, 0, errors.New("unexpected SASLFinal from target DB")
 			}
 			if err := scram.verifyServerFinal(message.Data); err != nil {
 				return nil, nil, pgproto3.BackendKeyData{}, 0, err
@@ -127,13 +127,13 @@ func dialBackendAuth(ctx context.Context, target spi.BackendTarget) (net.Conn, [
 			scramVerified = true
 
 		case *pgproto3.ErrorResponse:
-			return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("backend auth failed: %s", message.Message)
+			return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("target-DB auth failed: %s", message.Message)
 
 		case *pgproto3.NoticeResponse:
 			// Notices during service-account authentication have no authenticated frontend recipient.
 
 		default:
-			return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("unexpected backend auth message %T", message)
+			return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("unexpected target-DB auth message %T", message)
 		}
 	}
 
@@ -142,7 +142,7 @@ func dialBackendAuth(ctx context.Context, target spi.BackendTarget) (net.Conn, [
 	for {
 		message, err := frontend.Receive()
 		if err != nil {
-			return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("read backend startup response: %w", err)
+			return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("read target-DB startup response: %w", err)
 		}
 		switch message := message.(type) {
 		case *pgproto3.ParameterStatus:
@@ -154,16 +154,16 @@ func dialBackendAuth(ctx context.Context, target spi.BackendTarget) (net.Conn, [
 				return nil, nil, pgproto3.BackendKeyData{}, 0, err
 			}
 			if err := conn.SetDeadline(time.Time{}); err != nil {
-				return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("clear backend auth deadline: %w", err)
+				return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("clear target-DB auth deadline: %w", err)
 			}
 			keep = true
 			return conn, parameters, keyData, message.TxStatus, nil
 		case *pgproto3.ErrorResponse:
-			return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("backend startup failed: %s", message.Message)
+			return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("target-DB startup failed: %s", message.Message)
 		case *pgproto3.NoticeResponse:
 			// Ignore pre-ready notices; client authentication has not completed yet.
 		default:
-			return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("unexpected backend startup message %T", message)
+			return nil, nil, pgproto3.BackendKeyData{}, 0, fmt.Errorf("unexpected target-DB startup message %T", message)
 		}
 	}
 }
@@ -176,20 +176,20 @@ func validateStartupParameters(parameters []pgproto3.ParameterStatus) error {
 		case "client_encoding":
 			sawEncoding = true
 			if !strings.EqualFold(parameter.Value, "UTF8") {
-				return fmt.Errorf("unsafe backend startup client_encoding %q: %w", parameter.Value, errClientEncoding)
+				return fmt.Errorf("unsafe target-DB startup client_encoding %q: %w", parameter.Value, errClientEncoding)
 			}
 		case "standard_conforming_strings":
 			sawStdStrings = true
 			if !strings.EqualFold(parameter.Value, "on") {
-				return fmt.Errorf("unsafe backend startup standard_conforming_strings %q: %w", parameter.Value, errStdConformingStrings)
+				return fmt.Errorf("unsafe target-DB startup standard_conforming_strings %q: %w", parameter.Value, errStdConformingStrings)
 			}
 		}
 	}
 	if !sawEncoding {
-		return fmt.Errorf("backend did not report client_encoding at startup: %w", errClientEncoding)
+		return fmt.Errorf("target DB did not report client_encoding at startup: %w", errClientEncoding)
 	}
 	if !sawStdStrings {
-		return fmt.Errorf("backend did not report standard_conforming_strings at startup: %w", errStdConformingStrings)
+		return fmt.Errorf("target DB did not report standard_conforming_strings at startup: %w", errStdConformingStrings)
 	}
 	return nil
 }
@@ -214,7 +214,7 @@ func containsString(values []string, want string) bool {
 func (c *sessionCore) probeNamespace() ([]string, error) {
 	rows, err := c.runProbe(c.db.NamespaceProbeSQL(), 1, false)
 	if err != nil {
-		return nil, fmt.Errorf("backend namespace probe: %w", err)
+		return nil, fmt.Errorf("target-DB namespace probe: %w", err)
 	}
 	return namespaceFromRows(rows)
 }
@@ -233,7 +233,7 @@ func namespaceFromRows(rows [][]*string) ([]string, error) {
 func (c *sessionCore) probeTempColumns() ([]engine.TempColumn, error) {
 	rows, err := c.runProbe(c.db.TempColumnsProbeSQL(), 5, false)
 	if err != nil {
-		return nil, fmt.Errorf("backend temp-column probe: %w", err)
+		return nil, fmt.Errorf("target DB temp-column probe: %w", err)
 	}
 	return tempColumnsFromRows(rows)
 }
@@ -260,12 +260,12 @@ func tempColumnsFromRows(rows [][]*string) ([]engine.TempColumn, error) {
 }
 
 func (c *sessionCore) runProbe(sql string, expectedColumns int, quiet bool) ([][]*string, error) {
-	c.backend.Send(&pgproto3.Query{String: sql})
+	c.targetDb.Send(&pgproto3.Query{String: sql})
 	return c.collectProbe(expectedColumns, quiet)
 }
 
 func (c *sessionCore) collectProbe(expectedColumns int, quiet bool) ([][]*string, error) {
-	if err := c.backend.Flush(); err != nil {
+	if err := c.targetDb.Flush(); err != nil {
 		return nil, err
 	}
 	result := engine.StatementResult{Rows: make([][]*string, 0)}
@@ -284,8 +284,8 @@ func (c *sessionCore) collectProbe(expectedColumns int, quiet bool) ([][]*string
 			return collector.emit(message)
 		}
 	}
-	backendErr, streamErr := c.streamResult(nil, streamOpts{soft: true}, emit)
-	if err := firstErr(streamErr, collector.failed, backendErr); err != nil {
+	targetDbErr, streamErr := c.streamResult(nil, streamOpts{soft: true}, emit)
+	if err := firstErr(streamErr, collector.failed, targetDbErr); err != nil {
 		return nil, err
 	}
 	return result.Rows, nil
@@ -346,8 +346,8 @@ func (s *Server) quietRefetcher(sess *session) *engine.Refetcher {
 }
 
 func (s *Server) forwardCancelRequest(message *pgproto3.CancelRequest) {
-	if err := sendCancelRequest(s.backend.Host, s.backend.Port, message.ProcessID, message.SecretKey); err != nil {
-		slog.Warn("postgres CancelRequest forward failed", "host", s.backend.Host, "port", s.backend.Port, "error", err)
+	if err := sendCancelRequest(s.targetDb.Host, s.targetDb.Port, message.ProcessID, message.SecretKey); err != nil {
+		slog.Warn("postgres CancelRequest forward failed", "host", s.targetDb.Host, "port", s.targetDb.Port, "error", err)
 	}
 }
 
@@ -357,9 +357,9 @@ func sendCancelRequest(host string, port int, processID, secretKey uint32) error
 	if err != nil {
 		return fmt.Errorf("encode CancelRequest: %w", err)
 	}
-	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), backendHandshakeTimeout)
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), targetDbHandshakeTimeout)
 	if err != nil {
-		return fmt.Errorf("dial backend for cancel: %w", err)
+		return fmt.Errorf("dial target DB for cancel: %w", err)
 	}
 	defer conn.Close()
 	if err := conn.SetWriteDeadline(time.Now().Add(wire.SocketWriteTimeout)); err != nil {

--- a/goproxy/pgproxy/backend_cancel_test.go
+++ b/goproxy/pgproxy/backend_cancel_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/ridi-oss/proxy-monster/goproxy/spi"
 )
 
-// TestDialBackendAuthAbortsOnContextCancel proves the real PostgreSQL dial honors the target-DB open context: a
-// backend that accepts the TCP connection but never answers the startup exchange stalls the auth read, and
-// cancelling the context must close the conn and return at once — not block until backendHandshakeTimeout.
+// TestDialTargetDbAuthAbortsOnContextCancel proves the real PostgreSQL dial honors the target-DB open context: a
+// target DB that accepts the TCP connection but never answers the startup exchange stalls the auth read, and
+// cancelling the context must close the conn and return at once — not block until targetDbHandshakeTimeout.
 // This is the mechanism the run target-DB open relies on; the runner-level tests exercise only the fake provider.
-func TestDialBackendAuthAbortsOnContextCancel(t *testing.T) {
+func TestDialTargetDbAuthAbortsOnContextCancel(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		t.Fatalf("listen stalling backend: %v", err)
+		t.Fatalf("listen stalling target DB: %v", err)
 	}
 	defer listener.Close()
 
@@ -38,12 +38,12 @@ func TestDialBackendAuthAbortsOnContextCancel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse listener port: %v", err)
 	}
-	target := spi.BackendTarget{Host: host, Port: port, User: "u", Password: "p", Db: "d"}
+	target := spi.TargetDb{Host: host, Port: port, User: "u", Password: "p", Db: "d"}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	dialErr := make(chan error, 1)
 	go func() {
-		_, _, _, _, err := dialBackendAuth(ctx, target)
+		_, _, _, _, err := dialTargetDbAuth(ctx, target)
 		dialErr <- err
 	}()
 
@@ -53,7 +53,7 @@ func TestDialBackendAuthAbortsOnContextCancel(t *testing.T) {
 	case conn := <-accepted:
 		defer conn.Close()
 	case <-time.After(5 * time.Second):
-		t.Fatal("dial did not connect to the stalling backend")
+		t.Fatal("dial did not connect to the stalling target DB")
 	}
 
 	start := time.Now()
@@ -64,7 +64,7 @@ func TestDialBackendAuthAbortsOnContextCancel(t *testing.T) {
 			t.Fatal("dial returned nil error after context cancel; want the aborted handshake to fail")
 		}
 		if elapsed := time.Since(start); elapsed > 3*time.Second {
-			t.Fatalf("dial returned %s after cancel; want a prompt abort, not the %s handshake timeout", elapsed, backendHandshakeTimeout)
+			t.Fatalf("dial returned %s after cancel; want a prompt abort, not the %s handshake timeout", elapsed, targetDbHandshakeTimeout)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("dial did not abort promptly on context cancel")

--- a/goproxy/pgproxy/completion_test.go
+++ b/goproxy/pgproxy/completion_test.go
@@ -86,7 +86,7 @@ func TestCompletionReportExtendedSelectCountsRows(t *testing.T) {
 	}
 }
 
-// A statement whose backend result is an error still reports a completion, tagged status=error.
+// A statement whose target-DB result is an error still reports a completion, tagged status=error.
 func TestCompletionReportErroredStatement(t *testing.T) {
 	h := startBroker(t)
 	h.fake.decideFn = allowWithDecisionID(completionDecisionID)
@@ -94,7 +94,7 @@ func TestCompletionReportErroredStatement(t *testing.T) {
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
-	// An allowed statement the backend rejects (unknown table) relays an error, not a result set.
+	// An allowed statement the target DB rejects (unknown table) relays an error, not a result set.
 	rows, queryErr := conn.Query(context.Background(), "SELECT id FROM it_pgproxy.no_such_table_here")
 	if queryErr == nil {
 		for rows.Next() {
@@ -103,7 +103,7 @@ func TestCompletionReportErroredStatement(t *testing.T) {
 		rows.Close()
 	}
 	if queryErr == nil {
-		t.Fatal("Query on a missing table succeeded, want a backend error")
+		t.Fatal("Query on a missing table succeeded, want a target-DB error")
 	}
 
 	report := h.waitCompletions(t, 1)[0]

--- a/goproxy/pgproxy/conn.go
+++ b/goproxy/pgproxy/conn.go
@@ -19,7 +19,7 @@ const (
 )
 
 type sessionCore struct {
-	backend          *pgproto3.Frontend
+	targetDb         *pgproto3.Frontend
 	qe               *engine.QueryEngine
 	db               engine.Db
 	lastTxStatus     byte
@@ -34,7 +34,7 @@ type session struct {
 	sessionCore
 	client       *pgproto3.Backend
 	clientConn   net.Conn
-	backendConn  net.Conn
+	targetDbConn net.Conn
 	token        string
 	clientAddr   string
 	connectionID []byte
@@ -162,19 +162,19 @@ startupComplete:
 	defer func() { _ = s.client.CloseConnection(identity.ConnectionID) }()
 	slog.Info("authenticated postgres client", "client", rawClientConn.RemoteAddr().String(), "principal", identity.Principal, "roles", identity.Roles)
 
-	backendConn, parameters, keyData, txStatus, err := dialBackendAuth(context.Background(), s.backend)
+	targetDbConn, parameters, keyData, txStatus, err := dialTargetDbAuth(context.Background(), s.targetDb)
 	if err != nil {
-		slog.Warn("postgres backend unavailable", "host", s.backend.Host, "port", s.backend.Port, "error", err)
-		_ = sendError(client, "FATAL", "08004", "proxy-monster: backend unavailable", false, 0)
+		slog.Warn("postgres target DB unavailable", "host", s.targetDb.Host, "port", s.targetDb.Port, "error", err)
+		_ = sendError(client, "FATAL", "08004", "proxy-monster: target DB unavailable", false, 0)
 		return
 	}
-	defer backendConn.Close()
+	defer targetDbConn.Close()
 
 	client.SetMaxBodyLen(maxFrontendFrameBody)
 	clientIO.Conn = s.WrapClientConn(clientConn)
 	clientIO.strictReads = false
-	backendConn = s.WrapBackendConn(backendConn)
-	backend := pgproto3.NewFrontend(backendConn, backendConn)
+	targetDbConn = s.WrapTargetDbConn(targetDbConn)
+	targetDb := pgproto3.NewFrontend(targetDbConn, targetDbConn)
 
 	backendGen, ok := wire.NextBackendGeneration()
 	if !ok {
@@ -183,7 +183,7 @@ startupComplete:
 	}
 	sess := &session{
 		sessionCore: sessionCore{
-			backend:      backend,
+			targetDb:     targetDb,
 			qe:           engine.NewQueryEngine(s.db, s.client),
 			db:           s.db,
 			lastTxStatus: txStatus,
@@ -192,7 +192,7 @@ startupComplete:
 		},
 		client:       client,
 		clientConn:   clientIO,
-		backendConn:  backendConn,
+		targetDbConn: targetDbConn,
 		token:        password.Password,
 		clientAddr:   rawClientConn.RemoteAddr().String(),
 		connectionID: append([]byte(nil), identity.ConnectionID...),

--- a/goproxy/pgproxy/diag_e2e_test.go
+++ b/goproxy/pgproxy/diag_e2e_test.go
@@ -13,8 +13,8 @@ import (
 	pb "github.com/ridi-oss/proxy-monster/goproxy/internal/pb"
 )
 
-// End-to-end proof, through the real proxy against a real PostgreSQL backend, that a
-// diagnostic-redacted connection (Verdict.sanitize_diagnostics) never relays a stored value in a backend
+// End-to-end proof, through the real proxy against a real PostgreSQL target DB, that a
+// diagnostic-redacted connection (Verdict.sanitize_diagnostics) never relays a stored value in a target DB
 // error's fields — the whole-row `DETAIL: Failing row contains (…)` leak from the design — while a
 // non-redacted connection does (so the test exercises a genuine leak the redaction closes). Complements the
 // unit-level field-strip tests. See docs/diagnostic-redaction.md.

--- a/goproxy/pgproxy/diagcodes.go
+++ b/goproxy/pgproxy/diagcodes.go
@@ -5,7 +5,7 @@ import "github.com/ridi-oss/proxy-monster/goproxy/engine"
 // pgDiagnosticMessage maps a PostgreSQL SQLSTATE to a fixed, value-free identity string for a
 // diagnostic-redacted connection: the canonical condition name when the exact code is known, else
 // the SQLSTATE class name (first two characters), else the generic redacted string. The result is looked up
-// entirely from the code — never reconstructed from the backend's echoed message text — so no stored value
+// entirely from the code — never reconstructed from the target DB's echoed message text — so no stored value
 // can ride along. Both tables are the PostgreSQL error-code appendix's own fixed identities, so keeping
 // them preserves the error *class* without preserving any *content*. Unmapped codes degrade to the class or
 // generic message rather than leaking (fail-safe UX, not a security boundary — that is the strip itself).

--- a/goproxy/pgproxy/diagnostics.go
+++ b/goproxy/pgproxy/diagnostics.go
@@ -7,16 +7,16 @@ import (
 // A PostgreSQL ErrorResponse / NoticeResponse echoes the raw stored value that masking is meant to hide —
 // the DETAIL field alone dumps the whole offending row, including columns the statement never named and
 // columns the principal is denied. On a diagnostic-redacted connection (the control plane's per-decision
-// flag, fresh each Decide) the proxy must not relay those messages verbatim. Every backend error/notice
+// flag, fresh each Decide) the proxy must not relay those messages verbatim. Every target-DB error/notice
 // forward on a client-facing path goes through the two helpers below so the strip is applied in exactly
 // one place per frame type. See docs/diagnostic-redaction.md.
 
-// sanitizeError strips a backend ErrorResponse to what cannot carry a masked/denied value that a restricted
+// sanitizeError strips a target DB ErrorResponse to what cannot carry a masked/denied value that a restricted
 // principal could not otherwise reach:
 //
 //   - Message (the free-form primary text) is replaced with the SQLSTATE's canonical condition name — a
 //     fixed value-free identity looked up from the code (see pgDiagnosticMessage), never reconstructed from
-//     the backend's echoed text. It is the one field an ordinary error (a type conversion) fills with a
+//     the target DB's echoed text. It is the one field an ordinary error (a type conversion) fills with a
 //     value, and its content can't be bounded.
 //   - Detail is dropped: `DETAIL: Failing row contains (…)` prints columns the statement never named — the
 //     one reachable way an ordinary error exposes a masked *sibling* value.
@@ -36,7 +36,7 @@ func sanitizeError(msg *pgproto3.ErrorResponse) *pgproto3.ErrorResponse {
 	return &out
 }
 
-// forwardError sends a backend ErrorResponse to the client, sanitized when the current decision has
+// forwardError sends a target DB ErrorResponse to the client, sanitized when the current decision has
 // diagnostic redaction set, otherwise verbatim.
 func forwardError(sess *session, msg *pgproto3.ErrorResponse) {
 	if sess.qe.SanitizeDiagnostics() {
@@ -46,13 +46,13 @@ func forwardError(sess *session, msg *pgproto3.ErrorResponse) {
 	sess.client.Send(msg)
 }
 
-// forwardNotice sends a backend NoticeResponse to the client — forwarded even on a redacted connection. A
+// forwardNotice sends a target DB NoticeResponse to the client — forwarded even on a redacted connection. A
 // notice carries no value a restricted principal could not otherwise reach: server-generated notices are
 // advisory (object names, DDL, transaction state — never a row value), and the only way to put a value in
 // one is `RAISE NOTICE`, which needs PL/pgSQL and is denied for a restricted principal. A pre-existing
 // trigger / vouched function that RAISEs a NOTICE is the accepted residual — the same one the kept
 // ErrorResponse structural fields carry (see sanitizeError / docs/diagnostic-redaction.md). The copy
-// defends against pgproto3 reusing the backend receive buffer until the next client flush.
+// defends against pgproto3 reusing the target DB receive buffer until the next client flush.
 func forwardNotice(sess *session, msg *pgproto3.NoticeResponse) {
 	copyMessage := *msg
 	sess.client.Send(&copyMessage)

--- a/goproxy/pgproxy/diagnostics_test.go
+++ b/goproxy/pgproxy/diagnostics_test.go
@@ -10,7 +10,7 @@ import (
 
 const diagSentinel = "010-1234-5678"
 
-// A backend ErrorResponse for an ordinary constraint violation: the stored value lands ONLY in Detail (the
+// A target DB ErrorResponse for an ordinary constraint violation: the stored value lands ONLY in Detail (the
 // whole-row dump); the structural fields carry object names, not values, as PostgreSQL populates them for a
 // real (non-RAISE) error.
 func fullErrorResponse() *pgproto3.ErrorResponse {
@@ -77,7 +77,7 @@ func TestSanitizeErrorDoesNotMutateInput(t *testing.T) {
 	in := fullErrorResponse()
 	_ = sanitizeError(in)
 	if in.Detail == "" || in.Message == "check_violation" || in.UnknownFields == nil {
-		t.Error("sanitizeError mutated the backend frame instead of returning a copy")
+		t.Error("sanitizeError mutated the target-DB frame instead of returning a copy")
 	}
 }
 

--- a/goproxy/pgproxy/drain_test.go
+++ b/goproxy/pgproxy/drain_test.go
@@ -71,12 +71,12 @@ func TestDrainLetsInFlightStatementComplete(t *testing.T) {
 	h := startBroker(t)
 	client := newRawPGClient(t, h)
 
-	// pg_sleep holds the handler in the relay (reading the backend) across the Drain call.
+	// pg_sleep holds the handler in the relay (reading the target DB) across the Drain call.
 	client.frontend.Send(&pgproto3.Query{String: "SELECT pg_sleep(0.5)"})
 	if err := client.frontend.Flush(); err != nil {
 		t.Fatalf("send slow query: %v", err)
 	}
-	// Let the query reach the backend and begin relaying before draining.
+	// Let the query reach the target DB and begin relaying before draining.
 	time.Sleep(100 * time.Millisecond)
 
 	drained := make(chan struct{})

--- a/goproxy/pgproxy/extended.go
+++ b/goproxy/pgproxy/extended.go
@@ -11,7 +11,7 @@ import (
 	pb "github.com/ridi-oss/proxy-monster/goproxy/internal/pb"
 )
 
-// isCleanExecuteTerminal reports whether an extended-protocol Execute ended without a backend error: a
+// isCleanExecuteTerminal reports whether an extended-protocol Execute ended without a target-DB error: a
 // CommandComplete (statement done), an EmptyQueryResponse (empty statement), or a PortalSuspended (a
 // row-limited Execute that stopped with more rows pending) are all clean; an ErrorResponse is not.
 func isCleanExecuteTerminal(terminal pgproto3.BackendMessage) bool {
@@ -73,7 +73,7 @@ func refuseExtended(sess *session, code, message string) error {
 
 func (s *Server) awaitExtendedCompletion(sess *session, isTerminal func(pgproto3.BackendMessage) bool) (pgproto3.BackendMessage, error) {
 	for {
-		message, err := sess.backend.Receive()
+		message, err := sess.targetDb.Receive()
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +90,7 @@ func (s *Server) awaitExtendedCompletion(sess *session, isTerminal func(pgproto3
 			sess.client.Send(message)
 		default:
 			if !isTerminal(message) {
-				return nil, failClosedRelay(sess, "58000", "proxy-monster: malformed backend response", fmt.Errorf("unexpected backend extended response %T", message))
+				return nil, failClosedRelay(sess, "58000", "proxy-monster: malformed target-DB response", fmt.Errorf("unexpected target DB extended response %T", message))
 			}
 			if errMsg, failed := message.(*pgproto3.ErrorResponse); failed {
 				forwardError(sess, errMsg)
@@ -125,9 +125,9 @@ func (s *Server) handleParse(sess *session, message *pgproto3.Parse) error {
 	if proceed.RewrittenSQL != nil {
 		sentSQL = *proceed.RewrittenSQL
 	}
-	sess.backend.Send(&pgproto3.Parse{Name: message.Name, Query: sentSQL, ParameterOIDs: message.ParameterOIDs})
-	sess.backend.Send(&pgproto3.Flush{})
-	if err := sess.backend.Flush(); err != nil {
+	sess.targetDb.Send(&pgproto3.Parse{Name: message.Name, Query: sentSQL, ParameterOIDs: message.ParameterOIDs})
+	sess.targetDb.Send(&pgproto3.Flush{})
+	if err := sess.targetDb.Flush(); err != nil {
 		return err
 	}
 	terminal, err := s.awaitExtendedCompletion(sess, func(message pgproto3.BackendMessage) bool {
@@ -161,9 +161,9 @@ func (s *Server) handleBind(sess *session, message *pgproto3.Bind) error {
 	}
 
 	// Capture immediately before forwarding: the lockstep single writer guarantees nothing executes on the
-	// backend between this probe and Bind, so the captured context is exactly the one PostgreSQL binds under.
-	// Probing first also leaves no registry/backend inconsistency if capture fails. An aborted transaction
-	// fails here before PostgreSQL's equivalent 25P02 Bind, retaining the prior portal snapshot and backend portal.
+	// target DB between this probe and Bind, so the captured context is exactly the one PostgreSQL binds under.
+	// Probing first also leaves no registry/target DB inconsistency if capture fails. An aborted transaction
+	// fails here before PostgreSQL's equivalent 25P02 Bind, retaining the prior portal snapshot and target DB portal.
 	namespace, temps, err := s.probeBindContext(sess)
 	if err != nil {
 		if errors.Is(err, errClientEncoding) || errors.Is(err, errStdConformingStrings) {
@@ -172,9 +172,9 @@ func (s *Server) handleBind(sess *session, message *pgproto3.Bind) error {
 		return refuseExtended(sess, "58000", "bind-time namespace unavailable")
 	}
 
-	sess.backend.Send(message)
-	sess.backend.Send(&pgproto3.Flush{})
-	if err := sess.backend.Flush(); err != nil {
+	sess.targetDb.Send(message)
+	sess.targetDb.Send(&pgproto3.Flush{})
+	if err := sess.targetDb.Flush(); err != nil {
 		return err
 	}
 	terminal, err := s.awaitExtendedCompletion(sess, func(message pgproto3.BackendMessage) bool {
@@ -200,9 +200,9 @@ func (s *Server) handleBind(sess *session, message *pgproto3.Bind) error {
 }
 
 func (s *Server) handleDescribe(sess *session, message *pgproto3.Describe) error {
-	sess.backend.Send(message)
-	sess.backend.Send(&pgproto3.Flush{})
-	if err := sess.backend.Flush(); err != nil {
+	sess.targetDb.Send(message)
+	sess.targetDb.Send(&pgproto3.Flush{})
+	if err := sess.targetDb.Flush(); err != nil {
 		return err
 	}
 	_, err := s.awaitExtendedCompletion(sess, func(message pgproto3.BackendMessage) bool {
@@ -224,13 +224,13 @@ func (s *Server) runExtendedProbe(sess *session, sql string, expectedColumns int
 	statementName := fmt.Sprintf("__pm_probe_statement_%d__", sequence)
 	portalName := fmt.Sprintf("__pm_probe_portal_%d__", sequence)
 
-	sess.backend.Send(&pgproto3.Parse{Name: statementName, Query: sql})
-	sess.backend.Send(&pgproto3.Bind{DestinationPortal: portalName, PreparedStatement: statementName})
-	sess.backend.Send(&pgproto3.Execute{Portal: portalName})
-	sess.backend.Send(&pgproto3.Close{ObjectType: 'P', Name: portalName})
-	sess.backend.Send(&pgproto3.Close{ObjectType: 'S', Name: statementName})
-	sess.backend.Send(&pgproto3.Flush{})
-	if err := sess.backend.Flush(); err != nil {
+	sess.targetDb.Send(&pgproto3.Parse{Name: statementName, Query: sql})
+	sess.targetDb.Send(&pgproto3.Bind{DestinationPortal: portalName, PreparedStatement: statementName})
+	sess.targetDb.Send(&pgproto3.Execute{Portal: portalName})
+	sess.targetDb.Send(&pgproto3.Close{ObjectType: 'P', Name: portalName})
+	sess.targetDb.Send(&pgproto3.Close{ObjectType: 'S', Name: statementName})
+	sess.targetDb.Send(&pgproto3.Flush{})
+	if err := sess.targetDb.Flush(); err != nil {
 		return nil, err
 	}
 
@@ -248,7 +248,7 @@ func (s *Server) runExtendedProbe(sess *session, sql string, expectedColumns int
 	}
 
 	for {
-		message, err := sess.backend.Receive()
+		message, err := sess.targetDb.Receive()
 		if err != nil {
 			return nil, err
 		}
@@ -321,7 +321,7 @@ func (s *Server) runExtendedProbe(sess *session, sql string, expectedColumns int
 		case *pgproto3.NotificationResponse:
 			sess.client.Send(&pgproto3.NotificationResponse{PID: message.PID, Channel: message.Channel, Payload: message.Payload})
 		default:
-			fail(fmt.Errorf("unexpected backend probe response %T", message))
+			fail(fmt.Errorf("unexpected target DB probe response %T", message))
 		}
 	}
 }
@@ -335,7 +335,7 @@ func (s *Server) probeBindContext(sess *session) ([]string, []engine.TempColumn,
 	}
 	namespaceRows, err := s.runExtendedProbe(sess, s.db.NamespaceProbeSQL(), 1)
 	if err != nil {
-		return nil, nil, fmt.Errorf("backend namespace probe: %w", err)
+		return nil, nil, fmt.Errorf("target-DB namespace probe: %w", err)
 	}
 	namespace, err := namespaceFromRows(namespaceRows)
 	if err != nil {
@@ -345,7 +345,7 @@ func (s *Server) probeBindContext(sess *session) ([]string, []engine.TempColumn,
 
 	tempRows, err := s.runExtendedProbe(sess, s.db.TempColumnsProbeSQL(), 5)
 	if err != nil {
-		return nil, nil, fmt.Errorf("backend temp-column probe: %w", err)
+		return nil, nil, fmt.Errorf("target DB temp-column probe: %w", err)
 	}
 	temps, err := tempColumnsFromRows(tempRows)
 	if err != nil {
@@ -393,12 +393,12 @@ func (s *Server) handleExecute(sess *session, message *pgproto3.Execute) error {
 		}
 		masks = nil
 	}
-	// The fresh verdict authorizes the SQL already parsed on the backend. A fresh rewrite cannot replace
+	// The fresh verdict authorizes the SQL already parsed on the target DB. A fresh rewrite cannot replace
 	// that prepared statement, so RewrittenSQL is deliberately ignored at Execute.
 	start := time.Now()
-	sess.backend.Send(message)
-	sess.backend.Send(&pgproto3.Flush{})
-	if err := sess.backend.Flush(); err != nil {
+	sess.targetDb.Send(message)
+	sess.targetDb.Send(&pgproto3.Flush{})
+	if err := sess.targetDb.Flush(); err != nil {
 		return err
 	}
 	var relayStats engine.RelayStats
@@ -422,7 +422,7 @@ func (s *Server) relayExecuteStream(sess *session, masks []*pb.ColumnMask, stats
 	var masker *engine.RowMasker
 	bufferedFrames := 0
 	for {
-		message, err := sess.backend.Receive()
+		message, err := sess.targetDb.Receive()
 		if err != nil {
 			return nil, err
 		}
@@ -434,7 +434,7 @@ func (s *Server) relayExecuteStream(sess *session, masks []*pb.ColumnMask, stats
 					return nil, failClosedRelay(sess, "0A000", "proxy-monster: required mask could not be bound to a result column", errMaskUnbound)
 				}
 			}
-			// Tally the backend row before masking, so the volume reflects the backend result, not the
+			// Tally the target-DB row before masking, so the volume reflects the target-DB result, not the
 			// rewritten one.
 			stats.Rows++
 			stats.Bytes += dataRowBytes(message)
@@ -461,7 +461,7 @@ func (s *Server) relayExecuteStream(sess *session, masks []*pb.ColumnMask, stats
 			sess.skipToSync = true
 			return message, sess.client.Flush()
 		default:
-			return nil, failClosedRelay(sess, "58000", "proxy-monster: malformed backend response", fmt.Errorf("unexpected backend execute response %T", message))
+			return nil, failClosedRelay(sess, "58000", "proxy-monster: malformed target-DB response", fmt.Errorf("unexpected target DB execute response %T", message))
 		}
 
 		bufferedFrames++
@@ -475,9 +475,9 @@ func (s *Server) relayExecuteStream(sess *session, masks []*pb.ColumnMask, stats
 }
 
 func (s *Server) handleClose(sess *session, message *pgproto3.Close) error {
-	sess.backend.Send(message)
-	sess.backend.Send(&pgproto3.Flush{})
-	if err := sess.backend.Flush(); err != nil {
+	sess.targetDb.Send(message)
+	sess.targetDb.Send(&pgproto3.Flush{})
+	if err := sess.targetDb.Flush(); err != nil {
 		return err
 	}
 	terminal, err := s.awaitExtendedCompletion(sess, func(message pgproto3.BackendMessage) bool {
@@ -503,20 +503,20 @@ func (s *Server) handleClose(sess *session, message *pgproto3.Close) error {
 }
 
 func (s *Server) handleFlush(sess *session) error {
-	sess.backend.Send(&pgproto3.Flush{})
-	if err := sess.backend.Flush(); err != nil {
+	sess.targetDb.Send(&pgproto3.Flush{})
+	if err := sess.targetDb.Flush(); err != nil {
 		return err
 	}
 	return sess.client.Flush()
 }
 
 func (s *Server) handleSync(sess *session) error {
-	sess.backend.Send(&pgproto3.Sync{})
-	if err := sess.backend.Flush(); err != nil {
+	sess.targetDb.Send(&pgproto3.Sync{})
+	if err := sess.targetDb.Flush(); err != nil {
 		return err
 	}
 	for {
-		message, err := sess.backend.Receive()
+		message, err := sess.targetDb.Receive()
 		if err != nil {
 			return err
 		}
@@ -539,7 +539,7 @@ func (s *Server) handleSync(sess *session) error {
 			}
 			return nil
 		default:
-			return failClosedRelay(sess, "58000", "proxy-monster: malformed backend response", fmt.Errorf("unexpected backend sync response %T", message))
+			return failClosedRelay(sess, "58000", "proxy-monster: malformed target-DB response", fmt.Errorf("unexpected target DB sync response %T", message))
 		}
 	}
 }

--- a/goproxy/pgproxy/extended_test.go
+++ b/goproxy/pgproxy/extended_test.go
@@ -235,7 +235,7 @@ func TestExtendedCatalogRefreshDoesNotArmOnExecuteError(t *testing.T) {
 	}
 	client := newRawPGClient(t, h)
 
-	// Parse succeeds, then a direct backend session creates the same table before Execute so PostgreSQL's
+	// Parse succeeds, then a direct target-DB session creates the same table before Execute so PostgreSQL's
 	// Execute path returns ErrorResponse. The command must not arm on that terminal failure.
 	assertRawExtendedCompletion(t, client.sendSync(t, &pgproto3.Parse{Name: "refresh_ddl_error", Query: ddlSQL}), "ParseComplete", 'I')
 	if _, err := direct.Exec(ddlSQL); err != nil {
@@ -766,7 +766,7 @@ func TestExtendedPostBindSearchPathDriftCannotBypassPolicy(t *testing.T) {
 // the erroring Bind aborts the whole transaction (verified against PG16: 42P03 "cursor already exists",
 // then any following command returns 25P02, never 34000). Because every Bind error aborts the transaction,
 // no subsequent Execute can ever return rows, so a stale boundPortal snapshot cannot leak data. With an
-// ALLOW-all policy the proxy re-decides the Execute (a harmless audit decision) and relays the backend's
+// ALLOW-all policy the proxy re-decides the Execute (a harmless audit decision) and relays the target DB's
 // own 25P02 verbatim: zero DataRow frames reach the client. That transaction abort — not a 34000, which
 // real PostgreSQL never returns here — is what makes a rejected re-Bind safe.
 func TestExtendedRejectedRebindAbortsTransactionNoLeak(t *testing.T) {
@@ -798,7 +798,7 @@ func TestExtendedRejectedRebindAbortsTransactionNoLeak(t *testing.T) {
 	}
 	assertRawReadyForQuery(t, rebindFrames, 'E')
 
-	// Execute the still-mapped portal. The backend's aborted-transaction error (25P02) is relayed and no
+	// Execute the still-mapped portal. The target DB's aborted-transaction error (25P02) is relayed and no
 	// row ever flows; the proxy never fabricates a 34000, matching real PostgreSQL.
 	executeFrames := client.sendSync(t, &pgproto3.Execute{Portal: "p"})
 	for _, frame := range executeFrames {
@@ -808,7 +808,7 @@ func TestExtendedRejectedRebindAbortsTransactionNoLeak(t *testing.T) {
 	}
 	execErr, ok := executeFrames[0].(*pgproto3.ErrorResponse)
 	if !ok || execErr.Code != "25P02" {
-		t.Fatalf("Execute frame[0] = %#v, want backend 25P02 aborted-transaction error", executeFrames[0])
+		t.Fatalf("Execute frame[0] = %#v, want target DB 25P02 aborted-transaction error", executeFrames[0])
 	}
 	assertRawReadyForQuery(t, executeFrames, 'E')
 	// The transaction stays aborted; recovery from 'E' via ROLLBACK is covered by
@@ -817,7 +817,7 @@ func TestExtendedRejectedRebindAbortsTransactionNoLeak(t *testing.T) {
 
 // TestExtendedAbortedTransactionRecoversViaRollback pins that a connection wedged in the aborted-transaction
 // state ('E') recovers via ROLLBACK over BOTH protocols. Before the 'E'-state namespace-reuse guard, the
-// injected namespace probe hit the backend's 25P02 and the proxy refused ROLLBACK with 58000, leaving the
+// injected namespace probe hit the target DB's 25P02 and the proxy refused ROLLBACK with 58000, leaving the
 // only escape a disconnect — an availability regression on routine traffic (any error inside an explicit
 // transaction), and a divergence from vanilla PostgreSQL, which accepts ROLLBACK in the aborted state.
 func TestExtendedAbortedTransactionRecoversViaRollback(t *testing.T) {
@@ -856,7 +856,7 @@ func TestExtendedAbortedTransactionRecoversViaRollback(t *testing.T) {
 		client := newRawPGClient(t, h)
 		abortInTx(t, client)
 		// JDBC-style ROLLBACK: Parse/Bind/Execute. Every injected probe on this path (handleParse's namespace
-		// probe and handleBind's probeBindContext) must reuse the overlay rather than hit the aborted backend.
+		// probe and handleBind's probeBindContext) must reuse the overlay rather than hit the aborted target DB.
 		rollback := client.sendSync(t,
 			&pgproto3.Parse{Name: "rb", Query: "ROLLBACK"},
 			&pgproto3.Bind{DestinationPortal: "rbp", PreparedStatement: "rb"},
@@ -870,7 +870,7 @@ func TestExtendedAbortedTransactionRecoversViaRollback(t *testing.T) {
 // TestExtendedBindCoercionSetConfigLeaksAcrossSchema is a CHARACTERIZATION test for a known, out-of-scope
 // limitation (KNOWN_LIMITATIONS.md, backlog): a domain CHECK that calls set_config('search_path', …) moves
 // the path DURING Bind parameter coercion — after the proxy's pre-Bind probe but before PostgreSQL resolves
-// the portal's table names — so Execute is authorized under the stale probed snapshot while the backend binds
+// the portal's table names — so Execute is authorized under the stale probed snapshot while the target DB binds
 // the portal under the mutated path. The bare `people` reads id=10, which exists ONLY in the secondary
 // schema, so a real leak surfaces the secondary row ('secret-2') even though the policy DENIES the secondary
 // path. The proxy tracks search_path by SQL classification and cannot observe a set_config fired from inside
@@ -889,7 +889,7 @@ func TestExtendedBindCoercionSetConfigLeaksAcrossSchema(t *testing.T) {
 		return wireVerdict(&pb.Verdict{Decision: pb.EnfAction_ALLOW}), nil
 	}
 
-	// Create the evil domain directly on the backend (bypassing the proxy) and look up its OID so Parse can
+	// Create the evil domain directly on the target DB (bypassing the proxy) and look up its OID so Parse can
 	// declare $1 as that domain — forcing PostgreSQL to run its CHECK during Bind parameter coercion.
 	admin := dbtest.OpenPostgres(t, "")
 	for _, stmt := range []string{
@@ -938,7 +938,7 @@ func TestExtendedBindCoercionSetConfigLeaksAcrossSchema(t *testing.T) {
 		t.Fatalf("expected the documented Bind-coercion set_config leak to reproduce (secondary row 'secret-2'); it did not — the leak may no longer reproduce, so revisit KNOWN_LIMITATIONS.md")
 	}
 	// The leak is only meaningful if the proxy authorized under the STALE primary path (not the secondary
-	// one the backend actually bound). Assert no decision was ever made under the secondary schema.
+	// one the target DB actually bound). Assert no decision was ever made under the secondary schema.
 	for _, path := range decidedPaths {
 		for _, schema := range path {
 			if schema == secondarySchema {
@@ -1002,7 +1002,7 @@ func TestExtendedGucGuardOnExtendedPath(t *testing.T) {
 	assertPgError(t, err, "0A000", "client_encoding must remain UTF8")
 }
 
-func TestExtendedBackendRejectedParseLeavesNoStaleStatement(t *testing.T) {
+func TestExtendedTargetDbRejectedParseLeavesNoStaleStatement(t *testing.T) {
 	h := startBroker(t)
 	h.fake.decideFn = func(*pb.DecisionRequest) (*pb.WireDecision, error) {
 		return wireVerdict(&pb.Verdict{Decision: pb.EnfAction_ALLOW}), nil

--- a/goproxy/pgproxy/proxy_test.go
+++ b/goproxy/pgproxy/proxy_test.go
@@ -224,9 +224,9 @@ func startFakeCP(t *testing.T) (*fakeControlPlane, *cp.Client) {
 	return fake, client
 }
 
-func seedBackend(t *testing.T) dbtest.Backend {
+func seedTargetDb(t *testing.T) dbtest.TargetDb {
 	t.Helper()
-	backend := dbtest.Postgres(t)
+	targetDb := dbtest.Postgres(t)
 	seed := dbtest.OpenPostgres(t, "")
 	statements := []string{
 		"CREATE SCHEMA IF NOT EXISTS " + primarySchema,
@@ -245,7 +245,7 @@ func seedBackend(t *testing.T) dbtest.Backend {
 			t.Fatalf("seed statement %q: %v", statement, err)
 		}
 	}
-	return backend
+	return targetDb
 }
 
 type brokerHarness struct {
@@ -256,31 +256,31 @@ type brokerHarness struct {
 
 func startBroker(t *testing.T) *brokerHarness {
 	t.Helper()
-	backend := seedBackend(t)
-	return startBrokerForDB(t, backend, "app")
+	targetDb := seedTargetDb(t)
+	return startBrokerForDB(t, targetDb, "app")
 }
 
-// startBrokerForDB starts a broker whose service-account target points at a specific backend database, so a
+// startBrokerForDB starts a broker whose service-account target points at a specific target database, so a
 // test can exercise a session created under that database's stored GUC defaults (e.g. ALTER DATABASE ...
 // SET standard_conforming_strings=off). The client's requested database is irrelevant — the proxy always
 // dials its configured target.
-func startBrokerForDB(t *testing.T, backend dbtest.Backend, database string) *brokerHarness {
+func startBrokerForDB(t *testing.T, targetDb dbtest.TargetDb, database string) *brokerHarness {
 	t.Helper()
-	return startBrokerForDBSetup(t, backend, database, nil)
+	return startBrokerForDBSetup(t, targetDb, database, nil)
 }
 
-func startBrokerForDBSetup(t *testing.T, backend dbtest.Backend, database string, setup func(*fakeControlPlane)) *brokerHarness {
+func startBrokerForDBSetup(t *testing.T, targetDb dbtest.TargetDb, database string, setup func(*fakeControlPlane)) *brokerHarness {
 	t.Helper()
 	fake, cpClient := startFakeCP(t)
 	if setup != nil {
 		setup(fake)
 	}
-	target := spi.BackendTarget{
-		Host:     backend.Host,
-		Port:     backend.Port,
+	target := spi.TargetDb{
+		Host:     targetDb.Host,
+		Port:     targetDb.Port,
 		Db:       database,
-		User:     backend.User,
-		Password: backend.Password,
+		User:     targetDb.User,
+		Password: targetDb.Password,
 	}
 	server := pgproxy.New(0, target, cpClient, db.PgDb{}, nil)
 	return startBrokerServer(t, fake, server)
@@ -288,15 +288,15 @@ func startBrokerForDBSetup(t *testing.T, backend dbtest.Backend, database string
 
 func startBrokerTLS(t *testing.T) *brokerHarness {
 	t.Helper()
-	backend := seedBackend(t)
+	targetDb := seedTargetDb(t)
 	fake, cpClient := startFakeCP(t)
 	tlsProvider := proxytls.NewReloading("../proxytls/testdata/ec.crt", "../proxytls/testdata/ec-sec1.key")
-	target := spi.BackendTarget{
-		Host:     backend.Host,
-		Port:     backend.Port,
+	target := spi.TargetDb{
+		Host:     targetDb.Host,
+		Port:     targetDb.Port,
 		Db:       "app",
-		User:     backend.User,
-		Password: backend.Password,
+		User:     targetDb.User,
+		Password: targetDb.Password,
 	}
 	server := pgproxy.New(0, target, cpClient, db.PgDb{}, tlsProvider.Current)
 	return startBrokerServer(t, fake, server)
@@ -589,7 +589,7 @@ func TestEmptyStringSsnRoundTripsDistinctFromNullThroughMask(t *testing.T) {
 }
 
 // TestCopyOutResponseFailsClosed guards the relay's COPY backstop: the broker does not support the COPY
-// subprotocol, so a backend CopyOutResponse must fail closed (0A000) rather than desynchronize the wire.
+// subprotocol, so a target DB CopyOutResponse must fail closed (0A000) rather than desynchronize the wire.
 func TestCopyOutResponseFailsClosed(t *testing.T) {
 	h := startBroker(t)
 	h.fake.decideFn = func(*pb.DecisionRequest) (*pb.WireDecision, error) {
@@ -1093,7 +1093,7 @@ func TestStandardConformingStringsOffFailsClosed(t *testing.T) {
 }
 
 // TestNonUTF8ClientEncodingFailsClosed guards the identifier-binding invariant: the engine/control plane
-// read the client's SQL bytes as UTF-8, so a backend session that switches client_encoding away from UTF8
+// read the client's SQL bytes as UTF-8, so a target-DB session that switches client_encoding away from UTF8
 // would let the same bytes bind different objects on each side (a non-ASCII identifier could dodge its
 // mask/deny). client_encoding is GUC_REPORT, so the change is observed before the next statement runs and
 // the relay fails closed. The control plane ALLOWs the SET; the fail-closed is a relay-level backstop.
@@ -1117,12 +1117,12 @@ func TestNonUTF8ClientEncodingFailsClosed(t *testing.T) {
 // The on-change relay guard (TestStandardConformingStringsOffFailsClosed) only fires on a ParameterStatus
 // that ARRIVES after connect; a database whose stored default is standard_conforming_strings=off
 // (ALTER DATABASE ... SET) hands the session that divergent lexer from its very first statement, emitting
-// no on-change frame. The shared backend dial validates the startup ParameterStatus and fails closed at
+// no on-change frame. The shared target DB dial validates the startup ParameterStatus and fails closed at
 // connect, so the broker never admits such a session. Isolated on a dedicated database because the
 // suite-shared container persists across parallel test packages — mutating the "app" default would race
 // them.
 func TestUnsafeStartupStandardConformingStringsFailsClosed(t *testing.T) {
-	backend := dbtest.Postgres(t)
+	targetDb := dbtest.Postgres(t)
 	admin := dbtest.OpenPostgres(t, "")
 	const unsafeDB = "pm_it_scs_off"
 	if _, err := admin.Exec("DROP DATABASE IF EXISTS " + unsafeDB); err != nil {
@@ -1136,25 +1136,25 @@ func TestUnsafeStartupStandardConformingStringsFailsClosed(t *testing.T) {
 		t.Fatalf("set unsafe startup default: %v", err)
 	}
 
-	h := startBrokerForDB(t, backend, unsafeDB)
+	h := startBrokerForDB(t, targetDb, unsafeDB)
 	conn, err := h.connect(t, validToken, true)
 	if err == nil {
 		_ = conn.Close(context.Background())
 		t.Fatal("connect to a standard_conforming_strings=off database succeeded, want fail-closed at connect")
 	}
 	// The dial fails closed inside the service-account handshake, which the broker reports to the client as
-	// backend-unavailable (the specific cause is server-logged); no query is ever admitted.
-	assertPgError(t, err, "08004", "backend unavailable")
+	// target-DB-unavailable (the specific cause is server-logged); no query is ever admitted.
+	assertPgError(t, err, "08004", "target DB unavailable")
 	if requests := h.fake.requests(); len(requests) != 0 {
 		t.Fatalf("Decide requests = %d, want 0 (connection fails closed before any query)", len(requests))
 	}
 }
 
 func TestDisconnectAfterDDLDoesNotAffectSiblingConnection(t *testing.T) {
-	backend := seedBackend(t)
+	targetDb := seedTargetDb(t)
 	connectionIDs := [][]byte{[]byte("session-one-0001"), []byte("session-two-0002")}
 	var minted int
-	h := startBrokerForDBSetup(t, backend, "app", func(fake *fakeControlPlane) {
+	h := startBrokerForDBSetup(t, targetDb, "app", func(fake *fakeControlPlane) {
 		fake.setValidateFunc(func(*pb.ValidateTokenRequest) (*pb.WireIdentity, error) {
 			if minted >= len(connectionIDs) {
 				return nil, status.Error(codes.Internal, "too many sessions")
@@ -1231,8 +1231,8 @@ func eventIndexPG(events []string, target string, occurrence int) int {
 }
 
 func TestOnOpenRunsBeforeFirstReadyAndCloseConnectionRunsOnce(t *testing.T) {
-	backend := seedBackend(t)
-	h := startBrokerForDBSetup(t, backend, "app", func(fake *fakeControlPlane) {
+	targetDb := seedTargetDb(t)
+	h := startBrokerForDBSetup(t, targetDb, "app", func(fake *fakeControlPlane) {
 		fake.setOnOpen(&pb.ProxyCommand{
 			Command: &pb.ProxyCommand_Refetch{Refetch: &pb.Refetch{Schema: primarySchema}},
 		})
@@ -1255,8 +1255,8 @@ func TestOnOpenRunsBeforeFirstReadyAndCloseConnectionRunsOnce(t *testing.T) {
 }
 
 func TestOnOpenPushFailureRefusesConnectionAndClosesControlPlaneState(t *testing.T) {
-	backend := seedBackend(t)
-	h := startBrokerForDBSetup(t, backend, "app", func(fake *fakeControlPlane) {
+	targetDb := seedTargetDb(t)
+	h := startBrokerForDBSetup(t, targetDb, "app", func(fake *fakeControlPlane) {
 		fake.setOnOpen(&pb.ProxyCommand{
 			Command: &pb.ProxyCommand_Refetch{Refetch: &pb.Refetch{Schema: primarySchema}},
 		})

--- a/goproxy/pgproxy/relay.go
+++ b/goproxy/pgproxy/relay.go
@@ -25,7 +25,7 @@ const clientFlushThreshold = 64
 
 type streamOpts struct{ extended, soft bool }
 
-func (c *sessionCore) streamResult(masks []*pb.ColumnMask, opts streamOpts, emit func(pgproto3.BackendMessage) error) (backendErr error, err error) {
+func (c *sessionCore) streamResult(masks []*pb.ColumnMask, opts streamOpts, emit func(pgproto3.BackendMessage) error) (targetDbErr error, err error) {
 	var masker *engine.RowMasker
 	columnCount := -1
 	fail := func(cause error) bool {
@@ -35,7 +35,7 @@ func (c *sessionCore) streamResult(masks []*pb.ColumnMask, opts streamOpts, emit
 		return opts.soft
 	}
 	emitFrame := func(message pgproto3.BackendMessage, data bool) bool {
-		if data && (backendErr != nil || opts.soft && err != nil) {
+		if data && (targetDbErr != nil || opts.soft && err != nil) {
 			return true
 		}
 		if emit != nil {
@@ -47,9 +47,9 @@ func (c *sessionCore) streamResult(masks []*pb.ColumnMask, opts streamOpts, emit
 	}
 
 	for {
-		message, receiveErr := c.backend.Receive()
+		message, receiveErr := c.targetDb.Receive()
 		if receiveErr != nil {
-			return backendErr, receiveErr
+			return targetDbErr, receiveErr
 		}
 		out := message
 		data := true
@@ -60,7 +60,7 @@ func (c *sessionCore) streamResult(masks []*pb.ColumnMask, opts streamOpts, emit
 			if len(masks) > 0 {
 				masker = engine.NewRowMasker(masks, columnCount)
 				if masker == nil && !fail(errMaskUnbound) {
-					return backendErr, err
+					return targetDbErr, err
 				}
 			}
 		case *pgproto3.DataRow:
@@ -70,13 +70,13 @@ func (c *sessionCore) streamResult(masks []*pb.ColumnMask, opts streamOpts, emit
 					cause = fmt.Errorf("probe row returned %d columns, want %d", len(message.Values), columnCount)
 				}
 				if !fail(cause) {
-					return backendErr, err
+					return targetDbErr, err
 				}
 				continue
 			}
 			if len(masks) > 0 && masker == nil {
 				if !fail(errMaskUnbound) {
-					return backendErr, err
+					return targetDbErr, err
 				}
 				continue
 			}
@@ -88,16 +88,16 @@ func (c *sessionCore) streamResult(masks []*pb.ColumnMask, opts streamOpts, emit
 			columnCount = -1
 		case *pgproto3.ErrorResponse:
 			data = false
-			// The one client-facing backend-error site for both relays: on a diagnostic-redacted decision,
-			// strip the value-bearing fields before the frame is emitted (native wire) AND before backendErr
-			// is derived (run surfaces backendErr) — a PostgreSQL error can echo a masked/denied value the
+			// The one client-facing target-DB-error site for both relays: on a diagnostic-redacted decision,
+			// strip the value-bearing fields before the frame is emitted (native wire) AND before targetDbErr
+			// is derived (run surfaces targetDbErr) — a PostgreSQL error can echo a masked/denied value the
 			// statement never referenced (the whole-row `DETAIL`). See docs/diagnostic-redaction.md.
 			if c.qe != nil && c.qe.SanitizeDiagnostics() {
 				message = sanitizeError(message)
 				out = message
 			}
-			if backendErr == nil {
-				backendErr = errors.New(message.Message)
+			if targetDbErr == nil {
+				targetDbErr = errors.New(message.Message)
 			}
 		case *pgproto3.ParameterStatus:
 			data = false
@@ -105,7 +105,7 @@ func (c *sessionCore) streamResult(masks []*pb.ColumnMask, opts streamOpts, emit
 				c.qe.MarkNamespaceDirty()
 			}
 			if cause := guardParameterStatusValue(message.Name, message.Value); cause != nil && !fail(cause) {
-				return backendErr, err
+				return targetDbErr, err
 			}
 		case *pgproto3.NoticeResponse, *pgproto3.NotificationResponse:
 			data = false
@@ -113,29 +113,29 @@ func (c *sessionCore) streamResult(masks []*pb.ColumnMask, opts streamOpts, emit
 		case *pgproto3.ParseComplete, *pgproto3.BindComplete, *pgproto3.NoData, *pgproto3.CloseComplete, *pgproto3.PortalSuspended:
 			if !opts.extended {
 				if !fail(fmt.Errorf("%w %T", errUnexpectedFrame, message)) {
-					return backendErr, err
+					return targetDbErr, err
 				}
 				continue
 			}
 		case *pgproto3.CopyInResponse, *pgproto3.CopyOutResponse, *pgproto3.CopyBothResponse:
 			if !fail(errCopyStream) {
-				return backendErr, err
+				return targetDbErr, err
 			}
 			continue
 		case *pgproto3.ReadyForQuery:
 			c.lastTxStatus = message.TxStatus
 			if !emitFrame(message, false) {
-				return backendErr, err
+				return targetDbErr, err
 			}
-			return backendErr, err
+			return targetDbErr, err
 		default:
 			if !fail(fmt.Errorf("%w %T", errUnexpectedFrame, message)) {
-				return backendErr, err
+				return targetDbErr, err
 			}
 			continue
 		}
 		if !emitFrame(out, data) {
-			return backendErr, err
+			return targetDbErr, err
 		}
 	}
 }
@@ -239,12 +239,12 @@ func (s *Server) handleQuery(sess *session, sql string) error {
 	decision, denied, err := engine.ServeStatement(sess.qe,
 		sess.authzInput(sql, sess.token, sess.clientAddr, sess.connectionID, ref.RunAll), ref, nil,
 		func(toSend string, masks []*pb.ColumnMask) (bool, error) {
-			sess.backend.Send(&pgproto3.Query{String: toSend})
-			if err := sess.backend.Flush(); err != nil {
+			sess.targetDb.Send(&pgproto3.Query{String: toSend})
+			if err := sess.targetDb.Flush(); err != nil {
 				return false, err
 			}
 			bufferedFrames := 0
-			backendErr, streamErr := sess.streamResult(masks, streamOpts{}, func(message pgproto3.BackendMessage) error {
+			targetDbErr, streamErr := sess.streamResult(masks, streamOpts{}, func(message pgproto3.BackendMessage) error {
 				if row, ok := message.(*pgproto3.DataRow); ok {
 					relayStats.Rows++
 					relayStats.Bytes += dataRowBytes(row)
@@ -264,8 +264,8 @@ func (s *Server) handleQuery(sess *session, sql string) error {
 			if err := sess.client.Flush(); err != nil {
 				return false, err
 			}
-			relayStatus = engine.RelayStatus(backendErr == nil, nil)
-			return backendErr == nil, nil
+			relayStatus = engine.RelayStatus(targetDbErr == nil, nil)
+			return targetDbErr == nil, nil
 		})
 	// Post-relay, best-effort completion: only a relayed (Proceed) statement reports. A DENY relayed
 	// nothing, and EmitCompletion additionally no-ops for a decision with no audit id.
@@ -300,7 +300,7 @@ func mapWireStreamError(sess *session, err error) error {
 	case errors.Is(err, errStdConformingStrings):
 		return failClosedRelay(sess, "0A000", "proxy-monster: standard_conforming_strings must remain on", err)
 	case errors.Is(err, errUnexpectedFrame):
-		return failClosedRelay(sess, "58000", "proxy-monster: malformed backend response", err)
+		return failClosedRelay(sess, "58000", "proxy-monster: malformed target-DB response", err)
 	default:
 		return err
 	}
@@ -338,6 +338,6 @@ func failClosedRelay(sess *session, code, message string, cause error) error {
 
 func closeRelay(sess *session, cause error) error {
 	_ = sess.clientConn.Close()
-	_ = sess.backendConn.Close()
+	_ = sess.targetDbConn.Close()
 	return cause
 }

--- a/goproxy/pgproxy/run_session.go
+++ b/goproxy/pgproxy/run_session.go
@@ -17,7 +17,7 @@ type RunSession struct {
 	sessionCore
 	conn         net.Conn
 	keyData      pgproto3.BackendKeyData
-	target       spi.BackendTarget
+	target       spi.TargetDb
 	token        string
 	connectionID []byte
 	ref          *engine.Refetcher
@@ -25,12 +25,12 @@ type RunSession struct {
 	poisoned     bool
 }
 
-func NewRunSession(ctx context.Context, target spi.BackendTarget, db engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (*RunSession, error) {
-	conn, _, keyData, txStatus, err := dialBackendAuth(ctx, target)
+func NewRunSession(ctx context.Context, target spi.TargetDb, db engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (*RunSession, error) {
+	conn, _, keyData, txStatus, err := dialTargetDbAuth(ctx, target)
 	if err != nil {
 		return nil, err
 	}
-	conn = wire.WithBackendReadTimeout(conn, readTimeout)
+	conn = wire.WithTargetDbReadTimeout(conn, readTimeout)
 	generation, ok := wire.NextBackendGeneration()
 	if !ok {
 		_ = conn.Close()
@@ -38,7 +38,7 @@ func NewRunSession(ctx context.Context, target spi.BackendTarget, db engine.Db, 
 	}
 	s := &RunSession{
 		sessionCore: sessionCore{
-			backend:      pgproto3.NewFrontend(conn, conn),
+			targetDb:     pgproto3.NewFrontend(conn, conn),
 			qe:           engine.NewQueryEngine(db, client),
 			db:           db,
 			lastTxStatus: txStatus,
@@ -56,9 +56,9 @@ func NewRunSession(ctx context.Context, target spi.BackendTarget, db engine.Db, 
 	return s, nil
 }
 
-// OnOpen runs the on-open catalog fetch over the backend conn. A cancel of ctx (the control-plane closed the
+// OnOpen runs the on-open catalog fetch over the target DB conn. A cancel of ctx (the control-plane closed the
 // run, or the proxy is draining, during the target-DB open) closes the conn, which unwinds an in-flight fetch read
-// at once instead of holding the backend until readTimeout.
+// at once instead of holding the target DB until readTimeout.
 func (s *RunSession) OnOpen(ctx context.Context, cmds []*pb.Refetch) error {
 	defer context.AfterFunc(ctx, func() { _ = s.conn.Close() })()
 	return s.ref.RunAll(cmds)
@@ -79,17 +79,17 @@ func (s *RunSession) ServeStatement(sql string, maxRows int) (result engine.Stat
 				&pgproto3.Parse{Name: "", Query: toSend}, &pgproto3.Bind{}, &pgproto3.Describe{ObjectType: 'P'},
 				&pgproto3.Execute{MaxRows: max}, &pgproto3.Close{ObjectType: 'P'}, &pgproto3.Sync{},
 			} {
-				s.backend.Send(message)
+				s.targetDb.Send(message)
 			}
-			if runErr = s.backend.Flush(); runErr != nil {
+			if runErr = s.targetDb.Flush(); runErr != nil {
 				return false, runErr
 			}
 			collector := rowsCollector{maxRows: maxRows, result: &result}
-			backendErr, runErr := s.streamResult(masks, streamOpts{extended: true}, collector.emit)
+			targetDbErr, runErr := s.streamResult(masks, streamOpts{extended: true}, collector.emit)
 			runErr = firstErr(runErr, collector.failed)
 			s.poisoned = runErr != nil
 			s.pendingDirty = true
-			return backendErr == nil, firstErr(backendErr, runErr)
+			return targetDbErr == nil, firstErr(targetDbErr, runErr)
 		})
 	return result, err
 }
@@ -97,7 +97,7 @@ func (s *RunSession) ServeStatement(sql string, maxRows int) (result engine.Stat
 func (s *RunSession) Cancel() error {
 	if s.keyData.ProcessID == 0 {
 		_ = s.conn.Close()
-		return errors.New("cannot cancel: backend did not provide a cancellation key")
+		return errors.New("cannot cancel: target DB did not provide a cancellation key")
 	}
 	if err := sendCancelRequest(s.target.Host, s.target.Port, s.keyData.ProcessID, s.keyData.SecretKey); err != nil {
 		_ = s.conn.Close()

--- a/goproxy/pgproxy/serve_statement_test.go
+++ b/goproxy/pgproxy/serve_statement_test.go
@@ -14,7 +14,7 @@ import (
 
 func ptr(s string) *string { return &s }
 
-// encodePG serializes backend frames into the wire bytes a scripted backend would send.
+// encodePG serializes target-DB frames into the wire bytes a scripted target DB would send.
 func encodePG(t *testing.T, msgs ...pgproto3.BackendMessage) []byte {
 	t.Helper()
 	var buf []byte
@@ -28,7 +28,7 @@ func encodePG(t *testing.T, msgs ...pgproto3.BackendMessage) []byte {
 	return buf
 }
 
-// scriptedRunSession returns an RunSession wired to a scripted backend that, for each Execute call,
+// scriptedRunSession returns an RunSession wired to a scripted target DB that, for each Execute call,
 // consumes the client's Query and replies with the next response in order. Driving several statements over
 // one persistent session lets a test pin the persistent-session contracts (drain-through-ReadyForQuery so
 // the connection is reusable without statement/result skew; error-to-poison). Each response should end at
@@ -41,19 +41,19 @@ func (s *RunSession) execute(sql string, maxRows int) ([]string, [][]*string, in
 	if err != nil {
 		return nil, nil, 0, err
 	}
-	s.backend.Send(&pgproto3.Parse{Name: "", Query: sql})
-	s.backend.Send(&pgproto3.Bind{DestinationPortal: "", PreparedStatement: ""})
-	s.backend.Send(&pgproto3.Describe{ObjectType: 'P', Name: ""})
-	s.backend.Send(&pgproto3.Execute{Portal: "", MaxRows: executeMax})
-	s.backend.Send(&pgproto3.Close{ObjectType: 'P', Name: ""})
-	s.backend.Send(&pgproto3.Sync{})
-	if err := s.backend.Flush(); err != nil {
+	s.targetDb.Send(&pgproto3.Parse{Name: "", Query: sql})
+	s.targetDb.Send(&pgproto3.Bind{DestinationPortal: "", PreparedStatement: ""})
+	s.targetDb.Send(&pgproto3.Describe{ObjectType: 'P', Name: ""})
+	s.targetDb.Send(&pgproto3.Execute{Portal: "", MaxRows: executeMax})
+	s.targetDb.Send(&pgproto3.Close{ObjectType: 'P', Name: ""})
+	s.targetDb.Send(&pgproto3.Sync{})
+	if err := s.targetDb.Flush(); err != nil {
 		return nil, nil, 0, err
 	}
 	result := engine.StatementResult{Rows: make([][]*string, 0)}
 	collector := rowsCollector{maxRows: maxRows, result: &result}
-	backendErr, streamErr := s.streamResult(nil, streamOpts{extended: true}, collector.emit)
-	err = firstErr(backendErr, streamErr, collector.failed)
+	targetDbErr, streamErr := s.streamResult(nil, streamOpts{extended: true}, collector.emit)
+	err = firstErr(targetDbErr, streamErr, collector.failed)
 	if streamErr != nil || collector.failed != nil {
 		s.poisoned = true
 	}
@@ -67,15 +67,15 @@ func scriptedRunSession(t *testing.T, responses ...[]byte) (*RunSession, <-chan 
 	_ = client.SetDeadline(time.Now().Add(10 * time.Second))
 	_ = server.SetDeadline(time.Now().Add(10 * time.Second))
 
-	be := &RunSession{conn: client, sessionCore: sessionCore{backend: pgproto3.NewFrontend(client, client)}}
+	be := &RunSession{conn: client, sessionCore: sessionCore{targetDb: pgproto3.NewFrontend(client, client)}}
 	requests := make(chan []pgproto3.FrontendMessage, len(responses))
 	go func() {
 		defer close(requests)
-		backend := pgproto3.NewBackend(server, server)
+		targetDb := pgproto3.NewBackend(server, server)
 		for _, response := range responses {
 			messages := make([]pgproto3.FrontendMessage, 0, 6)
 			for range 6 {
-				message, err := backend.Receive()
+				message, err := targetDb.Receive()
 				if err != nil {
 					return
 				}
@@ -140,7 +140,7 @@ func scriptedStreamCore(t *testing.T, responses ...[]byte) (*sessionCore, func()
 			}
 		}
 	}()
-	return &sessionCore{backend: pgproto3.NewFrontend(client, client)}, func() { _ = client.Close(); _ = server.Close() }
+	return &sessionCore{targetDb: pgproto3.NewFrontend(client, client)}, func() { _ = client.Close(); _ = server.Close() }
 }
 
 func TestStreamResultSimpleRejectsExtendedAck(t *testing.T) {
@@ -174,14 +174,14 @@ func TestSoftProbeWidthMismatchDrainsForNextStatement(t *testing.T) {
 	defer server.Close()
 	_ = client.SetDeadline(time.Now().Add(10 * time.Second))
 	_ = server.SetDeadline(time.Now().Add(10 * time.Second))
-	core := &sessionCore{backend: pgproto3.NewFrontend(client, client)}
+	core := &sessionCore{targetDb: pgproto3.NewFrontend(client, client)}
 	go func() {
-		backend := pgproto3.NewBackend(server, server)
+		targetDb := pgproto3.NewBackend(server, server)
 		for _, response := range [][]byte{
 			encodePG(t, rowDesc("a", "b"), dataRow([]byte("one")), &pgproto3.ReadyForQuery{TxStatus: 'I'}),
 			encodePG(t, rowDesc("ok"), dataRow([]byte("next")), &pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")}, &pgproto3.ReadyForQuery{TxStatus: 'I'}),
 		} {
-			if _, err := backend.Receive(); err != nil {
+			if _, err := targetDb.Receive(); err != nil {
 				return
 			}
 			if _, err := server.Write(response); err != nil {
@@ -295,14 +295,14 @@ func TestRunSessionExecutePGRowsAffectedOnWrite(t *testing.T) {
 	}
 }
 
-func TestRunSessionExecutePGBackendError(t *testing.T) {
+func TestRunSessionExecutePGTargetDbError(t *testing.T) {
 	response := encodePG(t,
 		&pgproto3.ErrorResponse{Severity: "ERROR", Code: "42P01", Message: "relation \"nope\" does not exist"},
 		&pgproto3.ReadyForQuery{TxStatus: 'I'},
 	)
 	_, _, _, err := runSessionExecute(t, "SELECT * FROM nope", 0, response)
 	if err == nil || !strings.Contains(err.Error(), "does not exist") {
-		t.Fatalf("err = %v, want backend error surfaced", err)
+		t.Fatalf("err = %v, want target-DB error surfaced", err)
 	}
 }
 
@@ -403,7 +403,7 @@ func TestRunSessionExecutePGSequentialQueriesDoNotSkew(t *testing.T) {
 }
 
 // A protocol error must poison the session: the NEXT Execute fails closed with "unusable" without writing a
-// second Query to the backend (so a swallowed best-effort probe error cannot let a later statement read the
+// second Query to the target DB (so a swallowed best-effort probe error cannot let a later statement read the
 // failed statement's stale frames).
 func TestRunSessionExecutePGErrorPoisonsSession(t *testing.T) {
 	malformed := encodePG(t, &pgproto3.BackendKeyData{ProcessID: 1, SecretKey: 2})

--- a/goproxy/pgproxy/server.go
+++ b/goproxy/pgproxy/server.go
@@ -12,18 +12,18 @@ import (
 )
 
 // Server is the PostgreSQL wire broker: the shared wire.Server lifecycle (accept loop, connection tracking,
-// graceful drain) plus this protocol's per-connection handler and its backend/enforcement dependencies.
+// graceful drain) plus this protocol's per-connection handler and its target DB/enforcement dependencies.
 type Server struct {
 	*wire.Server
-	backend     spi.BackendTarget
+	targetDb    spi.TargetDb
 	client      spi.EnforcementClient
 	db          engine.Db
 	tlsProvider func() (*tls.Config, error)
 }
 
-// New constructs a PostgreSQL wire broker for one backend datasource.
-func New(port int, backend spi.BackendTarget, client spi.EnforcementClient, dbImpl engine.Db, tlsProvider func() (*tls.Config, error)) *Server {
-	s := &Server{backend: backend, client: client, db: dbImpl, tlsProvider: tlsProvider}
+// New constructs a PostgreSQL wire broker for one target DB datasource.
+func New(port int, targetDb spi.TargetDb, client spi.EnforcementClient, dbImpl engine.Db, tlsProvider func() (*tls.Config, error)) *Server {
+	s := &Server{targetDb: targetDb, client: client, db: dbImpl, tlsProvider: tlsProvider}
 	s.Server = wire.New(port, "pgproxy", s.handleConn)
 	return s
 }

--- a/goproxy/pgproxy/switchconn.go
+++ b/goproxy/pgproxy/switchconn.go
@@ -4,7 +4,7 @@ import "net"
 
 // switchConn lets a pgproto3 codec retain its buffered reader while the underlying socket changes. During
 // frontend startup, strictReads prevents pgproto3's chunk reader from swallowing a pipelined TLS ClientHello;
-// during backend startup, it prevents reads beyond ReadyForQuery before dialBackendAuth returns the connection.
+// during target-DB startup, it prevents reads beyond ReadyForQuery before dialTargetDbAuth returns the connection.
 type switchConn struct {
 	net.Conn
 	strictReads bool

--- a/goproxy/run/runner.go
+++ b/goproxy/run/runner.go
@@ -1,4 +1,4 @@
-// Package run drives proxy-dialed control-plane channels over dedicated backend sessions.
+// Package run drives proxy-dialed control-plane channels over dedicated target-DB sessions.
 package run
 
 import (
@@ -28,29 +28,29 @@ const (
 // QueryTimeoutMessage is the exact RunError message the proxy sends when a statement is aborted by the
 // PM_QUERY_TIMEOUT watchdog. The control-plane matches it (RunExecService.QUERY_TIMEOUT_MESSAGE) to
 // attribute the failure as a timeout (query.proxy_timeout) instead of a generic execution error — and,
-// crucially, to never report a timed-out statement as a success: some backends (e.g. MySQL SLEEP) return
-// a row when interrupted, so the watchdog's verdict, not the backend's, decides the outcome.
+// crucially, to never report a timed-out statement as a success: some target DBs (e.g. MySQL SLEEP) return
+// a row when interrupted, so the watchdog's verdict, not the target DB's, decides the outcome.
 const QueryTimeoutMessage = "statement aborted: PM_QUERY_TIMEOUT exceeded"
 
 var errQueryTimeout = errors.New(QueryTimeoutMessage)
 
 type runStream = spi.RunStream
 
-type backendFactory func(ctx context.Context, token string, connectionID []byte, guard engine.ExecGuard) (spi.BackendSession, error)
+type targetDbFactory func(ctx context.Context, token string, connectionID []byte, guard engine.ExecGuard) (spi.TargetDbSession, error)
 
 type Runner struct {
 	client       spi.RunClient
-	factory      backendFactory
+	factory      targetDbFactory
 	queryTimeout time.Duration
 }
 
-func NewRunner(client spi.RunClient, dbImpl engine.Db, backend spi.BackendTarget, provider spi.Provider, queryTimeout time.Duration) *Runner {
+func NewRunner(client spi.RunClient, dbImpl engine.Db, targetDb spi.TargetDb, provider spi.Provider, queryTimeout time.Duration) *Runner {
 	if queryTimeout == 0 {
 		queryTimeout = defaultQueryTimeout
 	}
 	readTimeout := queryTimeout + runSocketTimeoutGrace
-	factory := func(ctx context.Context, token string, connectionID []byte, guard engine.ExecGuard) (spi.BackendSession, error) {
-		return provider.NewRunSession(ctx, backend, dbImpl, client, token, connectionID, guard, readTimeout)
+	factory := func(ctx context.Context, token string, connectionID []byte, guard engine.ExecGuard) (spi.TargetDbSession, error) {
+		return provider.NewRunSession(ctx, targetDb, dbImpl, client, token, connectionID, guard, readTimeout)
 	}
 	return &Runner{client: client, factory: factory, queryTimeout: queryTimeout}
 }
@@ -73,7 +73,7 @@ func (r *Runner) Run(open spi.RunOpen, draining <-chan struct{}) {
 	// (~26s) target-DB open. The session id is the stream's first frame, so the control-plane attaches at
 	// once and EVERY failure below is attributable to this run rather than an unmatched stream it must wait
 	// out. RunProgress heartbeats keep its no-progress bound alive through the open; RunServing (below) then
-	// tells it the backend is ready for the query.
+	// tells it the target DB is ready for the query.
 	ready := &pb.RunReady{SessionId: open.SessionID}
 	if stream.Send(&pb.ProxyRunMsg{Kind: &pb.ProxyRunMsg_SessionReady{SessionReady: ready}}) != nil {
 		return
@@ -90,7 +90,7 @@ func (r *Runner) Run(open spi.RunOpen, draining <-chan struct{}) {
 		return
 	}
 
-	var sess spi.BackendSession
+	var sess spi.TargetDbSession
 	guard := func(exec func() error) error {
 		cancelDone := make(chan struct{})
 		var timedOut atomic.Bool
@@ -105,7 +105,7 @@ func (r *Runner) Run(open spi.RunOpen, draining <-chan struct{}) {
 		if !timer.Stop() {
 			<-cancelDone
 		}
-		// The watchdog fired: report a timeout regardless of what the backend returned, so an interrupted
+		// The watchdog fired: report a timeout regardless of what the target DB returned, so an interrupted
 		// statement is never surfaced as a completed one (the receive on cancelDone above orders this read
 		// after the Store). timedOut is only ever set on that path, so an ordinary finish reads false.
 		if timedOut.Load() {
@@ -114,7 +114,7 @@ func (r *Runner) Run(open spi.RunOpen, draining <-chan struct{}) {
 		return err
 	}
 	// Read the inbound before the (~26s) target-DB open — not after RunServing — so a RunClose the
-	// control-plane sends during the open, or a drain, aborts it instead of finishing a backend handshake for
+	// control-plane sends during the open, or a drain, aborts it instead of finishing a target-DB handshake for
 	// a run nobody is waiting for.
 	messages = receiveRunMessages(ctx, stream)
 	sess = r.openTargetDb(ctx, stream, messages, draining, open, guard)
@@ -185,25 +185,25 @@ func (r *Runner) Run(open spi.RunOpen, draining <-chan struct{}) {
 	}
 }
 
-// openTargetDb dials + authenticates the backend and runs the on-open catalog fetch, while keeping the run stream
+// openTargetDb dials + authenticates the target DB and runs the on-open catalog fetch, while keeping the run stream
 // alive with RunProgress heartbeats and concurrently watching the inbound and the drain. It returns the ready
 // session, or nil if the open failed or was aborted; on every nil return it has already released the reserved
-// connection (and, for a genuine backend failure, sent the RunError), so the caller only sends RunServing.
+// connection (and, for a genuine target-DB failure, sent the RunError), so the caller only sends RunServing.
 //
 // The open runs in its own goroutine under a cancellable child context — the ONLY writer to that context —
 // while this loop is the ONLY sender on the stream (the heartbeat), so neither the gRPC stream nor the open
-// contends. An early RunClose (the browser navigated away before the backend was ready), a closed or broken
-// stream, or a drain cancels the child context and returns at once; the in-flight backend dial / auth /
+// contends. An early RunClose (the browser navigated away before the target DB was ready), a closed or broken
+// stream, or a drain cancels the child context and returns at once; the in-flight target DB dial / auth /
 // catalog reads unwind on the cancel rather than finishing a handshake for a run nobody is waiting for, and
 // the open is reaped in the background (see abort). A close or drain that lands just as the open completes
 // still fails the open (the post-completion re-check) so a live session is never installed on an abandoned
 // run or a departing proxy — the editor re-homes to the replacement rather than onto a stream about to die.
-func (r *Runner) openTargetDb(ctx context.Context, stream runStream, messages <-chan *pb.ControlRunMsg, draining <-chan struct{}, open spi.RunOpen, guard engine.ExecGuard) spi.BackendSession {
+func (r *Runner) openTargetDb(ctx context.Context, stream runStream, messages <-chan *pb.ControlRunMsg, draining <-chan struct{}, open spi.RunOpen, guard engine.ExecGuard) spi.TargetDbSession {
 	openCtx, cancelOpen := context.WithCancel(ctx)
 	defer cancelOpen()
 
 	type openResult struct {
-		sess    spi.BackendSession
+		sess    spi.TargetDbSession
 		err     error
 		errWhat string
 	}
@@ -211,7 +211,7 @@ func (r *Runner) openTargetDb(ctx context.Context, stream runStream, messages <-
 	go func() {
 		sess, err := r.factory(openCtx, open.Token, open.ConnectionID, guard)
 		if err != nil {
-			done <- openResult{err: err, errWhat: "backend connection failed: "}
+			done <- openResult{err: err, errWhat: "target-DB connection failed: "}
 			return
 		}
 		if err := sess.OnOpen(openCtx, open.OnOpen); err != nil {
@@ -222,10 +222,10 @@ func (r *Runner) openTargetDb(ctx context.Context, stream runStream, messages <-
 	}()
 
 	// abort cancels the in-flight open and, in the background, reaps it and releases the reserved connection.
-	// The cancel unwinds the backend dial/auth/catalog reads at once; a catalog push RPC to the control-plane
+	// The cancel unwinds the target DB dial/auth/catalog reads at once; a catalog push RPC to the control-plane
 	// is not cancellable here and runs to its own deadline, so the reap runs off the hot path rather than
 	// making the drain/close wait out that deadline (and the follow-on connection-release RPC).
-	abort := func() spi.BackendSession {
+	abort := func() spi.TargetDbSession {
 		cancelOpen()
 		go func() {
 			res := <-done
@@ -322,7 +322,7 @@ func receiveRunMessages(ctx context.Context, stream runStream) <-chan *pb.Contro
 	return messages
 }
 
-func (r *Runner) cancelSession(sess spi.BackendSession) {
+func (r *Runner) cancelSession(sess spi.TargetDbSession) {
 	if err := sess.Cancel(); err != nil {
 		slog.Warn("run query cancellation failed", "error", err)
 	}
@@ -334,7 +334,7 @@ func (r *Runner) closeConnection(sessionID string, connectionID []byte) {
 	}
 }
 
-func (r *Runner) handleQuery(sess spi.BackendSession, stream runStream, query *pb.RunQuery) bool {
+func (r *Runner) handleQuery(sess spi.TargetDbSession, stream runStream, query *pb.RunQuery) bool {
 	maxRows := int(query.GetMaxRows())
 	if maxRows == 0 {
 		maxRows = defaultMaxRows

--- a/goproxy/run/runner_test.go
+++ b/goproxy/run/runner_test.go
@@ -219,7 +219,7 @@ func (f *runFakeCP) runSetFragmentPushError(err error) {
 type runEngineFixture struct {
 	runDB        engine.Db
 	runProvider  spi.Provider
-	runTarget    spi.BackendTarget
+	runTarget    spi.TargetDb
 	runTable     string
 	runNamespace []string
 }
@@ -229,13 +229,13 @@ type runCapturingProvider struct {
 	readTimeout chan time.Duration
 }
 
-func (p *runCapturingProvider) NewRunSession(ctx context.Context, target spi.BackendTarget, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.BackendSession, error) {
+func (p *runCapturingProvider) NewRunSession(ctx context.Context, target spi.TargetDb, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.TargetDbSession, error) {
 	p.readTimeout <- readTimeout
 	return p.Provider.NewRunSession(ctx, target, dbImpl, client, token, connectionID, guard, readTimeout)
 }
 
-// runSlowOpenProvider blocks the backend dial until release is closed, modeling a slow open against a large
-// remote backend. A test uses it to observe SessionReady landing before the open finishes and heartbeats
+// runSlowOpenProvider blocks the target DB dial until release is closed, modeling a slow open against a large
+// remote target DB. A test uses it to observe SessionReady landing before the open finishes and heartbeats
 // being sent while it is in flight — without depending on wall-clock timing. It honors the target-DB open context:
 // if that is cancelled (the control-plane closed the run, or the proxy drained, during the open) it returns
 // at once, standing in for a real dialect whose dial/auth aborts on cancel. entered, when non-nil, is closed
@@ -250,7 +250,7 @@ type runSlowOpenProvider struct {
 	beforeDelegate func()
 }
 
-func (p *runSlowOpenProvider) NewRunSession(ctx context.Context, target spi.BackendTarget, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.BackendSession, error) {
+func (p *runSlowOpenProvider) NewRunSession(ctx context.Context, target spi.TargetDb, dbImpl engine.Db, client spi.SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (spi.TargetDbSession, error) {
 	if p.entered != nil {
 		p.enterOnce.Do(func() { close(p.entered) })
 	}
@@ -319,7 +319,7 @@ func TestRunnerPostgresTempTablesAreSessionIsolated(t *testing.T) {
 	runSendQuery(fake2, readSQL, 20)
 	runExpectDecision(t, runRecv(t, fake2), pb.EnfAction_ALLOW, nil, "")
 	if message := runRecv(t, fake2); message.GetError() == nil || !strings.Contains(message.GetError().GetMessage(), "does not exist") {
-		t.Fatalf("session 2 bare temp read = %v, want backend relation-does-not-exist error", message)
+		t.Fatalf("session 2 bare temp read = %v, want target DB relation-does-not-exist error", message)
 	}
 }
 
@@ -738,7 +738,7 @@ func runCatalogRefreshContract(t *testing.T, fixture runEngineFixture) {
 		runExpectSingleClose(t, fake)
 	})
 
-	t.Run("backend-failed DDL does not refetch", func(t *testing.T) {
+	t.Run("target-DB-failed DDL does not refetch", func(t *testing.T) {
 		fake, client := runStartFakeCP(t, runSessionID)
 		waitDone := runLaunch(t, fake, client, fixture)
 		initialPushes := len(fake.runRecordedFragments())
@@ -748,7 +748,7 @@ func runCatalogRefreshContract(t *testing.T, fixture runEngineFixture) {
 		runSendQuery(fake, ddl, 20)
 		runExpectDecision(t, runRecv(t, fake), pb.EnfAction_ALLOW, nil, "")
 		if message := runRecv(t, fake); message.GetError() == nil {
-			t.Fatalf("backend-failed DDL message = %v, want RunError", message)
+			t.Fatalf("target-DB-failed DDL message = %v, want RunError", message)
 		}
 		waitDone()
 		if got := len(fake.runRecordedFragments()); got != initialPushes {
@@ -872,7 +872,7 @@ func runExpectSuccess(t *testing.T, fake *runFakeCP, rowsAffected int32) {
 // TestRunnerMySQLReprobesNamespaceAfterTrackerBypass is the run channel's namespace half of the
 // chained session-track bypass. A
 // client clears session_track_system_variables (silently defeating the sysvar tracker), then disables
-// session_track_schema (now unreported), then switches databases with a bare USE — defeating every backend
+// session_track_schema (now unreported), then switches databases with a bare USE — defeating every target DB
 // signal the proxy could observe the switch through. The current database really changed, so authorizing
 // the next statement under the stale schema would let it escape its policy. Probe-always closes the hole:
 // the engine re-reads DATABASE() before the next statement, so it is decided under the switched schema. The
@@ -918,7 +918,7 @@ func TestRunnerMySQLReprobesNamespaceAfterTrackerBypass(t *testing.T) {
 
 // TestRunnerPostgresRejectsUnsafeGUC proves the persistent PostgreSQL session holds the UTF-8 and
 // on-mode invariants the wire relay enforces (pgproxy/relay.go), so a session-scoped GUC change that
-// would let the control plane and the backend bind different objects for the same bytes fails closed and
+// would let the control plane and the target DB bind different objects for the same bytes fails closed and
 // terminates the session before any follow-up query can run.
 func TestRunnerPostgresRejectsUnsafeGUC(t *testing.T) {
 	fixture := runSeedPostgres(t)
@@ -1003,10 +1003,10 @@ func runAssertUnsafeMySQLStatementTerminates(t *testing.T, fixture runEngineFixt
 	runExpectSilence(t, fake, 200*time.Millisecond)
 }
 
-// TestRunnerMySQLCancelsSlowQuery proves the per-statement watchdog reaches the backend AND that a
+// TestRunnerMySQLCancelsSlowQuery proves the per-statement watchdog reaches the target DB AND that a
 // timed-out statement is reported as a timeout, never a success: with an injected short timeout the runner
 // dials a side connection and issues KILL QUERY, interrupting SLEEP(30) fast. MySQL SLEEP returns a success
-// row (1) when interrupted — but the watchdog's verdict overrides the backend, so the proxy sends the
+// row (1) when interrupted — but the watchdog's verdict overrides the target DB, so the proxy sends the
 // PM_QUERY_TIMEOUT sentinel error rather than a row + Done.
 func TestRunnerMySQLCancelsSlowQuery(t *testing.T) {
 	fixture := runSeedMySQL(t)
@@ -1029,7 +1029,7 @@ func TestRunnerMySQLCancelsSlowQuery(t *testing.T) {
 }
 
 // TestRunnerPostgresCancelsSlowQuery proves the watchdog's out-of-band CancelRequest reaches the
-// backend: pg_sleep(30) is canceled fast, the backend replies with an ErrorResponse, and the session ends
+// target DB: pg_sleep(30) is canceled fast, the target DB replies with an ErrorResponse, and the session ends
 // with a terminal error instead of blocking for the production timeout.
 func TestRunnerPostgresCancelsSlowQuery(t *testing.T) {
 	fixture := runSeedPostgres(t)
@@ -1192,7 +1192,7 @@ func TestRunnerDrainDoesNotStartAQueuedQuery(t *testing.T) {
 }
 
 // TestRunnerSendsRunReadyBeforeTargetDbOpenAndHeartbeats proves the run stream sends its id (RunReady) up front
-// and is kept alive through a slow open: SessionReady arrives before the (delayed) backend dial finishes — so
+// and is kept alive through a slow open: SessionReady arrives before the (delayed) target DB dial finishes — so
 // the CP can react to a stall or break during the open instead of waiting a blind budget — and RunProgress
 // heartbeats are emitted while the open runs, then RunServing once it completes.
 func TestRunnerSendsRunReadyBeforeTargetDbOpenAndHeartbeats(t *testing.T) {
@@ -1207,7 +1207,7 @@ func TestRunnerSendsRunReadyBeforeTargetDbOpenAndHeartbeats(t *testing.T) {
 	}()
 
 	// SessionReady must arrive while the target-DB open is still blocked — proving the run id is sent up front,
-	// not deferred until the backend is ready.
+	// not deferred until the target DB is ready.
 	select {
 	case <-fake.runReady:
 	case <-time.After(5 * time.Second):
@@ -1247,11 +1247,11 @@ func TestRunnerSendsRunReadyBeforeTargetDbOpenAndHeartbeats(t *testing.T) {
 	}
 }
 
-// TestRunnerCloseDuringTargetDbOpenAbortsBackend proves the proxy reads the inbound during the target-DB open: a
+// TestRunnerCloseDuringTargetDbOpenAbortsTargetDb proves the proxy reads the inbound during the target-DB open: a
 // RunClose the control-plane sends while the target-DB open is still in flight aborts the open at once and
-// releases the reserved connection, instead of finishing a backend handshake for a run nobody is waiting for.
+// releases the reserved connection, instead of finishing a target-DB handshake for a run nobody is waiting for.
 // The open is never released — the runner can only return by cancelling it — so a return is the abort.
-func TestRunnerCloseDuringTargetDbOpenAbortsBackend(t *testing.T) {
+func TestRunnerCloseDuringTargetDbOpenAbortsTargetDb(t *testing.T) {
 	fixture := runSeedMySQL(t)
 	entered := make(chan struct{})
 	fixture.runProvider = &runSlowOpenProvider{Provider: fixture.runProvider, release: make(chan struct{}), entered: entered}
@@ -1268,17 +1268,17 @@ func TestRunnerCloseDuringTargetDbOpenAbortsBackend(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		t.Fatal("runner did not abort the target-DB open on RunClose (still holding the backend handshake)")
+		t.Fatal("runner did not abort the target-DB open on RunClose (still holding the target-DB handshake)")
 	}
 	runWaitForCloses(t, fake, 1)
 	runExpectSingleClose(t, fake)
 	runExpectNoServing(t, fake)
 }
 
-// TestRunnerDrainDuringTargetDbOpenAbortsBackend is the redeploy analogue: a drain that lands while the backend
+// TestRunnerDrainDuringTargetDbOpenAbortsTargetDb is the redeploy analogue: a drain that lands while the target DB
 // open is in flight aborts it and releases the connection, so the proxy does not keep dialing for a run that
 // will re-home to the replacement.
-func TestRunnerDrainDuringTargetDbOpenAbortsBackend(t *testing.T) {
+func TestRunnerDrainDuringTargetDbOpenAbortsTargetDb(t *testing.T) {
 	fixture := runSeedMySQL(t)
 	entered := make(chan struct{})
 	fixture.runProvider = &runSlowOpenProvider{Provider: fixture.runProvider, release: make(chan struct{}), entered: entered}
@@ -1296,7 +1296,7 @@ func TestRunnerDrainDuringTargetDbOpenAbortsBackend(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		t.Fatal("runner did not abort the target-DB open on drain (still holding the backend handshake)")
+		t.Fatal("runner did not abort the target-DB open on drain (still holding the target-DB handshake)")
 	}
 	runWaitForCloses(t, fake, 1)
 	runExpectSingleClose(t, fake)
@@ -1304,7 +1304,7 @@ func TestRunnerDrainDuringTargetDbOpenAbortsBackend(t *testing.T) {
 }
 
 // TestRunnerDrainAsTargetDbOpenCompletesInstallsNoSession is the open-then-instant-drain case end to end: the
-// target-DB open runs to completion against the real backend with the drain closing during it, and the runner
+// target-DB open runs to completion against the real target DB with the drain closing during it, and the runner
 // must NOT send RunServing — no live editor session on a departing proxy — while still releasing the
 // connection. It reaches the aborted outcome by whichever path the scheduler picks (the outer drain-abort or
 // the post-completion re-check); the re-check branch itself is pinned deterministically by
@@ -1351,7 +1351,7 @@ func TestRunnerDrainAsTargetDbOpenCompletesInstallsNoSession(t *testing.T) {
 // TestRunnerCloseDuringRealDialAbortsIt drives the abort end to end through the REAL MySQL dial: a RunClose
 // sent while the dial is mid-handshake against a target that accepts TCP but never sends its greeting must
 // abort the dial and release the connection fast — exercising the real runner, the real gRPC control stream,
-// and the real provider.NewRunSession -> dialBackendAuthID (DialContext + AfterFunc), not a fake provider.
+// and the real provider.NewRunSession -> dialTargetDbAuthID (DialContext + AfterFunc), not a fake provider.
 // The release is asserted well under the dial's handshake timeout: a dial that ignored the cancel would leak
 // the connection until that timeout instead.
 func TestRunnerCloseDuringRealDialAbortsIt(t *testing.T) {
@@ -1403,7 +1403,7 @@ func TestRunnerDrainDuringRealDialAbortsIt(t *testing.T) {
 	runExpectNoServing(t, fake)
 }
 
-func TestRunnerCloseInFlightCancelsBackend(t *testing.T) {
+func TestRunnerCloseInFlightCancelsTargetDb(t *testing.T) {
 	fixture := runSeedMySQL(t)
 	fake, client := runStartFakeCP(t, runSessionID)
 	waitDone := runLaunch(t, fake, client, fixture)
@@ -1415,7 +1415,7 @@ func TestRunnerCloseInFlightCancelsBackend(t *testing.T) {
 	runSendClose(fake)
 	waitDone()
 	if elapsed := time.Since(start); elapsed > 20*time.Second {
-		t.Fatalf("runner closed in %s; RunClose did not interrupt the backend statement", elapsed)
+		t.Fatalf("runner closed in %s; RunClose did not interrupt the target-DB statement", elapsed)
 	}
 	runExpectSingleClose(t, fake)
 	runExpectMySQLSleepStopped(t, fixture)
@@ -1548,13 +1548,13 @@ func runStartFakeCP(t *testing.T, datasourceName string) (*runFakeCP, *cp.Client
 
 func runSeedMySQL(t *testing.T) runEngineFixture {
 	t.Helper()
-	backend := dbtest.MySQL(t)
+	targetDb := dbtest.MySQL(t)
 	seed := dbtest.OpenMySQL(t, "")
 	statements := []string{
 		"CREATE DATABASE IF NOT EXISTS " + runMySQLSchema,
 		"CREATE TABLE IF NOT EXISTS " + runMySQLSchema + ".pm_run_rows (id INT PRIMARY KEY, secret VARCHAR(64) NULL, note VARCHAR(64) NOT NULL DEFAULT '')",
 		"DELETE FROM " + runMySQLSchema + ".pm_run_rows",
-		// caching_sha2_password (mysql:8.0 default) so the run channel's shared backend dial is exercised against
+		// caching_sha2_password (mysql:8.0 default) so the run channel's shared target DB dial is exercised against
 		// it too; the ALTER re-salts each run, forcing the plaintext full-auth (public-key) path on first dial.
 		"CREATE USER IF NOT EXISTS '" + runMySQLService + "'@'%' IDENTIFIED WITH caching_sha2_password BY '" + runMySQLServicePwd + "'",
 		"ALTER USER '" + runMySQLService + "'@'%' IDENTIFIED WITH caching_sha2_password BY '" + runMySQLServicePwd + "'",
@@ -1570,8 +1570,8 @@ func runSeedMySQL(t *testing.T) runEngineFixture {
 	return runEngineFixture{
 		runDB:       db.MySqlDb{},
 		runProvider: mustProvider(t, engine.MySQL),
-		runTarget: spi.BackendTarget{
-			Host: backend.Host, Port: backend.Port, Db: runMySQLSchema,
+		runTarget: spi.TargetDb{
+			Host: targetDb.Host, Port: targetDb.Port, Db: runMySQLSchema,
 			User: runMySQLService, Password: runMySQLServicePwd,
 		},
 		runTable:     runMySQLSchema + ".pm_run_rows",
@@ -1581,7 +1581,7 @@ func runSeedMySQL(t *testing.T) runEngineFixture {
 
 func runSeedPostgres(t *testing.T) runEngineFixture {
 	t.Helper()
-	backend := dbtest.Postgres(t)
+	targetDb := dbtest.Postgres(t)
 	seed := dbtest.OpenPostgres(t, "")
 	statements := []string{
 		"CREATE SCHEMA IF NOT EXISTS " + runPGSchema,
@@ -1597,9 +1597,9 @@ func runSeedPostgres(t *testing.T) runEngineFixture {
 	return runEngineFixture{
 		runDB:       db.PgDb{},
 		runProvider: mustProvider(t, engine.Postgres),
-		runTarget: spi.BackendTarget{
-			Host: backend.Host, Port: backend.Port, Db: backend.DB,
-			User: backend.User, Password: backend.Password,
+		runTarget: spi.TargetDb{
+			Host: targetDb.Host, Port: targetDb.Port, Db: targetDb.DB,
+			User: targetDb.User, Password: targetDb.Password,
 		},
 		runTable:     runPGSchema + ".pm_run_rows",
 		runNamespace: []string{"pg_catalog", "public"},
@@ -1690,9 +1690,9 @@ func runWaitForClosesWithin(t *testing.T, fake *runFakeCP, count int, within tim
 }
 
 // runStallingTarget is a TCP endpoint that accepts connections and holds them open without ever writing, so a
-// backend handshake read against it stalls. accepted fires on the first accepted connection.
+// target-DB handshake read against it stalls. accepted fires on the first accepted connection.
 type runStallingTarget struct {
-	target   spi.BackendTarget
+	target   spi.TargetDb
 	accepted <-chan struct{}
 }
 
@@ -1733,7 +1733,7 @@ func runStartStallingTarget(t *testing.T) runStallingTarget {
 	})
 	addr := listener.Addr().(*net.TCPAddr)
 	return runStallingTarget{
-		target: spi.BackendTarget{
+		target: spi.TargetDb{
 			Host: addr.IP.String(), Port: addr.Port, Db: runMySQLSchema,
 			User: runMySQLService, Password: runMySQLServicePwd,
 		},

--- a/goproxy/run/table_detail.go
+++ b/goproxy/run/table_detail.go
@@ -19,13 +19,13 @@ const (
 // TableDetailRunner runs one short-lived, proxy-dialed table-detail session.
 type TableDetailRunner struct {
 	client   spi.TableDetailClient
-	backend  spi.BackendTarget
+	targetDb spi.TargetDb
 	provider spi.Provider
 }
 
 // NewTableDetailRunner constructs a table-detail runner for one datasource target.
-func NewTableDetailRunner(client spi.TableDetailClient, backend spi.BackendTarget, provider spi.Provider) *TableDetailRunner {
-	return &TableDetailRunner{client: client, backend: backend, provider: provider}
+func NewTableDetailRunner(client spi.TableDetailClient, targetDb spi.TargetDb, provider spi.Provider) *TableDetailRunner {
+	return &TableDetailRunner{client: client, targetDb: targetDb, provider: provider}
 }
 
 // Run blocks for the short table-detail session lifetime.
@@ -100,7 +100,7 @@ func (r *TableDetailRunner) Run(sessionID, schema, table string) {
 }
 
 func (r *TableDetailRunner) read(schema, table string) (*spi.TableDetail, error) {
-	sqlDB, err := r.provider.OpenTarget(r.backend)
+	sqlDB, err := r.provider.OpenTarget(r.targetDb)
 	if err != nil {
 		return nil, err
 	}
@@ -114,6 +114,6 @@ func (r *TableDetailRunner) read(schema, table string) (*spi.TableDetail, error)
 	}
 	defer conn.Close()
 
-	resolvedSchema := r.provider.Dialect().ResolveSchema(schema, r.backend.Db)
+	resolvedSchema := r.provider.Dialect().ResolveSchema(schema, r.targetDb.Db)
 	return r.provider.ReadTableDetail(conn, resolvedSchema, table)
 }

--- a/goproxy/run/table_detail_test.go
+++ b/goproxy/run/table_detail_test.go
@@ -103,12 +103,12 @@ func tableDetailRun(
 	tableDetailClient *cp.Client,
 	tableDetailFake *tableDetailFakeCP,
 	provider spi.Provider,
-	tableDetailBackend spi.BackendTarget,
+	tableDetailTargetDb spi.TargetDb,
 	tableDetailSessionID, schema, table string,
 ) *pb.ProxyTableDetailMsg {
 	t.Helper()
 	tableDetailFake.tableDetailExpect(tableDetailSessionID)
-	run.NewTableDetailRunner(tableDetailClient, tableDetailBackend, provider).Run(tableDetailSessionID, schema, table)
+	run.NewTableDetailRunner(tableDetailClient, tableDetailTargetDb, provider).Run(tableDetailSessionID, schema, table)
 	select {
 	case tableDetailObservation := <-tableDetailFake.observed:
 		if tableDetailObservation.err != nil {
@@ -124,13 +124,13 @@ func tableDetailRun(
 	}
 }
 
-func tableDetailBackend(tableDetailDBBackend dbtest.Backend) spi.BackendTarget {
-	return spi.BackendTarget{
-		Host:     tableDetailDBBackend.Host,
-		Port:     tableDetailDBBackend.Port,
-		Db:       tableDetailDBBackend.DB,
-		User:     tableDetailDBBackend.User,
-		Password: tableDetailDBBackend.Password,
+func tableDetailTargetDb(tableDetailDBTargetDb dbtest.TargetDb) spi.TargetDb {
+	return spi.TargetDb{
+		Host:     tableDetailDBTargetDb.Host,
+		Port:     tableDetailDBTargetDb.Port,
+		Db:       tableDetailDBTargetDb.DB,
+		User:     tableDetailDBTargetDb.User,
+		Password: tableDetailDBTargetDb.Password,
 	}
 }
 
@@ -253,8 +253,8 @@ func tableDetailAssertSeededTablesExist(t *testing.T, tableDetailSQLDB *sql.DB, 
 }
 
 func TestTableDetailMySQL(t *testing.T) {
-	tableDetailDBBackend := dbtest.MySQL(t)
-	tableDetailSQLDB := dbtest.OpenMySQL(t, tableDetailDBBackend.DB)
+	tableDetailDBTargetDb := dbtest.MySQL(t)
+	tableDetailSQLDB := dbtest.OpenMySQL(t, tableDetailDBTargetDb.DB)
 	tableDetailExec(t, tableDetailSQLDB, `
 DROP TABLE IF EXISTS pm_tdetail_orders;
 DROP TABLE IF EXISTS pm_tdetail_users;
@@ -282,15 +282,15 @@ CREATE TABLE pm_tdetail_plain (
 ) ENGINE=InnoDB;`)
 
 	tableDetailClient, tableDetailFake := tableDetailStartFakeCP(t)
-	tableDetailTarget := tableDetailBackend(tableDetailDBBackend)
+	tableDetailTarget := tableDetailTargetDb(tableDetailDBTargetDb)
 
 	tableDetailUsersPayload := tableDetailRequireResult(t, tableDetailRun(
 		t, tableDetailClient, tableDetailFake, mustProvider(t, engine.MySQL), tableDetailTarget,
 		"pm_tdetail_mysql_users", "public", "pm_tdetail_users",
 	))
 	tableDetailUsers, tableDetailUsersTop := tableDetailDecode(t, tableDetailUsersPayload)
-	if tableDetailUsers.Schema != tableDetailDBBackend.DB || tableDetailUsers.Table != "pm_tdetail_users" {
-		t.Fatalf("MySQL public selector resolved to %s.%s, want %s.pm_tdetail_users", tableDetailUsers.Schema, tableDetailUsers.Table, tableDetailDBBackend.DB)
+	if tableDetailUsers.Schema != tableDetailDBTargetDb.DB || tableDetailUsers.Table != "pm_tdetail_users" {
+		t.Fatalf("MySQL public selector resolved to %s.%s, want %s.pm_tdetail_users", tableDetailUsers.Schema, tableDetailUsers.Table, tableDetailDBTargetDb.DB)
 	}
 	tableDetailAssertColumns(t, tableDetailUsers, tableDetailUsersTop, map[string]struct {
 		dataType string
@@ -305,7 +305,7 @@ CREATE TABLE pm_tdetail_plain (
 
 	tableDetailOrdersPayload := tableDetailRequireResult(t, tableDetailRun(
 		t, tableDetailClient, tableDetailFake, mustProvider(t, engine.MySQL), tableDetailTarget,
-		"pm_tdetail_mysql_orders", tableDetailDBBackend.DB, "pm_tdetail_orders",
+		"pm_tdetail_mysql_orders", tableDetailDBTargetDb.DB, "pm_tdetail_orders",
 	))
 	tableDetailOrders, _ := tableDetailDecode(t, tableDetailOrdersPayload)
 	tableDetailAssertRelation(t, tableDetailOrders.ForeignKeys, "pm_tdetail_orders_user_fk", "pm_tdetail_orders", "pm_tdetail_users")
@@ -335,13 +335,13 @@ CREATE TABLE pm_tdetail_plain (
 	}
 	tableDetailAssertSeededTablesExist(t, tableDetailSQLDB,
 		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name IN (?, ?, ?)",
-		tableDetailDBBackend.DB, "pm_tdetail_users", "pm_tdetail_orders", "pm_tdetail_plain",
+		tableDetailDBTargetDb.DB, "pm_tdetail_users", "pm_tdetail_orders", "pm_tdetail_plain",
 	)
 }
 
 func TestTableDetailPostgres(t *testing.T) {
-	tableDetailDBBackend := dbtest.Postgres(t)
-	tableDetailSQLDB := dbtest.OpenPostgres(t, tableDetailDBBackend.DB)
+	tableDetailDBTargetDb := dbtest.Postgres(t)
+	tableDetailSQLDB := dbtest.OpenPostgres(t, tableDetailDBTargetDb.DB)
 	tableDetailExec(t, tableDetailSQLDB, `
 DROP SCHEMA IF EXISTS pm_tdetail_it CASCADE;
 CREATE SCHEMA pm_tdetail_it;
@@ -368,7 +368,7 @@ CREATE TABLE pm_tdetail_it.pm_tdetail_plain (
 );`)
 
 	tableDetailClient, tableDetailFake := tableDetailStartFakeCP(t)
-	tableDetailTarget := tableDetailBackend(tableDetailDBBackend)
+	tableDetailTarget := tableDetailTargetDb(tableDetailDBTargetDb)
 
 	tableDetailUsersPayload := tableDetailRequireResult(t, tableDetailRun(
 		t, tableDetailClient, tableDetailFake, mustProvider(t, engine.Postgres), tableDetailTarget,

--- a/goproxy/spi/spi.go
+++ b/goproxy/spi/spi.go
@@ -14,8 +14,8 @@ import (
 	pb "github.com/ridi-oss/proxy-monster/goproxy/internal/pb"
 )
 
-// BackendTarget is the per-datasource backend connection details (the service-account broker target).
-type BackendTarget struct {
+// TargetDb is the per-datasource target-DB connection details (the service-account broker target).
+type TargetDb struct {
 	Host     string
 	Port     int
 	Db       string
@@ -54,7 +54,7 @@ type TableDetailStream interface {
 	Recv() (*pb.ControlTableDetailMsg, error)
 }
 
-// SessionClient is the control-plane capability a held backend session needs. The concrete gRPC client
+// SessionClient is the control-plane capability a held target-DB session needs. The concrete gRPC client
 // implements it, while tests can inject a fake without pulling that implementation into the SPI.
 type SessionClient interface {
 	engine.Decider
@@ -93,11 +93,11 @@ type WireServer interface {
 	Drain(ctx context.Context)
 }
 
-// BackendSession is one dedicated run backend session.
-type BackendSession interface {
+// TargetDbSession is one dedicated run target-DB session.
+type TargetDbSession interface {
 	ServeStatement(sql string, maxRows int) (engine.StatementResult, error)
 	// OnOpen runs the on-open catalog fetch. ctx is the target-DB open context: if the control-plane closes the
-	// run (or the proxy drains) while the fetch is in flight, ctx is cancelled and the in-flight backend read
+	// run (or the proxy drains) while the fetch is in flight, ctx is cancelled and the in-flight target-DB read
 	// unwinds at once (a catalog push RPC to the control-plane still runs to its own deadline).
 	OnOpen(ctx context.Context, cmds []*pb.Refetch) error
 	Cancel() error
@@ -182,20 +182,20 @@ type Classification struct {
 	MaskFnName *string  `json:"maskFnName"`
 }
 
-// Provider bundles the per-dialect capabilities (backend connection, wire server, run session,
+// Provider bundles the per-dialect capabilities (target-DB connection, wire server, run session,
 // introspection) used by dialect-neutral consumers. The pure per-dialect facts (registration engine,
 // default ports, placeholder, schema resolution) live on engine.Dialect; a new dialect is one Provider
 // implementation plus one registry row.
 type Provider interface {
 	Dialect() engine.Dialect
 	NewDb() engine.Db
-	OpenTarget(target BackendTarget) (*sql.DB, error)
+	OpenTarget(target TargetDb) (*sql.DB, error)
 	ProbeNamespace(conn *sql.Conn, targetDb string) (defaultSchemas []string, mysqlLowerCaseTableNames *int32, err error)
 	ReadTableDetail(conn *sql.Conn, schema, table string) (*TableDetail, error)
-	NewWireServer(port int, backend BackendTarget, client EnforcementClient, db engine.Db, tlsProvider func() (*tls.Config, error)) WireServer
-	// NewRunSession dials and authenticates the backend. ctx is the target-DB open context: cancelling it aborts
-	// an in-flight dial/auth so a run the control-plane already closed does not finish a backend handshake.
-	NewRunSession(ctx context.Context, target BackendTarget, db engine.Db, client SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (BackendSession, error)
+	NewWireServer(port int, targetDb TargetDb, client EnforcementClient, db engine.Db, tlsProvider func() (*tls.Config, error)) WireServer
+	// NewRunSession dials and authenticates the target DB. ctx is the target-DB open context: cancelling it aborts
+	// an in-flight dial/auth so a run the control-plane already closed does not finish a target-DB handshake.
+	NewRunSession(ctx context.Context, target TargetDb, db engine.Db, client SessionClient, token string, connectionID []byte, guard engine.ExecGuard, readTimeout time.Duration) (TargetDbSession, error)
 }
 
 // Registry resolves the canonical PM_ENGINE name to its Provider. Consumers depend on this interface and

--- a/goproxy/wire/deadline.go
+++ b/goproxy/wire/deadline.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	frontendCommandIdleTimeout = 5 * time.Minute
-	backendResponseIdleTimeout = 30 * time.Minute
+	frontendCommandIdleTimeout  = 5 * time.Minute
+	targetDbResponseIdleTimeout = 30 * time.Minute
 )
 
 // SocketWriteTimeout is the write-inactivity bound applied to every proxied socket. Exported so a protocol
@@ -18,19 +18,19 @@ const SocketWriteTimeout = 30 * time.Second
 
 // WrapClientConn bounds the client socket with the command-idle timeout and makes its reads drain-aware, so
 // an idle handler returns promptly on shutdown to send its protocol notice rather than waiting out the idle
-// timeout. Only the client-facing conn is wrapped this way; a backend read mid-relay must not be cut short.
+// timeout. Only the client-facing conn is wrapped this way; a target-DB read mid-relay must not be cut short.
 func (s *Server) WrapClientConn(c net.Conn) net.Conn {
 	return withDrainAwareIODeadlines(c, frontendCommandIdleTimeout, SocketWriteTimeout, s.draining)
 }
 
-// WrapBackendConn bounds the backend socket with the response-idle timeout; it is not drain-aware.
-func (s *Server) WrapBackendConn(c net.Conn) net.Conn {
-	return withIODeadlines(c, backendResponseIdleTimeout, SocketWriteTimeout)
+// WrapTargetDbConn bounds the target DB socket with the response-idle timeout; it is not drain-aware.
+func (s *Server) WrapTargetDbConn(c net.Conn) net.Conn {
+	return withIODeadlines(c, targetDbResponseIdleTimeout, SocketWriteTimeout)
 }
 
-// WithBackendReadTimeout bounds a proxy-dialed run-session backend connection with a caller-chosen read-idle
+// WithTargetDbReadTimeout bounds a proxy-dialed run-session target-DB connection with a caller-chosen read-idle
 // timeout and the standard socket write timeout. Not drain-aware — the run drain is handled separately.
-func WithBackendReadTimeout(conn net.Conn, readTimeout time.Duration) net.Conn {
+func WithTargetDbReadTimeout(conn net.Conn, readTimeout time.Duration) net.Conn {
 	return withIODeadlines(conn, readTimeout, SocketWriteTimeout)
 }
 

--- a/goproxy/wire/server.go
+++ b/goproxy/wire/server.go
@@ -57,7 +57,7 @@ type Server struct {
 	serveExited chan struct{} // closed when Serve's accept loop returns, so Drain can wait for every accepted conn to register
 }
 
-// New constructs a wire broker for one backend datasource. name prefixes its errors and logs; handle runs
+// New constructs a wire broker for one target DB datasource. name prefixes its errors and logs; handle runs
 // per accepted connection on its own goroutine.
 func New(port int, name string, handle func(net.Conn)) *Server {
 	return &Server{
@@ -181,7 +181,7 @@ func (s *Server) Shutdown() {
 // in-flight statements finish, and unblocks every idle handler so it can forward a protocol-level shutdown
 // notice (see each protocol's conn.go) and close. It waits for all handlers to return, bounded by ctx; any
 // connection still live when ctx is done is force-closed. Forcing the client read deadline only interrupts a
-// handler blocked reading the next command — an in-flight relay reads the backend and writes the client, so
+// handler blocked reading the next command — an in-flight relay reads the target DB and writes the client, so
 // it is untouched and runs to completion.
 func (s *Server) Drain(ctx context.Context) {
 	s.Shutdown()

--- a/mise.toml
+++ b/mise.toml
@@ -32,7 +32,7 @@ pnpm = "10.22.0"
 # `PM_HTTP_PORT=41390 mise run control-plane`. `mise tasks ls` lists them.
 
 [tasks.up]
-description = "Start the local datastores (control-plane store + sample MySQL/PG backends); waits until healthy"
+description = "Start the local datastores (control-plane store + sample MySQL/PG target DBs); waits until healthy"
 shell = "bash -c"
 # Idempotent, and safe when two callers overlap: on an already-healthy stack this only reads state. Two
 # concurrent `docker compose up` runs on one project fight over the same containers, and the loser tears
@@ -62,7 +62,7 @@ shell = "bash -c"
 run = 'PM_DB_URL="${PM_DB_URL:-jdbc:postgresql://localhost:5442/proxymonster}" ./gradlew --no-daemon :control-plane:run'
 
 [tasks.proxy-mysql]
-description = "Run a wire proxy on :6033 fronting the sample MySQL backend (datasource acme-mysql)"
+description = "Run a wire proxy on :6033 fronting the sample MySQL target DB (datasource acme-mysql)"
 depends = ["up"]
 shell = "bash -c"
 run = '''
@@ -79,7 +79,7 @@ PM_CONTROL_PLANE_GRPC="${PM_CONTROL_PLANE_GRPC:-127.0.0.1:9090}" \
 '''
 
 [tasks.proxy-postgres]
-description = "Run a wire proxy on :6432 fronting the sample PostgreSQL backend (datasource acme-target)"
+description = "Run a wire proxy on :6432 fronting the sample PostgreSQL target DB (datasource acme-target)"
 depends = ["up"]
 shell = "bash -c"
 run = '''
@@ -159,8 +159,8 @@ cat <<BANNER
 dev: stack up.
   web console       http://localhost:41300
   control plane     ${cp_url}
-  MySQL proxy       127.0.0.1:${PM_MYSQL_PROXY_PORT:-6033}   → sample backend, datasource acme-mysql
-  PostgreSQL proxy  127.0.0.1:${PM_PG_PROXY_PORT:-6432}   → sample backend, datasource acme-target
+  MySQL proxy       127.0.0.1:${PM_MYSQL_PROXY_PORT:-6033}   → sample target DB, datasource acme-mysql
+  PostgreSQL proxy  127.0.0.1:${PM_PG_PROXY_PORT:-6432}   → sample target DB, datasource acme-target
 
 Ctrl-C stops what this task started; the datastores keep running -- stop them with: mise run down
 

--- a/mysqlwire/mysql.go
+++ b/mysqlwire/mysql.go
@@ -148,7 +148,7 @@ const serverGreetingCapabilities = uint32(CapLongPassword | CapProtocol41 | CapS
 // connectWithDB advertises CapConnectWithDB. An importer passes true only if it FORWARDS the
 // handshake-supplied database (parsing it via ParseHandshakeResponse's connectWithDBSupported and
 // issuing a COM_INIT_DB); otherwise the client's selected database is silently dropped. Both importers
-// forward it — goproxy/mysqlproxy relays it to the backend, and pmon's local broker replays it upstream
+// forward it — goproxy/mysqlproxy relays it to the target DB, and pmon's local broker replays it upstream
 // as COM_INIT_DB — so both pass true. Advertising it is also what keeps a JDBC driver parseable: such a
 // driver writes the database field whether or not the capability was offered, so a greeting that
 // withholds it leaves that field unclaimed and the auth-plugin name that follows is misread as the
@@ -565,7 +565,7 @@ func ParseHandshakeResponse(payload []byte, connectWithDBSupported bool) (Handsh
 	}, nil
 }
 
-// Greeting is the backend server data needed by the client role.
+// Greeting is the target-DB server data needed by the client role.
 type Greeting struct {
 	ConnectionID uint32
 	Scramble     []byte
@@ -573,7 +573,7 @@ type Greeting struct {
 	Capabilities uint32
 }
 
-// ParseHandshakeV10 parses a backend Initial Handshake.
+// ParseHandshakeV10 parses a target DB Initial Handshake.
 func ParseHandshakeV10(payload []byte) (Greeting, error) {
 	r := NewReader(payload)
 	protocol, err := r.U8()
@@ -629,7 +629,7 @@ func ParseHandshakeV10(payload []byte) (Greeting, error) {
 		return Greeting{}, err
 	}
 	if len(part2) < 12 {
-		return Greeting{}, errors.New("mysqlwire: backend greeting scramble is truncated")
+		return Greeting{}, errors.New("mysqlwire: target-DB greeting scramble is truncated")
 	}
 	scramble := append(append(make([]byte, 0, 20), part1...), part2[:12]...)
 	authPlugin := "mysql_native_password"
@@ -713,11 +713,11 @@ func EncryptCachingSHA2Password(password string, scramble []byte, pubKeyPEM []by
 	return rsa.EncryptOAEP(sha1.New(), rand.Reader, pub, plain, nil)
 }
 
-// BackendHandshakeResponse builds the service-account HandshakeResponse41. authPlugin names the client
+// TargetDbHandshakeResponse builds the service-account HandshakeResponse41. authPlugin names the client
 // authentication plugin advertised when CapPluginAuth is set — it MUST match the plugin whose response
 // bytes are in authResp (e.g. "mysql_native_password" or "caching_sha2_password"); an empty authPlugin
 // defaults to mysql_native_password.
-func BackendHandshakeResponse(caps uint32, user string, authResp []byte, database, authPlugin string) []byte {
+func TargetDbHandshakeResponse(caps uint32, user string, authResp []byte, database, authPlugin string) []byte {
 	if authPlugin == "" {
 		authPlugin = "mysql_native_password"
 	}

--- a/mysqlwire/mysql_test.go
+++ b/mysqlwire/mysql_test.go
@@ -87,7 +87,7 @@ func TestServerGreetingTLSCapabilities(t *testing.T) {
 func TestServerGreetingConnectWithDBOptIn(t *testing.T) {
 	scramble := bytes.Repeat([]byte{0x42}, 20)
 	// connectWithDB=true (e.g. goproxy/mysqlproxy, which relays a handshake-supplied database to the
-	// backend as COM_INIT_DB) must advertise CONNECT_WITH_DB, or a real client that gates writing the
+	// target DB as COM_INIT_DB) must advertise CONNECT_WITH_DB, or a real client that gates writing the
 	// database field on server-advertised support (unlike go-sql-driver/mysql, which writes it
 	// unconditionally) will set its own CapConnectWithDB bit without ever including the field.
 	greeting, err := ParseHandshakeV10(ServerGreetingSSL(7, scramble, "8.0.40-test", true))
@@ -312,7 +312,7 @@ func TestNativePasswordKnownVector(t *testing.T) {
 	}
 }
 
-func TestBackendHandshakeResponseDatabase(t *testing.T) {
+func TestTargetDbHandshakeResponseDatabase(t *testing.T) {
 	auth := []byte{1, 2, 3}
 	for _, test := range []struct {
 		name       string
@@ -329,7 +329,7 @@ func TestBackendHandshakeResponseDatabase(t *testing.T) {
 		{"empty plugin defaults to native", CapProtocol41 | CapSecureConn | CapPluginAuth | CapConnectWithDB, "app", "", "app", "mysql_native_password"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			payload := BackendHandshakeResponse(test.caps, "svc", auth, test.database, test.authPlugin)
+			payload := TargetDbHandshakeResponse(test.caps, "svc", auth, test.database, test.authPlugin)
 			r := NewReader(payload)
 			caps, err := r.U32()
 			if err != nil || caps != test.caps {

--- a/proto/src/main/proto/analyzer.proto
+++ b/proto/src/main/proto/analyzer.proto
@@ -62,7 +62,7 @@ message EngineConfig {
   // MySQL's server-level lower_case_table_names setting (0..2), required for MySQL. Absent for
   // PostgreSQL, which has no equivalent setting.
   optional int32 mysql_lower_case_table_names = 3;
-  // Whether the backend's live MySQL session sql_mode has ANSI_QUOTES active. When true the analyzer
+  // Whether the target DB's live MySQL session sql_mode has ANSI_QUOTES active. When true the analyzer
   // builds the MySQL dialect with the mysql_ansi_quotes tokenizer state, so `"col"` parses as a quoted
   // IDENTIFIER (a masked column read) rather than a string literal — matching the server, so a masked
   // column quoted with `"` is still masked instead of leaking cleartext. sql_mode is mutable per
@@ -84,7 +84,7 @@ message AnalyzeRequest {
 
 // ---- response side ----
 
-// One physical backend relation the statement scans (docs/facts-emission.md). catalog/schema/table
+// One physical target-DB relation the statement scans (docs/facts-emission.md). catalog/schema/table
 // is the resolved identity; covered is true once at least one traced column fact names this table
 // (see probe.go's SourceInfo doc comment for the full per-table coverage rationale).
 message SourceInfo {
@@ -387,7 +387,7 @@ message StatementFacts {
   // and the zero-or-more result-read grants are separate typed fields below, so the one kind signal cannot
   // be duplicated, and its absence on a resolved fact is structurally distinguishable.
   reserved 6;
-  // Ordered backend output names; RequireResultReadGrant.output_ordinals indexes this exact list.
+  // Ordered target-DB output names; RequireResultReadGrant.output_ordinals indexes this exact list.
   repeated string output_columns = 7;
   // was is_write — the analyzer emits DENY_STATEMENT column dispositions for write payloads directly, so
   // the control-plane needs no separate write flag (it only ever worded a deny message from it).

--- a/proto/src/main/proto/controlplane.proto
+++ b/proto/src/main/proto/controlplane.proto
@@ -52,7 +52,7 @@ service ControlPlane {
   rpc Events(EventsRequest) returns (stream ControlEvent);
   // The CP-driven execution channel. PROXY-DIALED bidi: the control-plane nudges the proxy over Events
   // (OpenRunChannel) to open this, so data flows both ways without the control-plane ever dialing into the
-  // proxy. It serves web-editor and workflow execution through the same backend + Decide path, streaming
+  // proxy. It serves web-editor and workflow execution through the same target DB + Decide path, streaming
   // the decision and masked rows back.
   rpc RunExec(stream ProxyRunMsg) returns (stream ControlRunMsg);
   // On-demand admin table-browser introspection. Also PROXY-DIALED: request selectors ride the Events
@@ -170,7 +170,7 @@ message SchemaFragmentPush {
   bytes content_hash = 4;               // the live DB-side hash the proxy just measured for this schema
   bool unchanged = 5;                   // true = live hash matched the REFETCH hash; columns omitted (no-op ack)
   repeated Column columns = 6;          // enforcement-relevant fields; reuses the catalog Column shape
-  uint64 backend_generation = 7;        // backend-connection instance that measured this fragment
+  uint64 backend_generation = 7;        // target-DB-connection instance that measured this fragment
 }
 message SchemaFragmentAck {
   uint64 generation = 1;                // per-connection generation after applying
@@ -190,11 +190,11 @@ message DecisionRequest {
   string client_addr = 5;           // end-client address, for the audit record
   // Per-connection catalog freshness: the session/temp tables live on THIS connection, invisible
   // to the datasource-global catalog. The proxy introspects them off its held connection and sends them so
-  // the control-plane resolves a bare name to the connection's temp (matching what the backend binds) instead
+  // the control-plane resolves a bare name to the connection's temp (matching what the target DB binds) instead
   // of a shadowed real table. Editor-session only; empty for one-shot/wire paths.
   repeated TempColumn temp_columns = 6;
   bytes connection_id = 7;
-  // Whether the backend's live MySQL session sql_mode has ANSI_QUOTES active, observed by the proxy per
+  // Whether the target DB's live MySQL session sql_mode has ANSI_QUOTES active, observed by the proxy per
   // statement (sql_mode is mutable per session). The control-plane forwards it to the analyzer's
   // EngineConfig so `"col"` is parsed as a quoted identifier (a masked column read) rather than a string,
   // letting the proxy relay an ANSI_QUOTES session under masking instead of failing it closed. Absent/false
@@ -207,7 +207,7 @@ message DecisionRequest {
 // creator was entitled to read, so an editor session reading its own temp is safe (elevation is a separate,
 // one-shot path that does not create persistent-session temps).
 message TempColumn {
-  string schema = 1;      // the temp namespace as the backend reports it (e.g. a pg_temp_N schema)
+  string schema = 1;      // the temp namespace as the target DB reports it (e.g. a pg_temp_N schema)
   string table = 2;
   string column = 3;
   string sql_type = 4;
@@ -252,7 +252,7 @@ message Verdict {
   // rejects it fail-closed).
   repeated ProxyCommand after_statement = 8;
   uint64 generation = 9;            // per-connection generation this verdict was computed under
-  // The diagnostic-redaction flag. When set, the proxy strips backend error/notice messages on
+  // The diagnostic-redaction flag. When set, the proxy strips target-DB error/notice messages on
   // this connection down to code + severity + a generic message (docs/diagnostic-redaction.md) — DB
   // diagnostics echo stored values that masking hides, so they are an unmasked side-channel. It is an
   // imperative command the proxy executes mechanically (not statement meaning), evaluated fresh per
@@ -315,21 +315,21 @@ message ProxyRunMsg {
     RunDecision decision = 2;         // the enforcement verdict + UX metadata (before any rows)
     RunResultRows result_rows = 3;    // masked rows (ALLOW/MASK only)
     RunDone done = 4;                 // terminal success (rows_affected for a write)
-    RunError error = 5;               // terminal failure (backend error, unsupported, ...)
+    RunError error = 5;               // terminal failure (target-DB error, unsupported, ...)
     RunProgress progress = 6;         // liveness heartbeat during the target-DB open; resets the CP's no-progress bound
-    RunServing serving = 7;           // the backend is connected and its on-open catalog work is done —
+    RunServing serving = 7;           // the target DB is connected and its on-open catalog work is done —
                                       // the control-plane may now send the query
   }
 }
 message ControlRunMsg {
   oneof kind {
     RunQuery query = 1;
-    RunClose close = 2;   // drop the session's backend connection; the proxy closes the stream
+    RunClose close = 2;   // drop the session's target-DB connection; the proxy closes the stream
     RunCancel cancel = 3; // cancel the in-flight statement out-of-band; a no-op when none is running
   }
 }
 message RunReady { string session_id = 1; }
-// A target-DB open liveness heartbeat: the proxy emits these while dialing + authenticating the backend and
+// A target-DB open liveness heartbeat: the proxy emits these while dialing + authenticating the target DB and
 // running its on-open catalog commands, so the control-plane can bound the open by lack of progress rather
 // than by a blind dial budget. It carries no payload — the control-plane treats every RunProgress purely as
 // "the proxy is still alive".

--- a/web/src/components/query/use-result-tabs.ts
+++ b/web/src/components/query/use-result-tabs.ts
@@ -118,7 +118,7 @@ export function useResultTabs(datasourceId: number | null, maxRows: number): Res
   const tokenRef = useRef<Record<string, number>>({}) // per-tab fetch token (race guard)
   const newId = () => `t${++idRef.current}`
 
-  // One persistent editor session (one held backend connection) per datasource, so SET/USE/temp
+  // One persistent editor session (one held target-DB connection) per datasource, so SET/USE/temp
   // persist across queries. Opened lazily on the first query and reused; closed on datasource change/unmount.
   const sessionIdRef = useRef<string | null>(null)
   const sessionDsRef = useRef<number | null>(null)

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -264,7 +264,7 @@ export function runQuery(datasourceId: number, input: QueryRequest): Promise<Que
 }
 
 // ---- Persistent editor sessions -----------------------------------
-// One held backend connection per editor session, so SET/USE/temp/BEGIN persist across queries.
+// One held target-DB connection per editor session, so SET/USE/temp/BEGIN persist across queries.
 
 /** POST /api/editor/sessions — open a persistent editor session for a datasource. */
 export function openEditorSession(datasourceId: number): Promise<{ sessionId: string }> {
@@ -306,7 +306,7 @@ export function deleteEditorTask(taskId: number): Promise<void> {
   return request<void>(`/api/editor/tasks/${taskId}`, { method: 'DELETE' })
 }
 
-/** DELETE /api/editor/sessions/{id} — close the session, freeing its backend connection. */
+/** DELETE /api/editor/sessions/{id} — close the session, freeing its target-DB connection. */
 export function closeEditorSession(sessionId: string): Promise<void> {
   return request<void>(`/api/editor/sessions/${encodeURIComponent(sessionId)}`, { method: 'DELETE' })
 }


### PR DESCRIPTION
## What

Rename the codebase's **"backend"** vocabulary — which everywhere means *the target database the proxy fronts* — to **target DB** / `TargetDb`. Pure terminology cleanup, **no behavior change**. "backend" read ambiguously (in general English it can be mistaken for the control-plane).

- Types: `spi.BackendTarget` → `spi.TargetDb`, `spi.BackendSession` → `spi.TargetDbSession`.
- Functions / consts / fields / params: `dialBackendAuth*`, `backendFactory`, `backendHandshakeTimeout`, `normalizeBackendOK`, `execBackendSet`, `mysqlwire.BackendHandshakeResponse`, `dbtest.Backend`, … → `target-DB` forms.
- Comments, wire / error strings (incl. the one proxy↔control-plane string, kept in sync on both sides), proto comments, and docs.

## Deliberately kept (these are NOT the target DB)

- External `pgproto3.Backend*` (pgx library types).
- `backend_generation` — a **proto wire field** and its generated accessors; renaming the field breaks the wire contract, so the whole "generation" vocabulary stays.
- Postgres **server-process** senses: `pg_terminate_backend` / `pg_cancel_backend` / `pg_backend_pid`, and prose about `pg_stat_activity`.
- `pmon`'s `control.Backend` (daemon service interface), `auditmon`'s audit-store container, the **web** "backend" (= the API server), and `mise.toml`'s "Kotlin backends" (JVM processes).

## One non-code change to flag

`goproxy/go.mod` gains `replace …/mysqlwire => ../mysqlwire`, mirroring the existing `analyzer` replace. Renaming the **exported** `mysqlwire.BackendHandshakeResponse` requires the GOWORK=off image build (which `goproxy/Dockerfile` already copies `../mysqlwire` in for) to resolve mysqlwire from source rather than the pinned published version.

## Verification

`mise run verify` (lint, JVM tests, Go `-race`, web build), `check-image-gomod` (GOWORK=off build), and `proto-check` (bindings regenerated, not hand-edited) — all green. No renamed-away symbol survives; the diff is balanced (+1088 / −1082), as expected for a pure rename. Skipped the 3-reviewer bakeoff (mechanical rename, no logic change) in favor of an integrity pass: every removed line carries a backend→target token or is gofmt/prose reflow with the value unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
