### PR TITLE
fix(control-plane): reject a missing proxy secret in production

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -459,15 +459,15 @@ PostgreSQL client verifies with the downloaded file instead.
 - 🔴 The advertised chain's root of trust is the `Register` credential, not a
   proxy identity. One system-wide shared secret (`PM_SECRET_TOKEN`)
   authenticates every proxy RPC and `Register` accepts a caller-asserted
-  datasource name, so whoever holds that secret — or anyone who can reach the
-  gRPC port while it is unset, which starts the gate open — can re-register any
-  datasource's advertised address and chain, serve a matching cert, and capture
-  that datasource's wire tokens. The fix is a datasource-bound registrar
-  identity (a per-datasource register credential, proxy mTLS bound to the
-  permitted name, or an admin-owned trust record), not a change to how the chain
-  is verified. Set `PM_SECRET_TOKEN` on the control plane and every proxy:
-  startup does not require it today, and [`docs/backlog.md`](./docs/backlog.md)
-  tracks failing startup when it is unset in production. Trust boundary:
+  datasource name, so whoever holds that secret can re-register any datasource's
+  advertised address and chain, serve a matching cert, and capture that
+  datasource's wire tokens. The fix is a datasource-bound registrar identity (a
+  per-datasource register credential, proxy mTLS bound to the permitted name, or
+  an admin-owned trust record), not a change to how the chain is verified.
+  Production startup requires `PM_SECRET_TOKEN` (it is rejected when
+  `PM_AUTH_DEBUG` is false), so the gate can no longer be left open by omission;
+  the admin-equivalent scope of that one shared secret is the remaining gap.
+  Trust boundary:
   [`docs/datasource-registration.md`](./docs/datasource-registration.md).
 - 🟡 Every certificate in the advertised file becomes a trust anchor for `pmon`,
   including the leaf: it loads the whole PEM into a Go root pool, and Go trusts

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Config.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Config.kt
@@ -216,6 +216,10 @@ data class Config(
                 "PM_SESSION_SECRET must be a non-default secret of at least 32 characters when PM_AUTH_DEBUG is false"
             }
             require(authDebug || oidc != null) { "PM_OIDC_* must be configured when PM_AUTH_DEBUG is false" }
