### PR TITLE
fix(control-plane): give each durable approval request a unique authz identity (GHSA-jq28)

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -309,11 +309,6 @@ tagging, table detail) and never feeds an enforcement decision.
   effect. The benign session statements the forbid does deny (`SET NAMES`,
   `BEGIN`, `SET @var`) are otherwise ungated, which is why they are the ones
   that need the channel rule.
-- 🔴 Role-approval `Request` EUID is not request-unique.
-  `Request::"<requester>#<datasource>"` omits the request id and requested role,
-  so one approval policy authorizes every later request that principal makes for
-  that datasource — a wrong-ALLOW. Tracked in
-  [`docs/backlog.md`](./docs/backlog.md).
 - 🔴 `system:admin` immutability assumes single-instance, migrate-before-serve.
   The `system:admin` group is immutable through the API and SCIM via runtime
   guards inside `UserGroupStore`, which are in-process: they serialize

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Access.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Access.kt
@@ -54,6 +54,17 @@ data class AccessRequest(
     val statementCarriesProtectedLiteral: Boolean? = null,
 )
 
+/**
+ * The authz view of this persisted approval request. Keys the Cedar `Request` EUID off the durable
+ * [AccessRequest.id] so a per-request approval policy cannot carry over to a later request with the same
+ * requester and datasource. This is the only persisted-path constructor of the resource, so no call site
+ * can reintroduce the non-unique legacy key.
+ */
+fun AccessRequest.toApprovalResource() = AuthzResource.ApprovalRequest(
+    requester = principal, id = id, approver = decidedBy, executedBy = executedBy,
+    datasourceName = datasourceName, roleName = roleName,
+)
+
 @Serializable
 data class AccessRequestInput(
     val roleId: Long, val datasourceId: Long? = null,
@@ -767,11 +778,7 @@ fun Route.accessRoutes(
             } else {
                 rows.filter {
                     authz.authorize(
-                        caller, AuthzAction.TASK_READ,
-                        AuthzResource.ApprovalRequest(
-                            requester = it.principal, approver = it.decidedBy, executedBy = it.executedBy,
-                            datasourceName = it.datasourceName, roleName = it.roleName,
-                        ),
+                        caller, AuthzAction.TASK_READ, it.toApprovalResource(),
                     ) is AuthzDecision.Allow
                 }
             },
@@ -823,11 +830,7 @@ fun Route.accessRoutes(
             // over a SINGLE role snapshot (authorizeWithContext) — the ROLE-request analog of the QUERY
             // approval routes' mayDecide (task.approve) call in Approvals.kt.
             val decision = authz.authorizeWithContext(
-                approver, AuthzAction.TASK_APPROVE,
-                AuthzResource.ApprovalRequest(
-                    requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
-                    datasourceName = req.datasourceName, roleName = req.roleName,
-                ),
+                approver, AuthzAction.TASK_APPROVE, req.toApprovalResource(),
                 call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
                 req.datasourceName,
                 req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
@@ -855,11 +858,7 @@ fun Route.accessRoutes(
             // Same role-scoped approver check as /approve — the reject path must ask the identical
             // Cedar question, so a role-scoped approval policy governs reject too (see /approve above).
             val decision = authz.authorizeWithContext(
-                approver, AuthzAction.TASK_APPROVE,
-                AuthzResource.ApprovalRequest(
-                    requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
-                    datasourceName = req.datasourceName, roleName = req.roleName,
-                ),
+                approver, AuthzAction.TASK_APPROVE, req.toApprovalResource(),
                 call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
                 req.datasourceName,
                 req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -189,10 +189,7 @@ internal fun taskReadableForPush(
     val decision = authz.authorizeWithContext(
         principal,
         AuthzAction.TASK_READ,
-        AuthzResource.ApprovalRequest(
-            requester = task.principal, approver = task.decidedBy, executedBy = task.executedBy,
-            datasourceName = task.datasourceName, roleName = task.roleName,
-        ),
+        task.toApprovalResource(),
         context,
         task.datasourceName,
         task.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
@@ -386,10 +386,7 @@ fun Route.approvalRoutes(
         val decision = authz.authorizeWithContext(
             call.userSession()?.principal ?: "debug-user",
             action,
-            AuthzResource.ApprovalRequest(
-                requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
-                datasourceName = req.datasourceName, roleName = req.roleName,
-            ),
+            req.toApprovalResource(),
             call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
             req.datasourceName,
             req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
@@ -404,10 +401,7 @@ fun Route.approvalRoutes(
         val decision = authz.authorizeWithContext(
             call.userSession()?.principal ?: "debug-user",
             AuthzAction.TASK_ASSUME,
-            AuthzResource.ApprovalRequest(
-                requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
-                datasourceName = req.datasourceName, roleName = req.roleName,
-            ),
+            req.toApprovalResource(),
             call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
             req.datasourceName,
             req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -4,7 +4,6 @@ import com.ridi.oss.proxymonster.controlplane.authz.Authz
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzContext
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzDecision
-import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
 import com.ridi.oss.proxymonster.controlplane.authz.ColumnRef
 import com.ridi.oss.proxymonster.controlplane.authz.ColumnVerdict
 import com.ridi.oss.proxymonster.controlplane.authz.FunctionRef
@@ -1155,10 +1154,7 @@ fun Route.editorSessionRoutes(
         if (!config.authDebug) {
             val mayRead = authz.authorizeWithContext(
                 principal, AuthzAction.TASK_READ,
-                AuthzResource.ApprovalRequest(
-                    requester = task.principal, approver = task.decidedBy, executedBy = task.executedBy,
-                    datasourceName = task.datasourceName, roleName = task.roleName,
-                ),
+                task.toApprovalResource(),
                 call.httpAuthzContext(config), task.datasourceName,
                 task.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
             )
@@ -1181,10 +1177,7 @@ fun Route.editorSessionRoutes(
         if (!config.authDebug) {
             val mayCancel = authz.authorizeWithContext(
                 principal, AuthzAction.TASK_CANCEL,
-                AuthzResource.ApprovalRequest(
-                    requester = task.principal, approver = task.decidedBy, executedBy = task.executedBy,
-                    datasourceName = task.datasourceName, roleName = task.roleName,
-                ),
+                task.toApprovalResource(),
                 call.httpAuthzContext(config), task.datasourceName,
                 task.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
             )
@@ -1238,10 +1231,7 @@ fun Route.editorSessionRoutes(
             ?: return@get call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "editor task")))
         val mayAssume = authz.authorizeWithContext(
             principal, AuthzAction.TASK_ASSUME,
-            AuthzResource.ApprovalRequest(
-                requester = task.principal, approver = task.decidedBy, executedBy = task.executedBy,
-                datasourceName = task.datasourceName, roleName = task.roleName,
-            ),
+            task.toApprovalResource(),
             call.httpAuthzContext(config), task.datasourceName,
             task.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
         )

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
@@ -64,9 +64,14 @@ sealed interface AuthzResource {
     data class AuditRecord(val principal: String) : AuthzResource
     /** The whole audit collection, for policies granting a global read capability. */
     data object AuditLog : AuthzResource
-    /** A task request. Datasource and role parents support scoped lifecycle policies. */
+    /** A task request. Datasource and role parents support scoped lifecycle policies. [id] is the durable
+     *  `access_request` row id — it disambiguates the EUID so an exact-Request policy cannot carry over from
+     *  one persisted request to a later one with the same requester and datasource. Null only for a
+     *  prospective check before a row exists (auto-approval), which falls back to the requester+datasource
+     *  contextual identity. */
     data class ApprovalRequest(
         val requester: String,
+        val id: Long? = null,
         val approver: String? = null,
         val executedBy: String? = null,
         val datasourceName: String? = null,
@@ -460,7 +465,9 @@ class Authz(
                 parents += roleEuid
                 extraEntities += Entity(roleEuid)
             }
-            val reqEuid = REQUEST_TYPE.of("${resource.requester}#${resource.datasourceName ?: "-"}")
+            // A durable request keys off its row id; the requester+datasource contextual form remains only for
+            // a prospective check before a row exists (auto-approval), where no durable id can be supplied.
+            val reqEuid = REQUEST_TYPE.of(resource.id?.toString() ?: "${resource.requester}#${resource.datasourceName ?: "-"}")
             val attrs = buildMap<String, Value> {
                 put("requester", requesterEuid)
                 resource.approver?.let { put("approver", USER_TYPE.of(it)) }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/RecipientResolver.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/RecipientResolver.kt
@@ -1,10 +1,10 @@
 package com.ridi.oss.proxymonster.controlplane.notify
 
 import com.ridi.oss.proxymonster.controlplane.AccessRequest
+import com.ridi.oss.proxymonster.controlplane.toApprovalResource
 import com.ridi.oss.proxymonster.controlplane.RoleResolver
 import com.ridi.oss.proxymonster.controlplane.authz.Authz
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
-import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
 import com.ridi.oss.proxymonster.controlplane.authz.SatisfiableVerdict
 import org.slf4j.LoggerFactory
 
@@ -34,13 +34,7 @@ class RecipientResolver(
     }
 
     private fun approverCandidates(req: AccessRequest): Set<String> {
-        val resource = AuthzResource.ApprovalRequest(
-            requester = req.principal,
-            approver = req.decidedBy,
-            executedBy = req.executedBy,
-            datasourceName = req.datasourceName,
-            roleName = req.roleName,
-        )
+        val resource = req.toApprovalResource()
         return candidateSource()
             .filter { candidate ->
                 authz.satisfiableAs(

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackDecisionHandler.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackDecisionHandler.kt
@@ -1,6 +1,7 @@
 package com.ridi.oss.proxymonster.controlplane.notify
 
 import com.ridi.oss.proxymonster.controlplane.AccessRequest
+import com.ridi.oss.proxymonster.controlplane.toApprovalResource
 import com.ridi.oss.proxymonster.controlplane.AccessStore
 import com.ridi.oss.proxymonster.controlplane.Channel
 import com.ridi.oss.proxymonster.controlplane.Datasource
@@ -9,7 +10,6 @@ import com.ridi.oss.proxymonster.controlplane.authz.Authz
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzContext
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzDecision
-import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
 import com.ridi.oss.proxymonster.controlplane.authz.authorizeWithContext
 import com.ridi.oss.proxymonster.controlplane.i18n.MessageCatalog
 import com.ridi.oss.proxymonster.controlplane.management.AuditActor
@@ -102,10 +102,7 @@ class SlackDecisionHandler(
         val decision = authz.authorizeWithContext(
             principal,
             AuthzAction.TASK_APPROVE,
-            AuthzResource.ApprovalRequest(
-                requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
-                datasourceName = req.datasourceName, roleName = req.roleName,
-            ),
+            req.toApprovalResource(),
             // No attested address: a Slack click carries none, so a policy requiring one denies. That is the
             // same fail-closed posture the system takes for any unknown attribute, and the reason `slack` is
             // its own channel rather than a flag.

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AuthzTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AuthzTest.kt
@@ -175,6 +175,30 @@ class AuthzTest {
         assertIs<AuthzDecision.Deny>(decision)
     }
 
+    @Test
+    fun `a request-specific policy cannot carry over to a later request with the same requester and datasource`() {
+        // An operator permit scoped to one exact Request EUID must match only that persisted request, not a
+        // later one that happens to share the requester and datasource — each durable request keys off its id.
+        // Routed through `toApprovalResource`, the single persisted-path constructor every route funnels
+        // through, so dropping the id there (the exact regression this closes) would fail here.
+        val authz = Authz(
+            CedarEngine(listOf(1L to """permit(principal, action == Action::"task.approve", resource == Request::"41");""")),
+            CedarPolicyStore(UnusedDataSource),
+            RoleSource { emptySet() },
+        )
+        fun row(id: Long) = AccessRequest(
+            id = id, principal = "requester@example.com", datasourceName = "acme",
+            requestedDurationSec = 3600, status = "PENDING", createdAt = "2026-01-01T00:00:00Z",
+        )
+        assertEquals(
+            AuthzDecision.Allow,
+            authz.authorize("approver@example.com", AuthzAction.TASK_APPROVE, row(41).toApprovalResource()),
+        )
+        assertIs<AuthzDecision.Deny>(
+            authz.authorize("approver@example.com", AuthzAction.TASK_APPROVE, row(42).toApprovalResource()),
+        )
+    }
+
     /** Regression: the Request's Datasource parent must be keyed by NAME (`Datasource::"acme-mysql"`),
      *  matching every other Datasource-keyed grant in the system — including this exact policy shape,
      *  straight from the doc's worked examples. Keyed by numeric id (`Datasource::"2"`) instead, a

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -219,8 +219,6 @@ Fixes for gaps documented in
   gate, so a manifest can't silently fall behind a new engine minor.
 - Route resource-bearing utility commands (e.g. `ANALYZE <table>`) through a
   Cedar gate instead of blanket passthrough, closing the existence oracle.
-- Make the role-approval `Request` EUID request-unique so one approval can't
-  authorize a principal's later requests.
 - Canonicalize introspected schema names on the proxy side (case-fold-aware),
   removing the interim MySQL lowercase fold in the control plane.
 - Broker a per-user target DB login so `SET PASSWORD` / `SET GLOBAL` stop


### PR DESCRIPTION
Fixes the GHSA-jq28-g7x3-q74c advisory (reported by @archepro84).

## The bug

A request-specific Cedar approval policy was keyed on a non-unique `Request` EUID `"<requester>#<datasource>"`, which omits the request id. A `permit(... action == Action::"task.approve", resource == Request::"<euid>")` minted for one `access_request` therefore carried over to a *later* request the same principal made for the same datasource — a wrong-ALLOW: one approval authorized every subsequent request on that datasource.

## The fix

Key the `Request` EUID off the durable `access_request` row id (mirroring `AccessGrant`, whose EUID already folds in its id). The requester+datasource string survives only as the fallback for the prospective auto-approval check, which runs before a row exists — the id-form (decimal) and fallback-form (always contains `#`) EUID spaces cannot collide.

A single `AccessRequest.toApprovalResource()` is now the only persisted-path constructor of the authz resource, so no call site can silently drop the id and reintroduce the non-unique key (replacing 11 inlined constructions).

## Where it could bite

Operators who hand-authored an exact `Request::"<requester>#<datasource>"` policy will find it no longer matches — it must be re-keyed to the numeric row id. No shipped/seeded policy uses an exact `Request` EUID, so a default deployment is unaffected; and such a policy could never have been request-specific under the old non-unique key anyway.

## Verification

`mise run verify` green. `AuthzTest` regression routes two rows (same requester+datasource, ids 41/42) through `toApprovalResource()` and asserts the exact-EUID permit allows the first and denies the second. Dual-reviewed (Codex/Sol/Grok): all confirmed every persisted site threads the correct id and no cross-format EUID collision exists.
