### PR TITLE
fix(analyzer): gate a table-targeted ANALYZE on the target's read (GHSA-2833)

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -281,14 +281,17 @@ tagging, table detail) and never feeds an enforcement decision.
   already exposed through that column, so it needs no separate table grant; only
   a table with zero traced columns and no table grant is denied. Verified on
   PostgreSQL (`KnownGapsTest`) and MySQL (`ScannedTableMySqlTest`).
-- 🔴 Utility-command passthrough is still an existence oracle. Analyzer-path
-  (`ANALYZED`-class) zero-column scans are covered above, but utility commands
-  that classify as passthrough and take a table target — e.g. `ANALYZE <table>`
-  (PostgreSQL, `SESSION` → wire/editor passthrough, gated only by
-  `datasource.connect`, not a table grant) — still disclose an ungranted table's
-  existence via a target-DB error. They return no rows. The fix routes each
-  resource-bearing utility to a Cedar gate instead of the blanket passthrough
-  ([`docs/facts-emission.md`](./docs/facts-emission.md)).
+- 🟡 Whole-database `ANALYZE` forms are gated by statement kind, not per-table
+  reads. A table-targeted `ANALYZE TABLE t` (MySQL) / `ANALYZE t` (PostgreSQL)
+  carries its target's result-read grant, so a principal who cannot read the
+  table cannot ANALYZE it. The forms that name no single table — bare PostgreSQL
+  `ANALYZE` (every accessible table), `ANALYZE INDEX`/`DATABASE`/`CLUSTER` —
+  carry only the `analyze_table` statement kind, so `stmt.cat.admin.maintenance`
+  gates them but no per-table read does. They name no table to probe, so they
+  are not a single-table existence oracle; a maintenance-privileged principal
+  running one can still surface an unreadable table's name through a forwarded
+  target-DB notice (the shared target-DB account, tracked in
+  [`docs/backlog.md`](./docs/backlog.md)).
 
 ## Authz / policy
 
@@ -510,18 +513,18 @@ connection so `SET`/`USE`/temp/`BEGIN` persist across queries. The one-shot
 path and `POST /api/datasources/{id}/query`, not the interactive editor.
 
 - 🟡 Editor statements decide as `Channel.EDITOR`, so `SESSION` statements
-  passthrough-ALLOW. Benign `SET`, `BEGIN`, `USE`, and `ANALYZE` are allowed on
-  the editor channel; classified privileged `SET` forms still pass their Utility
-  gate, and session statements stay denied on the workflow executor/viewer
-  channels. Because a persistent session holds ONE target-DB connection across
-  MANY statements, a session mutation can affect a later query on the same
-  connection; its safety rests on per-statement re-decide — every statement
-  round-trips to the proxy's `Decide` against that connection's live
-  per-connection catalog, so a mutated namespace is re-authorized rather than
-  carried silently, and a multi-statement `SET; SELECT` batch is rejected at
-  admission so passthrough only ever sees a pure session statement. Hard gate:
-  per-statement re-decide (or an explicit session-mutation refusal) must remain
-  the standing mitigation.
+  passthrough-ALLOW. Benign `SET`, `BEGIN`, and `USE` are allowed on the editor
+  channel; classified privileged `SET` forms still pass their Utility gate,
+  `ANALYZE` is gated by its statement kind and its target's read, and session
+  statements stay denied on the workflow executor/viewer channels. Because a
+  persistent session holds ONE target-DB connection across MANY statements, a
+  session mutation can affect a later query on the same connection; its safety
+  rests on per-statement re-decide — every statement round-trips to the proxy's
+  `Decide` against that connection's live per-connection catalog, so a mutated
+  namespace is re-authorized rather than carried silently, and a multi-statement
+  `SET; SELECT` batch is rejected at admission so passthrough only ever sees a
+  pure session statement. Hard gate: per-statement re-decide (or an explicit
+  session-mutation refusal) must remain the standing mitigation.
 - 🟡 Catalog adoption assumes one target DB behind a datasource. On MySQL a new
   connection may start from catalog content the control plane already holds
   rather than measuring the target DB itself, so its first statement decides

