### PR TITLE
fix(control-plane): gate per-datasource metadata on datasource.connect

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -716,8 +716,7 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
         post("/api/ingest/decision") {
             val expected = config.secretToken
             if (expected != null) {
-                val provided = call.request.headers["X-PM-Ingest-Token"]
-                if (provided != expected) {
+                if (!constantTimeEquals(call.request.headers["X-PM-Ingest-Token"], expected)) {
                     call.invalidToken("ingest")
                     return@post
                 }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Auth.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Auth.kt
@@ -11,6 +11,7 @@ import io.ktor.util.AttributeKey
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
+import java.security.MessageDigest
 import java.util.UUID
 
 /** The signed-cookie session name. */
@@ -109,6 +110,15 @@ fun ApplicationCall.webSession(): WebSessionRow? {
 
 /** Resolve the current server-side web session, or null if unauthenticated. */
 fun ApplicationCall.userSession(): UserSession? = webSession()?.let { UserSession(it.principal) }
+
+/** Compare a presented secret against the expected one without leaking its prefix through timing —
+ *  `==` on a standing secret is an oracle. Every standing-secret check goes through this: the ingest
+ *  token, the SCIM bearer, the proxy's gRPC transport secret, and the consent CSRF token (an HMAC of
+ *  the session secret, so it is standing per principal, not a per-request nonce). */
+fun constantTimeEquals(presented: String?, expected: String): Boolean {
+    if (presented == null) return false
+    return MessageDigest.isEqual(presented.toByteArray(Charsets.UTF_8), expected.toByteArray(Charsets.UTF_8))
+}
 
 // The fallback is reachable only when PM_AUTH_DEBUG admits a mutation without a session.
 fun ApplicationCall.auditActor(config: Config, channel: String = AuditSource.CONSOLE): AuditActor = AuditActor(

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Datasources.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Datasources.kt
@@ -4,7 +4,6 @@ import com.ridi.oss.proxymonster.classification.SystemTag
 import com.ridi.oss.proxymonster.controlplane.authz.Authz
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzDecision
-import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
 import com.ridi.oss.proxymonster.controlplane.authz.authorizeDatasourceAction
 import com.ridi.oss.proxymonster.controlplane.authz.requireAdmin
 import com.ridi.oss.proxymonster.controlplane.authz.resolveContextTags
@@ -843,9 +842,10 @@ fun Route.datasourceRoutes(
 ) {
     // A caller may connect to (and so browse the catalog of) a datasource iff Cedar grants
     // datasource.connect on it — the same name-keyed decision, with derived context tags, the proxy runs on
-    // connect. authDebug sees everything, matching every other route.
+    // connect. No authDebug arm: PM_AUTH_DEBUG is an AUTHENTICATION bypass, and `/auth/debug` persists its
+    // claimed roles as real assignments so Cedar can evaluate them, so short-circuiting the decision here
+    // would only hide the policy dev is configured to exercise.
     fun mayConnect(call: ApplicationCall, principal: String, ds: Datasource): Boolean {
-        if (config.authDebug) return true
         val roles = roleResolver.resolve(principal)
         val raw = call.httpAuthzContext(config)
         val tags = authz.resolveContextTags(principal, roles, ds.name, raw, ds.tags)
@@ -869,19 +869,10 @@ fun Route.datasourceRoutes(
         val connectableOnly = call.request.queryParameters["connectable"].equals("true", ignoreCase = true)
         // The list stays unfiltered by default — JIT-request compose must show datasources you cannot yet
         // connect to, precisely so they can be requested — but a row you may not connect to is stripped of
-        // its connection material. Otherwise the list answers what {id} and {id}/wire-cert refuse, and
-        // their datasource.connect gate is decorative.
-        //
-        // admin.datasources keeps the full row: administering a datasource means editing the very host/port
-        // it is being stripped of, and that authority is instance-wide, so it resolves once rather than
-        // per row.
-        val isDatasourceAdmin = config.authDebug ||
-            authz.authorize(principal, AuthzAction.ADMIN_DATASOURCES, AuthzResource.System, call.httpAuthzContext(config)) ==
-            AuthzDecision.Allow
-        val visible = when {
-            connectableOnly -> all.filter { mayConnect(call, principal, it) }
-            isDatasourceAdmin -> all
-            else -> all.map { if (mayConnect(call, principal, it)) it else it.withoutConnectionMaterial() }
+        // its connection material, the same decision {id} and {id}/wire-cert make. A row this list would
+        // answer more fully than {id} does is a bypass of {id}.
+        val visible = if (connectableOnly) all.filter { mayConnect(call, principal, it) } else {
+            all.map { if (mayConnect(call, principal, it)) it else it.withoutConnectionMaterial() }
         }
         call.respond(visible)
     }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Datasources.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Datasources.kt
@@ -4,6 +4,7 @@ import com.ridi.oss.proxymonster.classification.SystemTag
 import com.ridi.oss.proxymonster.controlplane.authz.Authz
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzDecision
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
 import com.ridi.oss.proxymonster.controlplane.authz.authorizeDatasourceAction
 import com.ridi.oss.proxymonster.controlplane.authz.requireAdmin
 import com.ridi.oss.proxymonster.controlplane.authz.resolveContextTags
@@ -61,14 +62,23 @@ data class Datasource(
     // The PEM certificate chain to trust for this datasource's proxy, leaf first, as the proxy advertised it
     // at registration. pmon uses it as the root pool for its upstream hop, with advertiseAddr checked against
     // it; the browser downloads the same bytes from {id}/wire-cert for psql/mysql/DataGrip. Null when the
-    // proxy has no wire TLS. Public material — this is what the proxy already presents to every TLS client —
-    // and a few KB on a poll no client makes hot, which is cheaper than a second round trip per datasource.
+    // proxy has no wire TLS. Not secret in itself — the proxy presents it to every TLS client — but it is
+    // still connection material, so it rides only on rows the caller may datasource.connect to.
     val advertiseCertChain: String? = null,
     // Whether this datasource's proxy serves client-facing TLS — a separate fact from the chain above, since a
     // proxy may serve a publicly-trusted certificate and publish nothing. A client reads this to know a
     // plaintext greeting must be refused; false means plaintext.
     val advertiseWireTls: Boolean = false,
-)
+) {
+    /**
+     * The same row with everything a caller would need to reach the proxy removed — the advertised address
+     * and certificate chain, and the advisory upstream coordinates. What survives is identity (name, engine,
+     * tags): enough to name the datasource in a JIT access request, not enough to dial it.
+     */
+    fun withoutConnectionMaterial(): Datasource = copy(
+        host = "", port = 0, dbName = "", advertiseAddr = null, advertiseCertChain = null,
+    )
+}
 
 // Admin create/update payload. This is OPTIONAL pre-provisioning only — a way to seed a row
 // (name + advisory connection fields) before its proxy first attaches; the proxy's Register is the
@@ -844,18 +854,36 @@ fun Route.datasourceRoutes(
         ) !is AuthzDecision.Deny
     }
 
-    // The datasource list + detail stay open to every authenticated principal: the SQL editor's picker,
+    // The datasource LIST stays open to every authenticated principal: the SQL editor's picker,
     // JIT-request compose (which must show datasources you CANNOT yet connect to, precisely so they can be
-    // requested), and token generation all need it — not an admin action. `?connectable=true` narrows the
-    // list to datasources the caller can connect to (for the query picker); the CATALOG itself is
-    // connect-gated below. Only mutation/config routes require admin.datasources.
+    // requested), and token generation all need it — not an admin action. `?connectable=true` narrows it to
+    // datasources the caller can connect to (for the query picker), and a row the caller cannot connect to
+    // is served without its connection material. Everything keyed to ONE datasource — the row, its catalog,
+    // its wire cert, its table detail — is connect-gated below. Only mutation/config routes require
+    // admin.datasources.
     get("/api/datasources") {
         // Discovery route: the pmon daemon reads this (with a Bearer wire token) to learn each datasource's
         // engine + advertised proxy address, so it can open a local broker port per datasource.
         val principal = call.requireApiOrBearer(config, tokenStore, userGroupStore) ?: return@get
         val all = management.listDatasources()
         val connectableOnly = call.request.queryParameters["connectable"].equals("true", ignoreCase = true)
-        call.respond(if (connectableOnly) all.filter { mayConnect(call, principal, it) } else all)
+        // The list stays unfiltered by default — JIT-request compose must show datasources you cannot yet
+        // connect to, precisely so they can be requested — but a row you may not connect to is stripped of
+        // its connection material. Otherwise the list answers what {id} and {id}/wire-cert refuse, and
+        // their datasource.connect gate is decorative.
+        //
+        // admin.datasources keeps the full row: administering a datasource means editing the very host/port
+        // it is being stripped of, and that authority is instance-wide, so it resolves once rather than
+        // per row.
+        val isDatasourceAdmin = config.authDebug ||
+            authz.authorize(principal, AuthzAction.ADMIN_DATASOURCES, AuthzResource.System, call.httpAuthzContext(config)) ==
+            AuthzDecision.Allow
+        val visible = when {
+            connectableOnly -> all.filter { mayConnect(call, principal, it) }
+            isDatasourceAdmin -> all
+            else -> all.map { if (mayConnect(call, principal, it)) it else it.withoutConnectionMaterial() }
+        }
+        call.respond(visible)
     }
     // Which datasources currently have a proxy attached (an open Events stream) — the admin liveness
     // view. Read-only; returns the set of attached datasource names.
@@ -890,9 +918,17 @@ fun Route.datasourceRoutes(
         call.respond(HttpStatusCode.Created, management.createDatasource(input.copy(engine = engine.wireName), call.auditActor(config)))
     }
     get("/api/datasources/{id}") {
-        if (!call.requireApi(config)) return@get
+        // Connect-gated, unlike the list: a single row carries advertiseAddr and advertiseCertChain, the
+        // same trust material {id}/wire-cert serves under datasource.connect. Leaving this on
+        // authentication alone would make that gate decorative.
+        val principal = call.requireApiOrBearer(config, tokenStore, userGroupStore) ?: return@get
         val id = call.idParam() ?: return@get call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
-        store.get(id)?.let { call.respond(it) } ?: call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "datasource")))
+        val datasource = store.get(id)
+            ?: return@get call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "datasource")))
+        if (!mayConnect(call, principal, datasource)) {
+            return@get call.respond(HttpStatusCode.Forbidden, ApiError("datasource.not_connectable"))
+        }
+        call.respond(datasource)
     }
     put("/api/datasources/{id}") {
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_DATASOURCES)) return@put
@@ -991,7 +1027,11 @@ fun Route.datasourceRoutes(
         call.respondText(chain, ContentType.parse("application/x-pem-file"))
     }
     get("/api/datasources/{id}/table-detail") {
-        if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_DATASOURCES)) return@get
+        // Same authority as {id}/catalog, and for the same reason: this is the physical shape of a table the
+        // caller may already browse, so gating it on the instance-wide admin action would hide index/FK/size
+        // metadata from exactly the people entitled to query the table. The per-column classifications it
+        // overlays are the ones {id}/catalog already serves under this gate.
+        val principal = call.requireApiOrBearer(config, tokenStore, userGroupStore) ?: return@get
         val id = call.idParam()?.takeIf { it > 0 }
             ?: return@get call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         val schema = call.request.queryParameters["schema"]
