### PR TITLE
fix(control-plane): PM_AUTH_DEBUG is a login method, nothing else

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,10 @@ the map of which file owns which prefix — and the gate each one calls — is i
 
 An authenticated session alone is never authorization. A route states its
 requirement by which gate helper it calls (`requireApi`, `requireAdmin`,
-`requireAuthz`, `requireScimAuth`), and `PM_AUTH_DEBUG` short-circuits all four.
+`requireAuthz`, `requireScimAuth`). `PM_AUTH_DEBUG` is an authentication
+setting: it adds a login method (`POST /auth/debug`, any principal with any
+roles, minted as a real session), and the gates read that session like any
+other.
 
 Errors are never English prose on the wire: a route responds
 `ApiError(code, params)` with a stable dot-namespaced code the web looks up as

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -338,7 +338,7 @@ schema automatically on boot. The defaults you're implicitly relying on here
 | `PM_HTTP_PORT` | `8080` | the web-facing JSON API |
 | `PM_GRPC_PORT` | `9090` | the proxy-facing gRPC surface (register, decide, catalog push) — never expose publicly |
 | `PM_DB_USER` / `PM_DB_PASSWORD` | `proxymonster` / `proxymonster` | matches `docker-compose.yml` |
-| `PM_AUTH_DEBUG` | `true` | a full auth bypass (`/auth/debug` logs in as ANY principal) — trusted machine only |
+| `PM_AUTH_DEBUG` | `true` | enables `/auth/debug`, a login as ANY principal with any roles — trusted machine only |
 | `PM_SECRET_TOKEN` | unset → gate OPEN | the shared proxy↔control-plane secret; set it once you're off a trusted loopback |
 | `PM_MCP_RESOURCE` | `http://127.0.0.1:8080/mcp` | MCP resource URI; its origin doubles as the co-hosted OAuth issuer |
 
@@ -416,12 +416,22 @@ but not required for this loopback walkthrough — without it the proxy runs
 plaintext, which is fine on `127.0.0.1` but must never be exposed beyond a fully
 trusted network (the wire token rides the password field in the clear).
 
