### PR TITLE
fix(engine): classify value-bearing system tables away from catalog

### DIFF
--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/MySqlSummaryTableLeakDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/MySqlSummaryTableLeakDbTest.kt
@@ -1,0 +1,94 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.grpc.EnfAction
+import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
+import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end regression on real MySQL + real Cedar for the value-bearing summary-table leak: on a CERTIFIED
+ * (governed) MySQL datasource, `performance_schema.user_variables_by_thread` and the `sys.x$…` statistics
+ * twins used to default to `system:catalog` and were readable by any viewer through the role-agnostic
+ * catalog permit. With the manifest families added they carry a dangerous tag, so the shipped forbid denies
+ * them even under a broad Datasource grant. The `mysql`/`performance_schema` system DBs are not in the
+ * fixture's introspected catalog (connection privileges), so the tables are seeded explicitly — this
+ * exercises the tag→Cedar path, not introspection. The named-table deny reason distinguishes the tag forbid
+ * overriding the broad grant from an uncovered deny.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MySqlSummaryTableLeakDbTest {
+    private lateinit var fx: EnforcementFixture
+    private val classifier = SystemClassificationService()
+    private val broad = "summary-broad@example.com"
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        fx = EnforcementFixture.mysql()
+        fx.datasourceStore.storePushedCatalog(
+            id = fx.datasource.id,
+            defaultSchemas = listOf(fx.datasource.dbName),
+            mysqlLowerCaseTableNames = 0,
+            engineVersion = "8.0.44",
+            columns = listOf(
+                DatasourceStore.PushedColumn("performance_schema", "user_variables_by_thread", "VARIABLE_NAME", "varchar", 1, true),
+                DatasourceStore.PushedColumn("performance_schema", "user_variables_by_thread", "VARIABLE_VALUE", "longtext", 2, true),
+                DatasourceStore.PushedColumn("sys", "x\$schema_table_statistics", "table_name", "varchar", 1, true),
+                // A genuinely structural catalog view stays browsable — proves the fix did not over-classify.
+                DatasourceStore.PushedColumn("information_schema", "TABLES", "TABLE_NAME", "varchar", 1, true),
+            ),
+        )
+        fx.dataSource.connection.use { c ->
+            c.prepareStatement("UPDATE datasource SET tags = '[\"system:production\"]'::jsonb WHERE id = ?").use {
+                it.setLong(1, fx.datasource.id)
+                it.executeUpdate()
+            }
+        }
+        val role = fx.policyStore.createRole(RoleInput("summary-broad-reader"))
+        fx.policyStore.createAssignment(RoleAssignmentInput(broad, role.id))
+        fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "test-summary-broad-grant",
+                cedarSrc = """permit(principal in Role::"summary-broad-reader", action, resource in Datasource::"${fx.datasource.name}");""",
+            ),
+            updatedBy = "test",
+        )
+    }
+
+    // Decide with the classifier active, OR with it disabled (null) — the null run is the control: with no
+    // system tag the broad Datasource grant permits the read, so an ALLOW there proves the grant is live and
+    // the table is analyzable; flipping to DENY only when the classifier is present proves the tag is what
+    // closes it (not deny-by-default, which would deny in both runs).
+    private fun decide(who: String, sql: String, classify: SystemClassificationService?) = decideQuery(
+        principal = who, ds = fx.datasourceStore.get(fx.datasource.id)!!, sql = sql, channel = Channel.WIRE,
+        catalog = fx.datasourceStore.catalog(fx.datasource.id), policyStore = fx.policyStore, accessStore = fx.accessStore,
+        userGroupStore = fx.userGroupStore, roleResolver = fx.roleResolver, authz = fx.authz,
+        systemClassification = classify,
+    )
+
+    @Test
+    fun `governed value-bearing summary tables deny under a broad grant while structural catalog still browses`() {
+        // count(*) exercises the table gate — the surface this classification closes.
+        val targets = listOf(
+            "select count(*) from performance_schema.user_variables_by_thread",
+            "select count(*) from sys.x\$schema_table_statistics",
+        )
+        for (sql in targets) {
+            val table = sql.substringAfter("from ").trim()
+            // Control: with the classifier OFF, the broad grant permits the read.
+            assertEquals(EnfAction.ALLOW, decide(broad, sql, null).action, "broad grant permits [$sql] with no classifier (control)")
+            // With the classifier ON, the tag forbid overrides that same broad grant, and the deny names the
+            // table (the tag-forbid table path), not an unrelated stage.
+            val ctx = decide(broad, sql, classifier)
+            assertEquals(EnfAction.DENY, ctx.action, "classifier tag must deny [$sql] (reason=${ctx.denyReason})")
+            assertTrue(ctx.denyReason.orEmpty().contains(table.substringAfter('.')), "deny must name $table: ${ctx.denyReason}")
+        }
+        // Structural catalog metadata is unchanged — still browsable with the classifier on.
+        assertEquals(EnfAction.ALLOW, decide(broad, "select count(*) from information_schema.TABLES", classifier).action, "structural catalog still browses")
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationServiceTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationServiceTest.kt
@@ -43,6 +43,70 @@ class SystemClassificationServiceTest {
         assertEquals("system:catalog", svc.tagForTable(Engine.MYSQL, auroraMysql, "def", "information_schema", "TABLES"))
     }
 
+    // Value-bearing MySQL system tables were absent from the manifest, so they defaulted to system:catalog and
+    // the role-agnostic catalog read permit exposed them to any viewer. This is a representative sample of the
+    // audit set (the full set is data in the manifests); structural metadata must still resolve to catalog.
+    @Test
+    fun `value-bearing MySQL system tables are classified, structural stays catalog`() {
+        fun tag(schema: String, table: String) = { v: String -> svc.tagForTable(Engine.MYSQL, v, "def", schema, table) }
+        val cases = listOf<Pair<String, (String) -> String?>>(
+            // critical — key/credential/code-load material (never relaxed).
+            "system:critical" to tag("performance_schema", "keyring_component_status"),
+            "system:critical" to tag("performance_schema", "user_defined_functions"),
+            "system:critical" to tag("performance_schema", "variables_by_thread"),
+            // data-leak — data values / user content / per-table statistics (relaxed on dev).
+            "system:data-leak" to tag("performance_schema", "user_variables_by_thread"),
+            "system:data-leak" to tag("performance_schema", "session_connect_attrs"),
+            "system:data-leak" to tag("performance_schema", "table_io_waits_summary_by_table"),
+            "system:data-leak" to tag("information_schema", "INNODB_FT_INDEX_CACHE"),
+            "system:data-leak" to tag("information_schema", "ROLE_TABLE_GRANTS"),
+            "system:data-leak" to tag("sys", "x\$schema_table_statistics"),
+            // activity — live/session/monitoring (relaxed on dev); replication topology demoted here.
+            "system:activity" to tag("performance_schema", "accounts"),
+            "system:activity" to tag("performance_schema", "host_cache"),
+            "system:activity" to tag("performance_schema", "socket_instances"),
+            "system:activity" to tag("performance_schema", "replication_asynchronous_connection_failover"),
+            "system:activity" to tag("mysql", "slave_relay_log_info"),
+            "system:activity" to tag("sys", "host_summary_by_file_io"),
+            "system:activity" to tag("sys", "x\$io_global_by_file_by_bytes"),
+            // structural definitions / config knobs / reference stay browsable.
+            "system:catalog" to tag("information_schema", "TABLES"),
+            "system:catalog" to tag("performance_schema", "setup_instruments"),
+            "system:catalog" to tag("sys", "version"),
+        )
+        for (v in listOf("8.0.44", "8.4.0")) {
+            for ((want, get) in cases) assertEquals(want, get(v), "$v: expected $want")
+        }
+    }
+
+    @Test
+    fun `value-bearing PostgreSQL system relations are classified, structural stays catalog`() {
+        for (v in listOf("PostgreSQL 16.4 on x86_64", "PostgreSQL 17.2 on x86_64")) {
+            // Live session/monitoring views — activity (exact rules, not a pg_replication_ family: that
+            // family would over-catch the structural pg_replication_origin).
+            assertEquals("system:activity", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_stat_activity"), v)
+            assertEquals("system:activity", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_statio_user_tables"), v)
+            assertEquals("system:activity", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_replication_slots"), v)
+            assertEquals("system:activity", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_replication_origin_status"), v)
+            // FDW option views expose raw srvoptions/fdwoptions — critical, mirroring the already-critical
+            // public foreign_server_options / pg_foreign_server twins; _pg_user_mappings exposes umoptions.
+            assertEquals("system:critical", svc.tagForTable(Engine.POSTGRES, v, "app", "information_schema", "_pg_user_mappings"), v)
+            assertEquals("system:critical", svc.tagForTable(Engine.POSTGRES, v, "app", "information_schema", "_pg_foreign_servers"), v)
+            assertEquals("system:critical", svc.tagForTable(Engine.POSTGRES, v, "app", "information_schema", "_pg_foreign_data_wrappers"), v)
+            // Grant/privilege views expose the access model — data-leak, parity with the MySQL role_*_grants.
+            assertEquals("system:data-leak", svc.tagForTable(Engine.POSTGRES, v, "app", "information_schema", "role_table_grants"), v)
+            assertEquals("system:data-leak", svc.tagForTable(Engine.POSTGRES, v, "app", "information_schema", "table_privileges"), v)
+            // pg_sequences.last_value reveals row/txn volume — data-leak (parity with MySQL schema_auto_increment_columns).
+            assertEquals("system:data-leak", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_sequences"), v)
+            // Structural catalog stays browsable. pg_statistic_ext (extended-stats DEFINITION, no override rule)
+            // proves pg_stat_ is precise — it is NOT swept to activity; and pg_replication_origin (structural
+            // origin ids) is NOT over-caught now that the pg_replication_ family was replaced by exacts.
+            assertEquals("system:catalog", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_class"), v)
+            assertEquals("system:catalog", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_statistic_ext"), v)
+            assertEquals("system:catalog", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_replication_origin"), v)
+        }
+    }
+
     @Test
     fun `Aurora PostgreSQL resolves to the PG major manifest`() {
         val auroraPg = "PostgreSQL 17.4 on x86_64 (aurora 17.4...)"
@@ -60,10 +124,13 @@ class SystemClassificationServiceTest {
         assertEquals("system:critical", svc.tagForTable(Engine.MYSQL, null, "def", "mysql", "user"))
         // An explicit data-leak stays data-leak (kept so its own forbid + the system:development relaxation apply).
         assertEquals("system:data-leak", svc.tagForTable(Engine.MYSQL, null, "def", "information_schema", "COLUMN_STATISTICS"))
-        // A catalog-default table (no explicit dangerous rule) is closed as critical, not opened as catalog.
+        // A catalog-default table (structural, no explicit dangerous rule) is closed as critical, not catalog.
         assertEquals("system:critical", svc.tagForTable(Engine.POSTGRES, null, "acme", "pg_catalog", "pg_class"))
-        // An unrecognized table in a fixed system schema (not in any shipped manifest) is likewise closed.
-        assertEquals("system:critical", svc.tagForTable(Engine.MYSQL, null, "def", "performance_schema", "user_variables_by_thread"))
+        // An unrecognized table in a fixed system schema (in no shipped manifest) is likewise closed as critical.
+        assertEquals("system:critical", svc.tagForTable(Engine.MYSQL, null, "def", "performance_schema", "not_a_real_pfs_table_xyz"))
+        // A table the manifest DOES classify dangerous keeps that explicit tag even with no governing version
+        // (the floor keeps an explicit critical/data-leak/activity) — user_variables_by_thread is data-leak.
+        assertEquals("system:data-leak", svc.tagForTable(Engine.MYSQL, null, "def", "performance_schema", "user_variables_by_thread"))
         // A catalog-mismatched MySQL system table (schema matches, catalog is not "def") must not downgrade to
         // catalog — it is still closed.
         assertEquals("system:critical", svc.tagForTable(Engine.MYSQL, null, "not-def", "mysql", "user"))

--- a/engine/src/main/resources/system-classification/mysql/8.0.json
+++ b/engine/src/main/resources/system-classification/mysql/8.0.json
@@ -272,6 +272,211 @@
       "schema": "sys",
       "name": "x$innodb_lock_waits",
       "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "user_defined_functions",
+      "tag": "system:critical"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "session_connect_attrs",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "session_account_connect_attrs",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "replication_connection_status",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "accounts",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "hosts",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "users",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "host_cache",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "binary_log_transaction_compression_stats",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "file_instances",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "global_status",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "session_status",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "table_handles",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "innodb_redo_log_files",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "log_status",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "tls_channel_status",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "replication_applier_configuration",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "replication_applier_status",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "replication_applier_filters",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "replication_applier_global_filters",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "replication_group_members",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "replication_group_member_stats",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "name": "schema_auto_increment_columns",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "sys",
+      "name": "schema_tables_with_full_table_scans",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "sys",
+      "name": "x$schema_tables_with_full_table_scans",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "sys",
+      "name": "x$ps_schema_table_statistics_io",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "sys",
+      "name": "latest_file_io",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "name": "x$latest_file_io",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "name": "metrics",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "name": "ps_check_lost_instrumentation",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "name": "schema_table_lock_waits",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "name": "x$schema_table_lock_waits",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "name": "session_ssl_status",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_column_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_routine_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_table_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "innodb_ft_index_cache",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "innodb_ft_index_table",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "mysql",
+      "name": "slave_relay_log_info",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "mysql",
+      "name": "slave_worker_info",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "objects_summary_global_by_type",
+      "tag": "system:activity"
     }
   ],
   "relationFamilies": [
@@ -348,6 +553,161 @@
     {
       "schema": "sys",
       "prefix": "x$user_summary_by_statement",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "user_variables_by_",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "status_by_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "variables_by_",
+      "tag": "system:critical"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$schema_table_statistics",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$schema_index_statistics",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "keyring_",
+      "tag": "system:critical"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "replication_asynchronous_connection_failover",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "table_io_waits_summary_",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "table_lock_waits_summary_",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "replication_applier_status_by_",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "events_errors_summary_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "events_waits_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "file_summary_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "memory_summary_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "socket_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "innodb_buffer_stats_by_",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$innodb_buffer_stats_by_",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "sys",
+      "prefix": "host_summary",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$host_summary",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "user_summary",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$user_summary",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "io_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$io_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "memory_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$memory_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "waits_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$waits_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "wait_classes_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$wait_classes_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$ps_digest_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "mysql",
+      "prefix": "replication_asynchronous_connection_failover",
       "tag": "system:activity"
     }
   ],

--- a/engine/src/main/resources/system-classification/mysql/8.4.json
+++ b/engine/src/main/resources/system-classification/mysql/8.4.json
@@ -272,6 +272,211 @@
       "schema": "sys",
       "name": "x$innodb_lock_waits",
       "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "user_defined_functions",
+      "tag": "system:critical"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "session_connect_attrs",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "session_account_connect_attrs",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "replication_connection_status",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "accounts",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "hosts",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "users",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "host_cache",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "binary_log_transaction_compression_stats",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "file_instances",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "global_status",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "session_status",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "table_handles",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "innodb_redo_log_files",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "log_status",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "tls_channel_status",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "replication_applier_configuration",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "replication_applier_status",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "replication_applier_filters",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "replication_applier_global_filters",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "replication_group_members",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "replication_group_member_stats",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "name": "schema_auto_increment_columns",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "sys",
+      "name": "schema_tables_with_full_table_scans",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "sys",
+      "name": "x$schema_tables_with_full_table_scans",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "sys",
+      "name": "x$ps_schema_table_statistics_io",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "sys",
+      "name": "latest_file_io",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "name": "x$latest_file_io",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "name": "metrics",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "name": "ps_check_lost_instrumentation",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "name": "schema_table_lock_waits",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "name": "x$schema_table_lock_waits",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "name": "session_ssl_status",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_column_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_routine_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_table_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "innodb_ft_index_cache",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "innodb_ft_index_table",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "mysql",
+      "name": "slave_relay_log_info",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "mysql",
+      "name": "slave_worker_info",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "name": "objects_summary_global_by_type",
+      "tag": "system:activity"
     }
   ],
   "relationFamilies": [
@@ -348,6 +553,161 @@
     {
       "schema": "sys",
       "prefix": "x$user_summary_by_statement",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "user_variables_by_",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "status_by_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "variables_by_",
+      "tag": "system:critical"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$schema_table_statistics",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$schema_index_statistics",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "keyring_",
+      "tag": "system:critical"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "replication_asynchronous_connection_failover",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "table_io_waits_summary_",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "table_lock_waits_summary_",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "replication_applier_status_by_",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "events_errors_summary_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "events_waits_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "file_summary_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "memory_summary_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "performance_schema",
+      "prefix": "socket_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "innodb_buffer_stats_by_",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$innodb_buffer_stats_by_",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "sys",
+      "prefix": "host_summary",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$host_summary",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "user_summary",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$user_summary",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "io_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$io_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "memory_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$memory_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "waits_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$waits_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "wait_classes_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$wait_classes_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "sys",
+      "prefix": "x$ps_digest_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "mysql",
+      "prefix": "replication_asynchronous_connection_failover",
       "tag": "system:activity"
     }
   ],

--- a/engine/src/main/resources/system-classification/postgres/16.json
+++ b/engine/src/main/resources/system-classification/postgres/16.json
@@ -204,6 +204,146 @@
       "schema": "pg_catalog",
       "name": "aurora_global_db_instance_status",
       "tag": "system:activity"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_prepared_xacts",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_subscription_rel",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "information_schema",
+      "name": "_pg_user_mappings",
+      "tag": "system:critical"
+    },
+    {
+      "schema": "information_schema",
+      "name": "_pg_foreign_servers",
+      "tag": "system:critical"
+    },
+    {
+      "schema": "information_schema",
+      "name": "_pg_foreign_data_wrappers",
+      "tag": "system:critical"
+    },
+    {
+      "schema": "information_schema",
+      "name": "_pg_foreign_tables",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "_pg_foreign_table_columns",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "foreign_table_options",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "column_options",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_column_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_routine_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_table_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_udt_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_usage_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "column_privileges",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "table_privileges",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "routine_privileges",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "udt_privileges",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "usage_privileges",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "enabled_roles",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "applicable_roles",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "administrable_role_authorizations",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_foreign_table",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_sequences",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_backend_memory_contexts",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_shmem_allocations",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_replication_slots",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_replication_origin_status",
+      "tag": "system:activity"
     }
   ],
   "relationFamilies": [
@@ -215,6 +355,16 @@
     {
       "schema": "pg_catalog",
       "prefix": "aurora_stat_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "pg_catalog",
+      "prefix": "pg_stat_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "pg_catalog",
+      "prefix": "pg_statio_",
       "tag": "system:activity"
     }
   ],

--- a/engine/src/main/resources/system-classification/postgres/17.json
+++ b/engine/src/main/resources/system-classification/postgres/17.json
@@ -204,6 +204,146 @@
       "schema": "pg_catalog",
       "name": "aurora_global_db_instance_status",
       "tag": "system:activity"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_prepared_xacts",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_subscription_rel",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "information_schema",
+      "name": "_pg_user_mappings",
+      "tag": "system:critical"
+    },
+    {
+      "schema": "information_schema",
+      "name": "_pg_foreign_servers",
+      "tag": "system:critical"
+    },
+    {
+      "schema": "information_schema",
+      "name": "_pg_foreign_data_wrappers",
+      "tag": "system:critical"
+    },
+    {
+      "schema": "information_schema",
+      "name": "_pg_foreign_tables",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "_pg_foreign_table_columns",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "foreign_table_options",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "column_options",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_column_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_routine_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_table_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_udt_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "role_usage_grants",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "column_privileges",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "table_privileges",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "routine_privileges",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "udt_privileges",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "usage_privileges",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "enabled_roles",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "applicable_roles",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "information_schema",
+      "name": "administrable_role_authorizations",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_foreign_table",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_sequences",
+      "tag": "system:data-leak"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_backend_memory_contexts",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_shmem_allocations",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_replication_slots",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "pg_catalog",
+      "name": "pg_replication_origin_status",
+      "tag": "system:activity"
     }
   ],
   "relationFamilies": [
@@ -215,6 +355,16 @@
     {
       "schema": "pg_catalog",
       "prefix": "aurora_stat_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "pg_catalog",
+      "prefix": "pg_stat_",
+      "tag": "system:activity"
+    },
+    {
+      "schema": "pg_catalog",
+      "prefix": "pg_statio_",
       "tag": "system:activity"
     }
   ],


### PR DESCRIPTION
Security hardening: complete the system-table classification so certified datasources do not expose value-bearing system tables through the role-agnostic `system:catalog` read permit (V8 seed `-100`).

The classifier defaults every unlisted system-schema table to `system:catalog`, which any connected principal may read (so schema introspection works). The manifests must raise the value-bearing tables above that default; several were missing, so they were world-readable — e.g. `performance_schema.user_variables_by_thread` returns another session`s user-variable VALUES; the `sys.x$` statistics twins; PostgreSQL `_pg_foreign_servers`/`_pg_foreign_data_wrappers` raw FDW options, the grant/privilege views, and `pg_sequences.last_value`. Confirmed end-to-end on MySQL 8.0.44.

Every system-schema table was enumerated from a real server of each certified version (MySQL 8.0/8.4, PostgreSQL 16/17), run through the classifier, and the ~400 resolving to `system:catalog` classified value-bearing vs structural. Adds 71 MySQL + ~31 PG family/exact rules across all four manifests: credential/key/security-policy → critical, data values/statistics/user content/grants → data-leak, live/session/monitoring/replication → activity. Structural definitions, `setup_*`, timers, charsets, reference stay catalog.

Every family prefix was verified against the real inventory to match only its intended tables (`pg_stat_` excludes `pg_statistic`/`pg_stats`) with no boot-validation conflict; sensitive columns confirmed on real 8.4/PG-17 schemas. Sibling of #170: that closed the uncertified/no-manifest path (default to critical); this closes the certified path (complete the manifests).

Verification: `mise run verify` green; unit + MySQL enforcement coverage with a null-vs-classifier control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqUFxkT2cZwoHDU5M9qQki