+            val secretToken = env("PM_SECRET_TOKEN")
+            require(authDebug || !secretToken.isNullOrBlank()) {
+                "PM_SECRET_TOKEN must be configured when PM_AUTH_DEBUG is false"
+            }
             if (!authDebug) {
                 requireSecureOidcUri(requireNotNull(oidc).issuer, "PM_OIDC_ISSUER")
                 require(oidc.redirectUri == "$mcpIssuer/auth/oidc/callback") {
@@ -243,7 +247,7 @@ data class Config(
                 dbUser = env("PM_DB_USER") ?: "proxymonster",
                 dbPassword = env("PM_DB_PASSWORD") ?: "proxymonster",
                 authDebug = authDebug,
-                secretToken = env("PM_SECRET_TOKEN"),
+                secretToken = secretToken,
                 sessionSecret = sessionSecret,
                 oidc = oidc,
                 resultKey = env("PM_RESULT_KEY")?.let { b64 ->

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ConfigGuardTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ConfigGuardTest.kt
@@ -27,6 +27,7 @@ class ConfigGuardTest {
         "PM_OIDC_CLIENT_ID" to "cid",
         "PM_OIDC_CLIENT_SECRET" to "secret",
         "PM_OIDC_REDIRECT_URI" to "https://proxy.example.com/auth/oidc/callback",
+        "PM_SECRET_TOKEN" to "proxy-shared-secret",
         *pairs,
     )
 
@@ -166,6 +167,34 @@ class ConfigGuardTest {
                 ),
             )
         }
+    }
+
+    @Test fun `debug off requires a non-blank proxy secret`() {
+        assertFailsWith<IllegalArgumentException> { Config.fromEnv(productionEnv("PM_SECRET_TOKEN" to "")) }
+        assertFailsWith<IllegalArgumentException> { Config.fromEnv(productionEnv("PM_SECRET_TOKEN" to "   ")) }
+        // The actual advisory case: the key entirely absent (env() returns null). productionEnv always sets
+        // it, so build a production env without it to pin that the null path fails closed too.
+        assertFailsWith<IllegalArgumentException> {
+            Config.fromEnv(
+                envOf(
+                    "PM_AUTH_DEBUG" to "false",
+                    "PM_MCP_RESOURCE" to "https://proxy.example.com/mcp",
+                    "PM_SESSION_SECRET" to "x".repeat(32),
+                    "PM_OIDC_ISSUER" to "https://idp.example.com",
+                    "PM_OIDC_CLIENT_ID" to "cid",
+                    "PM_OIDC_CLIENT_SECRET" to "secret",
+                    "PM_OIDC_REDIRECT_URI" to "https://proxy.example.com/auth/oidc/callback",
+                ),
+            )
+        }
+    }
+
+    @Test fun `debug off with a valid proxy secret boots and preserves it`() {
+        assertEquals("proxy-shared-secret", Config.fromEnv(productionEnv()).secretToken)
+    }
+
+    @Test fun `debug mode preserves the configured proxy secret value verbatim`() {
+        assertEquals("   ", Config.fromEnv(envOf("PM_SECRET_TOKEN" to "   ")).secretToken)
     }
 
     @Test fun `debug off requires secure canonical MCP origins`() {

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/oauth/OAuthRoutesDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/oauth/OAuthRoutesDbTest.kt
@@ -384,6 +384,7 @@ class OAuthRoutesDbTest {
             "PM_OIDC_CLIENT_ID" to "client",
             "PM_OIDC_CLIENT_SECRET" to "secret",
             "PM_OIDC_REDIRECT_URI" to "https://proxy.example/auth/oidc/callback",
+            "PM_SECRET_TOKEN" to "proxy-shared-secret",
         )
         assertFailsWith<IllegalArgumentException> { Config.fromEnv(base::get) }
         base["PM_SESSION_SECRET"] = "x".repeat(32)

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -8,13 +8,12 @@ forward work. MySQL leads PostgreSQL in priority.
 ## Deployment & operations
 
 - Explicit production mode: refuse startup when any debug bypass
-  (`PM_AUTH_DEBUG`, a committed session-secret fallback, an unset ingest token)
-  is enabled, instead of inferring production from a heuristic.
+  (`PM_AUTH_DEBUG`, a committed session-secret fallback) is enabled, instead of
+  inferring production from a heuristic.
 - Per-datasource authorization for posture. A proxy's `Register` currently
   overwrites a datasource's tags gated only by the shared proxy token; gate
-  posture mutation behind admin authz, forbid `Register` from overwriting an
-  existing datasource's posture, and fail startup when the proxy token is unset
-  in production.
+  posture mutation behind admin authz, and forbid `Register` from overwriting an
+  existing datasource's posture.
 - Multi-instance support. The system runs single-instance today. Before any
   rolling or multi-replica deploy: harden the `system:admin` bootstrap against a
   migrate-while-serving interleave (fleet-stopped migration, or

--- a/docs/policy-store.md
+++ b/docs/policy-store.md
@@ -374,14 +374,15 @@ posture validation), so this is purely about who may assert
 `system:development`: posture is self-asserted through the proxy
 self-registration gRPC path (`ControlPlaneGrpcService.register` passes the tag
 list into the `Datasources.register` upsert; a non-empty list overwrites an
-existing row's posture), gated only by the nullable shared `PM_SECRET_TOKEN`.
-Before the dev preset is relied on in production, that registration/token path
-(owned by [datasource-registration.md](./datasource-registration.md)) must close
-the boundary — any of: fail boot if the secret is unset in prod; gate
-posture-tag mutation behind admin authz rather than proxy self-assertion; or
-forbid `Register` from overwriting an existing datasource's posture. This doc's
-side is fail-closed given a trustworthy posture; that trust is asserted here,
-not enforced.
+existing row's posture), gated only by the shared `PM_SECRET_TOKEN` (required in
+production — startup is rejected when it is unset — so it can no longer be left
+open there). Before the dev preset is relied on in production, that
+registration/token path (owned by
+[datasource-registration.md](./datasource-registration.md)) must close the
+boundary — either: gate posture-tag mutation behind admin authz rather than
+proxy self-assertion; or forbid `Register` from overwriting an existing
+datasource's posture. This doc's side is fail-closed given a trustworthy
+posture; that trust is asserted here, not enforced.
 
 ## Interpretation — what a query gets, by preset × resource
 


### PR DESCRIPTION
Addresses the reported security issue [GHSA-52x6-28h6-9pjw](https://github.com/ridi-oss/proxy-monster/security/advisories/GHSA-52x6-28h6-9pjw).

Non-debug startup accepted a missing or whitespace-only `PM_SECRET_TOKEN`. Both proxy-facing gates — the gRPC `SecretTokenInterceptor` and the HTTP decision-ingest route — key on `expected != null`, so a null secret leaves them fully open: any party that can reach the ports drives the Decide RPC, datasource registration, and audit-record ingest unauthenticated.

Fail closed at config time, next to the sibling `PM_SESSION_SECRET` / `PM_OIDC` guards: require a non-blank `PM_SECRET_TOKEN` whenever `PM_AUTH_DEBUG` is false. Debug keeps the configured value verbatim, so dev`s optional-secret behavior is unchanged. Three now-stale docs are refreshed to match.

Verification: `mise run verify` green; `ConfigGuardTest` covers blank / whitespace / absent / success.

Reported by @archepro84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqUFxkT2cZwoHDU5M9qQki