-Confirm registration: `curl http://localhost:8080/api/datasources` should list
-both, each with a non-null `catalogSyncedAt` and `lastSeenAt`. This route isn't
-public — it requires an authenticated session — but works unauthenticated here
-because `PM_AUTH_DEBUG` (default `true`) skips that check; against a real
-deployment (`PM_AUTH_DEBUG=false`) the same bare `curl` gets a `401`, and you'd
-need a session cookie from the [login step](#first-login-and-first-query) first.
+Confirm registration with `GET /api/datasources`, which should list both, each
+with a non-null `catalogSyncedAt` and `lastSeenAt`. It needs a session, so log
+in first and reuse the cookie:
+
+```
+curl -c /tmp/pm.jar -X POST http://localhost:8080/auth/debug \
+  -H 'content-type: application/json' \
+  -d '{"principal":"you@example.com","roles":["system:development-viewer"]}'
+curl -b /tmp/pm.jar http://localhost:8080/api/datasources
+```
+
+The roles you log in with are the ones the response reflects: a row's connection
+material (`host`, `port`, `dbName`, `advertiseAddr`, `advertiseCertChain`) needs
+`datasource.connect` on that datasource, so a role that does not grant it sees
+the row's identity only. Easier from the console — see the
+[login step](#first-login-and-first-query).
 
 ### Run the web UI
 
@@ -477,8 +487,15 @@ PM_MCP_RESOURCE="http://127.0.0.1:8080/mcp" mise run control-plane
 With the local `PM_AUTH_DEBUG=true` default, `/oauth/authorize` uses a debug
 principal and auto-consents (`PM_OAUTH_DEBUG_AUTO_CONSENT`, default `true`) with
 no Okta round-trip — it still mints normal audience-bound OAuth bearer tokens,
-so discovery and client behavior stay identical to production. Add and authorize
-the user-scoped Claude Code connection:
+so discovery and client behavior stay identical to production.
+
+That flow selects a principal but assigns it no roles, and every MCP tool needs
+an `admin.*` grant, so the token authorizes nothing until its principal holds a
+role — a tool call answers `common.forbidden`. Sign that principal in through
+`/login` (debug login, with `system:admin`) first, or authorize with
+`?principal=` naming a principal that already has the role.
+
+Add and authorize the user-scoped Claude Code connection:
 
 ```
 claude mcp add --scope user --transport http proxy-monster http://127.0.0.1:8080/mcp
@@ -523,9 +540,10 @@ protected-resource metadata automatically.
 
 With `PM_AUTH_DEBUG=true` (the default), open http://localhost:41300/login and
 use the debug-login option to sign in as any principal (e.g. `you@example.com`)
-— no IdP needed. This also grants admin UI access outright: `PM_AUTH_DEBUG`
-bypasses the admin-route gate itself (`requireAdmin` short-circuits true), not
-Cedar — real per-query authorization is never bypassed, debug or not.
+with whatever roles you want — no IdP needed. Those roles are stored as real
+assignments, so the session authorizes exactly like an SSO one: the flag decides
+who you are, never what you may do. Sign in with `system:admin` for the admin
+UI, or with a narrow role to see precisely what that role sees.
 
 A clean principal has zero usable query access until roles are assigned
 (deny-by-default). Migrations do ship SYSTEM roles and preset policies (e.g.
@@ -580,9 +598,9 @@ PUT /api/datasources/{id}/classification
 {"schema":"acme","table":"payments","column":"card_number","tags":["pii"],"maskFnId":<id>}
 ```
 
-With debug auth on, the principal these API calls authorize as is `debug-user`,
-not the address you typed at the login screen — assign the role to that
-principal too if you're driving the walkthrough with `curl`.
+These API calls authorize as the principal you logged in as — the address you
+typed at the login screen, or the one in the `/auth/debug` body if you are
+driving the walkthrough with `curl`. Assign the role to that principal.
 
 ### Verify it works
 
@@ -612,6 +630,12 @@ per statement.
   (`V8__seed.sql`); harmless before your first login, self-resolves after. Under
   real OIDC (not debug auth), admin membership comes from the IdP's group claim
   via `PM_OIDC_GROUP_MAP`, not this endpoint.
+- The admin UI 403s, or a datasource row arrives without its host/port, with
+  `PM_AUTH_DEBUG=true` — the flag authenticates you, it does not grant anything.
+  Sign in at `/login` with the roles you need (`system:admin` for admin, a
+  `system:development-*` role for a `system:development`-tagged datasource).
+  Signing in with a narrow role and seeing exactly what it permits is the point;
+  a request carrying no session at all holds no roles and is denied accordingly.
 - Port already in use — this doc's ports (`5442`/`31307`/`5433` for Docker,
   `8080`/`9090` for control-plane, `6432`/`6033` for the two proxies, `41300`
   for web) are this doc's own choices, not hardcoded anywhere; override any of

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Access.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Access.kt
@@ -755,35 +755,28 @@ fun Route.accessRoutes(
     recorder: ManagementAuditRecorder,
 ) {
     get("/api/access-requests") {
-        if (!call.requireApi(config)) return@get
-        // Forward-filter by task.read (self seed shows own; admin/oversight shows all),
-        // replacing the unfiltered listing that exposed every principal's requests. authDebug (no
-        // session) keeps the full list, matching requireApi's dev bypass.
-        val caller = call.userSession()?.principal
+        val caller = call.requireApi() ?: return@get
+        // Forward-filter by task.read: the self seed shows own, admin/oversight shows all. Every row is
+        // decided — a listing that answers any of them unfiltered answers the whole table.
         val rows = store.listRequests(call.request.queryParameters["status"])
         call.respond(
-            if (caller == null) {
-                rows
-            } else {
-                rows.filter {
-                    authz.authorize(
-                        caller, AuthzAction.TASK_READ,
-                        AuthzResource.ApprovalRequest(
-                            requester = it.principal, approver = it.decidedBy, executedBy = it.executedBy,
-                            datasourceName = it.datasourceName, roleName = it.roleName,
-                        ),
-                    ) is AuthzDecision.Allow
-                }
+            rows.filter {
+                authz.authorize(
+                    caller, AuthzAction.TASK_READ,
+                    AuthzResource.ApprovalRequest(
+                        requester = it.principal, approver = it.decidedBy, executedBy = it.executedBy,
+                        datasourceName = it.datasourceName, roleName = it.roleName,
+                    ),
+                ) is AuthzDecision.Allow
             },
         )
     }
     post("/api/access-requests") {
-        if (!call.requireApi(config)) return@post
-        val principal = call.userSession()?.principal ?: "debug-user"
+        val principal = call.requireApi() ?: return@post
         val input = call.receive<AccessRequestInput>()
         // Opening a request against a datasource is gated by task.request on that datasource. A role
         // elevation need not target one (datasourceId is optional); a datasource-less request has no
-        // Datasource resource to decide, so authentication alone admits it. authDebug bypasses.
+        // Datasource resource to decide, so authentication alone admits it.
         val ds = input.datasourceId?.let(datasourceStore::get)
         // A datasourceId that names no LIVE datasource (soft-deleted or never-existed) must not fall through
         // to createRequest: the tombstone row still satisfies the FK, so the insert would otherwise succeed
@@ -791,7 +784,7 @@ fun Route.accessRoutes(
         if (input.datasourceId != null && ds == null) {
             return@post call.notFound("datasource")
         }
-        if (ds != null && !config.authDebug) {
+        if (ds != null) {
             val roles = roleResolver.resolve(principal)
             val raw = call.httpAuthzContext(config)
             val tags = authz.resolveContextTags(principal, roles, ds.name, raw, ds.tags)
@@ -805,91 +798,80 @@ fun Route.accessRoutes(
         call.respond(HttpStatusCode.Created, store.createRequest(principal, input, call.auditActor(config), recorder))
     }
     post("/api/access-requests/{id}/approve") {
-        if (!call.requireApi(config)) return@post
+        val approver = call.requireApi() ?: return@post
         val id = call.idParam() ?: return@post call.badId()
         val req = store.getRequest(id) ?: return@post call.notFound("access request")
         if (req.kind != "ROLE") {
             return@post call.respondError(HttpStatusCode.BadRequest, "approval.use_query_approval_endpoint")
         }
-        val approver = call.userSession()?.principal ?: "debug-user"
         // Self-approval is governed entirely by Cedar policy (the `no-self-approval` forbid, V11
         // seed) — never a hardcoded app-level rule. A deployment may disable that policy (dev/eval);
         // this route only ever asks authz "may this principal do this?" (docs/approval-workflow.md).
-        if (!config.authDebug) {
-            // roleName places the request in `Role::"<name>"` so a policy can scope who may approve by
-            // the ROLE being requested (`resource in Role::...`), not just the requester (Authz.kt,
-            // AuthzTest's Request-in-Role case). Without it that capability would be unreachable here.
-            // requester_ip + (when a datasource is in scope) its derived context.tags, resolved
-            // over a SINGLE role snapshot (authorizeWithContext) — the ROLE-request analog of the QUERY
-            // approval routes' mayDecide (task.approve) call in Approvals.kt.
-            val decision = authz.authorizeWithContext(
-                approver, AuthzAction.TASK_APPROVE,
-                AuthzResource.ApprovalRequest(
-                    requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
-                    datasourceName = req.datasourceName, roleName = req.roleName,
-                ),
-                call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
-                req.datasourceName,
-                req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
-            )
-            if (decision is AuthzDecision.Deny) {
-                return@post call.respondError(HttpStatusCode.Forbidden, "approval.not_approver")
-            }
+        // roleName places the request in `Role::"<name>"` so a policy can scope who may approve by
+        // the ROLE being requested (`resource in Role::...`), not just the requester (Authz.kt,
+        // AuthzTest's Request-in-Role case). Without it that capability would be unreachable here.
+        // requester_ip + (when a datasource is in scope) its derived context.tags, resolved
+        // over a SINGLE role snapshot (authorizeWithContext) — the ROLE-request analog of the QUERY
+        // approval routes' mayDecide (task.approve) call in Approvals.kt.
+        val decision = authz.authorizeWithContext(
+            approver, AuthzAction.TASK_APPROVE,
+            AuthzResource.ApprovalRequest(
+                requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
+                datasourceName = req.datasourceName, roleName = req.roleName,
+            ),
+            call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
+            req.datasourceName,
+            req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
+        )
+        if (decision is AuthzDecision.Deny) {
+            return@post call.respondError(HttpStatusCode.Forbidden, "approval.not_approver")
         }
         val body = runCatching { call.receive<ApproveInput>() }.getOrDefault(ApproveInput())
         store.approve(id, body.durationSec, approver, call.auditActor(config), recorder)?.let { call.respond(it) }
             ?: call.notFound("access request")
     }
     post("/api/access-requests/{id}/reject") {
-        if (!call.requireApi(config)) return@post
+        val approver = call.requireApi() ?: return@post
         val id = call.idParam() ?: return@post call.badId()
         val req = store.getRequest(id) ?: return@post call.notFound("access request")
         if (req.kind != "ROLE") {
             return@post call.respondError(HttpStatusCode.BadRequest, "approval.use_query_approval_endpoint")
         }
-        val approver = call.userSession()?.principal ?: "debug-user"
         // Self-approval is governed entirely by Cedar policy (the `no-self-approval` forbid, V11
         // seed) — never a hardcoded app-level rule. A deployment may disable that policy (dev/eval);
         // this route only ever asks authz "may this principal do this?" (docs/approval-workflow.md).
-        if (!config.authDebug) {
-            // Same role-scoped approver check as /approve — the reject path must ask the identical
-            // Cedar question, so a role-scoped approval policy governs reject too (see /approve above).
-            val decision = authz.authorizeWithContext(
-                approver, AuthzAction.TASK_APPROVE,
-                AuthzResource.ApprovalRequest(
-                    requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
-                    datasourceName = req.datasourceName, roleName = req.roleName,
-                ),
-                call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
-                req.datasourceName,
-                req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
-            )
-            if (decision is AuthzDecision.Deny) {
-                return@post call.respondError(HttpStatusCode.Forbidden, "approval.not_approver")
-            }
+        // Same role-scoped approver check as /approve — the reject path must ask the identical
+        // Cedar question, so a role-scoped approval policy governs reject too (see /approve above).
+        val decision = authz.authorizeWithContext(
+            approver, AuthzAction.TASK_APPROVE,
+            AuthzResource.ApprovalRequest(
+                requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
+                datasourceName = req.datasourceName, roleName = req.roleName,
+            ),
+            call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
+            req.datasourceName,
+            req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
+        )
+        if (decision is AuthzDecision.Deny) {
+            return@post call.respondError(HttpStatusCode.Forbidden, "approval.not_approver")
         }
         val body = call.receive<RejectInput>()
         store.reject(id, body.reason, approver, call.auditActor(config), recorder)?.let { call.respond(it) }
             ?: call.notFound("access request")
     }
     get("/api/access-grants") {
-        if (!call.requireApi(config)) return@get
+        val caller = call.requireApi() ?: return@get
         val principal = call.request.queryParameters["principal"]
         val active = call.request.queryParameters["active"]?.toBoolean() ?: false
-        // Forward-filter by task.read — an arbitrary ?principal= does not leak another
-        // principal's grants; each row is kept only if the caller may read it (own, or oversight).
-        val caller = call.userSession()?.principal
+        // Forward-filter by task.read: an arbitrary ?principal= selects which rows to look for, never
+        // which the caller may see — each row is kept only if the caller may read it (own, or oversight).
         val rows = store.listGrants(principal, active)
         call.respond(
-            if (caller == null) {
-                rows
-            } else {
-                rows.filter {
-                    authz.authorize(
-                        caller, AuthzAction.TASK_READ,
-                        AuthzResource.AccessGrant(owner = it.principal, id = it.id, roleName = it.roleName),
-                    ) is AuthzDecision.Allow
-                }
+            rows.filter {
+                authz.authorize(
+                    caller, AuthzAction.TASK_READ,
+                    AuthzResource.AccessGrant(owner = it.principal, id = it.id, roleName = it.roleName),
+                ) is AuthzDecision.Allow
             },
         )
     }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -108,16 +108,16 @@ internal fun Route.taskEventsRoute(
     appJson: Json,
 ) {
     sse("/api/tasks/events") {
-        val liveSession = if (config.authDebug) null else call.webSession()
-        val principal = liveSession?.principal ?: if (config.authDebug) "debug-user" else null
-        if (principal == null) {
+        val liveSession = call.webSession()
+        if (liveSession == null) {
             // No live session. EventSource cannot be told to STOP reconnecting after the 200 handshake, so
             // lengthen its reconnect backoff and end the stream (an expired-session tab then re-polls far less
             // aggressively; the app's 401ing polls redirect it to login). Poll is the truth.
             send(ServerSentEvent(retry = SSE_UNAUTH_RETRY_MS))
             return@sse
         }
-        val sessionId = liveSession?.id
+        val principal = liveSession.principal
+        val sessionId = liveSession.id
         val deviceId = call.deviceCookieId()
         val context = call.httpAuthzContext(config)
         val events = taskCompletionHub.subscribe(principal)
@@ -135,10 +135,10 @@ internal fun Route.taskEventsRoute(
                         // Bound the push to the SAME live `task.read` gate the poll/detail enforce, so a Cedar
                         // forbid (e.g. an untrusted zone) that 404s the poll also suppresses the push — the
                         // notification never reveals gated metadata. A denied/absent task is skipped.
-                        if (taskReadableForPush(config, principal, event.taskId, context, accessStore, authz, datasourceStore)) {
+                        if (taskReadableForPush(principal, event.taskId, context, accessStore, authz, datasourceStore)) {
                             send(ServerSentEvent(data = appJson.encodeToString(TaskEvent.serializer(), event), event = "task"))
                         }
-                        sessionStillLive(config, sessionId, deviceId, principalSessionStore)
+                        sessionStillLive(sessionId, deviceId, principalSessionStore)
                     }
                     onTimeout(SSE_SESSION_RECHECK_MS) {
                         // A session revoked / expired / newest-wins-displaced mid-stream must stop receiving
@@ -151,7 +151,7 @@ internal fun Route.taskEventsRoute(
                         // same throw inside the catch below, which is what turns a closed browser tab back
                         // into the non-event it is.
                         send(ServerSentEvent(comments = "keepalive"))
-                        sessionStillLive(config, sessionId, deviceId, principalSessionStore)
+                        sessionStillLive(sessionId, deviceId, principalSessionStore)
                     }
                 }
                 if (!keepOpen) break
@@ -169,14 +169,13 @@ internal fun Route.taskEventsRoute(
     }
 }
 
-/** True while the SSE stream's web session is still live (authDebug has no session and is always live). */
-internal fun sessionStillLive(config: Config, sessionId: Long?, deviceId: String?, store: PrincipalSessionStore): Boolean =
-    config.authDebug || (sessionId != null && store.resolveWeb(sessionId, deviceId) != null)
+/** True while the SSE stream's web session is still live — logging out or being displaced ends the stream. */
+internal fun sessionStillLive(sessionId: Long?, deviceId: String?, store: PrincipalSessionStore): Boolean =
+    sessionId != null && store.resolveWeb(sessionId, deviceId) != null
 
 /** Whether [principal] may still `task.read` [taskId] — the SAME live Cedar gate the poll/detail enforce,
  *  so the push cannot surface metadata the poll would 404. A missing task is not readable. */
 internal fun taskReadableForPush(
-    config: Config,
     principal: String,
     taskId: Long,
     context: AuthzContext,
@@ -184,7 +183,6 @@ internal fun taskReadableForPush(
     authz: Authz,
     datasourceStore: DatasourceStore,
 ): Boolean {
-    if (config.authDebug) return true
     val task = accessStore.getRequest(taskId) ?: return false
     val decision = authz.authorizeWithContext(
         principal,
@@ -309,15 +307,15 @@ internal fun computeMePermissions(principal: String, authz: Authz, context: Auth
 
 internal fun Route.mePermissionsRoute(config: Config, authz: Authz) {
     get("/api/me/permissions") {
-        if (!call.requireApi(config)) return@get
-        val permissions = if (config.authDebug) {
-            MePermissions(isAdmin = true, canReadAllAudit = true, canApprove = true)
-        } else {
-            val session = requireNotNull(call.userSession()) {
-                "requireApi admitted a non-debug request without a UserSession"
-            }
-            computeMePermissions(session.principal, authz, call.httpAuthzContext(config))
-        }
+        val principal = call.requireApi() ?: return@get
+        // Computed for the debug caller too. Claiming admin under authDebug would render every admin
+        // affordance for a session that logged in with a low-privilege role, and each one would then 403 on
+        // click — the console must describe the authority the routes will actually grant.
+        val permissions = computeMePermissions(
+            principal,
+            authz,
+            call.httpAuthzContext(config),
+        )
 
         // UI navigation and client-side guards are convenience only; every API authorizes independently.
         call.respond(permissions)
@@ -726,7 +724,7 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
             call.respond(HttpStatusCode.Accepted, mapOf("status" to "accepted"))
         }
 
-        // Live decision feed for the UI. Requires a session unless running in auth-debug mode.
+        // Live decision feed for the UI. Requires a session; each record is then filtered by audit.read.
         auditRoutes(config, store, authz)
 
         // Dev-only login shortcut; gated by PM_AUTH_DEBUG. OIDC (above) is the production path.

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
@@ -357,10 +357,8 @@ fun Route.approvalRoutes(
 
     // Whether the caller may open a query-approval request against this datasource (task.request on the
     // Datasource). The shipped global permit keeps this open by default; an operator can forbid it per
-    // datasource. authDebug bypasses.
-    fun mayRequest(call: ApplicationCall, ds: Datasource): Boolean {
-        if (config.authDebug) return true
-        val principal = call.userSession()?.principal ?: "debug-user"
+    // datasource.
+    fun mayRequest(call: ApplicationCall, principal: String, ds: Datasource): Boolean {
         val roles = roleResolver.resolve(principal)
         val raw = call.httpAuthzContext(config)
         val tags = authz.resolveContextTags(principal, roles, ds.name, raw, ds.tags)
@@ -374,17 +372,16 @@ fun Route.approvalRoutes(
     // task.approve (approve/reject/execute under R) or task.read (metadata) against the Request —
     // scoped to its role/datasource, with
     // requester != approver enforced by the shipped no-self-approval forbid. Approver eligibility is a
-    // Cedar policy, never the datasource's approver GROUP. authDebug bypasses, matching every route.
+    // Cedar policy, never the datasource's approver GROUP.
     //
     // The console is a real surface, so it names itself: WORKFLOW_VIEWER, the same channel a result view
     // runs on. Deciding and viewing are both the unelevated human side of a task and are scoped together.
     // It must never be `editor` or `wire` — those two carry [system:task-editor-self-approve] /
     // [system:task-wire-self-approve], which permit self-approval because a machine task runs under the
     // caller's OWN roles. A human approval elevates to R, so it stays under the no-self-approval forbid.
-    fun mayDecide(call: ApplicationCall, action: AuthzAction, req: AccessRequest): Boolean {
-        if (config.authDebug) return true
+    fun mayDecide(call: ApplicationCall, principal: String, action: AuthzAction, req: AccessRequest): Boolean {
         val decision = authz.authorizeWithContext(
-            call.userSession()?.principal ?: "debug-user",
+            principal,
             action,
             AuthzResource.ApprovalRequest(
                 requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
@@ -400,9 +397,9 @@ fun Route.approvalRoutes(
     // Result rows require Cedar authority to assume the task's R. No authDebug bypass: this is data
     // confidentiality, enforced in development too. Same channel as [mayDecide] and as the per-column
     // re-decision the released rows go through, so one policy scopes the whole console surface.
-    fun mayReadResult(call: ApplicationCall, req: AccessRequest): Boolean {
+    fun mayReadResult(call: ApplicationCall, principal: String, req: AccessRequest): Boolean {
         val decision = authz.authorizeWithContext(
-            call.userSession()?.principal ?: "debug-user",
+            principal,
             AuthzAction.TASK_ASSUME,
             AuthzResource.ApprovalRequest(
                 requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
@@ -439,8 +436,7 @@ fun Route.approvalRoutes(
     }
 
     post("/api/approvals") {
-        if (!call.requireApi(config)) return@post
-        val principal = call.userSession()?.principal ?: "debug-user"
+        val principal = call.requireApi() ?: return@post
         val input = call.receive<CreateApprovalInput>()
         if (input.reason.isBlank()) return@post call.respond(HttpStatusCode.BadRequest, ApiError("common.field_required", mapOf("fields" to "reason")))
 
@@ -475,7 +471,7 @@ fun Route.approvalRoutes(
             val ds = datasourceStore.list().firstOrNull { it.name == source.datasource }
                 ?: return@post call.respond(HttpStatusCode.Conflict, ApiError("common.not_found", mapOf("resource" to "datasource")))
             val datasourceId = ds.id
-            if (!mayRequest(call, ds)) {
+            if (!mayRequest(call, principal, ds)) {
                 return@post call.respond(HttpStatusCode.Forbidden, ApiError("common.forbidden"))
             }
             if (input.roleId == null) return@post call.respond(HttpStatusCode.BadRequest, ApiError("approval.role_required"))
@@ -514,7 +510,7 @@ fun Route.approvalRoutes(
         val ds = datasourceStore.get(input.datasourceId!!)
             ?: return@post call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "datasource")))
         val sql = input.sql!!
-        if (!mayRequest(call, ds)) {
+        if (!mayRequest(call, principal, ds)) {
             return@post call.respond(HttpStatusCode.Forbidden, ApiError("common.forbidden"))
         }
         if (input.roleId == null) return@post call.respond(HttpStatusCode.BadRequest, ApiError("approval.role_required"))
@@ -569,8 +565,7 @@ fun Route.approvalRoutes(
     // candidate role and offer the ones that return MORE than the requester's own roles. A dry-run — no
     // audit row is written.
     post("/api/approvals/discover-roles") {
-        if (!call.requireApi(config)) return@post
-        val principal = call.userSession()?.principal ?: "debug-user"
+        val principal = call.requireApi() ?: return@post
         val input = call.receive<DiscoverRolesRequest>()
         val ds = datasourceStore.get(input.datasourceId)
             ?: return@post call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "datasource")))
@@ -592,40 +587,38 @@ fun Route.approvalRoutes(
     }
 
     get("/api/approvals") {
-        if (!call.requireApi(config)) return@get
-        val principal = call.userSession()?.principal ?: "debug-user"
+        val principal = call.requireApi() ?: return@get
         call.respond(accessStore.listQueryRequests(status = call.request.queryParameters["status"], principal = principal))
     }
 
     get("/api/approvals/inbox") {
-        if (!call.requireApi(config)) return@get
+        val principal = call.requireApi() ?: return@get
         // Forward filter: every PENDING request the caller may approve (Cedar task.approve), not a
-        // group-membership join. authDebug shows all.
-        val requests = accessStore.listQueryRequests("PENDING", null).filter { mayDecide(call, AuthzAction.TASK_APPROVE, it) }
+        // group-membership join.
+        val requests = accessStore.listQueryRequests("PENDING", null).filter { mayDecide(call, principal, AuthzAction.TASK_APPROVE, it) }
         call.respond(requests)
     }
 
     get("/api/approvals/{id}") {
-        if (!call.requireApi(config)) return@get
+        val principal = call.requireApi() ?: return@get
         val id = call.idParam() ?: return@get call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
-        val principal = call.userSession()?.principal ?: "debug-user"
         val req = accessStore.getRequest(id)
         if (req == null || !req.isWorkflowApproval) return@get call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "query approval request")))
-        val isApprover = mayDecide(call, AuthzAction.TASK_APPROVE, req)
+        val isApprover = mayDecide(call, principal, AuthzAction.TASK_APPROVE, req)
         // Task metadata is gated by task.read. Saved rows are separate and remain behind task.assume.
-        if (!mayDecide(call, AuthzAction.TASK_READ, req)) {
+        if (!mayDecide(call, principal, AuthzAction.TASK_READ, req)) {
             return@get call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "query approval request")))
         }
         // task.read is a metadata gate; result-derived data stays behind task.assume. A caller who cannot
         // assume R sees execution status only (status/executor/timestamps/error) — never the result's row
         // count or output-column shape, which are cardinality/existence oracles the assume gate must close.
         val visibleMeta = queryResultStore?.meta(id)?.let { meta ->
-            if (mayReadResult(call, req)) meta else meta.copy(rowCount = null, columns = emptyList())
+            if (mayReadResult(call, principal, req)) meta else meta.copy(rowCount = null, columns = emptyList())
         }
         // Mirror /execute's gates: only the approver OF RECORD (decided_by) can run it, so a merely-eligible
         // approver who did not approve THIS task gets no Run affordance that would just 403.
         val canExecute = queryResultStore != null && isApprover && req.status == "APPROVED" && req.decidedBy == principal
-        val canCancel = req.status == "EXECUTING" && mayDecide(call, AuthzAction.TASK_CANCEL, req)
+        val canCancel = req.status == "EXECUTING" && mayDecide(call, principal, AuthzAction.TASK_CANCEL, req)
         call.respond(
             ApprovalDetail(
                 req,
@@ -638,15 +631,14 @@ fun Route.approvalRoutes(
     }
 
     post("/api/approvals/{id}/approve") {
-        if (!call.requireApi(config)) return@post
+        val principal = call.requireApi() ?: return@post
         val id = call.idParam() ?: return@post call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
-        val principal = call.userSession()?.principal ?: "debug-user"
         val req = accessStore.getRequest(id)
         if (req == null || !req.isWorkflowApproval) return@post call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "query approval request")))
         if (req.status != "PENDING") return@post call.respond(HttpStatusCode.Conflict, ApiError("approval.already_decided"))
         // Cedar owns the authorization: task.approve on this request, scoped to its role/datasource,
         // with requester != approver via the no-self-approval forbid.
-        if (!mayDecide(call, AuthzAction.TASK_APPROVE, req)) {
+        if (!mayDecide(call, principal, AuthzAction.TASK_APPROVE, req)) {
             return@post call.respond(HttpStatusCode.Forbidden, ApiError("approval.not_approver"))
         }
         // An approved QUERY request is executed under role R by an approver (execute-under-R); there is no
@@ -668,9 +660,8 @@ fun Route.approvalRoutes(
     }
 
     post("/api/approvals/{id}/reject") {
-        if (!call.requireApi(config)) return@post
+        val principal = call.requireApi() ?: return@post
         val id = call.idParam() ?: return@post call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
-        val principal = call.userSession()?.principal ?: "debug-user"
         val body = call.receive<RejectInput>()
         if (body.reason.isBlank()) return@post call.respond(HttpStatusCode.BadRequest, ApiError("common.field_required", mapOf("fields" to "reason")))
         val req = accessStore.getRequest(id)
@@ -678,7 +669,7 @@ fun Route.approvalRoutes(
         if (req.status != "PENDING") return@post call.respond(HttpStatusCode.Conflict, ApiError("approval.already_decided"))
         // Cedar owns the authorization: reject is the SAME task.approve decision as approve, scoped to its
         // role/datasource with requester != approver via the no-self-approval forbid.
-        if (!mayDecide(call, AuthzAction.TASK_APPROVE, req)) {
+        if (!mayDecide(call, principal, AuthzAction.TASK_APPROVE, req)) {
             return@post call.respond(HttpStatusCode.Forbidden, ApiError("approval.not_approver"))
         }
         val updated = accessStore.decideQueryRequest(
@@ -698,14 +689,13 @@ fun Route.approvalRoutes(
     }
 
     post("/api/approvals/{id}/cancel") {
-        if (!call.requireApi(config)) return@post
+        val principal = call.requireApi() ?: return@post
         val id = call.idParam() ?: return@post call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
-        val principal = call.userSession()?.principal ?: "debug-user"
         val req = accessStore.getRequest(id)
         if (req == null || !req.isWorkflowApproval) {
             return@post call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "query approval request")))
         }
-        if (!mayDecide(call, AuthzAction.TASK_CANCEL, req)) {
+        if (!mayDecide(call, principal, AuthzAction.TASK_CANCEL, req)) {
             return@post call.respond(HttpStatusCode.Forbidden, ApiError("approval.cancel_forbidden"))
         }
         when (req.status) {
@@ -738,9 +728,8 @@ fun Route.approvalRoutes(
     // ---- Execute under R ---------------------------------------------------------------
 
     post("/api/approvals/{id}/execute") {
-        if (!call.requireApi(config)) return@post
+        val executor = call.requireApi() ?: return@post
         val id = call.idParam() ?: return@post call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
-        val executor = call.userSession()?.principal ?: "debug-user"
         val req = accessStore.getRequest(id)
         if (req == null || !req.isWorkflowApproval) {
             return@post call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "query approval request")))
@@ -748,7 +737,7 @@ fun Route.approvalRoutes(
         // Authorize (task.approve) BEFORE disclosing task state: a caller who cannot approve this task gets a
         // uniform 403 regardless of its status, so the 409 already_executed/not_approved distinctions below are
         // never a state oracle for a non-approver. The approver-of-record identity is still pinned further down.
-        if (!mayDecide(call, AuthzAction.TASK_APPROVE, req)) {
+        if (!mayDecide(call, executor, AuthzAction.TASK_APPROVE, req)) {
             return@post call.respond(HttpStatusCode.Forbidden, ApiError("approval.not_approver"))
         }
         if (req.status in setOf("EXECUTING", "EXECUTED", "FAILED", "CANCELLED")) {
@@ -806,9 +795,8 @@ fun Route.approvalRoutes(
     // exactly the task's execute-as role set in the viewer's workflow-viewer context. Every successful
     // view and live-decision denial is audited; a deactivated viewer is hidden and an expired result is Gone.
     get("/api/approvals/{id}/result") {
-        if (!call.requireApi(config)) return@get
+        val principal = call.requireApi() ?: return@get
         val id = call.idParam() ?: return@get call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
-        val principal = call.userSession()?.principal ?: "debug-user"
         val req = accessStore.getRequest(id)
         if (req == null || !req.isWorkflowApproval) return@get call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "query approval request")))
         // Deprovisioning gate applies before result lookup. The live decideQuery path repeats this gate as
@@ -823,7 +811,7 @@ fun Route.approvalRoutes(
         val access = queryResultStore?.accessFor(id)
             ?: return@get call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "query approval request")))
         val meta = access.meta
-        if (!mayReadResult(call, req)) {
+        if (!mayReadResult(call, principal, req)) {
             return@get call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "query approval request")))
         }
         if (meta.status != "DONE") {

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/AuditRoutes.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/AuditRoutes.kt
@@ -17,19 +17,12 @@ private suspend fun ApplicationCall.respondAuditNotFound() {
 
 internal fun Route.auditRoutes(config: Config, store: AuditStore, authz: Authz) {
     get("/api/audit") {
-        // authDebug is authoritative and short-circuits before any session resolution (mirrors requireApi).
-        if (!call.requireApi(config)) return@get
+        // Which records a principal may read is Cedar's answer, taken below against the identity the gate
+        // admitted: an audit.read grant on the whole log returns everything, anything less returns own rows.
+        val principal = call.requireApi() ?: return@get
 
         val limit = (call.request.queryParameters["limit"]?.toIntOrNull() ?: 100)
             .coerceIn(1, 500)
-        if (config.authDebug) {
-            call.respond(store.recent(limit))
-            return@get
-        }
-
-        val principal = requireNotNull(call.userSession()) {
-            "audit list admitted a non-debug request without a UserSession"
-        }.principal
         val decision = authz.authorize(principal, AuthzAction.AUDIT_READ, AuthzResource.AuditLog, call.httpAuthzContext(config))
         val records = if (decision == AuthzDecision.Allow) {
             store.recent(limit)
@@ -40,20 +33,12 @@ internal fun Route.auditRoutes(config: Config, store: AuditStore, authz: Authz) 
     }
 
     get("/api/audit/{id}") {
-        if (!call.requireApi(config)) return@get
+        val principal = call.requireApi() ?: return@get
         val id = call.idParam() ?: return@get call.badId()
         val record = store.get(id) ?: return@get call.respondAuditNotFound()
 
-        if (config.authDebug) {
-            call.respond(record)
-            return@get
-        }
-
-        val session = requireNotNull(call.userSession()) {
-            "audit detail admitted a non-debug request without a UserSession"
-        }
         val decision = authz.authorize(
-            session.principal,
+            principal,
             AuthzAction.AUDIT_READ,
             AuthzResource.AuditRecord(record.principal),
             call.httpAuthzContext(config),

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Auth.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Auth.kt
@@ -120,9 +120,12 @@ fun constantTimeEquals(presented: String?, expected: String): Boolean {
     return MessageDigest.isEqual(presented.toByteArray(Charsets.UTF_8), expected.toByteArray(Charsets.UTF_8))
 }
 
-// The fallback is reachable only when PM_AUTH_DEBUG admits a mutation without a session.
+// Every mutation route gates on a session first (requireAdmin / requireAuthz both resolve one before they
+// decide), so this names the principal the authorization decision ran against and the trail cannot disagree
+// with the gate about who acted. Total rather than asserting that: an audit row is the last place to throw,
+// and an unattributed row is a louder signal than a 500 that loses the row entirely.
 fun ApplicationCall.auditActor(config: Config, channel: String = AuditSource.CONSOLE): AuditActor = AuditActor(
-    principal = userSession()?.principal ?: "unknown",
+    principal = userSession()?.principal ?: AuthAuditRecorder.PRINCIPAL_UNATTRIBUTED,
     clientAddr = httpRequesterIp(config),
     channel = channel,
 )

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Datasources.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Datasources.kt
@@ -766,13 +766,17 @@ class DatasourceStore(internal val dataSource: DataSource) {
 
 // ---- Routes ------------------------------------------------------------------------------
 
-/** Reject if no session and not in auth-debug mode (mirrors the /api/audit guard). */
-suspend fun ApplicationCall.requireApi(config: Config): Boolean {
-    if (!config.authDebug && userSession() == null) {
-        respond(HttpStatusCode.Unauthorized, ApiError("common.unauthenticated"))
-        return false
-    }
-    return true
+/**
+ * Returns the caller principal, or responds 401 and returns null. It hands back the identity so the gate and
+ * the name come from one call, and a handler never holds a principal the gate did not approve.
+ *
+ * A session is the only way in. `PM_AUTH_DEBUG` is an authentication setting — it adds the `/auth/debug`
+ * login, which mints a real session row with real role assignments — so every mode reaches this the same way.
+ */
+suspend fun ApplicationCall.requireApi(): String? {
+    userSession()?.principal?.let { return it }
+    respond(HttpStatusCode.Unauthorized, ApiError("common.unauthenticated"))
+    return null
 }
 
 suspend fun ApplicationCall.idParam(): Long? = parameters["id"]?.toLongOrNull()
@@ -813,15 +817,14 @@ private fun ApplicationCall.bearerWirePrincipal(tokenStore: TokenStore, userGrou
 }
 
 /**
- * Authenticate a read-only API call by web session, else (interim option a) a native-wire Bearer token, else
- * authDebug. Returns the caller principal, or responds 401 and returns null. Mirrors [requireApi] but adds
- * the Bearer path so the `pmon` daemon can discover datasources without a browser cookie. PRIVATE by design:
- * the Bearer path is discovery-only, so no other route file can reach it (compiler-enforced scope).
+ * Authenticate a read-only API call by web session, else (interim option a) a native-wire Bearer token.
+ * Returns the caller principal, or responds 401 and returns null. Mirrors [requireApi] but adds the Bearer
+ * path so the `pmon` daemon can discover datasources without a browser cookie. PRIVATE by design: the Bearer
+ * path is discovery-only, so no other route file can reach it (compiler-enforced scope).
  */
 private suspend fun ApplicationCall.requireApiOrBearer(config: Config, tokenStore: TokenStore, userGroupStore: UserGroupStore): String? {
     userSession()?.principal?.let { return it }
     bearerWirePrincipal(tokenStore, userGroupStore)?.let { return it }
-    if (config.authDebug) return "debug-user"
     respond(HttpStatusCode.Unauthorized, ApiError("common.unauthenticated"))
     return null
 }
@@ -879,7 +882,7 @@ fun Route.datasourceRoutes(
     // Which datasources currently have a proxy attached (an open Events stream) — the admin liveness
     // view. Read-only; returns the set of attached datasource names.
     get("/api/datasources/live") {
-        if (!call.requireApi(config)) return@get
+        call.requireApi() ?: return@get
         call.respond(eventsHub.attached())
     }
     // Admin "re-introspect now": push a RefreshCatalog down the datasource's open Events stream(s).
@@ -956,10 +959,9 @@ fun Route.datasourceRoutes(
         call.respond(store.test(ds, management.getDatasourceLiveness(ds.name).attached))
     }
     get("/api/datasources/{id}/catalog") {
-        // requireApiOrBearer, and the principal it RETURNS: a wire-token caller has no session, so resolving
-        // the principal from the session alone would fall through to the literal "debug-user" and run the
-        // Cedar check against a synthetic identity. The helper hands back whichever identity authenticated,
-        // and only answers "debug-user" when PM_AUTH_DEBUG actually says so.
+        // requireApiOrBearer, and the principal it RETURNS: a wire-token caller has no session, so reading
+        // the principal from the session alone would decide against nobody. The helper hands back whichever
+        // identity authenticated, session or token.
         val principal = call.requireApiOrBearer(config, tokenStore, userGroupStore) ?: return@get
         val id = call.idParam() ?: return@get call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         val datasource = store.get(id)
@@ -989,7 +991,7 @@ fun Route.datasourceRoutes(
         // Same gate and the same principal resolution as {id}/catalog: a browser session or a wire-token
         // Bearer. The console is today's only caller, since the chain also rides on the datasource list pmon
         // already polls — but a Bearer client asking for the certificate directly is a reasonable thing to do,
-        // and the alternative was a 401 for it plus a "debug-user" fallback in the authorization check.
+        // and session-only would answer it 401.
         val principal = call.requireApiOrBearer(config, tokenStore, userGroupStore) ?: return@get
         val id = call.idParam() ?: return@get call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         val datasource = store.get(id)

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/DeviceAuth.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/DeviceAuth.kt
@@ -254,7 +254,6 @@ class DeviceLoginStore(internal val dataSource: DataSource, private val crypto: 
     )
 }
 
-private const val DEV_PRINCIPAL = "debug-user"
 private const val DEVICE_POLL_INTERVAL_SEC = 2 // how often pmon polls /poll; the browser page approves out-of-band
 private const val DEVICE_LOGIN_TTL_SEC = 600L // 10 min to complete the device-auth dance
 

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Policies.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Policies.kt
@@ -175,7 +175,7 @@ fun Route.policyRoutes(
     management: PolicyManagementService =
         PolicyManagementService(CedarPolicyStore(store.dataSource), store, ManagementAuditRecorder(AuditStore(store.dataSource))),
 ) {
-    get("/api/roles") { if (!call.requireApi(config)) return@get; call.respond(management.listRoles()) }
+    get("/api/roles") { call.requireApi() ?: return@get; call.respond(management.listRoles()) }
     post("/api/roles") {
         if (!call.requireAdmin(config, authz, AuthzAction.ADMIN_POLICIES)) return@post
         val input = call.receive<RoleInput>()

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -942,11 +942,10 @@ fun Route.queryRoutes(
     runExecService: RunExecService,
 ) {
     post("/api/datasources/{id}/query") {
-        if (!call.requireApi(config)) return@post
+        val principal = call.requireApi() ?: return@post
         val id = call.idParam() ?: return@post call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         val ds = datasourceStore.get(id) ?: return@post call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "datasource")))
         val req = call.receive<QueryRequest>()
-        val principal = call.userSession()?.principal ?: "debug-user"
         // Auto-save the run to the principal's editor history (best-effort; never blocks the query).
         runCatching { historyStore.add(principal, id, req.sql) }
         try {
@@ -1011,11 +1010,10 @@ fun Route.editorSessionRoutes(
     taskCompletionHub: TaskCompletionHub? = null,
 ) {
     post("/api/editor/sessions") {
-        if (!call.requireApi(config)) return@post
+        val principal = call.requireApi() ?: return@post
         val input = call.receive<OpenEditorSessionInput>()
         val ds = datasourceStore.get(input.datasourceId)
             ?: return@post call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "datasource")))
-        val principal = call.userSession()?.principal ?: "debug-user"
         try {
             call.respond(EditorSessionOpened(runExecService.openSession(principal, ds, call.httpRequesterIp(config))))
         } catch (_: NoProxyAttachedException) {
@@ -1032,10 +1030,9 @@ fun Route.editorSessionRoutes(
     // Async submit: launch the run as an auto-approved EDITOR task on the held session and ACK 202 — no rows
     // inline (mirrors /api/approvals/{id}/execute). The web swaps its tab's taskId and polls to completion.
     post("/api/editor/sessions/{sessionId}/query") {
-        if (!call.requireApi(config)) return@post
+        val principal = call.requireApi() ?: return@post
         val sessionId = call.parameters["sessionId"]
             ?: return@post call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
-        val principal = call.userSession()?.principal ?: "debug-user"
         val req = call.receive<QueryRequest>()
         val sql = req.sql
         if (sql.isBlank()) {
@@ -1055,11 +1052,8 @@ fun Route.editorSessionRoutes(
             ?: return@post call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "datasource")))
         val store = queryResultStore
             ?: return@post call.respond(HttpStatusCode.ServiceUnavailable, ApiError("approval.result_storage_not_configured"))
-        // Self-approve on the editor channel: must clear task.request AND task.approve. authDebug bypasses.
-        if (!config.authDebug && !autoApproveTask(
-                principal, ownRoles, ds, call.httpAuthzContext(config), authz, Channel.EDITOR,
-            )
-        ) {
+        // Self-approve on the editor channel: must clear task.request AND task.approve.
+        if (!autoApproveTask(principal, ownRoles, ds, call.httpAuthzContext(config), authz, Channel.EDITOR)) {
             return@post call.respond(HttpStatusCode.Forbidden, ApiError("common.forbidden"))
         }
 
@@ -1141,56 +1135,50 @@ fun Route.editorSessionRoutes(
     // Poll: task status + child metadata. Owner-scoped to the caller's own EDITOR tasks (task.read/own);
     // 404 for a non-owner / non-EDITOR id, so it's not an existence oracle. Rows stay behind /result.
     get("/api/editor/tasks/{taskId}") {
-        if (!call.requireApi(config)) return@get
+        val principal = call.requireApi() ?: return@get
         val taskId = call.parameters["taskId"]?.toLongOrNull()
             ?: return@get call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
-        val principal = call.userSession()?.principal ?: "debug-user"
         val task = accessStore.getRequest(taskId)
         if (task == null || task.kind != "QUERY" || task.creatorKind != "EDITOR" || task.principal != principal) {
             return@get call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "editor task")))
         }
         // task.read gates the metadata (status, row count, column names, error code, timestamps) — the owner
         // guard above is not a substitute: a Cedar forbid (e.g. task.read denied from an untrusted zone) must
-        // still override the self-read permit. authDebug bypasses, matching every other route's Cedar gate.
-        if (!config.authDebug) {
-            val mayRead = authz.authorizeWithContext(
-                principal, AuthzAction.TASK_READ,
-                AuthzResource.ApprovalRequest(
-                    requester = task.principal, approver = task.decidedBy, executedBy = task.executedBy,
-                    datasourceName = task.datasourceName, roleName = task.roleName,
-                ),
-                call.httpAuthzContext(config), task.datasourceName,
-                task.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
-            )
-            if (mayRead is AuthzDecision.Deny) {
-                return@get call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "editor task")))
-            }
+        // still override the self-read permit.
+        val mayRead = authz.authorizeWithContext(
+            principal, AuthzAction.TASK_READ,
+            AuthzResource.ApprovalRequest(
+                requester = task.principal, approver = task.decidedBy, executedBy = task.executedBy,
+                datasourceName = task.datasourceName, roleName = task.roleName,
+            ),
+            call.httpAuthzContext(config), task.datasourceName,
+            task.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
+        )
+        if (mayRead is AuthzDecision.Deny) {
+            return@get call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "editor task")))
         }
         call.respond(EditorTaskStatus(task.id, task.status, queryResultStore?.meta(taskId)))
     }
 
     post("/api/editor/tasks/{taskId}/cancel") {
-        if (!call.requireApi(config)) return@post
+        val principal = call.requireApi() ?: return@post
         val taskId = call.parameters["taskId"]?.toLongOrNull()
             ?: return@post call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
-        val principal = call.userSession()?.principal ?: "debug-user"
         val task = accessStore.getRequest(taskId)
         if (task == null || task.kind != "QUERY" || task.creatorKind != "EDITOR" || task.principal != principal) {
             return@post call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "editor task")))
         }
-        if (!config.authDebug) {
-            val mayCancel = authz.authorizeWithContext(
-                principal, AuthzAction.TASK_CANCEL,
-                AuthzResource.ApprovalRequest(
-                    requester = task.principal, approver = task.decidedBy, executedBy = task.executedBy,
-                    datasourceName = task.datasourceName, roleName = task.roleName,
-                ),
-                call.httpAuthzContext(config), task.datasourceName,
-                task.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
-            )
-            if (mayCancel is AuthzDecision.Deny) {
-                return@post call.respond(HttpStatusCode.Forbidden, ApiError("approval.cancel_forbidden"))
-            }
+        val mayCancel = authz.authorizeWithContext(
+            principal, AuthzAction.TASK_CANCEL,
+            AuthzResource.ApprovalRequest(
+                requester = task.principal, approver = task.decidedBy, executedBy = task.executedBy,
+                datasourceName = task.datasourceName, roleName = task.roleName,
+            ),
+            call.httpAuthzContext(config), task.datasourceName,
+            task.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
+        )
+        if (mayCancel is AuthzDecision.Deny) {
+            return@post call.respond(HttpStatusCode.Forbidden, ApiError("approval.cancel_forbidden"))
         }
         if (task.status != "EXECUTING") {
             return@post call.respond(EditorTaskStatus(task.id, task.status, queryResultStore?.meta(taskId)))
@@ -1216,10 +1204,9 @@ fun Route.editorSessionRoutes(
     // Rows: task.assume gates the viewer (no authDebug bypass — data confidentiality), then the stored result
     // is re-decided live under the task's execute-as roles on the EDITOR channel — mirrors the approval view.
     get("/api/editor/tasks/{taskId}/result") {
-        if (!call.requireApi(config)) return@get
+        val principal = call.requireApi() ?: return@get
         val taskId = call.parameters["taskId"]?.toLongOrNull()
             ?: return@get call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
-        val principal = call.userSession()?.principal ?: "debug-user"
         val task = accessStore.getRequest(taskId)
         // Owner-scoped (frozen contract): an editor result is readable ONLY by its own submitter. The
         // task.assume check below is defense-in-depth (the owner passes it via the task.assume-parties policy);
@@ -1296,10 +1283,9 @@ fun Route.editorSessionRoutes(
     // Delete-on-close: drop the tab's saved rows + its task row (CASCADE). Owner-scoped + EDITOR-only, so a
     // leaked id can't delete another principal's task; a non-owner / unknown id is a silent, idempotent 204.
     delete("/api/editor/tasks/{taskId}") {
-        if (!call.requireApi(config)) return@delete
+        val principal = call.requireApi() ?: return@delete
         val taskId = call.parameters["taskId"]?.toLongOrNull()
             ?: return@delete call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
-        val principal = call.userSession()?.principal ?: "debug-user"
         val task = accessStore.getRequest(taskId)
         if (task != null && task.kind == "QUERY" && task.creatorKind == "EDITOR" && task.principal == principal) {
             if (task.status == "EXECUTING") runExecService.cancelActiveRun(taskId)
@@ -1310,13 +1296,12 @@ fun Route.editorSessionRoutes(
     }
 
     delete("/api/editor/sessions/{sessionId}") {
-        if (!call.requireApi(config)) return@delete
+        val principal = call.requireApi() ?: return@delete
         val sessionId = call.parameters["sessionId"]
             ?: return@delete call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
         // Close only if the caller owns the session (mirrors runOnSession) — a leaked sessionId must not let
         // another principal tear down this connection. Idempotent NoContent regardless, so it's not an
         // existence oracle for someone else's session id.
-        val principal = call.userSession()?.principal ?: "debug-user"
         runExecService.closeSessionOwnedBy(sessionId, principal)
         call.respond(HttpStatusCode.NoContent)
     }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/QueryHistory.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/QueryHistory.kt
@@ -63,14 +63,13 @@ class QueryHistoryStore(private val dataSource: DataSource) {
 
 fun Route.queryHistoryRoutes(config: Config, store: QueryHistoryStore) {
     get("/api/query-history") {
-        if (!call.requireApi(config)) return@get
-        val principal = call.userSession()?.principal ?: "debug-user"
+        val principal = call.requireApi() ?: return@get
         val limit = (call.request.queryParameters["limit"]?.toIntOrNull() ?: 50).coerceIn(1, 200)
         call.respond(store.recent(principal, limit))
     }
     delete("/api/query-history") {
-        if (!call.requireApi(config)) return@delete
-        store.clear(call.userSession()?.principal ?: "debug-user")
+        val principal = call.requireApi() ?: return@delete
+        store.clear(principal)
         call.respond(HttpStatusCode.NoContent)
     }
 }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Tokens.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Tokens.kt
@@ -270,13 +270,16 @@ class TokenStore(internal val dataSource: DataSource) {
 
 // ---- Routes -----------------------------------------------------------------
 
-private fun principalOf(call: io.ktor.server.application.ApplicationCall) = call.userSession()?.principal ?: "debug-user"
+// Nullable, unlike a gated route's principal: these routes resolve the caller to BUILD the Token resource
+// they then authorize against, so this necessarily runs before any gate. Null means no session, and each
+// caller answers 401 itself rather than asserting a name it has not yet had approved.
+private fun principalOf(call: io.ktor.server.application.ApplicationCall) = call.userSession()?.principal
 private fun rolesOf(call: io.ktor.server.application.ApplicationCall) = call.userSession()?.roles ?: emptyList()
 
 /** The audited actor of a token route: whoever made the request, resolved the same way the route's own
  *  authorization resolves it — never the token's owner, who may be someone else on the revoke path. */
-private fun callerActor(call: io.ktor.server.application.ApplicationCall, config: Config) =
-    AuditActor(principalOf(call), clientAddr = call.httpRequesterIp(config), channel = CHANNEL_WIRE)
+private fun callerActor(principal: String, call: io.ktor.server.application.ApplicationCall, config: Config) =
+    AuditActor(principal, clientAddr = call.httpRequesterIp(config), channel = CHANNEL_WIRE)
 
 fun Route.tokenRoutes(
     config: Config,
@@ -290,6 +293,7 @@ fun Route.tokenRoutes(
     // principal to mint its own, a kind-scoped forbid can bar a role from long-lived PATs.
     post("/api/wire-tokens") {
         val principal = principalOf(call)
+            ?: return@post call.respond(HttpStatusCode.Unauthorized, ApiError("common.unauthenticated"))
         if (!call.requireAuthz(config, authz, AuthzAction.TOKEN_MINT, AuthzResource.Token(principal, TokenKind.SESSION))) return@post
         val ttl = call.receive<MintSessionTokenInput>().ttlSeconds ?: store.sessionTtlSeconds
         val roles = rolesOf(call)
@@ -297,7 +301,7 @@ fun Route.tokenRoutes(
         // check + the INSERT run on ONE transaction under the per-principal advisory lock,
         // so a concurrent SCIM/liveness teardown can't slip its revoke between them and leave a
         // token that survives the deprovision (resurrectable on a later reactivation).
-        val minter = callerActor(call, config)
+        val minter = callerActor(principal, call, config)
         val issued = store.dataSource.mintForActivePrincipalLocked(principal, userGroupStore) { c ->
             store.issue(TokenKind.SESSION, principal, roles, name = null, ttlSeconds = ttl, c).also { token ->
                 authAudit.success(
@@ -321,18 +325,20 @@ fun Route.tokenRoutes(
         // list another principal's (token.list oversight seed). This returns METADATA only; a token's
         // secret is only ever exposed at mint (token.mint) and is never re-readable. kind is irrelevant here.
         val target = call.request.queryParameters["principal"] ?: principalOf(call)
+            ?: return@get call.respond(HttpStatusCode.Unauthorized, ApiError("common.unauthenticated"))
         if (!call.requireAuthz(config, authz, AuthzAction.TOKEN_LIST, AuthzResource.Token(target, kind = null))) return@get
         call.respond(store.list(target))
     }
     post("/api/tokens") {
         val principal = principalOf(call)
+            ?: return@post call.respond(HttpStatusCode.Unauthorized, ApiError("common.unauthenticated"))
         if (!call.requireAuthz(config, authz, AuthzAction.TOKEN_MINT, AuthzResource.Token(principal, TokenKind.USER))) return@post
         val input = call.receive<CreateTokenInput>()
         val ttl = input.ttlSeconds ?: store.defaultUserTtlSeconds
         val roles = rolesOf(call)
         // Same locked check-then-mint as /api/wire-tokens above — no fresh credentials
         // for a deactivated principal, and no revoke can race between the check and the INSERT.
-        val minter = callerActor(call, config)
+        val minter = callerActor(principal, call, config)
         val issued = store.dataSource.mintForActivePrincipalLocked(principal, userGroupStore) { c ->
             store.issue(TokenKind.USER, principal, roles, input.name?.ifBlank { null }, ttl, c).also { token ->
                 authAudit.success(
@@ -359,7 +365,8 @@ fun Route.tokenRoutes(
         if (!call.requireAuthz(config, authz, AuthzAction.TOKEN_REVOKE, AuthzResource.Token(token.principal, TokenKind.fromWire(token.kind)))) return@delete
         // The actor is the CALLER, not the token's owner: an oversight seed lets an identity admin revoke
         // someone else's token, and attributing that to the owner would name the victim as the actor.
-        val revoker = callerActor(call, config)
+        // requireAuthz above admitted this request, so the session is present.
+        val revoker = callerActor(call.requireApi() ?: return@delete, call, config)
         val revoked = store.dataSource.inTx { c ->
             store.revoke(id, token.principal, c).also { changed ->
                 if (changed) {

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
@@ -828,11 +828,8 @@ internal fun Authz.authorizeWithContext(
 }
 
 /**
- * Gate an admin/privileged route: `true` if [Config.authDebug] (the dev-only bypass — mirrors
- * `requireApi`'s posture, the trusted-network dev story; this is NOT a Cedar bypass, Cedar
- * itself is never skipped, only never *reached* here), else 401 with no session, else the real
- * [Authz.authorize] decision (403 + the deny reason on Deny). This is what closes the "admin routes
- * require admin.*, not any session" hole once `config.authDebug=false` in production.
+ * Gate an admin/privileged route: 401 with no session, else the real [Authz.authorize] decision (403 +
+ * the deny reason on Deny). This is what closes the "admin routes require admin.*, not any session" hole.
  *
  * The ONE choke point every admin route funnels through — threading
  * [com.ridi.oss.proxymonster.controlplane.httpAuthzContext] here fixes `requester_ip` for every admin
@@ -849,11 +846,14 @@ suspend fun ApplicationCall.requireAdmin(
 
 /**
  * The general per-(action, resource) route gate — [requireAdmin]'s body, named for the routes that
- * aren't admin surfaces (token.* / workflow.* self-service and grant routes). Same posture:
- * [Config.authDebug] dev bypass → true; no session → 401; else the real
- * [Authz.authorize] decision (403 + reason on Deny). [requireAdmin] is the `System`-resource alias.
+ * aren't admin surfaces (token.* / workflow.* self-service and grant routes). No session → 401; else the
+ * real [Authz.authorize] decision (403 + reason on Deny). [requireAdmin] is the `System`-resource alias.
  * Build the [resource] (e.g. `Token(owner)`) from [userSession]'s principal at the call site, since it
- * usually references the caller — under `authDebug` this short-circuits before the session is read.
+ * usually references the caller.
+ *
+ * A dev session decides here like an SSO one: `PM_AUTH_DEBUG` adds the `/auth/debug` login (email plus the
+ * roles you ask for, minted as real assignments), so signing in with a LOW-privilege role holds you to it —
+ * which is how you test one.
  */
 suspend fun ApplicationCall.requireAuthz(
     config: Config,
@@ -861,13 +861,11 @@ suspend fun ApplicationCall.requireAuthz(
     action: AuthzAction,
     resource: AuthzResource,
 ): Boolean {
-    if (config.authDebug) return true
-    val session = userSession()
-    if (session == null) {
+    val principal = userSession()?.principal ?: run {
         respond(HttpStatusCode.Unauthorized, ApiError("common.unauthenticated"))
         return false
     }
-    return when (val decision = authz.authorize(session.principal, action, resource, httpAuthzContext(config))) {
+    return when (val decision = authz.authorize(principal, action, resource, httpAuthzContext(config))) {
         AuthzDecision.Allow -> true
         is AuthzDecision.Deny -> {
             respond(HttpStatusCode.Forbidden, ApiError("common.forbidden", mapOf("detail" to decision.reason)))

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/mcp/McpServer.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/mcp/McpServer.kt
@@ -212,17 +212,15 @@ private class McpAuthorizer(private val config: Config, private val core: Contro
             )
         }
         val roles = core.roleResolver.resolve(context.principal)
-        if (!config.authDebug) {
-            val decision = core.authz.authorizeAs(
-                context.principal,
-                roles,
-                capability.action,
-                capability.resource,
-                AuthzContext(channel = Channel.MCP.contextValue, requesterIp = context.requesterIp),
-            )
-            if (decision is AuthzDecision.Deny) {
-                throw McpAuthorizationException(ApiError("common.forbidden", mapOf("detail" to decision.reason)), roles)
-            }
+        val decision = core.authz.authorizeAs(
+            context.principal,
+            roles,
+            capability.action,
+            capability.resource,
+            AuthzContext(channel = Channel.MCP.contextValue, requesterIp = context.requesterIp),
+        )
+        if (decision is AuthzDecision.Deny) {
+            throw McpAuthorizationException(ApiError("common.forbidden", mapOf("detail" to decision.reason)), roles)
         }
         return roles
     }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/LocaleRoutes.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/LocaleRoutes.kt
@@ -23,9 +23,7 @@ data class LocaleInput(val locale: String)
  */
 fun Route.localeRoutes(config: Config, store: NotificationStore) {
     put("/api/me/locale") {
-        if (!call.requireApi(config)) return@put
-        val principal = call.userSession()?.principal
-            ?: return@put call.respond(HttpStatusCode.Unauthorized, ApiError("common.unauthenticated"))
+        val principal = call.requireApi() ?: return@put
         val locale = call.receive<LocaleInput>().locale.trim().lowercase()
         // Validated against the same closed set the catalog carries: an unknown locale has no messages, and
         // storing one would fall every message back to the default forever.

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/oauth/OAuthRoutes.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/oauth/OAuthRoutes.kt
@@ -166,9 +166,15 @@ fun Route.mcpOAuthRoutes(
         }
         val canonicalScope = canonicalScopes(requestedScopes)
         if (config.authDebug) {
+            // Like /auth/debug, this is a login: it mints a real session below. So it has to be TOLD who —
+            // an explicit ?principal= or an existing console session — rather than defaulting to a synthetic
+            // name, which would mint a session for a principal nobody chose and then authorize MCP tools as it.
             val principal = params["principal"]?.takeIf(String::isNotBlank)
                 ?: call.userSession()?.principal
-                ?: "debug-user"
+                ?: run {
+                    call.respond(HttpStatusCode.BadRequest, OAuthError("login_required"))
+                    return@get
+                }
             val pending = McpPendingAuthorization(clientId, redirectUri, resource, canonicalScope, state, challenge, principal)
             call.sessions.set(MCP_OAUTH_PENDING_COOKIE, pending)
             // Debug OAuth and the web console intentionally share the same authenticated session,

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AccessListingForwardFilterDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AccessListingForwardFilterDbTest.kt
@@ -1,0 +1,172 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.testLoginRoute
+import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
+import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
+import io.ktor.server.sessions.Sessions
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import javax.sql.DataSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * `GET /api/access-requests` and `GET /api/access-grants` forward-filter every row through `task.read`, so
+ * one principal never sees another's. Both are covered together because they are the same shape twice: a
+ * listing that decides per row, where anything short-circuiting the filter returns the whole table.
+ *
+ * The shipped seeds decide this: `workflow.self-request` grants `task.read` on a Request whose requester is
+ * the caller, `workflow.self-grant` on an AccessGrant it owns. Neither test grants anything beyond those, so
+ * a filter that stops running shows up immediately as a stranger's row in the response.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AccessListingForwardFilterDbTest {
+    private lateinit var dataSource: DataSource
+    private lateinit var core: ControlPlaneCore
+    private lateinit var config: Config
+    private var roleId: Long = 0
+
+    private val owner = "owner@example.com"
+    private val stranger = "stranger@example.com"
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_access_forward_filter"))
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        core = ControlPlaneCore(dataSource)
+
+        val sessionStore = PrincipalSessionStore(dataSource, null)
+        for (p in listOf(owner, stranger)) {
+            core.userGroupStore.createUser(AppUserInput(principal = p), core.tokenStore, core.accessStore, sessionStore)
+        }
+        roleId = core.policyStore.createRole(RoleInput("forward-filter-role")).id
+
+        // One ROLE request owned by `owner`, approved so it also produces an access_grant row for `owner`.
+        val request = core.accessStore.createRequest(owner, AccessRequestInput(roleId = roleId, requestedDurationSec = 3600))
+        core.accessStore.approve(request.id, 3600, owner)
+
+        // authDebug=TRUE throughout: the flag is the thing under test, so a listing keyed on it fails here.
+        // Asserting a security property under the safe configuration asserts almost nothing.
+        config = Config(
+            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = true, secretToken = null,
+            sessionSecret = "access-forward-filter-secret", oidc = null, resultKey = null, scimToken = null,
+            sessionWindowSeconds = 3600, idpRecheckIntervalSeconds = 600, devMarker = true,
+        )
+    }
+
+    private fun ApplicationTestBuilder.wire(): HttpClient {
+        application { installRoutes() }
+        return createClient {
+            expectSuccess = false
+            install(HttpCookies)
+            install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+    }
+
+    private fun Application.installRoutes() {
+        val sessionStore = PrincipalSessionStore(dataSource, null)
+        attributes.put(PRINCIPAL_SESSION_STORE, sessionStore)
+        install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
+        install(Sessions) { webSessionCookie(sessionStore, config.sessionSecret) }
+        routing {
+            testLoginRoute(sessionStore, config)
+            accessRoutes(
+                config, core.accessStore, core.authz, core.datasourceStore, core.roleResolver,
+                ManagementAuditRecorder(AuditStore(dataSource)),
+            )
+        }
+    }
+
+    @Test
+    fun `the requests listing shows a principal its own rows and never another's`() = testApplication {
+        val client = wire()
+
+        client.post("/test/session/$owner")
+        assertTrue(
+            client.get("/api/access-requests").bodyAsText().contains(owner),
+            "the owner must see the request it opened",
+        )
+
+        client.post("/test/session/$stranger")
+        val response = client.get("/api/access-requests")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(
+            emptyList(), response.body<List<AccessRequest>>(),
+            "a stranger holding no task.read grant must see an empty list, not merely a redacted one",
+        )
+    }
+
+    @Test
+    fun `the grants listing shows a principal its own rows and never another's`() = testApplication {
+        val client = wire()
+
+        client.post("/test/session/$owner")
+        assertTrue(
+            client.get("/api/access-grants").bodyAsText().contains(owner),
+            "the owner must see the grant it holds",
+        )
+
+        client.post("/test/session/$stranger")
+        val response = client.get("/api/access-grants")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(
+            emptyList(), response.body<List<AccessGrant>>(),
+            "a stranger must see an empty list, not merely one with the owner's row redacted",
+        )
+    }
+
+    /**
+     * `?principal=` selects whose rows to LOOK for; it never widens what may be returned. Asking for another
+     * principal's grants by name yields nothing, because each row still has to clear `task.read`.
+     */
+    @Test
+    fun `a principal query parameter does not widen the grants listing`() = testApplication {
+        val client = wire()
+        client.post("/test/session/$stranger")
+
+        val response = client.get("/api/access-grants?principal=$owner")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(
+            emptyList(), response.body<List<AccessGrant>>(),
+            "naming another principal must not bypass the per-row filter",
+        )
+    }
+
+    /** `PM_AUTH_DEBUG` enables a login, so a caller that has not used one is refused with no row attached. */
+    @Test
+    fun `both listings reject a caller with no session even under auth debug`() = testApplication {
+        val client = wire()
+        val requests = client.get("/api/access-requests")
+        assertEquals(HttpStatusCode.Unauthorized, requests.status)
+        assertFalse(requests.bodyAsText().contains(owner), "a rejected read must carry no row: ${requests.bodyAsText()}")
+
+        val grants = client.get("/api/access-grants")
+        assertEquals(HttpStatusCode.Unauthorized, grants.status)
+        assertFalse(grants.bodyAsText().contains(owner), "a rejected read must carry no row: ${grants.bodyAsText()}")
+
+        // Naming a principal is not a way in either.
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/api/access-grants?principal=$owner").status)
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalDiscoverPickSubmitRouteDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalDiscoverPickSubmitRouteDbTest.kt
@@ -3,6 +3,8 @@ package com.ridi.oss.proxymonster.controlplane
 import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
 import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.testLoginRoute
+import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
@@ -16,9 +18,7 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.routing.routing
-import io.ktor.server.sessions.SessionTransportTransformerMessageAuthentication
 import io.ktor.server.sessions.Sessions
-import io.ktor.server.sessions.cookie
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import kotlinx.serialization.json.Json
@@ -36,7 +36,7 @@ import kotlin.test.assertTrue
  * ([EnforcementFixture.postgres]).
  *
  * It also carries ROUTE-level teeth for the R-ALONE preview, in the case that actually distinguishes
- * it: `debug-user` here HOLDS an own role (`base-reader`, which runs `select id, ssn from users` with
+ * it: the requester here HOLDS an own role (`base-reader`, which runs `select id, ssn from users` with
  * `ssn` masked). Two candidates are seeded so the union and R-alone decisions genuinely diverge:
  *   * `full-reader` unmasks `ssn` ON ITS OWN → offered under both models (the positive round-trip pick);
  *   * `unmask-only` grants unmasked-`ssn` but NO datasource.connect/sql.select, so ALONE it DENYs, while
@@ -50,9 +50,11 @@ import kotlin.test.assertTrue
 class ApprovalDiscoverPickSubmitRouteDbTest {
     private lateinit var fx: EnforcementFixture
     private lateinit var runExecService: RunExecService
+    private lateinit var sessionStore: PrincipalSessionStore
     private lateinit var config: Config
 
     private val sql = "select id, ssn from users"
+    private val requester = "dev@example.com"
 
     @BeforeAll
     fun setup() {
@@ -61,6 +63,7 @@ class ApprovalDiscoverPickSubmitRouteDbTest {
         // Never exercised by discover-roles or the proactive-compose POST /api/approvals — both routes
         // stop at decideQuery / accessStore.createQueryRequest, well short of runExecService.
         runExecService = RunExecService(ControlPlaneCore(fx.dataSource))
+        sessionStore = PrincipalSessionStore(fx.dataSource, null)
 
         // A datasource-scoped query-approval policy row (a global NULL-datasource row is already seeded
         // and unique, so this is scoped to fx.datasource — same shape as ApprovalExecuteRouteDbTest.setup
@@ -69,10 +72,8 @@ class ApprovalDiscoverPickSubmitRouteDbTest {
         // the request; discover-roles itself doesn't consult it, but the end-to-end submit step does.
         seedRolesForUnionVsAloneTeeth()
 
-        // authDebug=true: the requester is the literal `debug-user`, who (per seedRolesForUnionVsAloneTeeth)
-        // holds `base-reader` — so the baseline for `sql` is a genuine masked ALLOW, not a stubbed one.
         config = Config(
-            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = true, secretToken = null,
+            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = false, secretToken = null,
             sessionSecret = "discover-pick-submit-test-secret", oidc = null, resultKey = null, scimToken = null,
             sessionWindowSeconds = 3600, idpRecheckIntervalSeconds = 600, devMarker = true,
         )
@@ -92,9 +93,9 @@ class ApprovalDiscoverPickSubmitRouteDbTest {
         fun grant(name: String, src: String) =
             fx.cedarPolicyStore.create(CedarPolicyInput(name = name, cedarSrc = src), updatedBy = "discover-pick-submit-test")
 
-        // debug-user's OWN role: connects + selects, cleartext except pii, pii (ssn) masked → baseline MASK.
+        // The requester's OWN role: connects + selects, cleartext except pii, pii (ssn) masked → baseline MASK.
         val baseReader = fx.policyStore.createRole(RoleInput("base-reader"))
-        fx.policyStore.createAssignment(RoleAssignmentInput("debug-user", baseReader.id))
+        fx.policyStore.createAssignment(RoleAssignmentInput(requester, baseReader.id))
         grant("base-reader-connect-select", """permit(principal in Role::"base-reader", action in [Action::"datasource.connect", Action::"stmt.cat.read"], resource in Datasource::"${ds.name}");""")
         grant("base-reader-users-unmasked", """permit(principal in Role::"base-reader", action == Action::"result.read.unmasked", resource in Table::"$usersEuid") unless { resource in Tag::"pii" };""")
         grant("base-reader-users-masked-pii", """permit(principal in Role::"base-reader", action == Action::"result.read.masked", resource in Table::"$usersEuid") when { resource in Tag::"pii" };""")
@@ -111,10 +112,13 @@ class ApprovalDiscoverPickSubmitRouteDbTest {
         grant("unmask-only-users-unmasked", """permit(principal in Role::"unmask-only", action == Action::"result.read.unmasked", resource in Table::"$usersEuid");""")
     }
 
-    private fun ApplicationTestBuilder.wire(): HttpClient {
+    private suspend fun ApplicationTestBuilder.wire(): HttpClient {
         application {
+            attributes.put(PRINCIPAL_SESSION_STORE, sessionStore)
             install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
+            install(Sessions) { webSessionCookie(sessionStore, config.sessionSecret) }
             routing {
+                testLoginRoute(sessionStore, config)
                 approvalRoutes(
                     config, fx.accessStore, fx.auditStore, fx.datasourceStore, fx.policyStore,
                     fx.userGroupStore, null, fx.roleResolver,
@@ -122,11 +126,13 @@ class ApprovalDiscoverPickSubmitRouteDbTest {
                 )
             }
         }
-        return createClient {
+        val client = createClient {
             expectSuccess = false
             install(HttpCookies)
             install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
         }
+        assertEquals(HttpStatusCode.NoContent, client.post("/test/session/$requester").status)
+        return client
     }
 
     @Test
@@ -141,7 +147,7 @@ class ApprovalDiscoverPickSubmitRouteDbTest {
         val discovered = discoverResponse.body<DiscoverRolesResponse>()
         assertTrue(
             discovered.baselineAllowed,
-            "debug-user holds base-reader, which runs the query with ssn masked -> the baseline is a masked ALLOW",
+            "the requester holds base-reader, which runs the query with ssn masked -> the baseline is a masked ALLOW",
         )
 
         val offered = discovered.options.map { it.roleName }.toSet()

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalExecuteRouteDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalExecuteRouteDbTest.kt
@@ -1,10 +1,12 @@
 package com.ridi.oss.proxymonster.controlplane
 
+import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
 import com.ridi.oss.proxymonster.controlplane.grpc.CONTROL_PROTOCOL_VERSION
 import com.ridi.oss.proxymonster.controlplane.grpc.ControlPlaneGrpcService
 import com.ridi.oss.proxymonster.controlplane.grpc.GrpcServer
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.testLoginRoute
 import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
 import com.ridi.oss.proxymonster.grpc.ControlPlaneGrpcKt
 import com.ridi.oss.proxymonster.grpc.EnfAction as WireEnfAction
@@ -31,15 +33,10 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
-import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.server.response.respond
-import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import io.ktor.server.sessions.Sessions
-import io.ktor.server.sessions.sessions
-import io.ktor.server.sessions.set
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.CompletableDeferred
@@ -77,9 +74,9 @@ import kotlin.test.fail
  * the fake proxy's Events/runExec streams land on the same `proxyEventsHub` — mirrors
  * `GrpcRunExecDbTest`) so the DENY plays back over the real execute-under-R wire path, not a mock.
  *
- * Runs under `authDebug=true` (the executor principal is the literal `debug-user`): `mayDecide`
- * short-circuits true under authDebug, isolating the DENY branch from the R-scoped authority gate — that
- * gate gets its own coverage in [ElevationContextRouteAuthzDbTest].
+ * The fixture grants the executor `task.approve` outright, clearing `mayDecide` so the DENY branch is
+ * isolated from the R-scoped authority gate, which gets its own coverage in
+ * [ElevationContextRouteAuthzDbTest].
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ApprovalExecuteRouteDbTest {
@@ -93,7 +90,9 @@ class ApprovalExecuteRouteDbTest {
     private lateinit var stub: ControlPlaneGrpcKt.ControlPlaneCoroutineStub
     private lateinit var rawChannel: ManagedChannel
 
-    private val executor = "debug-user" // the authDebug fallback principal (no session cookie is sent)
+    private lateinit var sessionStore: PrincipalSessionStore
+
+    private val executor = "approver@example.com"
     private val requester = "requester@example.com"
 
     @BeforeAll
@@ -104,20 +103,34 @@ class ApprovalExecuteRouteDbTest {
         core = ControlPlaneCore(dataSource)
         runExecService = RunExecService(core)
         resultStore = QueryResultStore(dataSource, ResultCrypto(ByteArray(32) { it.toByte() }))
+        sessionStore = PrincipalSessionStore(dataSource, null)
 
         datasource = core.datasourceStore.create(
             DatasourceInput(name = "exec-route-ds", engine = "postgres", host = "localhost", port = 5432, dbName = "app"),
         )
 
-        // debug-user (the authDebug fallback executor) is registered as an app_user; authDebug bypasses the
-        // approve-authority gate, isolating the execute-under-R branch under test.
+        // The executor holds a real task.approve grant, clearing mayDecide — which is what isolates the
+        // branches actually under test here (the execute-under-R DENY floor and the approver-of-record
+        // identity check) from the authority gate in front of them.
         core.userGroupStore.createUser(
-            AppUserInput(principal = executor), core.tokenStore, core.accessStore,
-            PrincipalSessionStore(dataSource, null),
+            AppUserInput(principal = executor), core.tokenStore, core.accessStore, sessionStore,
+        )
+        // task.read and task.cancel come along because the suite drives the console's own sequence — read the
+        // detail, execute, cancel the in-flight run — and each of those asks its own Cedar question.
+        core.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "exec-route-test-task-authority",
+                cedarSrc = """permit(
+                    principal == User::"$executor",
+                    action in [Action::"task.approve", Action::"task.read", Action::"task.cancel"],
+                    resource
+                );""",
+            ),
+            updatedBy = null,
         )
 
         config = Config(
-            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = true, secretToken = null,
+            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = false, secretToken = null,
             sessionSecret = "exec-route-test-secret", oidc = null, resultKey = null, scimToken = null,
             sessionWindowSeconds = 3600, idpRecheckIntervalSeconds = 600, devMarker = true,
         )
@@ -143,10 +156,14 @@ class ApprovalExecuteRouteDbTest {
         require(predicate()) { "timed out awaiting: $what" }
     }
 
+    /** The routes plus a client; sign it in with [login] before driving anything. */
     private fun ApplicationTestBuilder.wire(): HttpClient {
         application {
+            attributes.put(PRINCIPAL_SESSION_STORE, sessionStore)
             install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
+            install(Sessions) { webSessionCookie(sessionStore, config.sessionSecret) }
             routing {
+                testLoginRoute(sessionStore, config)
                 approvalRoutes(
                     config, core.accessStore, core.auditStore, core.datasourceStore, core.policyStore,
                     core.userGroupStore, resultStore, core.roleResolver,
@@ -161,32 +178,11 @@ class ApprovalExecuteRouteDbTest {
         }
     }
 
-    private fun ApplicationTestBuilder.wireAuthenticated(): HttpClient {
-        val cfg = config.copy(authDebug = false)
-        val sessionStore = PrincipalSessionStore(dataSource, null)
-        application {
-            attributes.put(PRINCIPAL_SESSION_STORE, sessionStore)
-            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
-            install(Sessions) { webSessionCookie(sessionStore, cfg.sessionSecret) }
-            routing {
-                post("/test/session/{principal}") {
-                    val deviceId = call.ensureDeviceCookie(secure = false)
-                    call.sessions.set(
-                        WebSessionRef(sessionStore.mintWeb(requireNotNull(call.parameters["principal"]), null, 7200, 900, deviceId)),
-                    )
-                    call.respond(HttpStatusCode.NoContent)
-                }
-                approvalRoutes(
-                    cfg, core.accessStore, core.auditStore, core.datasourceStore, core.policyStore,
-                    core.userGroupStore, resultStore, core.roleResolver, core.authz, runExecService,
-                )
-            }
-        }
-        return createClient {
-            expectSuccess = false
-            install(HttpCookies)
-            install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
-        }
+    /** [wire]'d client, signed in as the approver of record every seeded request defaults to. */
+    private suspend fun ApplicationTestBuilder.wireAsExecutor(): HttpClient = wire().also { it.login(executor) }
+
+    private suspend fun HttpClient.login(principal: String) {
+        assertEquals(HttpStatusCode.NoContent, post("/test/session/$principal").status)
     }
 
     /** A QUERY request elevating [requester] to a fresh role R on [datasource], already APPROVED —
@@ -220,7 +216,7 @@ class ApprovalExecuteRouteDbTest {
 
     @Test
     fun `a DENY-under-R at execute leaks no result and stores nothing (fail-closed floor)`() = testApplication {
-        val client = wire()
+        val client = wireAsExecutor()
         val roleR = "exec-deny-role"
         val id = seedApprovedRoleRequest(roleR)
 
@@ -316,7 +312,7 @@ class ApprovalExecuteRouteDbTest {
      */
     @Test
     fun `a second execute after a successful first is rejected with 409 approval_already_executed, storing exactly one result`() = testApplication {
-        val client = wire()
+        val client = wireAsExecutor()
         val roleR = "exec-once-role"
         val id = seedApprovedRoleRequest(roleR)
 
@@ -379,7 +375,7 @@ class ApprovalExecuteRouteDbTest {
      */
     @Test
     fun `execute returns 202 EXECUTING while the run is still in flight, then completes to EXECUTED and DONE`() = testApplication {
-        val client = wire()
+        val client = wireAsExecutor()
         val id = seedApprovedRoleRequest("exec-async-role")
 
         supervisorScope {
@@ -436,7 +432,7 @@ class ApprovalExecuteRouteDbTest {
 
     @Test
     fun `canceling an in-flight approval terminalizes both rows and emits RunCancel`() = testApplication {
-        val client = wire()
+        val client = wireAsExecutor()
         val id = seedApprovedRoleRequest("exec-cancel-role")
 
         supervisorScope {
@@ -479,7 +475,7 @@ class ApprovalExecuteRouteDbTest {
 
     @Test
     fun `V46 allows the requester to cancel and denies an unrelated principal without sending control`() = testApplication {
-        val client = wireAuthenticated()
+        val client = wire()
         val approver = "cancel-approver@example.com"
         val unrelated = "cancel-unrelated@example.com"
         for (principal in listOf(requester, approver, unrelated)) {
@@ -512,7 +508,7 @@ class ApprovalExecuteRouteDbTest {
 
     @Test
     fun `cancel is idempotent after execution and rejects pending tasks`() = testApplication {
-        val client = wire()
+        val client = wireAsExecutor()
         val executed = seedApprovedRoleRequest("exec-cancel-terminal-role")
         dataSource.connection.use { c ->
             c.prepareStatement("UPDATE access_request SET status = 'EXECUTED' WHERE id = ?").use { ps ->
@@ -537,7 +533,7 @@ class ApprovalExecuteRouteDbTest {
     /** The async task model exposes no /release or /withhold routes; hitting them 404s. */
     @Test
     fun `removed release and withhold routes return 404`() = testApplication {
-        val client = wire()
+        val client = wireAsExecutor()
         val id = seedApprovedRoleRequest("exec-removed-routes-role")
         assertEquals(HttpStatusCode.NotFound, client.post("/api/approvals/$id/release").status)
         assertEquals(HttpStatusCode.NotFound, client.post("/api/approvals/$id/withhold").status)
@@ -547,15 +543,15 @@ class ApprovalExecuteRouteDbTest {
      * The approver of record must be the one who executes (executedBy = decided_by = the approver). An
      * eligible approver B who did not approve THIS task cannot run a task approved by A: /execute rejects
      * with 403 `approval.not_the_approver` BEFORE the execute-once claim, so nothing runs and the task
-     * stays APPROVED. Under authDebug the R-scoped authority gate (`mayDecide`) short-circuits true, so this
-     * identity check — which has NO authDebug bypass — is the sole gate under test here. The positive case
+     * stays APPROVED. The fixture's blanket `task.approve` grant clears the R-scoped authority gate
+     * (`mayDecide`), so this identity check is the sole gate under test here. The positive case
      * (the approver of record executes and proceeds) is the default `decidedBy = executor` seed the other
      * tests above exercise.
      */
     @Test
     fun `execute by an approver other than the approver of record is 403 not_the_approver and runs nothing`() = testApplication {
-        val client = wire()
-        // Approved by a DIFFERENT approver A; the /execute caller is the authDebug principal debug-user (B).
+        val client = wireAsExecutor()
+        // Approved by a DIFFERENT approver A; the /execute caller is the signed-in executor (B).
         val id = seedApprovedRoleRequest("exec-wrong-approver-role", decidedBy = "approver-a@example.com")
 
         val denied = client.post("/api/approvals/$id/execute")

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultDeactivationDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultDeactivationDbTest.kt
@@ -2,15 +2,20 @@ package com.ridi.oss.proxymonster.controlplane
 
 import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.testLoginRoute
+import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
+import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.get
+import io.ktor.client.request.post
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.server.sessions.SessionTransportTransformerMessageAuthentication
+import io.ktor.server.routing.routing
 import io.ktor.server.sessions.Sessions
-import io.ktor.server.sessions.cookie
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import kotlinx.serialization.json.Json
@@ -25,17 +30,17 @@ import kotlin.test.assertEquals
  * viewer's outcome: an active viewer passes the gate and reaches the re-decision, which itself fails closed on
  * an empty {R} (no raw-snapshot side-channel) and returns 403 `result_view_denied`; a deactivated viewer is
  * turned away at the gate first with 404, no result-existence oracle. The 403-vs-404 difference IS the gate's
- * effect. Under authDebug the viewer is `debug-user`, also the task requester, so the shipped task.assume
- * party policy admits it; removing the deactivation gate would turn the deactivated case's 404 into the same
- * 403 and fail the second test.
+ * effect. The viewer is also the task requester, so the shipped task.assume party policy admits it; removing
+ * the deactivation gate would turn the deactivated case's 404 into the same 403 and fail the second test.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ApprovalResultDeactivationDbTest {
     private lateinit var fx: EnforcementFixture
     private lateinit var resultStore: QueryResultStore
     private lateinit var runExecService: RunExecService
+    private lateinit var sessionStore: PrincipalSessionStore
     private lateinit var config: Config
-    private val viewer = "debug-user" // the authDebug fallback principal (no session cookie is sent)
+    private val viewer = "dev@example.com"
 
     @BeforeAll
     fun setup() {
@@ -45,8 +50,9 @@ class ApprovalResultDeactivationDbTest {
         // runExecService is only reached by /execute, never by the /result path under test — but
         // approvalRoutes requires it. A core over the same DB is sufficient (it is never invoked here).
         runExecService = RunExecService(ControlPlaneCore(fx.dataSource))
+        sessionStore = PrincipalSessionStore(fx.dataSource, null)
         config = Config(
-            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = true, secretToken = null,
+            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = false, secretToken = null,
             sessionSecret = "test-secret", oidc = null, resultKey = null,
             scimToken = null, sessionWindowSeconds = 3600, idpRecheckIntervalSeconds = 600, devMarker = true,
         )
@@ -55,14 +61,26 @@ class ApprovalResultDeactivationDbTest {
         )
     }
 
-    private fun ApplicationTestBuilder.installApprovalRoutes() {
-        install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
-        routing {
-            approvalRoutes(
-                config, fx.accessStore, fx.auditStore, fx.datasourceStore, fx.policyStore,
-                fx.userGroupStore, resultStore, fx.roleResolver, fx.authz, runExecService,
-            )
+    private suspend fun ApplicationTestBuilder.installApprovalRoutes(): HttpClient {
+        application {
+            attributes.put(PRINCIPAL_SESSION_STORE, sessionStore)
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
+            install(Sessions) { webSessionCookie(sessionStore, config.sessionSecret) }
+            routing {
+                testLoginRoute(sessionStore, config)
+                approvalRoutes(
+                    config, fx.accessStore, fx.auditStore, fx.datasourceStore, fx.policyStore,
+                    fx.userGroupStore, resultStore, fx.roleResolver, fx.authz, runExecService,
+                )
+            }
         }
+        val client = createClient {
+            expectSuccess = false
+            install(HttpCookies)
+            install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+        assertEquals(HttpStatusCode.NoContent, client.post("/test/session/$viewer").status)
+        return client
     }
 
     /** A QUERY task + stored result whose requester may assume R through the shipped party policy. */
@@ -84,10 +102,9 @@ class ApprovalResultDeactivationDbTest {
 
     @Test
     fun `an active viewer passes the deactivation gate and reaches the live re-decision — positive control`() = testApplication {
-        installApprovalRoutes()
+        val client = installApprovalRoutes()
         fx.userGroupStore.setUserActive(viewer, true)
         val id = storedResultId()
-        val client = createClient { install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) } }
         val resp = client.get("/api/approvals/$id/result")
         // The gate is passed; the empty-{R} re-decision then denies fail-closed (never the stored snapshot).
         assertEquals(HttpStatusCode.Forbidden, resp.status, "an active viewer must reach the live re-decision")
@@ -96,10 +113,9 @@ class ApprovalResultDeactivationDbTest {
 
     @Test
     fun `a deactivated viewer is gated out before any result decision — NotFound, no existence oracle`() = testApplication {
-        installApprovalRoutes()
+        val client = installApprovalRoutes()
         val id = storedResultId()
         fx.userGroupStore.setUserActive(viewer, false)
-        val client = createClient { install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) } }
         val resp = client.get("/api/approvals/$id/result")
         assertEquals(
             HttpStatusCode.NotFound, resp.status,

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalSurfaceCreatorKindDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalSurfaceCreatorKindDbTest.kt
@@ -1,7 +1,10 @@
 package com.ridi.oss.proxymonster.controlplane
 
+import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.testLoginRoute
+import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
@@ -16,6 +19,7 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.routing.routing
+import io.ktor.server.sessions.Sessions
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import kotlinx.serialization.json.Json
@@ -35,9 +39,8 @@ import kotlin.test.assertTrue
  * task per Decide, so without the creator_kind guard every statement the principal ran would pollute their
  * approvals feed and expose a nonsensical (null-SQL) approve/execute action surface.
  *
- * Runs under authDebug=true, so the Cedar task.approve/read gates short-circuit true and the creator_kind
- * guard is the SOLE gate under test: if it were absent, these routes would happily serve the WIRE/EDITOR
- * rows here.
+ * The caller is granted task.approve/read/assume outright, so the creator_kind guard is the SOLE gate under
+ * test: if it were absent, these routes would happily serve the WIRE/EDITOR rows here.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ApprovalSurfaceCreatorKindDbTest {
@@ -48,7 +51,9 @@ class ApprovalSurfaceCreatorKindDbTest {
     private lateinit var datasource: Datasource
     private lateinit var config: Config
 
-    private val principal = "debug-user" // the authDebug fallback principal (no session cookie is sent)
+    private lateinit var sessionStore: PrincipalSessionStore
+
+    private val principal = "dev@example.com"
 
     @BeforeAll
     fun setup() {
@@ -58,31 +63,52 @@ class ApprovalSurfaceCreatorKindDbTest {
         core = ControlPlaneCore(dataSource)
         runExecService = RunExecService(core)
         resultStore = QueryResultStore(dataSource, ResultCrypto(ByteArray(32) { it.toByte() }))
+        sessionStore = PrincipalSessionStore(dataSource, null)
         datasource = core.datasourceStore.create(
             DatasourceInput(name = "surface-ds", engine = "postgres", host = "localhost", port = 5432, dbName = "app"),
         )
+        // Blanket task authority for the caller, so every 404 below is the creator_kind guard's and never a
+        // missing grant. task.assume covers the /result case, which is gated separately from the rest.
+        core.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "approval-surface-test-task-authority",
+                cedarSrc = """permit(
+                    principal == User::"$principal",
+                    action in [
+                        Action::"task.approve", Action::"task.read", Action::"task.cancel", Action::"task.assume"
+                    ],
+                    resource
+                );""",
+            ),
+            updatedBy = null,
+        )
         config = Config(
-            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = true, secretToken = null,
+            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = false, secretToken = null,
             sessionSecret = "surface-test-secret", oidc = null, resultKey = null, scimToken = null,
             sessionWindowSeconds = 3600, idpRecheckIntervalSeconds = 600, devMarker = true,
         )
     }
 
-    private fun ApplicationTestBuilder.wire(): HttpClient {
+    private suspend fun ApplicationTestBuilder.wire(): HttpClient {
         application {
+            attributes.put(PRINCIPAL_SESSION_STORE, sessionStore)
             install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
+            install(Sessions) { webSessionCookie(sessionStore, config.sessionSecret) }
             routing {
+                testLoginRoute(sessionStore, config)
                 approvalRoutes(
                     config, core.accessStore, core.auditStore, core.datasourceStore, core.policyStore,
                     core.userGroupStore, resultStore, core.roleResolver, core.authz, runExecService,
                 )
             }
         }
-        return createClient {
+        val client = createClient {
             expectSuccess = false
             install(HttpCookies)
             install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
         }
+        assertEquals(HttpStatusCode.NoContent, client.post("/test/session/$principal").status)
+        return client
     }
 
     private fun seedWorkflowRequest(): Long = core.accessStore.createQueryRequest(
@@ -130,7 +156,7 @@ class ApprovalSurfaceCreatorKindDbTest {
         assertUnreachableAsApproval(client, seedEditorTask())
     }
 
-    /** Every id-addressed approval route must 404 a non-WORKFLOW task even though authDebug clears the Cedar gate. */
+    /** Every id-addressed approval route must 404 a non-WORKFLOW task even though the Cedar gate passes. */
     private suspend fun assertUnreachableAsApproval(client: HttpClient, id: Long) {
         assertEquals(HttpStatusCode.NotFound, client.get("/api/approvals/$id").status, "detail")
         assertEquals(HttpStatusCode.NotFound, client.post("/api/approvals/$id/approve").status, "approve")

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AuditReadRoutesDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AuditReadRoutesDbTest.kt
@@ -7,6 +7,7 @@ import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyStore
 import com.ridi.oss.proxymonster.controlplane.authz.RoleSource
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.testLoginRoute
 import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -21,14 +22,8 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.server.response.respond
-import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
-import io.ktor.server.sessions.SessionTransportTransformerMessageAuthentication
 import io.ktor.server.sessions.Sessions
-import io.ktor.server.sessions.cookie
-import io.ktor.server.sessions.set
-import io.ktor.server.sessions.sessions
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import kotlinx.serialization.decodeFromString
@@ -88,7 +83,7 @@ class AuditReadRoutesDbTest {
     }
 
     @Test
-    fun `unauthenticated non-debug list is rejected without authorization`() = testApplication {
+    fun `an unauthenticated list is rejected without authorization`() = testApplication {
         val app = wireAuditApp(authDebug = false)
         app.roleSource.reset()
 
@@ -174,23 +169,30 @@ class AuditReadRoutesDbTest {
         }
     }
 
+    /**
+     * `PM_AUTH_DEBUG` authenticates nobody: with no session the read is 401 before any decision, and a dev
+     * session is decided exactly like an SSO one. This principal holds no audit.read grant on the
+     * collection, so it falls back to its own rows (none) rather than being handed every principal's trail.
+     */
     @Test
-    fun `auth debug returns all rows and details without authorization or a session`() = testApplication {
+    fun `under auth debug a sessionless read is rejected and a signed-in read still authorizes`() = testApplication {
         val app = wireAuditApp(authDebug = true)
 
         app.roleSource.reset()
+        assertEquals(HttpStatusCode.Unauthorized, app.client.get("/api/audit?limit=500").status)
+        assertEquals(0, app.roleSource.lookupCount, "an unauthenticated read must not reach Cedar")
+
+        app.client.login(GRANTLESS)
+        app.roleSource.reset()
         val listResponse = app.client.get("/api/audit?limit=500")
         assertEquals(HttpStatusCode.OK, listResponse.status)
-        val records: List<AuditEvent> = listResponse.body()
-        assertEquals(normalIds + e3Id, records.mapNotNull { it.id }.toSet())
-        assertEquals("approval_lifecycle", records.single { it.id == e3Id }.kind)
-        assertEquals(0, app.roleSource.lookupCount)
+        assertEquals(emptyList(), listResponse.body<List<AuditEvent>>().mapNotNull { it.id })
+        assertTrue(app.roleSource.lookupCount > 0, "the decision must run: authDebug authenticates, never authorizes")
 
-        app.roleSource.reset()
+        // Another principal's record is not readable without a grant — 404, the same non-oracle the
+        // collection fallback implies.
         val detailResponse = app.client.get("/api/audit/${bobIds.first()}")
-        assertEquals(HttpStatusCode.OK, detailResponse.status)
-        assertEquals(BOB, detailResponse.body<AuditEvent>().principal)
-        assertEquals(0, app.roleSource.lookupCount)
+        assertEquals(HttpStatusCode.NotFound, detailResponse.status)
     }
 
     @Test
@@ -279,12 +281,7 @@ class AuditReadRoutesDbTest {
             webSessionCookie(sessionStore, config.sessionSecret)
         }
         routing {
-            post("/test/session/{principal}") {
-                val principal = requireNotNull(call.parameters["principal"])
-                val deviceId = call.ensureDeviceCookie(secure = false)
-                call.sessions.set(WebSessionRef(sessionStore.mintWeb(principal, null, config.webSessionAbsoluteSeconds, config.webSessionIdleSeconds, deviceId)))
-                call.respond(HttpStatusCode.NoContent)
-            }
+            testLoginRoute(sessionStore, config)
             auditRoutes(config, auditStore, authz)
         }
     }
@@ -318,5 +315,9 @@ class AuditReadRoutesDbTest {
         const val ALICE = "alice"
         const val BOB = "bob"
         const val AUDITOR = "auditor-user"
+
+        // A principal with no roles and no audited rows of its own, so a read that fell back to own-rows
+        // returns an observably EMPTY list rather than one that merely looks filtered.
+        const val GRANTLESS = "grantless"
     }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AuthAuditDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AuthAuditDbTest.kt
@@ -82,13 +82,20 @@ class AuthAuditDbTest {
         core = ControlPlaneCore(dataSource)
         grpc = ControlPlaneGrpcService(core)
         val policyStore = CedarPolicyStore(dataSource)
-        authz = Authz(CedarEngine(policyStore), policyStore, RoleSource { emptySet() })
+        // token-admin@example.com holds system:admin so the seeded token.revoke oversight policy applies to
+        // it — the cross-principal revoke below is the case under test, and it has to be authorized for real.
+        // Everyone else resolves to no roles, so their own token.mint still comes from the token.self seed.
+        authz = Authz(
+            CedarEngine(policyStore),
+            policyStore,
+            RoleSource { principal -> if (principal == "token-admin@example.com") setOf("system:admin") else emptySet() },
+        )
         sessionStore = PrincipalSessionStore(dataSource, null)
         datasourceName = core.datasourceStore.create(DatasourceInput("auth-audit-ds", "postgres")).name
     }
 
-    /** authDebug bypasses requireAuthz, so the routes under test decide nothing here — the point is who the
-     *  audit row NAMES, and a signed-in caller is established through the same web-session cookie the app uses.
+    /** The point here is who the audit row NAMES, not whether the route admits — a signed-in caller is
+     *  established through the same web-session cookie the app uses, and authorizes on its real roles.
      *  The test host's socket peer is trusted as an edge so [CALLER_ADDR] resolves off `X-Forwarded-For`,
      *  which is how the recorder's client-address wiring is pinned to a known value. */
     private fun testConfig() = Config(

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/CedarPolicyRoutesTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/CedarPolicyRoutesTest.kt
@@ -14,9 +14,12 @@ import com.ridi.oss.proxymonster.controlplane.management.ManagementAuditRecorder
 import com.ridi.oss.proxymonster.controlplane.management.PolicyManagementService
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.testLoginRoute
+import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.post
@@ -29,9 +32,7 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.routing.routing
-import io.ktor.server.sessions.SessionTransportTransformerMessageAuthentication
 import io.ktor.server.sessions.Sessions
-import io.ktor.server.sessions.cookie
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import kotlinx.serialization.json.Json
@@ -53,7 +54,10 @@ import kotlin.test.assertTrue
 class CedarPolicyRoutesTest {
     private lateinit var ds: DataSource
     private lateinit var store: CedarPolicyStore
+    private lateinit var sessionStore: PrincipalSessionStore
     private lateinit var authz: Authz
+
+    private val admin = "dev@example.com"
 
     @BeforeAll
     fun setup() {
@@ -61,7 +65,11 @@ class CedarPolicyRoutesTest {
         ds = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_cedar_policy_routes"))
         Flyway.configure().dataSource(ds).load().migrate()
         store = CedarPolicyStore(ds)
-        authz = Authz(CedarEngine(store), store, RoleSource { emptySet() })
+        sessionStore = PrincipalSessionStore(ds, null)
+        // These routes are admin-gated, so the caller needs a real role: system:admin, which the seeded
+        // bootstrap policy grants admin.* to. Roles come from the RoleSource port rather than a seeded
+        // assignment, keeping the fixture's authority explicit.
+        authz = Authz(CedarEngine(store), store, RoleSource { setOf("system:admin") })
     }
 
     @Test
@@ -133,7 +141,7 @@ class CedarPolicyRoutesTest {
     }
 
     @Test
-    fun `debug HTTP mutation records the unknown console actor exactly once`() = testApplication {
+    fun `an HTTP mutation records the console actor exactly once`() = testApplication {
         store.setEnabled(-1, enabled = true, updatedBy = "setup@example.com")
         val before = adminToggleCount()
         val response = policyClient().post("/api/policies/-1/disable")
@@ -145,7 +153,9 @@ class CedarPolicyRoutesTest {
                    WHERE kind='admin' AND resource='Policy::"-1"' ORDER BY id DESC LIMIT 1""",
             ).use { ps -> ps.executeQuery().use { rs -> rs.next(); (1..4).map(rs::getString) } }
         }
-        assertEquals(listOf("admin.policies", "Policy::\"-1\"", "console", "unknown"), row)
+        // The row names the principal the authorization decision ran against, so the trail and the gate
+        // cannot disagree about who acted.
+        assertEquals(listOf("admin.policies", "Policy::\"-1\"", "console", admin), row)
     }
 
     @Test
@@ -230,16 +240,25 @@ class CedarPolicyRoutesTest {
     private fun tagRule(tag: String): String =
         """permit(principal, action == Action::"context.tag::$tag", resource) when { context has channel };"""
 
-    private fun ApplicationTestBuilder.policyClient(): HttpClient {
+    /** The routes plus a client already signed in as [admin] — every case below is an admin mutation. */
+    private suspend fun ApplicationTestBuilder.policyClient(): HttpClient {
+        val config = config()
         application {
-            val config = config()
+            attributes.put(PRINCIPAL_SESSION_STORE, sessionStore)
             install(ContentNegotiation) { json(Json { encodeDefaults = true }) }
-            routing { cedarPolicyRoutes(config, authz, store) }
+            install(Sessions) { webSessionCookie(sessionStore, config.sessionSecret) }
+            routing {
+                testLoginRoute(sessionStore, config)
+                cedarPolicyRoutes(config, authz, store)
+            }
         }
-        return createClient {
+        val client = createClient {
             expectSuccess = false
+            install(HttpCookies)
             install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
         }
+        assertEquals(HttpStatusCode.NoContent, client.post("/test/session/$admin").status)
+        return client
     }
 
     private fun config() = Config(
@@ -247,7 +266,7 @@ class CedarPolicyRoutesTest {
         dbUrl = "",
         dbUser = "",
         dbPassword = "",
-        authDebug = true,
+        authDebug = false,
         secretToken = null,
         sessionSecret = "policy-route-test-secret",
         oidc = null,

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/EditorSubmitRouteDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/EditorSubmitRouteDbTest.kt
@@ -6,6 +6,7 @@ import com.ridi.oss.proxymonster.controlplane.grpc.ControlPlaneGrpcService
 import com.ridi.oss.proxymonster.controlplane.grpc.GrpcServer
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.testLoginRoute
 import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
 import com.ridi.oss.proxymonster.grpc.ControlPlaneGrpcKt
 import com.ridi.oss.proxymonster.grpc.ControlRunMsg
@@ -36,12 +37,8 @@ import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.server.response.respond
-import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import io.ktor.server.sessions.Sessions
-import io.ktor.server.sessions.sessions
-import io.ktor.server.sessions.set
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.CompletableDeferred
@@ -78,11 +75,11 @@ import kotlin.test.fail
  * returns 202 while the run proceeds async on the held session, the enforced result is SAVED (not returned
  * inline), and the client observes completion by polling. Delete-on-close removes the tab's task + rows.
  *
- * Runs under `authDebug=true`, so the caller is the literal `debug-user` (given a role so the fail-closed
- * "own roles" gate passes) and the editor self-approve Cedar gate is bypassed — the V44 self-approve policy
- * gets its own isolated coverage in [EditorSelfApproveAuthzDbTest]. The masked re-decision at GET /result
- * (the shared `decideResultView`) is covered by the Approval result tests; here the result view's GATING
- * (not-ready 409, non-owner task.assume 404) is exercised, which never reaches the analyzer.
+ * The caller signs in as an ordinary principal holding one role, which the fail-closed "own roles" gate
+ * requires; the V44 editor self-approve policy gets its own isolated coverage in
+ * [EditorSelfApproveAuthzDbTest]. The masked re-decision at GET /result (the shared `decideResultView`) is
+ * covered by the Approval result tests; here the result view's GATING (not-ready 409, non-owner task.assume
+ * 404) is exercised, which never reaches the analyzer.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class EditorSubmitRouteDbTest {
@@ -96,8 +93,9 @@ class EditorSubmitRouteDbTest {
     private lateinit var stub: ControlPlaneGrpcKt.ControlPlaneCoroutineStub
     private lateinit var rawChannel: ManagedChannel
     private lateinit var appScope: CoroutineScope
+    private lateinit var sessionStore: PrincipalSessionStore
 
-    private val caller = "debug-user" // the authDebug fallback principal (no session cookie is sent)
+    private val caller = "dev@example.com"
 
     @BeforeAll
     fun setup() {
@@ -108,20 +106,20 @@ class EditorSubmitRouteDbTest {
         runExecService = RunExecService(core)
         resultStore = QueryResultStore(dataSource, ResultCrypto(ByteArray(32) { it.toByte() }))
         appScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        sessionStore = PrincipalSessionStore(dataSource, null)
 
         datasource = core.datasourceStore.create(
             DatasourceInput(name = "editor-submit-ds", engine = "postgres", host = "localhost", port = 5432, dbName = "app"),
         )
         core.userGroupStore.createUser(
-            AppUserInput(principal = caller), core.tokenStore, core.accessStore,
-            PrincipalSessionStore(dataSource, null),
+            AppUserInput(principal = caller), core.tokenStore, core.accessStore, sessionStore,
         )
-        // The editor requires the caller to have ≥1 own role (fail-closed) — give debug-user one.
+        // The editor requires the caller to have ≥1 own role (fail-closed).
         val roleId = core.policyStore.createRole(RoleInput("editor-analyst")).id
         core.policyStore.createAssignment(RoleAssignmentInput(caller, roleId))
 
         config = Config(
-            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = true, secretToken = null,
+            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = false, secretToken = null,
             sessionSecret = "editor-submit-test-secret", oidc = null, resultKey = null, scimToken = null,
             sessionWindowSeconds = 3600, idpRecheckIntervalSeconds = 600, devMarker = true,
         )
@@ -143,57 +141,31 @@ class EditorSubmitRouteDbTest {
         require(predicate()) { "timed out awaiting: $what" }
     }
 
-    private fun ApplicationTestBuilder.wire(cfg: Config = config, hub: TaskCompletionHub? = null): HttpClient {
+    /**
+     * The routes plus a client already signed in as [caller] — every editor route resolves the caller from
+     * a real web-session cookie (the same webSessionCookie transport App uses).
+     */
+    private suspend fun ApplicationTestBuilder.wire(hub: TaskCompletionHub? = null): HttpClient {
         application {
+            attributes.put(PRINCIPAL_SESSION_STORE, sessionStore)
             install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
+            install(Sessions) { webSessionCookie(sessionStore, config.sessionSecret) }
             routing {
+                testLoginRoute(sessionStore, config)
                 editorSessionRoutes(
-                    cfg, core.datasourceStore, core.accessStore, resultStore,
+                    config, core.datasourceStore, core.accessStore, resultStore,
                     core.policyStore, core.userGroupStore, core.roleResolver, core.authz, runExecService,
                     appScope, core.systemClassification, hub,
                 )
             }
         }
-        return createClient {
+        val client = createClient {
             expectSuccess = false
             install(HttpCookies)
             install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
         }
-    }
-
-    // A session-authenticated wiring for the non-authDebug Cedar gate: [cfg] must have authDebug=false, so
-    // requireApi needs a real web-session cookie. A /test/session/{principal} route mints one (the same
-    // webSessionCookie transport App uses), and [login] sets it on the client before driving the route.
-    private fun ApplicationTestBuilder.wireAuthenticated(cfg: Config): HttpClient {
-        val sessionStore = PrincipalSessionStore(dataSource, null)
-        application {
-            attributes.put(PRINCIPAL_SESSION_STORE, sessionStore)
-            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
-            install(Sessions) { webSessionCookie(sessionStore, cfg.sessionSecret) }
-            routing {
-                post("/test/session/{principal}") {
-                    val deviceId = call.ensureDeviceCookie(secure = false)
-                    call.sessions.set(
-                        WebSessionRef(sessionStore.mintWeb(requireNotNull(call.parameters["principal"]), null, 7200, 900, deviceId)),
-                    )
-                    call.respond(HttpStatusCode.NoContent)
-                }
-                editorSessionRoutes(
-                    cfg, core.datasourceStore, core.accessStore, resultStore,
-                    core.policyStore, core.userGroupStore, core.roleResolver, core.authz, runExecService,
-                    appScope, core.systemClassification,
-                )
-            }
-        }
-        return createClient {
-            expectSuccess = false
-            install(HttpCookies)
-            install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
-        }
-    }
-
-    private suspend fun HttpClient.login(principal: String) {
-        assertEquals(HttpStatusCode.NoContent, post("/test/session/$principal").status)
+        assertEquals(HttpStatusCode.NoContent, client.post("/test/session/$caller").status)
+        return client
     }
 
     private fun rowsChunk(columns: List<String>, rows: List<List<String?>>): ProxyRunMsg = proxyRunMsg {
@@ -470,13 +442,10 @@ class EditorSubmitRouteDbTest {
 
     @Test
     fun `a task_read forbid denies the owner's poll with 404`() = testApplication {
-        // The other route tests run under authDebug (Cedar bypassed). task.read gates the poll metadata, so a
-        // Cedar forbid must override the owner self-read permit — the owner guard alone is not the authorization.
-        // Wire the route with authDebug=false so the gate actually runs, authenticating as the task owner via a
-        // real web-session cookie. The CedarEngine polls stateVersion, so a freshly-inserted forbid takes effect
-        // live and its deletion restores the baseline.
-        val client = wireAuthenticated(config.copy(authDebug = false))
-        client.login(caller)
+        // task.read gates the poll metadata, so a Cedar forbid must override the owner self-read permit —
+        // the owner guard alone is not the authorization. The CedarEngine polls stateVersion, so a
+        // freshly-inserted forbid takes effect live and its deletion restores the baseline.
+        val client = wire()
         val task = core.accessStore.createEditorTask(
             caller, datasource.id, "select id from t", listOf("editor-analyst"), caller,
         )
@@ -507,8 +476,8 @@ class EditorSubmitRouteDbTest {
     @Test
     fun `poll and result for a non-owner editor task are 404`() = testApplication {
         val client = wire()
-        // A task owned by someone OTHER than the authDebug caller (debug-user): poll is owner-scoped and
-        // result is task.assume-scoped, so both 404 for debug-user.
+        // A task owned by someone OTHER than the signed-in caller: poll is owner-scoped and result is
+        // task.assume-scoped, so both 404.
         val other = core.accessStore.createEditorTask(
             "someone-else@example.com", datasource.id, "select id from t", listOf("editor-analyst"), "someone-else@example.com",
         )

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/MePermissionsRouteTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/MePermissionsRouteTest.kt
@@ -4,6 +4,7 @@ import com.ridi.oss.proxymonster.controlplane.authz.Authz
 import com.ridi.oss.proxymonster.controlplane.authz.CedarEngine
 import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyStore
 import com.ridi.oss.proxymonster.controlplane.authz.RoleSource
+import com.ridi.oss.proxymonster.controlplane.support.testLoginRoute
 import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -18,14 +19,8 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.server.response.respond
-import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
-import io.ktor.server.sessions.SessionTransportTransformerMessageAuthentication
 import io.ktor.server.sessions.Sessions
-import io.ktor.server.sessions.cookie
-import io.ktor.server.sessions.set
-import io.ktor.server.sessions.sessions
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import java.sql.Connection
@@ -101,23 +96,40 @@ class MePermissionsRouteTest {
         Json.parseToJsonElement(body).jsonObject.getValue("isAdmin").jsonPrimitive.boolean
 
     @Test
-    fun `non-debug requests require a session`() = testApplication {
+    fun `requests require a session`() = testApplication {
         val client = wirePermissionsApp(config(authDebug = false), authz(), dataSource)
 
         assertEquals(HttpStatusCode.Unauthorized, client.get("/api/me/permissions").status)
     }
 
+    /**
+     * A session is what authenticates, in either mode: `PM_AUTH_DEBUG` is a login METHOD, so turning it on
+     * changes nothing about needing to log in first.
+     */
     @Test
-    fun `auth debug returns all capabilities without a session`() = testApplication {
+    fun `auth debug does not admit a caller without a session`() = testApplication {
         val client = wirePermissionsApp(config(authDebug = true), authz(), dataSource)
+
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/api/me/permissions").status)
+    }
+
+    /**
+     * The capabilities reported are the ones Cedar actually grants the logged-in principal. Claiming admin
+     * for a session signed in with a low-privilege role would render every admin affordance and each one
+     * would 403 on click — the console has to describe the authority the routes will actually grant.
+     */
+    @Test
+    fun `a principal holding no roles claims no capabilities`() = testApplication {
+        val client = wirePermissionsApp(config(authDebug = true), authz(), dataSource)
+        assertEquals(HttpStatusCode.NoContent, client.post("/test/session/roleless").status)
 
         val response = client.get("/api/me/permissions")
         assertEquals(HttpStatusCode.OK, response.status)
         val payload = Json.parseToJsonElement(response.bodyAsText()).jsonObject
         assertEquals(setOf("isAdmin", "canReadAllAudit", "canApprove"), payload.keys)
-        assertEquals(true, payload.getValue("isAdmin").jsonPrimitive.boolean)
-        assertEquals(true, payload.getValue("canReadAllAudit").jsonPrimitive.boolean)
-        assertEquals(true, payload.getValue("canApprove").jsonPrimitive.boolean)
+        assertEquals(false, payload.getValue("isAdmin").jsonPrimitive.boolean)
+        assertEquals(false, payload.getValue("canReadAllAudit").jsonPrimitive.boolean)
+        assertEquals(false, payload.getValue("canApprove").jsonPrimitive.boolean)
     }
 
     @Test
@@ -206,12 +218,7 @@ private fun Application.installPermissionsTestApp(config: Config, authz: Authz, 
         webSessionCookie(sessionStore, config.sessionSecret)
     }
     routing {
-        post("/test/session/{principal}") {
-            val principal = requireNotNull(call.parameters["principal"])
-            val deviceId = call.ensureDeviceCookie(secure = false)
-            call.sessions.set(WebSessionRef(sessionStore.mintWeb(principal, null, config.webSessionAbsoluteSeconds, config.webSessionIdleSeconds, deviceId)))
-            call.respond(HttpStatusCode.NoContent)
-        }
+        testLoginRoute(sessionStore, config)
         mePermissionsRoute(config, authz)
     }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TableDetailDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TableDetailDbTest.kt
@@ -7,6 +7,8 @@ import com.ridi.oss.proxymonster.controlplane.authz.RoleSource
 import com.ridi.oss.proxymonster.controlplane.grpc.ControlPlaneGrpcService
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.testLoginRoute
+import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
 import com.ridi.oss.proxymonster.grpc.ControlEvent
 import com.ridi.oss.proxymonster.grpc.ProxyTableDetailMsg
 import com.ridi.oss.proxymonster.grpc.controlTableDetailMsg
@@ -23,8 +25,10 @@ import com.ridi.oss.proxymonster.probe.TableMetadata
 import com.ridi.oss.proxymonster.probe.TableRelation
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.client.request.post
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
@@ -33,9 +37,7 @@ import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.routing.routing
-import io.ktor.server.sessions.SessionTransportTransformerMessageAuthentication
 import io.ktor.server.sessions.Sessions
-import io.ktor.server.sessions.cookie
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.CompletableDeferred
@@ -77,12 +79,14 @@ class TableDetailDbTest {
     private lateinit var mysql: Fixture
     private val fakeProxies = ArrayList<FakeTableDetailProxy>()
 
+    private val caller = "dev@example.com"
+
     private val config = Config(
         httpPort = 0,
         dbUrl = "",
         dbUser = "",
         dbPassword = "",
-        authDebug = true,
+        authDebug = false,
         secretToken = null,
         sessionSecret = "table-detail-test-secret",
         oidc = null,
@@ -103,9 +107,8 @@ class TableDetailDbTest {
         policyStore = core.policyStore
         val cedarStore = CedarPolicyStore(metadata)
         // This suite exercises detail ASSEMBLY, not the connect gate (DatasourceMetadataConnectGateDbTest
-        // owns that), so the engine carries an outright connect permit rather than leaning on PM_AUTH_DEBUG —
-        // the flag bypasses authentication, never the Cedar decision, so a route reached under it still needs
-        // a grant. The permit goes to the ENGINE, which is what authorize() reads.
+        // owns that), so the engine carries an outright connect permit and every case signs in as an
+        // ordinary principal. The permit goes to the ENGINE, which is what authorize() reads.
         authz = Authz(
             CedarEngine(listOf(1L to """permit(principal, action == Action::"datasource.connect", resource);""")),
             cedarStore,
@@ -374,17 +377,25 @@ class TableDetailDbTest {
         )
     }
 
-    private fun ApplicationTestBuilder.wireTableDetailApp(): HttpClient {
+    /** The routes plus a client already signed in as [caller] — the detail route needs an authenticated one. */
+    private suspend fun ApplicationTestBuilder.wireTableDetailApp(): HttpClient {
         application { installTableDetailTestApp() }
-        return createClient {
+        val client = createClient {
             expectSuccess = false
+            install(HttpCookies)
             install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
         }
+        assertEquals(HttpStatusCode.NoContent, client.post("/test/session/$caller").status)
+        return client
     }
 
     private fun Application.installTableDetailTestApp() {
+        val sessionStore = PrincipalSessionStore(metadata, null)
+        attributes.put(PRINCIPAL_SESSION_STORE, sessionStore)
         install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
+        install(Sessions) { webSessionCookie(sessionStore, config.sessionSecret) }
         routing {
+            testLoginRoute(sessionStore, config)
             datasourceRoutes(config, authz, core.roleResolver, datasourceStore, core.proxyEventsHub, TableDetailService(core), core.tokenStore, core.userGroupStore)
         }
     }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TaskEventsRouteDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TaskEventsRouteDbTest.kt
@@ -25,7 +25,6 @@ class TaskEventsRouteDbTest {
     private lateinit var datasource: Datasource
     private lateinit var sessionStore: PrincipalSessionStore
     private lateinit var prod: Config
-    private lateinit var debug: Config
     private val caller = "alice@example.com"
 
     @BeforeAll
@@ -46,14 +45,28 @@ class TaskEventsRouteDbTest {
             sessionSecret = "task-events-test", oidc = null, resultKey = null, scimToken = null,
             sessionWindowSeconds = 3600, idpRecheckIntervalSeconds = 600, devMarker = true,
         )
-        debug = prod.copy(authDebug = true)
     }
 
     private fun newTask(): Long =
         core.accessStore.createEditorTask(caller, datasource.id, "select 1", listOf("editor-analyst"), caller).id
 
-    private fun readable(taskId: Long, config: Config = prod) =
-        taskReadableForPush(config, caller, taskId, AuthzContext(), core.accessStore, core.authz, core.datasourceStore)
+    private fun readable(taskId: Long) =
+        taskReadableForPush(caller, taskId, AuthzContext(), core.accessStore, core.authz, core.datasourceStore)
+
+    /**
+     * A stream lasts exactly as long as its session, in every mode. `PM_AUTH_DEBUG` is a login method, not a
+     * way to stream without logging in, so a logged-out or displaced dev session stops receiving pushes just
+     * as it would in production.
+     */
+    @Test
+    fun `a stream ends when its session dies, and no session never streams`() {
+        val deviceId = "sse-device"
+        val sessionId = sessionStore.mintWeb(caller, null, prod.webSessionAbsoluteSeconds, prod.webSessionIdleSeconds, deviceId)
+        assertTrue(sessionStillLive(sessionId, deviceId, sessionStore), "a live session streams")
+        assertTrue(sessionStore.endWeb(sessionId, "logout"), "the fixture must actually end the session")
+        assertFalse(sessionStillLive(sessionId, deviceId, sessionStore), "a dead session's stream ends")
+        assertFalse(sessionStillLive(null, null, sessionStore), "a caller with no session never streams")
+    }
 
     @Test
     fun `the push task_read filter mirrors the poll - owner allowed, a forbid suppresses, absent denied`() {
@@ -75,21 +88,20 @@ class TaskEventsRouteDbTest {
         }
         assertTrue(readable(task), "with the forbid gone the push is allowed again")
 
-        // An absent task is never pushable (no oracle), and authDebug bypasses the gate (dev parity with routes).
+        // An absent task is never pushable — no oracle. PM_AUTH_DEBUG cannot change that: it decides who the
+        // caller is, never what they may read, so the filter runs for real in dev too.
         assertFalse(readable(-999_999L), "a missing task is not readable")
-        assertTrue(readable(-999_999L, debug), "authDebug bypasses the gate")
     }
 
     @Test
     fun `session liveness tracks minting and revocation`() {
         val sessionId = sessionStore.mintWeb(caller, null, 7200, 900, "device-1")
-        assertTrue(sessionStillLive(prod, sessionId, "device-1", sessionStore), "a freshly minted session is live")
+        assertTrue(sessionStillLive(sessionId, "device-1", sessionStore), "a freshly minted session is live")
 
         assertTrue(sessionStore.endWeb(sessionId, "test-logout"))
-        assertFalse(sessionStillLive(prod, sessionId, "device-1", sessionStore), "a revoked session is not live → stream ends")
+        assertFalse(sessionStillLive(sessionId, "device-1", sessionStore), "a revoked session is not live → stream ends")
 
-        // authDebug has no session and is always live; a null session id is never live.
-        assertTrue(sessionStillLive(debug, null, null, sessionStore))
-        assertFalse(sessionStillLive(prod, null, "device-1", sessionStore))
+        // A null session id is never live, flag or no flag.
+        assertFalse(sessionStillLive(null, "device-1", sessionStore))
     }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TokenRoutesDeactivationTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TokenRoutesDeactivationTest.kt
@@ -6,18 +6,22 @@ import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyStore
 import com.ridi.oss.proxymonster.controlplane.authz.RoleSource
 import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.testLoginRoute
+import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
+import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.routing
 import io.ktor.server.sessions.Sessions
-import io.ktor.server.sessions.SessionTransportTransformerMessageAuthentication
-import io.ktor.server.sessions.cookie
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import kotlinx.serialization.Serializable
@@ -48,6 +52,11 @@ class TokenRoutesDeactivationTest {
     private lateinit var userGroupStore: UserGroupStore
     private lateinit var authz: Authz
     private lateinit var config: Config
+    private lateinit var sessionStore: PrincipalSessionStore
+
+    // The deprovisioned caller every mint test below runs as. Both routes mint for the SESSION-holder, so
+    // the caller has to be the deactivated principal itself for the backstop to be what refuses.
+    private val caller = "dev@example.com"
 
     @BeforeAll
     fun setup() {
@@ -57,34 +66,42 @@ class TokenRoutesDeactivationTest {
         tokenStore = TokenStore(ds)
         accessStore = AccessStore(ds)
         daemonSessionStore = PrincipalSessionStore(ds, null)
+        sessionStore = PrincipalSessionStore(ds, null)
         userGroupStore = UserGroupStore(ds)
-        // authDebug=true below bypasses authz in requireAuthz, so this instance is only needed to satisfy
-        // the route signature; back it with the real migrated policy store all the same.
+        // The mint routes gate on token.mint, which the seeded self-permit grants a principal on its OWN
+        // Token — so the engine reads the real migrated policy store and the caller needs no role.
         val policyStore = CedarPolicyStore(ds)
         authz = Authz(CedarEngine(policyStore), policyStore, RoleSource { emptySet() })
         config = Config(
-            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = true, secretToken = null,
+            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = false, secretToken = null,
             sessionSecret = "test-secret", oidc = null, resultKey = null,
             scimToken = null, sessionWindowSeconds = 3600, idpRecheckIntervalSeconds = 600, devMarker = true,
         )
-        // principalOf(call) falls back to this literal under authDebug when no session cookie is
-        // sent (Tokens.kt:194) — no test here installs one. Deactivate it once, up front, so every
-        // mint-route test below sees a deprovisioned caller.
-        userGroupStore.createUser(AppUserInput(principal = "debug-user"), tokenStore, accessStore, daemonSessionStore)
-        userGroupStore.setUserActive("debug-user", false)
+        userGroupStore.createUser(AppUserInput(principal = caller), tokenStore, accessStore, daemonSessionStore)
+        userGroupStore.setUserActive(caller, false)
     }
 
-    private fun ApplicationTestBuilder.installTokenRoutes() {
-        install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
-        routing {
-            tokenRoutes(config, tokenStore, userGroupStore, authz, AuthAuditRecorder(AuditStore(ds)))
+    private fun ApplicationTestBuilder.installTokenRoutes(): HttpClient {
+        application {
+            attributes.put(PRINCIPAL_SESSION_STORE, sessionStore)
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
+            install(Sessions) { webSessionCookie(sessionStore, config.sessionSecret) }
+            routing {
+                testLoginRoute(sessionStore, config)
+                tokenRoutes(config, tokenStore, userGroupStore, authz, AuthAuditRecorder(AuditStore(ds)))
+            }
+        }
+        return createClient {
+            expectSuccess = false
+            install(HttpCookies)
+            install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
         }
     }
 
     @Test
     fun `POST api-wire-tokens for a deactivated principal is refused before minting`() = testApplication {
-        installTokenRoutes()
-        val client = createClient { install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) } }
+        val client = installTokenRoutes()
+        assertEquals(HttpStatusCode.NoContent, client.post("/test/session/$caller").status)
 
         val resp = client.post("/api/wire-tokens") {
             contentType(ContentType.Application.Json)
@@ -96,8 +113,8 @@ class TokenRoutesDeactivationTest {
 
     @Test
     fun `POST api-tokens for a deactivated principal is refused before minting`() = testApplication {
-        installTokenRoutes()
-        val client = createClient { install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) } }
+        val client = installTokenRoutes()
+        assertEquals(HttpStatusCode.NoContent, client.post("/test/session/$caller").status)
 
         val resp = client.post("/api/tokens") {
             contentType(ContentType.Application.Json)

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/WebSessionRoutesDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/WebSessionRoutesDbTest.kt
@@ -149,7 +149,7 @@ class WebSessionRoutesDbTest {
             module(config, core)
             routing {
                 serverGet("/test/protected") {
-                    if (!call.requireApi(config.copy(authDebug = false))) return@serverGet
+                    call.requireApi() ?: return@serverGet
                     call.respond(HttpStatusCode.OK)
                 }
             }
@@ -388,7 +388,7 @@ class WebSessionRoutesDbTest {
             module(config, ControlPlaneCore(dataSource))
             routing {
                 serverGet("/test/protected") {
-                    if (!call.requireApi(config.copy(authDebug = false))) return@serverGet
+                    call.requireApi() ?: return@serverGet
                     call.respond(HttpStatusCode.OK)
                 }
             }
@@ -435,7 +435,7 @@ class WebSessionRoutesDbTest {
             module(config, ControlPlaneCore(dataSource))
             routing {
                 serverGet("/api/test/protected") {
-                    if (!call.requireApi(config.copy(authDebug = false))) return@serverGet
+                    call.requireApi() ?: return@serverGet
                     call.respond(HttpStatusCode.OK)
                 }
             }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackNotificationE2eDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackNotificationE2eDbTest.kt
@@ -5,6 +5,7 @@ import com.ridi.oss.proxymonster.controlplane.AppUserInput
 import com.ridi.oss.proxymonster.controlplane.Config
 import com.ridi.oss.proxymonster.controlplane.ControlPlaneCore
 import com.ridi.oss.proxymonster.controlplane.CreateApprovalResponse
+import com.ridi.oss.proxymonster.controlplane.PRINCIPAL_SESSION_STORE
 import com.ridi.oss.proxymonster.controlplane.PrincipalSessionStore
 import com.ridi.oss.proxymonster.controlplane.QueryResultStore
 import com.ridi.oss.proxymonster.controlplane.ResultCrypto
@@ -20,6 +21,8 @@ import com.ridi.oss.proxymonster.controlplane.runApprovedTask
 import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
 import com.ridi.oss.proxymonster.controlplane.support.MockSlack
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.controlplane.support.testLoginRoute
+import com.ridi.oss.proxymonster.controlplane.support.webSessionCookie
 import com.ridi.oss.proxymonster.grpc.ControlPlaneGrpcKt
 import com.ridi.oss.proxymonster.grpc.EnfAction as WireEnfAction
 import com.ridi.oss.proxymonster.grpc.ProxyRunMsg
@@ -37,6 +40,7 @@ import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -46,6 +50,7 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.routing.routing
+import io.ktor.server.sessions.Sessions
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.CoroutineScope
@@ -100,10 +105,11 @@ class SlackNotificationE2eDbTest {
     private lateinit var http: HttpClient
     private lateinit var svc: NotificationService
     private lateinit var socket: SlackSocketMode
+    private lateinit var sessionStore: PrincipalSessionStore
 
-    // The compose route runs under authDebug, so the requester is the literal debug principal; the Slack click
-    // resolves the approver's verified email to its own active app_user principal.
-    private val requester = "debug-user"
+    // The requester signs in to the compose route; the Slack click resolves the approver's verified email to
+    // its own active app_user principal.
+    private val requester = "dev@example.com"
     private val approver = "admin@example.com"
     private var runnerRoleId = 0L
     private val runScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -116,8 +122,9 @@ class SlackNotificationE2eDbTest {
         core = ControlPlaneCore(fx.dataSource)
         resultStore = QueryResultStore(fx.dataSource, ResultCrypto(ByteArray(32) { it.toByte() }))
         runExecService = RunExecService(core)
+        sessionStore = PrincipalSessionStore(fx.dataSource, null)
         config = Config(
-            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = true, secretToken = null,
+            httpPort = 0, dbUrl = "", dbUser = "", dbPassword = "", authDebug = false, secretToken = null,
             sessionSecret = "e2e-test-secret", oidc = null, resultKey = null, scimToken = null,
             sessionWindowSeconds = 3600, idpRecheckIntervalSeconds = 600, devMarker = true,
         )
@@ -204,10 +211,14 @@ class SlackNotificationE2eDbTest {
         }
     }
 
-    private fun ApplicationTestBuilder.wire(): HttpClient {
+    /** The compose route plus a client already signed in as [requester]. */
+    private suspend fun ApplicationTestBuilder.wire(): HttpClient {
         application {
+            attributes.put(PRINCIPAL_SESSION_STORE, sessionStore)
             install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true; encodeDefaults = true }) }
+            install(Sessions) { webSessionCookie(sessionStore, config.sessionSecret) }
             routing {
+                testLoginRoute(sessionStore, config)
                 approvalRoutes(
                     config, core.accessStore, core.auditStore, core.datasourceStore, core.policyStore,
                     core.userGroupStore, resultStore, core.roleResolver, core.authz, runExecService,
@@ -215,10 +226,13 @@ class SlackNotificationE2eDbTest {
                 )
             }
         }
-        return createClient {
+        val client = createClient {
             expectSuccess = false
+            install(HttpCookies)
             install(ClientContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
         }
+        assertEquals(HttpStatusCode.NoContent, client.post("/test/session/$requester").status)
+        return client
     }
 
     private suspend fun awaitUntil(what: String, predicate: () -> Boolean) {

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/WebSessionTestSupport.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/WebSessionTestSupport.kt
@@ -4,8 +4,16 @@ import com.ridi.oss.proxymonster.controlplane.PrincipalSessionStorage
 import com.ridi.oss.proxymonster.controlplane.PrincipalSessionStore
 import com.ridi.oss.proxymonster.controlplane.SESSION_COOKIE
 import com.ridi.oss.proxymonster.controlplane.WebSessionRef
+import com.ridi.oss.proxymonster.controlplane.Config
+import com.ridi.oss.proxymonster.controlplane.ensureDeviceCookie
 import com.ridi.oss.proxymonster.controlplane.jsonSessionSerializer
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
 import io.ktor.server.sessions.CookieIdSessionBuilder
+import io.ktor.server.sessions.sessions
+import io.ktor.server.sessions.set
 import io.ktor.server.sessions.SessionTransportTransformerMessageAuthentication
 import io.ktor.server.sessions.SessionsConfig
 import io.ktor.server.sessions.cookie
@@ -22,5 +30,31 @@ fun SessionsConfig.webSessionCookie(
         this.serializer = serializer
         transform(SessionTransportTransformerMessageAuthentication(secret.toByteArray()))
         configure()
+    }
+}
+
+/**
+ * A `POST /test/session/{principal}` route that mints a real web session and sets its cookie, so a suite
+ * can sign in as any principal in one call. `PM_AUTH_DEBUG` authenticates nobody on its own — it enables a
+ * login method — so a route test has to log in exactly like the console does.
+ *
+ * Install inside `routing { }` alongside the routes under test, then call it before the requests that need
+ * a caller. The test client needs a cookie jar (`install(HttpCookies)`) for the cookie to be carried.
+ */
+fun Route.testLoginRoute(store: PrincipalSessionStore, config: Config) {
+    post("/test/session/{principal}") {
+        val deviceId = call.ensureDeviceCookie(secure = false)
+        call.sessions.set(
+            WebSessionRef(
+                store.mintWeb(
+                    requireNotNull(call.parameters["principal"]),
+                    null,
+                    config.webSessionAbsoluteSeconds,
+                    config.webSessionIdleSeconds,
+                    deviceId,
+                ),
+            ),
+        )
+        call.respond(HttpStatusCode.NoContent)
     }
 }

--- a/docs/authz-model.md
+++ b/docs/authz-model.md
@@ -354,9 +354,10 @@ of a route and the gate it calls. Paths are relative to
 | Users, groups, group-to-role map | `/api/users**`, `/api/groups**` | `Users.kt` | `requireAdmin(admin.identity)` |
 | Cedar policies | `/api/policies**` | `authz/CedarPolicyStore.kt` | `requireAdmin(admin.policies)` |
 
-- `requireApi(config)` (`Datasources.kt`) — a live web session, or
-  `PM_AUTH_DEBUG`. Authentication only, no authorization. Routes behind it do
-  their own per-row Cedar filtering (audit, tasks, grants).
+- `requireApi()` (`Datasources.kt`) — a live web session, returning the caller
+  principal so a route never re-reads it behind an assertion. Authentication
+  only, no authorization. Routes behind it do their own per-row Cedar filtering
+  (audit, tasks, grants).
 - `requireAdmin(config, authz, action)` (`authz/Authz.kt`) — a session plus
   `authorize(principal, admin.datasources | admin.policies | admin.identity, System) == Allow`.
   401 (`common.unauthenticated`) without a session, 403 (`common.forbidden`,
@@ -369,8 +370,16 @@ of a route and the gate it calls. Paths are relative to
   constant-time compared, TLS-only. Not a session and not Cedar: this is an
   IdP-to-control-plane integration ([`auth-model.md`](./auth-model.md)).
 
-`PM_AUTH_DEBUG` short-circuits all four to allow. It is a full authentication
-bypass and must be off in production.
+`PM_AUTH_DEBUG` is an authentication setting: it enables one extra **login
+method**, `POST /auth/debug`, which signs in as any principal with any roles and
+mints a real session row with real role assignments, exactly as the OIDC
+callback does. Keep it off in production — that login lets the caller name its
+own identity.
+
+A session it mints is an ordinary session, so the gates above read it like any
+other and a dev session authorizes on the roles it logged in with. Sign in with
+a low-privilege role and you are held to it, which is how you see what such a
+role sees.
 
 Ungated by design: `GET /health`, `GET /auth/config`, the OIDC and
 device-authorization routes (they mint the session), and `POST /auth/logout`,
@@ -430,11 +439,9 @@ rows from the list. That is deliberate: classification and policy work run off
 wants admins browsing live table metadata grants them a connect policy, the same
 one that lets them query it.
 
-`PM_AUTH_DEBUG` does not short-circuit the connect decision either. It is an
-authentication bypass, and `POST /auth/debug` persists its claimed roles as real
-assignments precisely so Cedar evaluates them — so a dev session sees exactly
-what its roles grant. A bare `PM_AUTH_DEBUG=1` with no debug login resolves to a
-principal with no roles, and therefore reads no connection material.
+A dev session decides here like any other: `POST /auth/debug` persists its
+claimed roles as real assignments, so Cedar evaluates them and the session reads
+exactly the connection material those roles grant.
 
 ## What this fixes (falls out of the model, not bolted on)
 

--- a/docs/mcp-access-control.md
+++ b/docs/mcp-access-control.md
@@ -34,7 +34,7 @@ MCP covers the access-control management surface only. Target-database query
 execution, approvals, and audit-log tools are later MCP work tracked in
 [backlog.md](./backlog.md), not architectural non-goals. proxy-monster has no
 table-level tag store and does not add one, so MCP exposes only the column tags
-that already exist. The `authDebug` bypass remains available for development.
+that already exist. `PM_AUTH_DEBUG` provides the development login method.
 
 ## Why this shape
 
@@ -78,9 +78,10 @@ Three facts about the system force the design.
   token carrying `mcp:policies:write` still gets a live `admin.policies` Cedar
   check and is denied if the user lacks the role. A token _without_ that scope
   is rejected before Cedar runs. Scope subtracts, never adds.
-- Development debug parity. When `config.authDebug` is on, MCP supports the same
-  local-development authentication/authorization bypass as the other
-  control-plane surfaces; developers do not need Okta to exercise MCP locally.
+- Development debug parity. When `config.authDebug` is on, MCP accepts the same
+  dev login the other control-plane surfaces do, so developers do not need Okta
+  to exercise MCP locally. The principal chosen authorizes on its own roles, so
+  a tool call needs an `admin.*` grant.
 - Audience binding. Access tokens are bound to this resource (`resource` = the
   MCP endpoint's canonical URI, RFC 8707). A token minted for any other audience
   is rejected. proxy-monster never forwards a received token upstream (no
@@ -176,14 +177,19 @@ fallback). The client reads resource metadata → discovers the same-origin AS �
 uses its CIMD URL as `client_id` → runs auth-code+PKCE → authenticates through
 Okta → consents → calls `/mcp` with the bearer.
 
-### Development bypass
+### Development login
 
 With `PM_AUTH_DEBUG=true`, the authorization routes replace the Okta step with a
 dev-only principal selection equivalent to the existing `/auth/debug` flow and
 may auto-consent. It still issues a normal resource-bound bearer so MCP
-discovery, PKCE, token validation, and tool dispatch are exercised locally; the
-control plane then applies its existing authDebug authorization bypass.
+discovery, PKCE, token validation, and tool dispatch are exercised locally.
 Development needs no Okta connection and no second non-OAuth MCP transport.
+
+The principal must be named — an explicit `?principal=` or an existing console
+session — because this route mints a session for it. Tool dispatch then runs the
+ordinary Cedar check, so that principal needs an `admin.*` grant or every tool
+answers `common.forbidden`; sign in at `/login` with `system:admin` first, or
+authorize as a principal that already holds the role.
 
 ### Tokens
 
@@ -361,10 +367,10 @@ shape from `/validate` verbatim.
 
 ## Security & failure modes
 
-- `authDebug` on → local MCP calls use the existing debug principal/bypass with
-  no Okta round trip. With debug off, canonical HTTPS MCP/OAuth origins are
-  required; the authorization server rejects the public dev session secret and
-  incomplete OIDC configuration.
+- `authDebug` on → local MCP calls use the dev login with no Okta round trip,
+  and authorize on that principal's real roles. With debug off, canonical HTTPS
+  MCP/OAuth origins are required; the authorization server rejects the public
+  dev session secret and incomplete OIDC configuration.
 - Token for wrong audience / expired / revoked → `401`, `WWW-Authenticate`
   points back at resource metadata (the client re-auths).
 - Scope missing → tool error `mcp.insufficient_scope` _before_ Cedar (structured


### PR DESCRIPTION
`PM_AUTH_DEBUG` did two unrelated things:

1. enabled `POST /auth/debug` — a login that mints a **real** session row with real role assignments, so the session is indistinguishable from an SSO one downstream;
2. separately let a request carrying **no session at all** through the gates, as a synthetic `debug-user`.

Only the first is needed, and the second is what made the first useless for its main purpose: signing in with a low-privilege role couldn't restrict anything, because eleven Cedar decisions were short-circuited whenever the flag was on. Dev was the one environment where you could not observe what a restricted role sees.

The second is also what forced the synthetic principal to exist. A route admitted without a session still needs a name for whoever is acting, so the code invented one — and then that invented name had to be reasoned about wherever it landed. It was not always safe:

**`GET /api/access-requests` returned every principal's access requests to a sessionless caller** (`if (caller == null) rows`), skipping the per-row `task.read` filter entirely.

## What changed

No session is now 401 everywhere — `requireApi`, `requireApiOrBearer`, `requireAuthz`. `debug-user`, `DEBUG_PRINCIPAL`, and DeviceAuth's dead `DEV_PRINCIPAL` are gone, and the eleven decisions the flag used to skip (`task.request`, `task.approve`, `task.read`, `task.cancel`, the editor self-approve, `audit.read` ×2, the SSE push filter, every MCP tool, plus the `requireAuthz` chokepoint behind ~40 admin routes) now run for real.

`requireApi` returns the caller principal instead of a `Boolean`, matching its sibling `requireApiOrBearer`. Thirty-one routes had gated and then re-read the session behind `userSession()!!.principal` — an assertion safe only because of a line a few rows above it. The gate and the name now come from one call, so a handler cannot hold a principal the gate never approved.

Falling out of the rest: the SSE stream and `sessionStillLive` lose their `config` parameter, `/api/me/permissions` is computed rather than hardcoded to full admin (it would otherwise render admin affordances that 403 on click), and the audit actor names the principal the decision ran against instead of `"unknown"`.

The debug MCP authorize route now requires an explicit `?principal=` or an existing console session. It mints a session, so it is a login too — and a login should be told who rather than defaulting to a name nobody chose.

## Where it could bite

A bare `PM_AUTH_DEBUG=1` with no `/auth/debug` login now gets 401 rather than acting as `debug-user`. Log in — the console's debug login prefills roles, and `/auth/debug` takes an email plus whatever roles you want — and everything works as before, except a narrow role now genuinely restricts you.

INSTALL.md's bare-`curl` walkthrough step is replaced with a working `-c`/`-b` cookie-jar recipe. `docs/authz-model.md`, `docs/mcp-access-control.md`, and `AGENTS.md` no longer claim the flag short-circuits the gates. One permanent stale artifact: `V6__sessions.sql`'s comment describes the old short-circuit, and migrations are frozen by CI.

Left for a follow-up: `config` is now an unused parameter on `requireApiOrBearer` and a few helpers — removing it is churn that does not belong in this diff.

## Verification

`mise run verify` green, zero failures. Mutation-tested: restoring the old `!config.authDebug &&` in `requireApi` fails exactly the two rewritten tests and nothing else. The `requireApi` signature sweep was checked binding-by-binding — 23 removed, 23 added, every variable name preserved — since a mangled rewrite could have silently swapped which identity a route acts as.

Thirteen test classes had signed in through the removed bypass. They now log in via one shared `testLoginRoute` helper, which replaces nine copy-pasted copies of the same route. Three had encoded the bypass in their assertions and now assert that Cedar **ran** — stronger than what they replaced, which asserted it was skipped.

Reviewed by Codex and a Sol subagent; both found real issues fixed here (an SSE liveness regression and the MCP token gap). The third reviewer (Grok) never returned a verdict, so this had two reviews, not three — and both predate the last two rounds of change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEUc883LA49F1oKZxwvBnh