@@ -1002,6 +1042,9 @@ fun Route.datasourceRoutes(
         }
         val datasource = store.get(id)
             ?: return@get call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "datasource")))
+        if (!mayConnect(call, principal, datasource)) {
+            return@get call.respond(HttpStatusCode.Forbidden, ApiError("datasource.not_connectable"))
+        }
         try {
             call.respond(management.getTableDetail(datasource.name, schema, table))
         } catch (e: ManagementException) {

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Scim.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Scim.kt
@@ -31,7 +31,6 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
-import java.security.MessageDigest
 import java.sql.SQLException
 import org.slf4j.Logger
 
@@ -206,11 +205,6 @@ internal fun resolveScimTls(
     val asserted = forwardedProto?.split(',')?.lastOrNull()?.trim()
     return asserted.equals("https", ignoreCase = true)
 }
-
-/** Constant-time bearer compare — do NOT replace with `==`/`!=` (see Tokens.kt's ingest-token check
- *  for the naive version this deliberately avoids; a standing SCIM secret is a juicier timing target). */
-private fun constantTimeEquals(a: String, b: String): Boolean =
-    MessageDigest.isEqual(a.toByteArray(Charsets.UTF_8), b.toByteArray(Charsets.UTF_8))
 
 // ---- mapping helpers -----------------------------------------------------------------------------
 

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/SecretTokenInterceptor.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/grpc/SecretTokenInterceptor.kt
@@ -1,5 +1,6 @@
 package com.ridi.oss.proxymonster.controlplane.grpc
 
+import com.ridi.oss.proxymonster.controlplane.constantTimeEquals
 import com.ridi.oss.proxymonster.grpc.WireMetadata
 import io.grpc.Contexts
 import io.grpc.Metadata
@@ -7,7 +8,6 @@ import io.grpc.ServerCall
 import io.grpc.ServerCallHandler
 import io.grpc.ServerInterceptor
 import io.grpc.Status
-import java.security.MessageDigest
 
 /**
  * Gate on the proxy's transport secret (`x-pm-secret-token`, docs/datasource-registration.md).
@@ -33,10 +33,5 @@ class SecretTokenInterceptor(private val expected: String?) : ServerInterceptor 
         }
         val ctx = io.grpc.Context.current().withValue(WireMetadata.SECRET_TOKEN_CTX, presented)
         return Contexts.interceptCall(ctx, call, headers, next)
-    }
-
-    private fun constantTimeEquals(a: String?, b: String): Boolean {
-        if (a == null) return false
-        return MessageDigest.isEqual(a.toByteArray(Charsets.UTF_8), b.toByteArray(Charsets.UTF_8))
     }
 }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/oauth/OAuthRoutes.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/oauth/OAuthRoutes.kt
@@ -17,6 +17,7 @@ import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.CHANNE
 import com.ridi.oss.proxymonster.controlplane.AuthAuditRecorder.Companion.PRINCIPAL_UNATTRIBUTED
 import com.ridi.oss.proxymonster.controlplane.Config
 import com.ridi.oss.proxymonster.controlplane.auditedValue
+import com.ridi.oss.proxymonster.controlplane.constantTimeEquals
 import com.ridi.oss.proxymonster.controlplane.PrincipalSessionStore
 import com.ridi.oss.proxymonster.controlplane.WebSessionRef
 import com.ridi.oss.proxymonster.controlplane.ensureDeviceCookie
@@ -48,7 +49,6 @@ import io.ktor.server.sessions.get
 import io.ktor.server.sessions.sessions
 import io.ktor.server.sessions.set
 import kotlinx.serialization.Serializable
-import java.security.MessageDigest
 import java.sql.Connection
 import java.util.Locale
 import java.util.ResourceBundle
@@ -375,7 +375,7 @@ fun Route.mcpOAuthRoutes(
         if (user == null) return@delete call.respond(HttpStatusCode.Unauthorized, OAuthError("login_required"))
         val expectedCsrf = consentCsrf(config.sessionSecret, user.principal)
         val suppliedCsrf = call.request.headers["X-PM-CSRF"]
-        if (suppliedCsrf == null || !MessageDigest.isEqual(suppliedCsrf.toByteArray(), expectedCsrf.toByteArray())) {
+        if (!constantTimeEquals(suppliedCsrf, expectedCsrf)) {
             return@delete call.respond(HttpStatusCode.BadRequest, OAuthError("invalid_request"))
         }
         if (id == null) return@delete call.respond(HttpStatusCode.BadRequest, OAuthError("invalid_request"))

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DatasourceMetadataConnectGateDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DatasourceMetadataConnectGateDbTest.kt
@@ -1,0 +1,295 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
+import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
+import com.ridi.oss.proxymonster.grpc.Engine
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.server.sessions.Sessions
+import io.ktor.server.sessions.sessions
+import io.ktor.server.sessions.set
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import javax.sql.DataSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The `datasource.connect` gate on the per-datasource metadata reads: `GET /api/datasources/{id}` and
+ * `GET /api/datasources/{id}/table-detail`, plus the list route that carries the same fields.
+ *
+ * These three are one authorization surface, and testing them apart is what lets a hole survive: the
+ * row and the list both carry the `advertiseAddr`/`advertiseCertChain` that `{id}/wire-cert` releases
+ * only under `datasource.connect`, so a gate on any one of them alone is bypassable through the others.
+ *
+ * Pinned per route: unauthenticated is 401, an authenticated caller without `datasource.connect` is
+ * 403, a granted caller is admitted, the grant does not carry from one datasource to another, and the
+ * Bearer path runs the same decision. The list keeps non-connectable rows but strips their connection
+ * material, since JIT-request compose must still show what you cannot yet reach. `authDebug` is off —
+ * with it on every gate short-circuits and this test would prove nothing.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DatasourceMetadataConnectGateDbTest {
+    private lateinit var dataSource: DataSource
+    private lateinit var core: ControlPlaneCore
+    private lateinit var config: Config
+    private lateinit var datasource: Datasource
+    private lateinit var ungranted: Datasource
+
+    private val connector = "connector@example.com"
+    private val stranger = "stranger@example.com"
+
+    private val chainPem =
+        "-----BEGIN CERTIFICATE-----\n" +
+            "MIIBkTCB+wIJAKZ5Zm1kZm1kMA0GCSqGSIb3DQEBCwUAMBUxEzARBgNVBAMTCnBt\n" +
+            "-----END CERTIFICATE-----\n"
+
+    // Bound to ONE datasource by name, not a bare `resource`: an unconstrained permit would still admit a
+    // gate that authorized the wrong datasource (or resolved the resource from the wrong place), so the
+    // second datasource below is what proves the decision is keyed to the row being asked for.
+    private val connectPermit = """permit(
+        principal in Role::"connector",
+        action == Action::"datasource.connect",
+        resource == Datasource::"gated-ds"
+    );"""
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_ds_metadata_gate"))
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        core = ControlPlaneCore(dataSource)
+
+        core.datasourceStore.register(
+            name = "gated-ds", engine = Engine.MYSQL, host = "db", port = 3306, dbName = "app",
+            tags = emptyList(), advertiseAddr = "proxy.example.com:6033",
+            advertiseCertChain = chainPem, advertiseWireTls = true,
+        )
+        datasource = core.datasourceStore.getByName("gated-ds")!!
+
+        // A second datasource nobody is granted: the connector's permit names "gated-ds", so this one must
+        // stay 403 for everyone. Without it the suite could not tell a per-datasource decision from a blanket
+        // "is any connect policy enabled" check.
+        core.datasourceStore.register(
+            name = "other-ds", engine = Engine.MYSQL, host = "db2", port = 3306, dbName = "app",
+            tags = emptyList(), advertiseAddr = "other.example.com:6033",
+            advertiseCertChain = chainPem, advertiseWireTls = true,
+        )
+        ungranted = core.datasourceStore.getByName("other-ds")!!
+
+        val role = core.policyStore.createRole(RoleInput("connector"))
+        core.policyStore.createAssignment(RoleAssignmentInput(connector, role.id))
+        for (p in listOf(connector, stranger)) {
+            core.userGroupStore.createUser(
+                AppUserInput(principal = p), core.tokenStore, core.accessStore,
+                PrincipalSessionStore(dataSource, null),
+            )
+        }
+        core.cedarPolicyStore.create(
+            CedarPolicyInput(name = "ds-metadata-connect", cedarSrc = connectPermit), updatedBy = null,
+        )
+
+        config = Config(
+            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = false, secretToken = null,
+            sessionSecret = "ds-metadata-gate-test-secret", oidc = null, resultKey = null, scimToken = null,
+            sessionWindowSeconds = 3600, idpRecheckIntervalSeconds = 600, devMarker = true,
+        )
+    }
+
+    private fun ApplicationTestBuilder.wire(): HttpClient {
+        application { installRoutes() }
+        return createClient {
+            expectSuccess = false
+            install(HttpCookies)
+            install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+    }
+
+    private fun Application.installRoutes() {
+        val sessionStore = PrincipalSessionStore(dataSource, null)
+        attributes.put(PRINCIPAL_SESSION_STORE, sessionStore)
+        install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
+        install(Sessions) { webSessionCookie(sessionStore, config.sessionSecret) }
+        routing {
+            post("/test/session/{principal}") {
+                val deviceId = call.ensureDeviceCookie(secure = false)
+                call.sessions.set(
+                    WebSessionRef(
+                        sessionStore.mintWeb(
+                            requireNotNull(call.parameters["principal"]),
+                            null,
+                            config.webSessionAbsoluteSeconds,
+                            config.webSessionIdleSeconds,
+                            deviceId,
+                        ),
+                    ),
+                )
+                call.respond(HttpStatusCode.NoContent)
+            }
+            datasourceRoutes(
+                config, core.authz, core.roleResolver, core.datasourceStore, core.proxyEventsHub,
+                TableDetailService(core), core.tokenStore, core.userGroupStore,
+            )
+        }
+    }
+
+    @Test
+    fun `the datasource row is 401 unauthenticated`() = testApplication {
+        val client = wire()
+        val res = client.get("/api/datasources/${datasource.id}")
+        assertEquals(HttpStatusCode.Unauthorized, res.status)
+        assertFalse(
+            res.bodyAsText().contains("BEGIN CERTIFICATE"),
+            "an unauthenticated response must not carry the advertised chain",
+        )
+    }
+
+    /**
+     * The decision is keyed to the datasource being asked for. The connector's permit names `gated-ds`, so
+     * the SAME session must be admitted there and refused here — the assertion an unconstrained `resource`
+     * permit could not make.
+     */
+    @Test
+    fun `a connect grant on one datasource does not carry to another`() = testApplication {
+        val client = wire()
+        client.post("/test/session/$connector")
+        assertEquals(HttpStatusCode.OK, client.get("/api/datasources/${datasource.id}").status)
+        assertEquals(
+            HttpStatusCode.Forbidden, client.get("/api/datasources/${ungranted.id}").status,
+            "the grant names one datasource; a gate keyed to anything coarser would admit both",
+        )
+        assertEquals(
+            HttpStatusCode.Forbidden,
+            client.get("/api/datasources/${ungranted.id}/table-detail?schema=app&table=t").status,
+        )
+    }
+
+    /**
+     * The Bearer path is why these routes use `requireApiOrBearer` rather than `requireApi`: pmon holds a
+     * wire token, not a cookie. Swapping the helper back would leave every session test passing.
+     */
+    @Test
+    fun `a wire-token Bearer caller is authorized by the same connect decision`() = testApplication {
+        val token = core.tokenStore.issue(
+            TokenKind.USER, connector, roles = emptyList(), name = "gate-test", ttlSeconds = 300,
+        )
+        val client = wire()
+        val granted = client.get("/api/datasources/${datasource.id}") {
+            header(HttpHeaders.Authorization, "Bearer ${token.token}")
+        }
+        assertEquals(HttpStatusCode.OK, granted.status, "a wire token is a valid identity on this route")
+        val refused = client.get("/api/datasources/${ungranted.id}") {
+            header(HttpHeaders.Authorization, "Bearer ${token.token}")
+        }
+        assertEquals(
+            HttpStatusCode.Forbidden, refused.status,
+            "the Bearer path must run the same per-datasource decision, not skip it",
+        )
+    }
+
+    @Test
+    fun `the datasource row is 403 without datasource-connect, chain withheld`() = testApplication {
+        val client = wire()
+        client.post("/test/session/$stranger")
+        val res = client.get("/api/datasources/${datasource.id}")
+        assertEquals(
+            HttpStatusCode.Forbidden, res.status,
+            "the row carries the same advertiseCertChain {id}/wire-cert gates on datasource.connect; " +
+                "admitting it on a session alone makes that gate decorative",
+        )
+        assertFalse(res.bodyAsText().contains("BEGIN CERTIFICATE"), "a forbidden response must not carry the chain")
+    }
+
+    @Test
+    fun `a granted caller reads the datasource row`() = testApplication {
+        val client = wire()
+        client.post("/test/session/$connector")
+        assertEquals(HttpStatusCode.OK, client.get("/api/datasources/${datasource.id}").status)
+    }
+
+    /**
+     * The list is the alternate path to the same bytes: filtering it would break JIT-request compose (which
+     * must show datasources you cannot yet connect to), so the row survives with its connection material
+     * stripped. Without this the `{id}` gate above is bypassable by asking for the list instead.
+     */
+    @Test
+    fun `the list keeps non-connectable rows but strips their connection material`() = testApplication {
+        val client = wire()
+        client.post("/test/session/$stranger")
+        val res = client.get("/api/datasources")
+        assertEquals(HttpStatusCode.OK, res.status)
+        val body = res.bodyAsText()
+        assertTrue(body.contains("gated-ds"), "the datasource must stay visible so it can be requested")
+        assertFalse(
+            body.contains("BEGIN CERTIFICATE"),
+            "the list must not answer what {id} and {id}/wire-cert refuse; got: $body",
+        )
+        assertFalse(body.contains("proxy.example.com"), "the advertised address is connection material too")
+    }
+
+    @Test
+    fun `the list keeps connection material for a connectable row`() = testApplication {
+        val client = wire()
+        client.post("/test/session/$connector")
+        val body = client.get("/api/datasources").bodyAsText()
+        assertTrue(body.contains("BEGIN CERTIFICATE"), "a caller granted connect must still get the chain")
+        assertTrue(body.contains("proxy.example.com"), "a caller granted connect must still get the address")
+    }
+
+    @Test
+    fun `table-detail is 401 unauthenticated`() = testApplication {
+        val client = wire()
+        val res = client.get("/api/datasources/${datasource.id}/table-detail?schema=app&table=t")
+        assertEquals(HttpStatusCode.Unauthorized, res.status)
+    }
+
+    @Test
+    fun `table-detail is 403 without datasource-connect`() = testApplication {
+        val client = wire()
+        client.post("/test/session/$stranger")
+        val res = client.get("/api/datasources/${datasource.id}/table-detail?schema=app&table=t")
+        assertEquals(
+            HttpStatusCode.Forbidden, res.status,
+            "table-detail overlays the same classifications {id}/catalog serves under datasource.connect",
+        )
+    }
+
+    /**
+     * The gate must clear for a granted caller. No proxy is attached here, so the route runs past
+     * authorization and fails at dispatch — asserted as the exact 502 the no-proxy path maps to, not merely
+     * "not 403": a 500 from any unrelated crash would satisfy the weaker claim and hide a broken gate.
+     */
+    @Test
+    fun `a granted caller passes the table-detail gate and fails at proxy dispatch`() = testApplication {
+        val client = wire()
+        client.post("/test/session/$connector")
+        val res = client.get("/api/datasources/${datasource.id}/table-detail?schema=app&table=t")
+        assertEquals(HttpStatusCode.BadGateway, res.status, "expected the no-proxy dispatch failure past the gate")
+        assertTrue(
+            res.bodyAsText().contains("table_introspection_failed"),
+            "expected datasource.table_introspection_failed, got: ${res.bodyAsText()}",
+        )
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TableDetailDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TableDetailDbTest.kt
@@ -102,7 +102,15 @@ class TableDetailDbTest {
         datasourceStore = core.datasourceStore
         policyStore = core.policyStore
         val cedarStore = CedarPolicyStore(metadata)
-        authz = Authz(CedarEngine(emptyList()), cedarStore, RoleSource { emptySet() })
+        // This suite exercises detail ASSEMBLY, not the connect gate (DatasourceMetadataConnectGateDbTest
+        // owns that), so the engine carries an outright connect permit rather than leaning on PM_AUTH_DEBUG —
+        // the flag bypasses authentication, never the Cedar decision, so a route reached under it still needs
+        // a grant. The permit goes to the ENGINE, which is what authorize() reads.
+        authz = Authz(
+            CedarEngine(listOf(1L to """permit(principal, action == Action::"datasource.connect", resource);""")),
+            cedarStore,
+            RoleSource { emptySet() },
+        )
         postgres = createFixture("detail-postgres", "postgres", "detail_schema", "detail_pg")
         mysql = createFixture("detail-mysql", "mysql", "detail_mysql", "detail_my")
         fakeProxies += FakeTableDetailProxy(core, postgres.datasource.name) { schema, table ->

--- a/docs/authz-model.md
+++ b/docs/authz-model.md
@@ -341,7 +341,7 @@ of a route and the gate it calls. Paths are relative to
 | Audit ingest (from the proxy) | `/api/ingest/decision` | `App.kt` | `X-PM-Ingest-Token` vs `PM_SECRET_TOKEN`; open when that env is unset (dev only) |
 | Audit read | `/api/audit`, `/api/audit/{id}` | `AuditRoutes.kt` | `requireApi` + Cedar `audit.read` — allow on `AuditLog` returns all rows, else own rows only |
 | Caller capability summary | `/api/me/permissions` | `App.kt` | `requireApi`; UI convenience, computed from `admin.*` + `audit.read` |
-| Datasources, catalog, classification | `/api/datasources**` | `Datasources.kt` | mixed: list = `requireApiOrBearer`; `live`, `{id}` = `requireApi`; `{id}/catalog` = `requireApi` + `datasource.connect`; rest = `requireAdmin(admin.datasources)` |
+| Datasources, catalog, classification | `/api/datasources**` | `Datasources.kt` | mixed: list = `requireApiOrBearer`, redacting non-connectable rows; `live` = `requireApi`; `{id}`, `{id}/catalog`, `{id}/wire-cert`, `{id}/table-detail` = `requireApiOrBearer` + `datasource.connect`; rest = `requireAdmin(admin.datasources)` |
 | One-shot editor query | `/api/datasources/{id}/query` | `Query.kt` | `requireApi`, then the per-statement `decideQuery` |
 | Editor sessions and tasks | `/api/editor/**` | `Query.kt` | `requireApi` + owner scope; cancel adds `task.cancel`, result adds `task.assume` |
 | Task-completion SSE | `/api/tasks/events` | `App.kt` | resolves the session itself; each push re-filtered through `task.read` |
@@ -391,23 +391,43 @@ Two exceptions to "session or nothing":
 - `POST /api/ingest/decision` is the proxy's audit-ingest path. It checks
   `X-PM-Ingest-Token` against `PM_SECRET_TOKEN` — and when that env is unset the
   gate is open to any caller, which is dev-only.
-- `GET /api/datasources` is the one `/api/**` route that also accepts
+- The read-only datasource routes (`GET /api/datasources` and the per-datasource
+  `{id}`, `{id}/catalog`, `{id}/wire-cert`, `{id}/table-detail`) also accept
   `Authorization: Bearer <wire token>` (`requireApiOrBearer`, private to
   `Datasources.kt`), because `pmon` must discover datasources without a browser
   cookie. Only the native-wire kinds `SESSION` and `USER` are accepted; `EDITOR`
   and `APPROVER_EXEC` are rejected, and a deactivated principal's surviving
   token fails closed. Roles are still resolved server-side, so this is an extra
-  authentication surface, not a privilege grant, and it is wired into this one
-  read-only route: a leaked wire token cannot mutate a datasource or mint
-  another credential over HTTP.
+  authentication surface, not a privilege grant, and it is wired into read-only
+  routes only: a leaked wire token cannot mutate a datasource or mint another
+  credential over HTTP.
 
 `GET /api/datasources?connectable=true` narrows the list to datasources the
 caller may `datasource.connect` to — the same name-keyed Cedar decision, with
 derived context tags, the proxy runs on connect. The unfiltered default is
 deliberate: JIT-request compose must show datasources you cannot yet connect to,
-precisely so they can be requested. The catalog itself
-(`GET /api/datasources/{id}/catalog`) is connect-gated, returning
-`datasource.not_connectable` otherwise.
+precisely so they can be requested. Everything keyed to one datasource is
+connect-gated, returning `datasource.not_connectable` otherwise: the row itself
+(`{id}`, which carries the advertised address and certificate chain), its
+catalog, its wire certificate, and its live table detail. Reading a table's
+physical shape needs the same authority as querying it.
+
+The unfiltered list is the alternate path to those same bytes, so it redacts
+rather than filters: a row the caller cannot connect to keeps its identity
+(name, engine, tags) and loses its connection material — `host`, `port`,
+`dbName`, `advertiseAddr`, `advertiseCertChain`. Enough to name in an access
+request, not enough to dial. `admin.datasources` receives the full row, since
+administering a datasource means editing the fields being stripped.
+
+`admin.datasources` does **not** imply any of the four connect-gated reads. The
+seeded `system:admin` role carries the three `admin.*` actions and no
+`datasource.connect` — it is administrative, not a data reader — so on a stock
+install an admin who holds no connect grant gets `datasource.not_connectable`
+from all four, `{id}/table-detail` included. That is deliberate: classification
+and policy work run off `{id}/catalog`, which has always required connect, and
+the console reaches `{id}/table-detail` only from the SQL editor's table
+browser. An operator who wants admins browsing live table metadata grants them a
+connect policy, the same one that lets them query it.
 
 ## What this fixes (falls out of the model, not bolted on)
 

--- a/docs/authz-model.md
+++ b/docs/authz-model.md
@@ -416,18 +416,25 @@ The unfiltered list is the alternate path to those same bytes, so it redacts
 rather than filters: a row the caller cannot connect to keeps its identity
 (name, engine, tags) and loses its connection material — `host`, `port`,
 `dbName`, `advertiseAddr`, `advertiseCertChain`. Enough to name in an access
-request, not enough to dial. `admin.datasources` receives the full row, since
-administering a datasource means editing the fields being stripped.
+request, not enough to dial. There is no admin exemption: a list row that
+answered more fully than `{id}` does would simply be a way around `{id}`.
 
-`admin.datasources` does **not** imply any of the four connect-gated reads. The
-seeded `system:admin` role carries the three `admin.*` actions and no
+`admin.datasources` does **not** imply any of these reads. The seeded
+`system:admin` role carries the three `admin.*` actions and no
 `datasource.connect` — it is administrative, not a data reader — so on a stock
 install an admin who holds no connect grant gets `datasource.not_connectable`
-from all four, `{id}/table-detail` included. That is deliberate: classification
-and policy work run off `{id}/catalog`, which has always required connect, and
-the console reaches `{id}/table-detail` only from the SQL editor's table
-browser. An operator who wants admins browsing live table metadata grants them a
-connect policy, the same one that lets them query it.
+from all four per-datasource routes, `{id}/table-detail` included, and redacted
+rows from the list. That is deliberate: classification and policy work run off
+`{id}/catalog`, which has always required connect, and the console reaches
+`{id}/table-detail` only from the SQL editor's table browser. An operator who
+wants admins browsing live table metadata grants them a connect policy, the same
+one that lets them query it.
+
+`PM_AUTH_DEBUG` does not short-circuit the connect decision either. It is an
+authentication bypass, and `POST /auth/debug` persists its claimed roles as real
+assignments precisely so Cedar evaluates them — so a dev session sees exactly
+what its roles grant. A bare `PM_AUTH_DEBUG=1` with no debug login resolves to a
+principal with no roles, and therefore reads no connection material.
 
 ## What this fixes (falls out of the model, not bolted on)
 


### PR DESCRIPTION
`GET /api/datasources/{id}/table-detail` required the instance-wide `admin.datasources` action, so a developer who could browse a datasource's catalog — PII badges included — got "no policy permits this action" on the Columns/Indexes/Relations/Metadata tabs. It now runs the same Cedar `datasource.connect` decision as `{id}/catalog` and `{id}/wire-cert`.

Two sibling holes fell out of fixing it, since all three routes serve the same bytes:

- `GET /api/datasources/{id}` was authentication-only, no Cedar, and returns `advertiseAddr` + `advertiseCertChain` — the material `{id}/wire-cert` gates. Now connect-gated.
- `GET /api/datasources` (the list) served those same fields to any authenticated caller, which would have left the other two gates bypassable. It stays unfiltered — JIT-request compose must show datasources you cannot yet connect to — but a non-connectable row is stripped of `host`/`port`/`dbName`/`advertiseAddr`/`advertiseCertChain`.

Third commit closes two bypasses of the gate this PR adds. `PM_AUTH_DEBUG` is an authentication bypass, but `mayConnect` was also treating it as an authorization one (`if (authDebug) return true`), skipping Cedar entirely for all four per-datasource reads. And the list route briefly exempted `admin.datasources` from redaction — since `{id}` has no admin arm, an admin-readable list row was just a way around `{id}`.

Second commit: the ingest token was compared with `!=`, a timing oracle on a standing secret that writes into the tamper-evident audit chain. One shared `constantTimeEquals` now backs all four standing-secret checks (ingest, SCIM bearer, gRPC transport secret, OAuth consent CSRF — that last is an HMAC of the session secret, not a per-request nonce).

## Where it could bite

`admin.datasources` does **not** imply `datasource.connect`, and the seeded `system:admin` role carries no connect grant. On a stock install an admin without one gets 403 from the four per-datasource reads and redacted rows from the list. Deliberate and documented in `docs/authz-model.md`: classification work runs off `{id}/catalog`, which has always required connect, and the console reaches `table-detail` only from the SQL editor's table browser.

A bare `PM_AUTH_DEBUG=1` with no `/auth/debug` login now resolves to a principal with no roles, so it reads no connection material. Logging in via `/auth/debug` works as before — it persists claimed roles as real assignments, which is why the bypass was unnecessary.

Known follow-up: ~8 other sites still use `authDebug` to skip a Cedar decision (`Approvals`, `Access`, `Query`, `AuditRoutes`). Being fixed separately; `mayConnect` is in scope here because it gates these routes.

## Verification

`mise run verify` green. New `DatasourceMetadataConnectGateDbTest` (10 cases) pins per route: 401 unauthenticated, 403 without connect, admitted with it, a grant on one datasource not carrying to another, the Bearer/pmon path running the same decision, and the list redaction in both directions. Mutation-tested — removing the gate fails exactly the 403 cases and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEUc883LA49F1oKZxwvBnh