### PR TITLE
fix(control-plane): close unmanifested system tables fail-closed

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationService.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationService.kt
@@ -15,8 +15,10 @@ import org.slf4j.LoggerFactory
  * Keyed off the STORED `datasource.engine_version` (raw `SELECT version()` + `(aurora <v>)`), so it is
  * path-agnostic — it works identically for a proxy-`PushCatalog` datasource and a legacy CP-introspected one,
  * without touching either catalog path. A datasource whose version is absent or an uncertified major resolves
- * to no manifest → no system tag → the object stays deny-by-default (system schemas closed) unless the
- * operator enables the nearest-major fallback.
+ * to no manifest; its FIXED system schemas then stay closed (a table is treated as [SystemTag.CRITICAL]
+ * unless a shipped manifest explicitly classifies it as dangerous — see [tagForTable]), and its dangerous
+ * functions fall back to the version-independent union floor ([tagForFunction]). A user schema stays
+ * unclassified.
  */
 class SystemClassificationService(
     private val store: SystemClassificationStore = SystemClassificationStore.load(),
@@ -37,9 +39,44 @@ class SystemClassificationService(
         )
     }
 
-    /** The shipped `system:` tag id for a Table, or null when no manifest governs the datasource. */
-    fun tagForTable(engine: Engine, engineVersion: String?, catalog: String, schema: String, table: String): String? =
-        classifierFor(engine, engineVersion)?.classifyRelation(catalog, schema, table)?.id
+    /**
+     * The shipped `system:` tag id for a Table, or null when the table is not in a system schema (ordinary
+     * user classification then applies).
+     *
+     * A datasource with NO governing manifest (absent or uncertified `engine_version`, fallback off) cannot
+     * classify its system schemas, yet the classifier's [SystemTag.CATALOG] default plus the role-agnostic
+     * `system:catalog` read permit would make every unrecognized fixed-system-schema table world-readable.
+     * That is fail-open: the manifests do not enumerate every value-bearing system table (e.g. MySQL
+     * `performance_schema.user_variables_by_thread`, the `sys.x$…` twins), so an unrecognized one cannot be
+     * assumed benign catalog metadata. So a fixed system schema without a governing manifest is closed:
+     * an explicitly-dangerous tag any shipped manifest of the engine assigns is kept (it routes through its
+     * own Cedar forbid), and everything else — the catalog default and any unrecognized or catalog-mismatched
+     * relation — is treated as [SystemTag.CRITICAL] so the unconditional critical forbid denies it even under
+     * a broad Datasource grant. Ephemeral `pg_temp_`/`pg_toast` schemas are excluded
+     * ([Engine.isFixedSystemSchema]): their connection-local handling owns that separate path.
+     */
+    fun tagForTable(engine: Engine, engineVersion: String?, catalog: String, schema: String, table: String): String? {
+        classifierFor(engine, engineVersion)?.let { return it.classifyRelation(catalog, schema, table)?.id }
+        if (!engine.isFixedSystemSchema(schema)) return null
+        return (noManifestDangerousFloor(engine, catalog, schema, table) ?: SystemTag.CRITICAL).id
+    }
+
+    /**
+     * The strongest EXPLICIT dangerous tag (stronger than [SystemTag.CATALOG]) any shipped manifest of [engine]
+     * assigns the relation, or null when no manifest classifies it beyond the catalog default. Used only for a
+     * datasource with no governing manifest: an explicit critical/data-leak/activity classification is
+     * version-stable enough to trust (and over-classifying is fail-safe), while the bare catalog default cannot
+     * be distinguished from an unrecognized relation, so [tagForTable] closes that case instead.
+     */
+    private fun noManifestDangerousFloor(engine: Engine, catalog: String, schema: String, table: String): SystemTag? {
+        var tag: SystemTag? = null
+        for (classifier in store.classifiersForEngine(engine.wireName)) {
+            val t = classifier.classifyRelation(catalog, schema, table) ?: continue
+            if (t == SystemTag.CATALOG) continue
+            tag = if (tag == null) t else SystemTag.stronger(tag, t)
+        }
+        return tag
+    }
 
     /**
      * The shipped `system:` tag id for a called function, or null when it is an ordinary safe function

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationEnforcementDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationEnforcementDbTest.kt
@@ -19,8 +19,10 @@ import kotlin.test.assertTrue
  * forbidden on the production floor by the shipped forbids — the forbid overriding even a broad grant.
  * `system:critical` is never relaxed; `system:activity`/`data-leak` are relaxed on `system:development` (V32).
  * The classifier keys off `datasource.engine_version` (set here to a PG-17 `version()` string). A datasource
- * with NO version resolves to no manifest → no system tag → deny-by-default (system schemas closed) — the
- * transitional/fail-closed posture. Running this test also proves the shipped SYSTEM policies compile against
+ * with NO version resolves to no manifest, so its fixed system schemas stay closed: an explicitly-dangerous
+ * table keeps its tag, and any unrecognized/catalog-default one is treated as critical and denied even under
+ * a broad grant — fail-closed, since an unrecognized system table cannot be assumed benign catalog metadata.
+ * Running this test also proves the shipped SYSTEM policies compile against
  * schema.cedarschema at boot (the fixture's CedarEngine load).
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -129,12 +131,42 @@ class SystemClassificationEnforcementDbTest {
     }
 
     @Test
-    fun `without an engine_version, system schemas stay deny-by-default`() {
+    fun `without an engine_version, fixed system schemas stay closed`() {
         setEngineVersion(null)
-        // No version → no manifest → no system tag → the object is ungranted → deny-by-default (safe).
-        // Even the otherwise-open pg_class is denied because there is no classification to permit it.
-        assertEquals(EnfAction.DENY, decide("select count(*) from pg_catalog.pg_class"), "no version → no system:catalog permit → deny")
-        assertEquals(EnfAction.DENY, decide("select count(*) from pg_catalog.pg_authid"), "no version → still denied (fail-closed)")
+        // No manifest governs, so a fixed system schema is closed: an unrecognized/catalog-default table
+        // (pg_class) is treated as critical and denied, and pg_authid is denied too. Fail-closed — an
+        // unrecognized fixed-system table cannot be assumed benign catalog metadata.
+        assertEquals(EnfAction.DENY, decide("select count(*) from pg_catalog.pg_class"), "no version → pg_class treated as critical → denied")
+        assertEquals(EnfAction.DENY, decide("select count(*) from pg_catalog.pg_authid"), "no version → pg_authid denied")
+    }
+
+    @Test
+    fun `without an engine_version, the floor still forbids a system table under a broad datasource grant`() {
+        // The advisory case (GHSA-j984-q948-4xq8): a datasource with no governing manifest, a broad Datasource
+        // read grant, and a query on a fixed system table. Before the floor, pg_authid was untagged and the
+        // broad grant read it; the floor now tags it system:critical so the shipped forbid overrides the grant.
+        setEngineVersion(null)
+        val broad = "broad-nomanifest@example.com"
+        val role = fx.policyStore.createRole(RoleInput("broad-nomanifest-reader"))
+        fx.policyStore.createAssignment(RoleAssignmentInput(broad, role.id))
+        fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "test-broad-nomanifest-grant",
+                cedarSrc = """permit(principal in Role::"broad-nomanifest-reader", action, resource in Datasource::"${fx.datasource.name}");""",
+            ),
+            updatedBy = "test",
+        )
+        fun decideAs(who: String, sql: String) = decideQuery(
+            principal = who, ds = fx.datasourceStore.get(fx.datasource.id)!!, sql = sql, channel = Channel.WIRE,
+            catalog = fx.datasourceStore.catalog(fx.datasource.id), policyStore = fx.policyStore, accessStore = fx.accessStore,
+            userGroupStore = fx.userGroupStore, roleResolver = fx.roleResolver, authz = fx.authz,
+            systemClassification = classifier,
+        ).action
+        assertEquals(EnfAction.DENY, decideAs(broad, "select count(*) from pg_catalog.pg_authid"), "no-manifest critical floor overrides the broad grant")
+        assertEquals(EnfAction.DENY, decideAs(broad, "select rolname from pg_catalog.pg_authid"), "and on the column path too")
+        // And an unrecognized/catalog-default fixed-system table is closed under the same grant — the fix does
+        // not open the -100 catalog permit to unclassified system relations on an unmanifested datasource.
+        assertEquals(EnfAction.DENY, decideAs(broad, "select count(*) from pg_catalog.pg_class"), "no-manifest pg_class is closed, not browsable")
     }
 
     // A query calling a dangerous builtin is DENIED by the shipped system:data-leak/critical
@@ -152,10 +184,10 @@ class SystemClassificationEnforcementDbTest {
         // critical (pg_catalog exact, net-new vs dangerousFuncs) and data-leak (pageinspect *) both deny.
         assertEquals(EnfAction.DENY, decide("select pg_terminate_backend(1) from pg_catalog.pg_class"), "pg_terminate_backend (system:critical) must deny by policy")
         assertEquals(EnfAction.DENY, decide("select get_raw_page('pg_class', 0) from pg_catalog.pg_class"), "get_raw_page (system:data-leak) must deny by policy")
-        // No version → no classification → the function gate is inert (this DENY is deny-by-default for the
-        // ungranted table scan, not the function forbid — proven by the safe-baseline ALLOW above flipping).
+        // No version → the fixed system table itself is closed (pg_class treated as critical), so even a safe
+        // function over it denies at the table gate — the function gate is not reached.
         setEngineVersion(null)
-        assertEquals(EnfAction.DENY, decide("select now() from pg_catalog.pg_class"), "no version → table scan itself denies (function gate inert)")
+        assertEquals(EnfAction.DENY, decide("select now() from pg_catalog.pg_class"), "no version → pg_class closed → table scan denies")
     }
 
     @Test

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationEnforcementMySqlDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationEnforcementMySqlDbTest.kt
@@ -1,0 +1,136 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.grpc.EnfAction
+import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
+import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * MySQL end-to-end coverage for the no-governing-manifest system-table floor (GHSA-j984-q948-4xq8) — the
+ * primary engine, on real MySQL + real Cedar. The unit test proves the tags; this proves they reach Cedar
+ * through `decideQuery` and that the shipped forbids override a broad Datasource grant.
+ *
+ * The fixture connection cannot see the `mysql`/`performance_schema` system databases in
+ * `information_schema.columns`, so those tables never enter the introspected catalog. They are seeded here
+ * explicitly — this test exercises the tag→Cedar ENFORCEMENT path, not catalog introspection. The version is
+ * an UNCERTIFIED-but-present string (`5.7.44`): that is the advisory's real posture (no governing manifest,
+ * fallback off) and the one the MySQL analyzer can resolve schemas under — a truly blank version is a
+ * degenerate pre-registration state with no catalog at all.
+ *
+ * Each deny is asserted to carry the table-authorization reason naming the table, which distinguishes the tag
+ * forbid overriding the broad grant from an unanalyzable/uncovered deny: under a broad grant an UNtagged table
+ * would ALLOW, so a named-table deny is the load-bearing signal that the floor tagged it.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SystemClassificationEnforcementMySqlDbTest {
+    private lateinit var fx: EnforcementFixture
+    private val classifier = SystemClassificationService()
+    private val broad = "broad-mysql@example.com"
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        fx = EnforcementFixture.mysql()
+        fx.datasourceStore.storePushedCatalog(
+            id = fx.datasource.id,
+            defaultSchemas = listOf(fx.datasource.dbName),
+            mysqlLowerCaseTableNames = 0,
+            engineVersion = "5.7.44",
+            columns = listOf(
+                // An explicit system:critical credential table.
+                DatasourceStore.PushedColumn("mysql", "user", "User", "char", 1, false),
+                DatasourceStore.PushedColumn("mysql", "user", "authentication_string", "text", 2, true),
+                // A value-bearing table NO shipped manifest classifies — the fail-closed critical default; the
+                // raw cross-session-variable surface the advisory closes.
+                DatasourceStore.PushedColumn("performance_schema", "user_variables_by_thread", "VARIABLE_NAME", "varchar", 1, true),
+                DatasourceStore.PushedColumn("performance_schema", "user_variables_by_thread", "VARIABLE_VALUE", "longtext", 2, true),
+                // An explicit system:data-leak table — kept at its tag (not force-critical), so system:development still relaxes it.
+                DatasourceStore.PushedColumn("information_schema", "COLUMN_STATISTICS", "SCHEMA_NAME", "varchar", 1, true),
+            ),
+        )
+        val role = fx.policyStore.createRole(RoleInput("broad-mysql-reader"))
+        fx.policyStore.createAssignment(RoleAssignmentInput(broad, role.id))
+        fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "test-broad-mysql-grant",
+                cedarSrc = """permit(principal in Role::"broad-mysql-reader", action, resource in Datasource::"${fx.datasource.name}");""",
+            ),
+            updatedBy = "test",
+        )
+    }
+
+    private fun setEngineVersion(v: String) {
+        fx.dataSource.connection.use { c ->
+            c.prepareStatement("UPDATE datasource SET engine_version = ? WHERE id = ?").use { ps ->
+                ps.setString(1, v)
+                ps.setLong(2, fx.datasource.id)
+                ps.executeUpdate()
+            }
+        }
+    }
+
+    private fun setTags(json: String) {
+        fx.dataSource.connection.use { c ->
+            c.prepareStatement("UPDATE datasource SET tags = ?::jsonb WHERE id = ?").use { ps ->
+                ps.setString(1, json)
+                ps.setLong(2, fx.datasource.id)
+                ps.executeUpdate()
+            }
+        }
+    }
+
+    private fun decideAs(who: String, sql: String) = decideQuery(
+        principal = who, ds = fx.datasourceStore.get(fx.datasource.id)!!, sql = sql, channel = Channel.WIRE,
+        catalog = fx.datasourceStore.catalog(fx.datasource.id), policyStore = fx.policyStore, accessStore = fx.accessStore,
+        userGroupStore = fx.userGroupStore, roleResolver = fx.roleResolver, authz = fx.authz,
+        systemClassification = classifier,
+    )
+
+    @Test
+    fun `an uncertified MySQL broad grant cannot read a fixed system table`() {
+        setEngineVersion("5.7.44")
+        setTags("""["system:production"]""")
+        // mysql.user (explicit critical) and performance_schema.user_variables_by_thread (catalog-default →
+        // critical default) both deny THROUGH the table forbid — the named-table reason proves the tag
+        // overrode the broad grant rather than an uncovered-table deny.
+        for (table in listOf("mysql.user", "performance_schema.user_variables_by_thread")) {
+            val ctx = decideAs(broad, "select count(*) from $table")
+            assertEquals(EnfAction.DENY, ctx.action, "broad grant must not read $table (reason=${ctx.denyReason})")
+            assertTrue(
+                ctx.denyReason.orEmpty().contains(table.substringAfter('.')),
+                "the deny must be the table forbid overriding the broad grant, not an uncovered deny: ${ctx.denyReason}",
+            )
+        }
+        // The column path inherits the table's tag, so a projected column of a critical table denies too.
+        // (Project authentication_string, not User — a bare `User` parses as the USER() builtin, not a column.)
+        val col = decideAs(broad, "select authentication_string from mysql.user")
+        assertEquals(EnfAction.DENY, col.action, "column path must deny too (reason=${col.denyReason})")
+    }
+
+    @Test
+    fun `an uncertified MySQL explicit data-leak table is kept not forced critical so dev relaxes it`() {
+        setEngineVersion("5.7.44")
+        // information_schema.COLUMN_STATISTICS is an explicit data-leak in the manifests; the floor keeps that
+        // tag rather than promoting everything to critical. On the production floor it denies…
+        setTags("""["system:production"]""")
+        assertEquals(EnfAction.DENY, decideAs(broad, "select count(*) from information_schema.COLUMN_STATISTICS").action, "data-leak denies on the production floor")
+        // …and on a development datasource the shipped data-leak relaxation still applies, proving the floor
+        // did not force it to the unconditional critical forbid.
+        setTags("""["system:development"]""")
+        assertEquals(EnfAction.ALLOW, decideAs(broad, "select count(*) from information_schema.COLUMN_STATISTICS").action, "data-leak is relaxed on system:development")
+    }
+
+    @Test
+    fun `a governed MySQL datasource is unaffected by the no-manifest floor`() {
+        // With a certified version the classifier owns the decision: mysql.user is still critical (denied),
+        // proving the governed path is untouched by the floor.
+        setEngineVersion("8.0.44")
+        setTags("""["system:production"]""")
+        assertEquals(EnfAction.DENY, decideAs(broad, "select count(*) from mysql.user").action, "governed mysql.user stays denied")
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationServiceTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationServiceTest.kt
@@ -48,8 +48,29 @@ class SystemClassificationServiceTest {
         val auroraPg = "PostgreSQL 17.4 on x86_64 (aurora 17.4...)"
         assertEquals("system:critical", svc.tagForTable(Engine.POSTGRES, auroraPg, "acme", "pg_catalog", "pg_authid"))
         assertEquals("system:catalog", svc.tagForTable(Engine.POSTGRES, auroraPg, "acme", "pg_catalog", "pg_class"))
-        // no version → no manifest → null (deny-by-default)
-        assertNull(svc.tagForTable(Engine.POSTGRES, null, "acme", "pg_catalog", "pg_authid"))
+    }
+
+    @Test
+    fun `a fixed system table without a governing manifest is closed`() {
+        // No governing manifest (null version, fallback off): a fixed system schema must not fall through
+        // untagged (a broad Datasource grant would read it). An explicitly-dangerous manifest tag is kept;
+        // everything else — the bare catalog default, an unrecognized table, or a catalog-mismatched one — is
+        // treated as system:critical so the unconditional forbid closes it. Fail-closed: unprovable ⇒ critical.
+        assertEquals("system:critical", svc.tagForTable(Engine.POSTGRES, null, "acme", "pg_catalog", "pg_authid"))
+        assertEquals("system:critical", svc.tagForTable(Engine.MYSQL, null, "def", "mysql", "user"))
+        // An explicit data-leak stays data-leak (kept so its own forbid + the system:development relaxation apply).
+        assertEquals("system:data-leak", svc.tagForTable(Engine.MYSQL, null, "def", "information_schema", "COLUMN_STATISTICS"))
+        // A catalog-default table (no explicit dangerous rule) is closed as critical, not opened as catalog.
+        assertEquals("system:critical", svc.tagForTable(Engine.POSTGRES, null, "acme", "pg_catalog", "pg_class"))
+        // An unrecognized table in a fixed system schema (not in any shipped manifest) is likewise closed.
+        assertEquals("system:critical", svc.tagForTable(Engine.MYSQL, null, "def", "performance_schema", "user_variables_by_thread"))
+        // A catalog-mismatched MySQL system table (schema matches, catalog is not "def") must not downgrade to
+        // catalog — it is still closed.
+        assertEquals("system:critical", svc.tagForTable(Engine.MYSQL, null, "not-def", "mysql", "user"))
+        // An ordinary user table is not a system resource, so it is never floored.
+        assertNull(svc.tagForTable(Engine.POSTGRES, null, "acme", "public", "orders"))
+        // Ephemeral pg_temp_/pg_toast are not fixed system schemas — their connection-local path owns them.
+        assertNull(svc.tagForTable(Engine.POSTGRES, null, "acme", "pg_temp_3", "scratch"))
     }
 
     // tagForFunction resolves a BARE function name (the only form the analyzer can emit, since


### PR DESCRIPTION
Addresses the reported security issue [GHSA-j984-q948-4xq8](https://github.com/ridi-oss/proxy-monster/security/advisories/GHSA-j984-q948-4xq8).

A fixed engine-owned system table on a datasource with no governing manifest (absent or uncertified `engine_version`, fallback off) was left untagged, so a broad Datasource read grant could reach a credential surface such as `pg_catalog.pg_authid` that a certified datasource denies.

Close a fixed system schema without a governing manifest: `tagForTable` keeps an explicitly-dangerous manifest tag (routed through its own Cedar forbid, `system:development` still relaxes activity/data-leak), and treats everything else — the `CATALOG` default, an unrecognized table, or a catalog-mismatched one — as `system:critical`, so the unconditional forbid denies it even under a broad grant. The `CATALOG` default could not be trusted here because it is world-readable via the role-agnostic catalog permit; fail-closed treats an unprovable system relation as maximally sensitive. Unmanifested system schemas stay closed (the documented posture); the fix additionally closes the broad-grant path. Cedar-routed, no `Query.kt` change.

Verification: `mise run verify` green; unit + PostgreSQL + MySQL (uncertified 5.7) enforcement coverage.

Reported by @archepro84 (different remediation approach than the reporter fork, by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqUFxkT2cZwoHDU5M9qQki