--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -119,12 +119,14 @@ func EmitFacts(sql string, engineConfig *pb.EngineConfig, sch *schema.Mapping, n
 		facts = emitSetFacts(root, eng)
 	case exp.KindCommand:
 		facts = emitCommandFacts(root, eng)
-	case exp.KindTransaction, exp.KindCommit, exp.KindRollback, exp.KindSavepoint, exp.KindUse, exp.KindAnalyze, exp.KindReset:
+	case exp.KindTransaction, exp.KindCommit, exp.KindRollback, exp.KindSavepoint, exp.KindUse, exp.KindReset:
 		// PostgreSQL `RESET <guc>` / `RESET ALL` (sqlglot-go v0.16 models it as a dedicated Reset node) only
 		// restores a session variable to its default — a de-escalation, never a privilege gain — so it is a
 		// benign session passthrough. (MySQL RESET MASTER/REPLICA is a privileged admin op that degrades to
 		// Command and is denied there; it never reaches this Reset-node case.)
 		facts = passthroughFacts()
+	case exp.KindAnalyze:
+		facts = emitAnalyzeFacts(root, eng, qualifySchema, validatedNamespace)
 	case exp.KindAlter, exp.KindDrop, exp.KindTruncateTable:
 		facts = ddlFacts(root, eng)
 	case exp.KindCreate:
@@ -321,6 +323,29 @@ func emitDescribeFacts(root exp.Expression, eng engine, qualifySchema schema.Sch
 		return emitLineageFacts(this, eng, qualifySchema, namespace, true)
 	}
 	return unanalyzableFacts("PARSE", "DESCRIBE target is not a table or analyzable statement")
+}
+
+// emitAnalyzeFacts gates a table-targeted ANALYZE the same way DESCRIBE is: a table statistics command
+// reveals the table's existence and touches its rows, so it must carry the same result-read grant a
+// `SELECT * FROM <table>` would (routed through lineage with explain = true — for authorization, not row
+// masking). Without it the statement resolves connect-only and becomes an existence oracle that bypasses
+// the result-read gate. The single-table target is exact: a multi-table `ANALYZE TABLE t1, t2` leaves the
+// list tail unconsumed and the parser degrades the whole statement to Command, which never reaches here.
+// The statement-kind exec grant is attached centrally in EmitFacts, so the kind gate applies regardless.
+func emitAnalyzeFacts(root exp.Expression, eng engine, qualifySchema schema.Schema, namespace NamespaceConfig) *pb.StatementFacts {
+	this := root.This()
+	kind := ""
+	if k := root.Arg("kind"); k != nil {
+		kind = strings.ToUpper(fmt.Sprint(k))
+	}
+	// MySQL `ANALYZE TABLE t` (kind TABLE) and PostgreSQL/Presto `ANALYZE t` (no kind) both target one table
+	// to read. INDEX / DATABASE / CLUSTER / bare all-table ANALYZE carry no single readable table target and
+	// stay a benign passthrough — still exec-gated by the statement kind.
+	if (kind == "TABLE" || kind == "") && this != nil && this.Kind() == exp.KindTable {
+		selectRoot := exp.Select(exp.Args{"expressions": []exp.Expression{exp.Star(nil)}, "from_": exp.From(exp.Args{"this": this.Copy()})})
+		return emitLineageFacts(selectRoot, eng, qualifySchema, namespace, true)
+	}
+	return passthroughFacts()
 }
 
 func emitShowFacts(root exp.Expression, eng engine) *pb.StatementFacts {

--- a/analyzer/probe/mysql_statement_coverage_test.go
+++ b/analyzer/probe/mysql_statement_coverage_test.go
@@ -275,8 +275,8 @@ var mysqlStatements = []mysqlStatement{
 	{"SET DEFAULT ROLE", "SET DEFAULT ROLE 'r' TO 'u'@'h'", "stmt.kind.set_default_role + utility:SET_DEFAULT_ROLE", pb.StatementKind_STATEMENT_KIND_SET_DEFAULT_ROLE},
 
 	// ---- Table maintenance (§15.7.3) ----
-	// GAP: ANALYZE is in the session-passthrough set (facts.go), so it is connect-only; CHECK/OPTIMIZE/REPAIR fail closed.
-	{"ANALYZE TABLE", "ANALYZE TABLE users", "stmt.kind.analyze_table", pb.StatementKind_STATEMENT_KIND_ANALYZE_TABLE},
+	// ANALYZE gates the target table's read (facts.go), so it is not connect-only; CHECK/OPTIMIZE/REPAIR fail closed.
+	{"ANALYZE TABLE", "ANALYZE TABLE users", "result.read + stmt.kind.analyze_table", pb.StatementKind_STATEMENT_KIND_ANALYZE_TABLE},
 	{"CHECK TABLE", "CHECK TABLE users", "unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_STMT_UNKNOWN},       // parse error
 	{"CHECKSUM TABLE", "CHECKSUM TABLE users", "unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_STMT_UNKNOWN}, // parse error
 	{"OPTIMIZE TABLE", "OPTIMIZE TABLE users", "stmt.kind.optimize_table + unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_OPTIMIZE_TABLE},
@@ -447,12 +447,10 @@ var privilegedNeedingGate = map[string]bool{
 // documented as an open boundary in docs/system-classification.md and are closed by the statement-typing
 // redesign (docs/statement-typing.md), which removes the benign catch-all passthrough they fall into.
 //
-//	ANALYZE TABLE                       — in the analyzer's SESSION passthrough set (facts.go).
 //	SET sql_log_bin                     — restricted SESSION variable; SET is gated by scope/PASSWORD only.
 //	SHOW MASTER STATUS / SHOW BINARY LOGS / SHOW REPLICAS / SHOW SLAVE HOSTS
 //	                                    — replication topology/binlog reads the analyzer emits no utility for.
 var knownConnectOnlyGaps = map[string]bool{
-	"ANALYZE TABLE":      true,
 	"SET sql_log_bin":    true,
 	"SHOW MASTER STATUS": true,
 	"SHOW BINARY LOGS":   true,

--- a/analyzer/probe/statement_facts_test.go
+++ b/analyzer/probe/statement_facts_test.go
@@ -170,6 +170,64 @@ func TestStatementFactsExplainAnalyzesInnerQuery(t *testing.T) {
 	}
 }
 
+func TestStatementFactsAnalyzeTableGatesTableRead(t *testing.T) {
+	// A table-targeted ANALYZE must carry the same result-read grant SELECT * FROM the table would, so the
+	// result-read gate governs it and it is not an existence oracle. Both MySQL `ANALYZE TABLE t` and
+	// PostgreSQL `ANALYZE t` target one table to read. The read grants must name THAT table (a second target,
+	// `sink`, pins that they follow the target rather than a hardcoded one). The statement is relayed as-is:
+	// ExplainOfQuery (authorization, not row masking) and no SELECT rewritten_sql leaking back onto the wire.
+	for _, tc := range []struct {
+		name  string
+		facts *pb.StatementFacts
+		table string
+	}{
+		{"mysql ANALYZE TABLE users", mysqlFacts(t, "ANALYZE TABLE users"), "users"},
+		{"mysql ANALYZE TABLE sink", mysqlFacts(t, "ANALYZE TABLE sink"), "sink"},
+		{"postgres ANALYZE users", postgresFacts(t, "ANALYZE users"), "users"},
+		{"postgres ANALYZE sink", postgresFacts(t, "ANALYZE sink"), "sink"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if !tc.facts.GetResolved() || factsKind(tc.facts) != pb.StatementKind_STATEMENT_KIND_ANALYZE_TABLE {
+				t.Fatalf("expected resolved ANALYZE_TABLE: %+v", tc.facts)
+			}
+			if !tc.facts.GetExplainOfQuery() || tc.facts.GetRewrittenSql() != "" {
+				t.Fatalf("ANALYZE must not rewrite onto the wire: %+v", tc.facts)
+			}
+			// Every emitted column read grant must name the ANALYZE target, and there must be at least one —
+			// a grant on a different table would mean the read gate governs the wrong resource.
+			gated := false
+			for _, grant := range tc.facts.GetResultReads() {
+				c := grant.GetColumn()
+				if c == nil {
+					continue
+				}
+				if c.GetIdentity().GetTable() != tc.table {
+					t.Fatalf("ANALYZE %s emitted a read grant on %q, not the target: %+v", tc.table, c.GetIdentity().GetTable(), grant)
+				}
+				gated = true
+			}
+			if !gated {
+				t.Fatalf("ANALYZE %s did not gate the table read: %+v", tc.table, tc.facts.GetResultReads())
+			}
+		})
+	}
+}
+
+func TestStatementFactsAnalyzeAdversarialFormsFailClosed(t *testing.T) {
+	// The two ANALYZE forms that resolve to a table node but must NOT read-gate as a plain table both rely on
+	// sqlglot-go's parse/lineage to fail closed: MySQL multi-table `ANALYZE TABLE t1, t2` degrades to a
+	// Command (the list tail is unconsumed), and PostgreSQL's column-list `ANALYZE t (col)` parses the target
+	// as an anonymous table-valued source that star-expansion refuses. If a future sqlglot-go bump widened
+	// either, the synthetic SELECT * could resolve with no grants — connect-only, the oracle reopened. Pin
+	// them unresolved so that regression fails here rather than silently.
+	if f := mysqlFacts(t, "ANALYZE TABLE users, sink"); f.GetResolved() {
+		t.Fatalf("multi-table ANALYZE must fail closed (unresolved), got: %+v", f)
+	}
+	if f := postgresFacts(t, "ANALYZE users (ssn)"); f.GetResolved() {
+		t.Fatalf("column-list ANALYZE must fail closed (unresolved), got: %+v", f)
+	}
+}
+
 func TestStatementFactsNoFromUnknownFunctionGrant(t *testing.T) {
 	facts := postgresFacts(t, "SELECT my_udf()")
 	if !facts.GetResolved() {

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/StatementKindGapDenialDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/StatementKindGapDenialDbTest.kt
@@ -105,6 +105,34 @@ class StatementKindGapDenialDbTest {
     }
 
     @Test
+    fun `ANALYZE TABLE holding the admin kind but no read on the table denies at the read gate — the existence oracle is closed`() {
+        // The kind gate is not the whole gate for ANALYZE: a table-targeted ANALYZE also carries the target's
+        // result-read grant, so `ANALYZE TABLE users` is authorized like `SELECT * FROM users`. This principal
+        // holds stmt.cat.admin.maintenance — it PASSES the analyze_table kind gate — but has no read on `users`,
+        // so the read gate denies. Before the analyzer gated the read, ANALYZE resolved connect-only and an
+        // unauthorized principal learned the table exists (and error-probed it). The deny must NOT be the kind
+        // reason: that would mean the kind gate caught it and the read gate never ran.
+        val maint = "maint-only@example.com"
+        val role = fx.policyStore.createRole(RoleInput("maint-only"))
+        fx.policyStore.createAssignment(RoleAssignmentInput(maint, role.id))
+        fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "maint-only-grant",
+                cedarSrc = """permit(principal in Role::"maint-only", action in [Action::"datasource.connect", Action::"stmt.cat.admin.maintenance"], resource in Datasource::"${fx.datasource.name}");""",
+            ),
+            updatedBy = "test",
+        )
+        val d = decide("ANALYZE TABLE users", maint)
+        assertEquals(EnfAction.DENY, d.action, "ANALYZE must deny without a read grant on the table")
+        // The deny must come from the READ gate, which names the target table — not the kind gate (which this
+        // principal clears) and not an unrelated structural stage.
+        assertTrue(
+            d.denyReason.orEmpty() != "statement kind 'analyze_table' is not permitted" && d.denyReason.orEmpty().contains("users"),
+            "the deny must be the read gate naming the table: ${d.denyReason}",
+        )
+    }
+
+    @Test
     fun `a benign metadata SHOW stays allowed while a replication SHOW denies`() {
         // `analyst@example.com` has stmt.cat.metadata + stmt.cat.session (not admin). The SHOW split holds:
         // a schema-introspecting SHOW is metadata (passthrough allow), a replication SHOW is admin.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -217,8 +217,6 @@ Fixes for gaps documented in
   grant hygiene.
 - Per-engine-version golden inventory of system objects plus a CI release-diff
   gate, so a manifest can't silently fall behind a new engine minor.
-- Route resource-bearing utility commands (e.g. `ANALYZE <table>`) through a
-  Cedar gate instead of blanket passthrough, closing the existence oracle.
 - Make the role-approval `Request` EUID request-unique so one approval can't
   authorize a principal's later requests.
 - Canonicalize introspected schema names on the proxy side (case-fold-aware),


### PR DESCRIPTION
Fixes the GHSA-2833-494g-4434 advisory (reported by @archepro84).

## The bug

A table-targeted `ANALYZE TABLE users` (MySQL) / `ANALYZE users` (PostgreSQL) resolved *connect-only* in the analyzer — it carried its statement-kind execute grant but **no result-read grant**. So a principal who could not read a table could still ANALYZE it, learning the table exists and error-probing it: an existence oracle past the result-read gate.

## The fix

`emitAnalyzeFacts` gates a single-table ANALYZE the way `DESCRIBE TABLE` already is — it builds a synthetic `SELECT * FROM <target>` and routes it through lineage (`explain=true`, for authorization, not row masking), emitting the target's read grants so the deny-by-default read gate governs ANALYZE. `explain=true` nils the synthetic rewrite and the original ANALYZE's rewrite is re-derived, so the wire still relays ANALYZE — never a SELECT. The kind gate is unchanged; ANALYZE now clears both the kind gate and the read gate.

Forms with no single-table target stay as they were: MySQL multi-table `ANALYZE TABLE t1, t2` degrades to a Command (fail-closed); PostgreSQL column-list `ANALYZE t (col)` parses to an anonymous source that star-expansion refuses (fail-closed unanalyzable); bare/whole-DB `ANALYZE`, `ANALYZE INDEX/DATABASE/CLUSTER` carry only the `admin.maintenance` kind gate (they name no table to read-gate — documented in KNOWN_LIMITATIONS).

## Verification

`mise run verify` green. Go probe tests assert the read grant follows the target (`users`/`sink` cross-check), that no SELECT reaches the wire, and that the two adversarial forms stay fail-closed. A real-MySQL+Cedar enforcement test proves a principal holding `admin.maintenance` but no read on the table is denied at the read gate (naming the table), not the kind gate. Dual-reviewed (Sol/Grok + an independent opus standing in for the Codex leg, which aborted on a content filter): all confirmed the single-table oracle is closed with no fail-open path.
