### PR TITLE
feat(control-plane): recut statement disclosure to omit|auto|full and notify the requester

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -120,13 +120,16 @@ configured per proxy under `PM_TARGET_*`.
   half-configured mode. Socket Mode means the CP dials out; no inbound ingress
   is added. Set `PM_WEB_ORIGIN` too, or the message's "open request" link points
   at the control plane rather than the console.
-- `PM_NOTIFY_STATEMENT` / `PM_NOTIFY_STATEMENT_MAX` — _optional_. How much of a
-  requester's SQL a notification may carry: `truncated` (default, first
-  `PM_NOTIFY_STATEMENT_MAX` characters, default `200`), `full`, or `omit`. A
+- `PM_NOTIFY_STATEMENT` — _optional_. How much of a requester's SQL a
+  notification may carry: `auto` (default) shows a statement only when a
+  disclosure hint clears it, hiding one whose predicate compares a literal
+  against a classified column; `full` shows it to pending approvers regardless,
+  then hides a flagged one once the task is handled; `omit` never shows SQL. A
   statement's literals can be the very values a policy protects — masking acts
   on results, not predicates — so `omit` is the setting for data that must not
   leave in query text. Approve-and-run is offered only when the message carries
-  the whole statement, whatever the mode.
+  the whole statement, whatever the mode. (Legacy `truncated` boots as `auto`
+  with a warning.)
 - `PM_NOTIFY_LOCALE` — _optional_. Fallback language (`en` · `ko`) for a
   recipient who has not set one in the console. Default `en`.
 - `PM_AUTH_DEBUG` / `PM_DEV` / `PM_OAUTH_DEBUG_AUTO_CONSENT` — _dev-only_.

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Config.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Config.kt
@@ -100,8 +100,7 @@ data class Config(
     // posture as an unset PM_SCIM_TOKEN disabling SCIM, never a degraded half-configured mode.
     val slackBotToken: String? = null,
     val slackAppToken: String? = null,
-    val notifyStatement: String = "truncated",
-    val notifyStatementMax: Int = 200,
+    val notifyStatement: String = "auto",
     // Fallback language for a recipient who has never set one (app_user.locale).
     val notifyLocale: String = "en",
 ) {
@@ -228,15 +227,21 @@ data class Config(
             }
 
             // A set-but-garbage value fails fast rather than silently falling back: a misconfigured
-            // disclosure mode would decide how much query text leaves the building.
-            val notifyStatement = (env("PM_NOTIFY_STATEMENT") ?: "truncated").trim().lowercase()
-            require(notifyStatement in setOf("truncated", "full", "omit")) {
-                "PM_NOTIFY_STATEMENT must be one of truncated|full|omit; got '$notifyStatement'"
+            // disclosure mode decides how much query text leaves the building. The removed `truncated` mode
+            // (a first-N-chars cut is no PII guarantee) coerces to `auto` — the hint-gated show it always was
+            // beneath the truncation — with a warning, so an existing config is not broken by the rename.
+            val notifyStatement = (env("PM_NOTIFY_STATEMENT") ?: "auto").trim().lowercase().let {
+                if (it == "truncated") {
+                    org.slf4j.LoggerFactory.getLogger(Config::class.java)
+                        .warn("PM_NOTIFY_STATEMENT=truncated is removed; using auto (hint-gated disclosure)")
+                    "auto"
+                } else {
+                    it
+                }
             }
-            val notifyStatementMax = env("PM_NOTIFY_STATEMENT_MAX")?.let {
-                it.toIntOrNull() ?: throw IllegalArgumentException("PM_NOTIFY_STATEMENT_MAX must be a positive integer; got '$it'")
-            } ?: 200
-            require(notifyStatementMax > 0) { "PM_NOTIFY_STATEMENT_MAX must be greater than zero" }
+            require(notifyStatement in setOf("omit", "auto", "full")) {
+                "PM_NOTIFY_STATEMENT must be one of omit|auto|full; got '$notifyStatement'"
+            }
             val notifyLocale = (env("PM_NOTIFY_LOCALE") ?: "en").trim().lowercase()
             require(notifyLocale in setOf("en", "ko")) { "PM_NOTIFY_LOCALE must be one of en|ko; got '$notifyLocale'" }
 
@@ -282,7 +287,6 @@ data class Config(
                 slackBotToken = env("PM_SLACK_BOT_TOKEN")?.takeIf { it.isNotBlank() },
                 slackAppToken = env("PM_SLACK_APP_TOKEN")?.takeIf { it.isNotBlank() },
                 notifyStatement = notifyStatement,
-                notifyStatementMax = notifyStatementMax,
                 notifyLocale = notifyLocale,
             )
         }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationRenderer.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationRenderer.kt
@@ -29,30 +29,46 @@ class NotificationRenderer(private val catalog: MessageCatalog = MessageCatalog(
             ?.replace("```", "``​`")
             ?.let { "```$it```" }
             ?: "_${catalog.text("field.statement_hidden", locale)}_"
-        val params = mapOf(
-            // requester/decidedBy are already resolved to `<@id>` mentions by the transport; escaping them
-            // would break the mention. The free-text and name fields are escaped — a requester's reason is
-            // otherwise raw mrkdwn beside the real Approve button, able to forge a mention, emphasis, or a
-            // link ("Security reviewed — approve below" + <https://evil|Open>).
-            "requester" to m.requester,
-            "datasource" to escapeMrkdwn(m.datasource),
-            "statement" to statement,
-            "decidedBy" to (m.decidedBy ?: "—"),
-            "rowCount" to (m.rowCount?.toString() ?: "—"),
-            "role" to (m.roleName?.let { catalog.text("field.role", locale, mapOf("role" to escapeMrkdwn(it))) } ?: ""),
-        )
-        return buildString {
-            append(catalog.text(bodyKey(m), locale, params))
-            m.reason?.takeIf { it.isNotBlank() && m.event == NotificationEvent.TASK_REQUESTED }?.let {
-                val reason = escapeMrkdwn(it.take(REASON_MAX_CHARS))
-                append("\n").append(catalog.text("field.reason", locale, mapOf("reason" to reason)))
-            }
-            // Only say "open it to read the statement" when there was one to withhold: an OMIT-configured
-            // statement and one truncated by length both land here.
-            if (m.statement.text == null || !m.statement.complete) {
-                append("\n").append(catalog.text("field.statement_hidden_note", locale))
-            }
+        // Each message is one template. The optional trailers are pre-rendered fragments — a leading newline
+        // plus their own sub-template, or empty — the same shape as `role`, so the template owns the whole
+        // layout (line breaks and field order) rather than code assembling it piece by piece.
+        val reason = m.reason
+            ?.takeIf { it.isNotBlank() && m.event == NotificationEvent.TASK_REQUESTED }
+            ?.let { "\n" + catalog.text("field.reason", locale, mapOf("reason" to escapeMrkdwn(it.take(REASON_MAX_CHARS)))) }
+            ?: ""
+        // The receipt's approver list is `<@id>` mentions resolved by the transport. In the requester's OWN DM,
+        // where no approver is a member, they render as names without pinging anyone — so, like requester and
+        // decidedBy, they are NOT escaped.
+        val notified = m.notifiedApprovers
+            .takeIf { it.isNotEmpty() && m.event == NotificationEvent.TASK_SUBMITTED }
+            ?.let { "\n" + catalog.text("field.notified", locale, mapOf("notified" to it.joinToString(", "))) }
+            ?: ""
+        // "Open it to read the statement" only where one was withheld — never on the requester's own receipt,
+        // which omits the statement by design (they authored it).
+        val statementNote = if (m.event != NotificationEvent.TASK_SUBMITTED && (m.statement.text == null || !m.statement.complete)) {
+            "\n" + catalog.text("field.statement_hidden_note", locale)
+        } else {
+            ""
         }
+        return catalog.text(
+            bodyKey(m),
+            locale,
+            mapOf(
+                // requester/decidedBy/notified arrive as `<@id>` mentions from the transport; escaping them
+                // would break the mention. The free-text and name fields are escaped — a requester's reason is
+                // otherwise raw mrkdwn beside the real Approve button, able to forge a mention, emphasis, or a
+                // link ("Security reviewed — approve below" + <https://evil|Open>).
+                "requester" to m.requester,
+                "datasource" to escapeMrkdwn(m.datasource),
+                "statement" to statement,
+                "decidedBy" to (m.decidedBy ?: "—"),
+                "rowCount" to (m.rowCount?.toString() ?: "—"),
+                "role" to (m.roleName?.let { catalog.text("field.role", locale, mapOf("role" to escapeMrkdwn(it))) } ?: ""),
+                "reason" to reason,
+                "notified" to notified,
+                "statementNote" to statementNote,
+            ),
+        )
     }
 
     /** The plain-text line for a client that renders no blocks. Never carries the statement. */
@@ -66,6 +82,7 @@ class NotificationRenderer(private val catalog: MessageCatalog = MessageCatalog(
 
     private fun bodyKey(m: NotificationMessage): String = when (m.event) {
         NotificationEvent.TASK_REQUESTED -> "task.requested"
+        NotificationEvent.TASK_SUBMITTED -> "task.submitted"
         NotificationEvent.TASK_DECIDED -> if (m.approved == true) "task.decided_approved" else "task.decided_rejected"
         NotificationEvent.TASK_EXECUTED -> "task.executed"
         NotificationEvent.TASK_FAILED -> "task.failed"

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationService.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationService.kt
@@ -27,7 +27,6 @@ class NotificationService(
     private val queryResultStore: QueryResultStore?,
     private val webBaseUrl: String,
     private val disclosure: StatementDisclosure,
-    private val statementMaxChars: Int,
     private val defaultLocale: String,
 ) {
     private val log = LoggerFactory.getLogger(NotificationService::class.java)
@@ -120,10 +119,14 @@ class NotificationService(
                 status = "PENDING",
                 createdAt = "",
             )
+            // The requester hears about their own request as a receipt (TASK_SUBMITTED), never as an approver
+            // of it — so they get exactly one message even where policy would let them approve their own.
+            val approvers = recipients.recipientsFor(subject).filter { it != requester }
             for (transport in transports) {
-                for (recipient in recipients.recipientsFor(subject)) {
+                for (recipient in approvers) {
                     store.enqueue(c, taskId, NotificationEvent.TASK_REQUESTED, transport.name, recipient)
                 }
+                store.enqueue(c, taskId, NotificationEvent.TASK_SUBMITTED, transport.name, requester)
             }
         }.onFailure { log.warn("notification emit failed task={} event=task.requested", taskId, it) }
     }
@@ -224,13 +227,30 @@ class NotificationService(
     fun localeOf(principal: String): String? = store.localeOf(principal)
 
     private fun buildMessage(row: OutboxRow, req: AccessRequest, transport: NotificationTransport): NotificationMessage {
-        // A statement whose predicate compares a literal against a CLASSIFIED column is withheld whatever the
-        // configured mode: the protected value is in the query text itself, where masking never reaches it.
-        // Advisory and reader-neutral; NULL (never analyzed) is treated the same way — an unanalyzable
-        // statement is not evidence of a safe one.
-        val effectiveDisclosure =
-            if (req.statementCarriesProtectedLiteral != false) StatementDisclosure.OMIT else disclosure
-        val statement = renderStatement(req.sql, effectiveDisclosure, statementMaxChars, transport.statementHardLimit)
+        // The disclosure decision: mode × event × hint. The hint (statementCarriesProtectedLiteral) flags a
+        // predicate comparing a literal against a CLASSIFIED column — a protected value sitting in the query
+        // text, where masking never reaches it; NULL (never analyzed) counts as "might carry one". AUTO shows
+        // only a cleared statement. FULL shows it to PENDING approvers regardless, then — once the task is
+        // handled (every other event) — falls back to AUTO, so a PII value does not persist in the channel.
+        // The requester's own receipt (SUBMITTED) never carries the statement: they authored it, and keeping
+        // it out leaves that message disclosure-free.
+        val cleared = req.statementCarriesProtectedLiteral == false
+        // `pending` is the LIVE task state, not merely the request event: a backed-off task.requested that
+        // finally delivers after the task was decided must not be the first to surface a flagged statement
+        // under FULL. Once the status leaves PENDING, FULL falls back to the hint like every handled message.
+        val pending = row.event == NotificationEvent.TASK_REQUESTED && req.status == "PENDING"
+        val show = row.event != NotificationEvent.TASK_SUBMITTED &&
+            discloseStatement(disclosure, pending = pending, cleared = cleared)
+        val statement = renderStatement(req.sql, show, transport.statementHardLimit)
+        // The requester's receipt names who was actually asked — the durable task.requested recipients, not a
+        // fresh eligibility recompute that role churn between enqueue and delivery could drift from (and that
+        // would re-run Cedar per candidate). Plain identities, resolved to display by the transport without an
+        // `<@id>` ping, since each already got their own message.
+        val notifiedApprovers = if (row.event == NotificationEvent.TASK_SUBMITTED) {
+            store.recipientsOfRequest(req.id).filter { it != req.principal }.sorted()
+        } else {
+            emptyList()
+        }
         // Result-derived facts (row count, error code) are a cardinality/existence oracle, so they go only to
         // the two identities that authored the run — the requester and the principal who actually executed it.
         // A merely eligible co-approver hears that the task finished, never how many rows it returned.
@@ -255,6 +275,7 @@ class NotificationService(
             errorCode = meta?.errorCode,
             deepLink = URLBuilder(webBaseUrl).appendPathSegments("workflows", req.id.toString()).buildString(),
             actions = actionsFor(row.event, req, statement),
+            notifiedApprovers = notifiedApprovers,
         )
     }
 

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStore.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStore.kt
@@ -194,6 +194,10 @@ class NotificationStore(private val dataSource: DataSource) {
             }
         }
 
+    /** [recipientsOfRequest] on the store's own connection, for a delivery-time read outside any transaction. */
+    fun recipientsOfRequest(taskId: Long): Set<String> =
+        dataSource.connection.use { c -> recipientsOfRequest(c, taskId) }
+
     /** Record where a message landed, so a later event edits it in place. */
     fun rememberMessage(taskId: Long, transport: String, recipient: String, externalRef: String) {
         dataSource.connection.use { c ->

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/Notifications.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/Notifications.kt
@@ -12,14 +12,17 @@ package com.ridi.oss.proxymonster.controlplane.notify
 /** What happened. The workflow states this once; who hears it and how are decided downstream. */
 enum class NotificationEvent(val wire: String) {
     TASK_REQUESTED("task.requested"),
+    TASK_SUBMITTED("task.submitted"),
     TASK_DECIDED("task.decided"),
     TASK_EXECUTED("task.executed"),
     TASK_FAILED("task.failed"),
     TASK_CANCELLED("task.cancelled"),
     ;
 
-    /** True when this event should edit an existing message rather than start a new thread of its own. */
-    val isUpdate: Boolean get() = this != TASK_REQUESTED
+    /** True when this event should edit an existing message rather than start a new thread of its own. The two
+     *  creation events — the approvers' request and the requester's own receipt — start threads; every later
+     *  event edits the message its recipient already holds. */
+    val isUpdate: Boolean get() = this != TASK_REQUESTED && this != TASK_SUBMITTED
 
     companion object {
         fun fromWire(wire: String): NotificationEvent? = entries.firstOrNull { it.wire == wire }
@@ -37,16 +40,26 @@ enum class NotificationEvent(val wire: String) {
 /**
  * How much of the requester's statement may leave the building (docs/notifications.md, "The statement in the
  * message"). A statement's literals can be the very values a policy protects — `WHERE ssn = '…'` leaks a
- * value masking never sees, because masking acts on results.
+ * value masking never sees, because masking acts on results. The disclosure hint
+ * (`protectedPredicateLiterals`) flags a statement whose predicate compares a literal against a classified
+ * column; [AUTO] and [FULL] both consult it.
  */
 enum class StatementDisclosure {
-    TRUNCATED,
-    FULL,
+    /** Never show the statement — the message carries metadata only. */
     OMIT,
+
+    /** Show the statement only when the hint has cleared it (no protected literal detected); hide it
+     *  otherwise. An unanalyzable statement (no hint) is treated as unsafe and hidden. */
+    AUTO,
+
+    /** Show the whole statement while the task is PENDING, so an approver can read it and approve-and-run.
+     *  Once the task is HANDLED (decided, executed, failed, cancelled — by anyone), fall back to [AUTO]: hide
+     *  the statement if the hint flags a protected literal, so a PII value does not linger in the channel. */
+    FULL,
     ;
 
     companion object {
-        /** Parse `PM_NOTIFY_STATEMENT`. An unrecognized value is a config error the caller fails fast on. */
+        /** Parse a normalized `PM_NOTIFY_STATEMENT` value (`omit`|`auto`|`full`). */
         fun parse(raw: String?): StatementDisclosure? =
             raw?.trim()?.uppercase()?.let { v -> entries.firstOrNull { it.name == v } }
     }
@@ -56,39 +69,39 @@ enum class StatementDisclosure {
  * The statement as it will actually appear, and whether anything was cut.
  *
  * [complete] is the gate on approve-and-run: an approver may only decide from a message carrying the WHOLE
- * statement. The test is what the recipient can read, never which mode the operator configured — a short
- * statement under TRUNCATED was not truncated, and a long one under FULL is still elided by a transport's own
- * length ceiling. See [renderStatement].
+ * statement. The test is what the recipient can read, never which mode the operator configured — a statement
+ * shown under FULL is still elided by a transport's own length ceiling. See [renderStatement].
  */
 data class RenderedStatement(val text: String?, val complete: Boolean)
 
 /**
- * Apply [disclosure] to [sql], then the transport's own [hardLimit] (0 = none). The result is [complete] only
- * when the full statement survived both — the flag is an input to rendering, and the button is decided after.
+ * The statement text to place in a message. [show] is the disclosure decision the caller has already made
+ * (mode × event × hint); a false [show] or a null [sql] yields no text. When shown, the only cut is the
+ * transport's own [hardLimit] (0 = none): [complete] is true only when the whole statement fit under it, and
+ * that flag is what gates approve-and-run.
  */
-fun renderStatement(
-    sql: String?,
-    disclosure: StatementDisclosure,
-    maxChars: Int,
-    hardLimit: Int = 0,
-): RenderedStatement {
-    if (sql == null) return RenderedStatement(null, complete = false)
-    if (disclosure == StatementDisclosure.OMIT) return RenderedStatement(null, complete = false)
-
-    // The tightest applicable ceiling wins. FULL has no configured limit of its own, so only the transport's
-    // applies; TRUNCATED takes the smaller of the two.
-    val configured = if (disclosure == StatementDisclosure.TRUNCATED) maxChars else Int.MAX_VALUE
-    val ceiling = when {
-        hardLimit <= 0 -> configured
-        else -> minOf(configured, hardLimit)
-    }
-    if (ceiling <= 0) return RenderedStatement(null, complete = false)
-    if (sql.length <= ceiling) return RenderedStatement(sql, complete = true)
+fun renderStatement(sql: String?, show: Boolean, hardLimit: Int = 0): RenderedStatement {
+    if (sql == null || !show) return RenderedStatement(null, complete = false)
+    if (hardLimit <= 0 || sql.length <= hardLimit) return RenderedStatement(sql, complete = true)
     // The ellipsis has to fit INSIDE the ceiling, or a transport that hard-rejects an over-length field
     // would reject the very message that was truncated to satisfy it.
-    val keep = (ceiling - 1).coerceAtLeast(0)
+    val keep = (hardLimit - 1).coerceAtLeast(0)
     return RenderedStatement(sql.take(keep) + "…", complete = false)
 }
+
+/**
+ * Whether a message may show the statement, from the operator's [disclosure] mode, whether the task is still
+ * [pending] (the approvers' request, before any decision), and whether the disclosure hint has [cleared] the
+ * statement (no protected literal detected — an unanalyzed statement is NOT cleared). OMIT never shows; AUTO
+ * always defers to the hint; FULL shows a pending statement whatever the hint says, then falls back to AUTO
+ * once the task is handled, so a protected literal does not linger in the channel after the decision.
+ */
+fun discloseStatement(disclosure: StatementDisclosure, pending: Boolean, cleared: Boolean): Boolean =
+    when (disclosure) {
+        StatementDisclosure.OMIT -> false
+        StatementDisclosure.AUTO -> cleared
+        StatementDisclosure.FULL -> pending || cleared
+    }
 
 /** An action a message may offer. [OPEN] is always available; the other two are gated. */
 enum class NotificationAction { APPROVE_AND_RUN, DENY, OPEN }
@@ -115,6 +128,9 @@ data class NotificationMessage(
     val errorCode: String? = null,
     val deepLink: String,
     val actions: Set<NotificationAction>,
+    /** SUBMITTED only: the approvers the request was routed to, shown to the requester as their receipt.
+     *  Plain identities, not `<@id>` mentions — the requester learns who can act without re-pinging them. */
+    val notifiedApprovers: List<String> = emptyList(),
 )
 
 /** The outcome of one delivery attempt. Only the transport knows which failures are worth another try. */

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationsWiring.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationsWiring.kt
@@ -54,8 +54,7 @@ fun Application.installNotifications(
         accessStore = accessStore,
         queryResultStore = queryResultStore,
         webBaseUrl = config.webBaseUrl,
-        disclosure = StatementDisclosure.parse(config.notifyStatement) ?: StatementDisclosure.TRUNCATED,
-        statementMaxChars = config.notifyStatementMax,
+        disclosure = StatementDisclosure.parse(config.notifyStatement) ?: StatementDisclosure.AUTO,
         defaultLocale = config.notifyLocale,
     )
     // A plain poll rather than LISTEN/NOTIFY: the table is the queue, so a notification would only be a

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackTransport.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackTransport.kt
@@ -87,11 +87,14 @@ class SlackTransport(
      *  `<…|link>`, a `<!mention>`, or an entity. Mirrors NotificationRenderer's escape for the fields it owns. */
     private fun escapeMrkdwn(s: String): String = s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
-    /** The message with every principal it NAMES (the requester, the decider) resolved to a Slack mention. */
+    /** The message with every principal it NAMES (the requester, the decider, the notified approvers) resolved
+     *  to a Slack mention. A mention in the requester's own DM, where the approvers are not members, renders as
+     *  a name and pings no one — the point is a readable handle, not a second notification. */
     private suspend fun withMentions(message: NotificationMessage): NotificationMessage =
         message.copy(
             requester = mentionFor(message.requester),
             decidedBy = message.decidedBy?.let { mentionFor(it) },
+            notifiedApprovers = message.notifiedApprovers.map { mentionFor(it) },
         )
 
     override suspend fun deliver(to: String, message: NotificationMessage, locale: String): DeliveryResult {

--- a/control-plane/src/main/resources/messages/en/notifications.json
+++ b/control-plane/src/main/resources/messages/en/notifications.json
@@ -1,22 +1,25 @@
 {
   "task": {
-    "requested": "*{requester}* wants to run {statement} on *{datasource}*{role}",
+    "requested": "*{requester}* wants to run {statement} on *{datasource}*{role}{reason}{statementNote}",
     "requested_fallback": "{requester} wants to run a query on {datasource}",
-    "decided_approved": "*{requester}*'s request to run {statement} on *{datasource}* was approved by *{decidedBy}* and is running.",
-    "decided_rejected": "*{requester}*'s request to run {statement} on *{datasource}* was denied by *{decidedBy}*.",
+    "submitted": "Your request to run a query on *{datasource}*{role} is pending approval.{notified}",
+    "submitted_fallback": "Your request on {datasource} is pending approval",
+    "decided_approved": "*{requester}*'s request to run {statement} on *{datasource}* was approved by *{decidedBy}* and is running.{statementNote}",
+    "decided_rejected": "*{requester}*'s request to run {statement} on *{datasource}* was denied by *{decidedBy}*.{statementNote}",
     "decided_fallback": "{requester}'s request on {datasource} was decided by {decidedBy}",
-    "executed": "*{requester}*'s request to run {statement} on *{datasource}* finished — {rowCount} rows.",
+    "executed": "*{requester}*'s request to run {statement} on *{datasource}* finished — {rowCount} rows.{statementNote}",
     "executed_fallback": "{requester}'s request on {datasource} finished",
-    "failed": "*{requester}*'s request to run {statement} on *{datasource}* failed.",
+    "failed": "*{requester}*'s request to run {statement} on *{datasource}* failed.{statementNote}",
     "failed_fallback": "{requester}'s request on {datasource} failed",
-    "cancelled": "*{requester}*'s request to run {statement} on *{datasource}* was cancelled.",
+    "cancelled": "*{requester}*'s request to run {statement} on *{datasource}* was cancelled.{statementNote}",
     "cancelled_fallback": "{requester}'s request on {datasource} was cancelled"
   },
   "field": {
     "role": " as *{role}*",
     "reason": "_{reason}_",
     "statement_hidden": "a query",
-    "statement_hidden_note": "_The statement is not shown here. Open the request to read it._"
+    "statement_hidden_note": "_The statement is not shown here. Open the request to read it._",
+    "notified": "Notified for approval: {notified}"
   },
   "action": {
     "approve_and_run": "Approve and run",

--- a/control-plane/src/main/resources/messages/ko/notifications.json
+++ b/control-plane/src/main/resources/messages/ko/notifications.json
@@ -1,22 +1,25 @@
 {
   "task": {
-    "requested": "*{requester}* 님이 *{datasource}*에서 {statement} 실행을 요청했습니다{role}",
+    "requested": "*{requester}* 님이 *{datasource}*에서 {statement} 실행을 요청했습니다{role}{reason}{statementNote}",
     "requested_fallback": "{requester} 님이 {datasource}에서 쿼리 실행을 요청했습니다",
-    "decided_approved": "*{datasource}*에서 {statement}를 실행하려는 *{requester}* 님의 요청을 *{decidedBy}* 님이 승인했고 실행 중입니다.",
-    "decided_rejected": "*{datasource}*에서 {statement}를 실행하려는 *{requester}* 님의 요청을 *{decidedBy}* 님이 거부했습니다.",
+    "submitted": "*{datasource}*에서 쿼리를 실행하려는 요청이 승인 대기 중입니다{role}.{notified}",
+    "submitted_fallback": "{datasource}에 대한 요청이 승인 대기 중입니다",
+    "decided_approved": "*{datasource}*에서 {statement}를 실행하려는 *{requester}* 님의 요청을 *{decidedBy}* 님이 승인했고 실행 중입니다.{statementNote}",
+    "decided_rejected": "*{datasource}*에서 {statement}를 실행하려는 *{requester}* 님의 요청을 *{decidedBy}* 님이 거부했습니다.{statementNote}",
     "decided_fallback": "{datasource}에 대한 {requester} 님의 요청을 {decidedBy} 님이 처리했습니다",
-    "executed": "*{datasource}*에서 {statement}를 실행하려는 *{requester}* 님의 요청이 완료되었습니다 — {rowCount}행.",
+    "executed": "*{datasource}*에서 {statement}를 실행하려는 *{requester}* 님의 요청이 완료되었습니다 — {rowCount}행.{statementNote}",
     "executed_fallback": "{datasource}에 대한 {requester} 님의 요청이 완료되었습니다",
-    "failed": "*{datasource}*에서 {statement}를 실행하려는 *{requester}* 님의 요청이 실패했습니다.",
+    "failed": "*{datasource}*에서 {statement}를 실행하려는 *{requester}* 님의 요청이 실패했습니다.{statementNote}",
     "failed_fallback": "{datasource}에 대한 {requester} 님의 요청이 실패했습니다",
-    "cancelled": "*{datasource}*에서 {statement}를 실행하려는 *{requester}* 님의 요청이 취소되었습니다.",
+    "cancelled": "*{datasource}*에서 {statement}를 실행하려는 *{requester}* 님의 요청이 취소되었습니다.{statementNote}",
     "cancelled_fallback": "{datasource}에 대한 {requester} 님의 요청이 취소되었습니다"
   },
   "field": {
     "role": " (역할: *{role}*)",
     "reason": "_{reason}_",
     "statement_hidden": "쿼리",
-    "statement_hidden_note": "_전체 구문은 여기에 표시되지 않습니다. 요청을 열어 확인하세요._"
+    "statement_hidden_note": "_전체 구문은 여기에 표시되지 않습니다. 요청을 열어 확인하세요._",
+    "notified": "승인 알림 대상: {notified}"
   },
   "action": {
     "approve_and_run": "승인 후 실행",

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ConfigGuardTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ConfigGuardTest.kt
@@ -47,6 +47,16 @@ class ConfigGuardTest {
         assertFailsWith<IllegalArgumentException> { Config.fromEnv(envOf("PM_QUERY_TIMEOUT" to "abc")) }
     }
 
+    @Test fun `PM_NOTIFY_STATEMENT takes omit auto full, coerces legacy truncated, rejects the rest`() {
+        assertEquals("auto", Config.fromEnv(envOf()).notifyStatement, "default is auto")
+        assertEquals("omit", Config.fromEnv(envOf("PM_NOTIFY_STATEMENT" to "omit")).notifyStatement)
+        assertEquals("full", Config.fromEnv(envOf("PM_NOTIFY_STATEMENT" to "FULL")).notifyStatement)
+        // The removed `truncated` must not fail boot — it coerces to `auto` (logged).
+        assertEquals("auto", Config.fromEnv(envOf("PM_NOTIFY_STATEMENT" to "truncated")).notifyStatement)
+        // Anything else is a config error, not a silent default.
+        assertFailsWith<IllegalArgumentException> { Config.fromEnv(envOf("PM_NOTIFY_STATEMENT" to "sometimes")) }
+    }
+
     @Test fun `PM_QUERY_TIMEOUT is bounded to the proxy's duration-safe ceiling (no ms overflow)`() {
         // The shared CP+proxy maximum: accepted here, rejected one above. Keeps queryExchangeTimeoutMs /
         // the run-stream cap from overflowing Long, and keeps the lockstep contract with goproxy exact.

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationServiceDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationServiceDbTest.kt
@@ -15,7 +15,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.time.Duration
+import com.ridi.oss.proxymonster.controlplane.RoleAssignmentInput
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -56,7 +59,6 @@ class NotificationServiceDbTest {
             queryResultStore = null,
             webBaseUrl = "https://console.example",
             disclosure = StatementDisclosure.FULL,
-            statementMaxChars = 10_000,
             defaultLocale = "en",
         )
     }
@@ -85,6 +87,102 @@ class NotificationServiceDbTest {
                 ps.setInt(1, attempts); ps.setLong(2, task); ps.setString(3, event.wire); ps.executeUpdate()
             }
         }
+    }
+
+    private fun countRows(task: Long, event: NotificationEvent, recipient: String): Int =
+        fx.dataSource.connection.use { c ->
+            c.prepareStatement("SELECT count(*) FROM notification_outbox WHERE task_id=? AND event=? AND recipient=?").use { ps ->
+                ps.setLong(1, task); ps.setString(2, event.wire); ps.setString(3, recipient)
+                ps.executeQuery().use { it.next(); it.getInt(1) }
+            }
+        }
+
+    private fun setHint(task: Long, value: Boolean?) {
+        fx.dataSource.connection.use { c ->
+            c.prepareStatement("UPDATE access_request SET statement_carries_protected_literal = ? WHERE id = ?").use { ps ->
+                if (value == null) ps.setNull(1, java.sql.Types.BOOLEAN) else ps.setBoolean(1, value)
+                ps.setLong(2, task); ps.executeUpdate()
+            }
+        }
+    }
+
+    private fun setStatus(task: Long, status: String) {
+        fx.dataSource.connection.use { c ->
+            c.prepareStatement("UPDATE access_request SET status = ? WHERE id = ?").use { ps ->
+                ps.setString(1, status); ps.setLong(2, task); ps.executeUpdate()
+            }
+        }
+    }
+
+    private fun adminRoleId(): Long = fx.policyStore.listRoles().first { it.name == "system:admin" }.id
+
+    private fun serviceWith(disclosure: StatementDisclosure, candidates: List<String> = emptyList()) =
+        NotificationService(
+            store = store,
+            recipients = RecipientResolver(fx.authz, fx.roleResolver) { candidates },
+            transports = listOf(transport),
+            accessStore = fx.accessStore,
+            queryResultStore = null,
+            webBaseUrl = "https://console.example",
+            disclosure = disclosure,
+            defaultLocale = "en",
+        )
+
+    @Test
+    fun `emitRequested sends the requester a receipt and never routes them the approver message`() {
+        val task = newTask(principal = "req@example.com").id
+        fx.dataSource.connection.use { c ->
+            svc.emitRequested(c, task, "req@example.com", fx.datasource, roleName = null)
+        }
+        // The requester always gets a task.submitted receipt (here with no approvers, the candidate source is
+        // empty) — and never a task.requested addressed to themselves, whatever routing would resolve.
+        assertEquals("PENDING", statusOf(task, NotificationEvent.TASK_SUBMITTED, "req@example.com"))
+        assertEquals(0, countRows(task, NotificationEvent.TASK_REQUESTED, "req@example.com"))
+    }
+
+    @Test
+    fun `an eligible requester is still dropped from the approver message and only gets the receipt`() {
+        // Make the requester resolve as a genuine approver candidate, so the exclusion filter has something to
+        // drop — without it they would receive both task.requested and task.submitted.
+        val requester = "self@example.com"
+        fx.policyStore.createAssignment(RoleAssignmentInput(requester, adminRoleId()))
+        val routing = serviceWith(StatementDisclosure.AUTO, candidates = listOf(requester))
+        val task = newTask(principal = requester).id
+        fx.dataSource.connection.use { c -> routing.emitRequested(c, task, requester, fx.datasource, roleName = null) }
+        assertEquals(0, countRows(task, NotificationEvent.TASK_REQUESTED, requester))
+        assertEquals("PENDING", statusOf(task, NotificationEvent.TASK_SUBMITTED, requester))
+    }
+
+    @Test
+    fun `the requester receipt lists the durable task-requested recipients and carries no statement`() = runBlocking {
+        val task = newTask(principal = "req@example.com").id
+        setHint(task, true) // even a flagged task: the receipt stays disclosure-free
+        // Two approvers were actually asked (durable rows). The candidate source is empty, so a receipt that
+        // recomputed eligibility would list nobody — asserting bob+carol proves it reads the outbox instead.
+        enqueue(task, NotificationEvent.TASK_REQUESTED, "bob@x")
+        enqueue(task, NotificationEvent.TASK_REQUESTED, "carol@x")
+        enqueue(task, NotificationEvent.TASK_SUBMITTED, "req@example.com")
+        svc.drainOnce()
+        val receipt = transport.delivered.single { it.event == NotificationEvent.TASK_SUBMITTED }
+        assertEquals(listOf("bob@x", "carol@x"), receipt.notifiedApprovers, "the receipt names who was actually asked")
+        assertNull(receipt.statement.text, "the requester's receipt never carries the statement")
+    }
+
+    @Test
+    fun `full shows a flagged statement while pending and hides it once the task is handled`() = runBlocking {
+        val task = newTask().id
+        setHint(task, true) // flagged: auto would withhold this
+        enqueue(task, NotificationEvent.TASK_REQUESTED, "bob@x")
+        svc.drainOnce() // svc is FULL
+        assertNotNull(transport.delivered.single().statement.text, "full shows a pending approver even a flagged statement")
+
+        // The same request, now handled, on a fresh (late/replayed) task.requested row: full falls back to the
+        // hint and withholds it, so a protected literal never surfaces for the first time after the decision.
+        setStatus(task, "REJECTED")
+        transport.delivered.clear()
+        enqueue(task, NotificationEvent.TASK_REQUESTED, "carol@x")
+        svc.drainOnce()
+        assertNull(transport.delivered.single().statement.text, "once handled, full hides a flagged statement even on a task.requested")
     }
 
     @Test
@@ -210,7 +308,6 @@ class NotificationServiceDbTest {
             queryResultStore = resultStore,
             webBaseUrl = "https://console.example",
             disclosure = StatementDisclosure.FULL,
-            statementMaxChars = 10_000,
             defaultLocale = "en",
         )
         // The terminal event goes to the requester AND a mere co-approver who neither requested nor ran it.

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationsTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationsTest.kt
@@ -9,9 +9,9 @@ import kotlin.test.assertTrue
  * What the recipient can actually read, and therefore whether they may approve from the message
  * (docs/notifications.md, "Never approve what you cannot see").
  *
- * The rule is deliberately about the RENDERED text, not the configured mode: a short statement under
- * TRUNCATED was never truncated, and a long one under FULL is still elided by a transport's own ceiling.
- * Writing the gate against the mode gets both edges backwards, which is what these cases pin.
+ * The rule is deliberately about the RENDERED text, not the configured mode: a shown statement that fits is
+ * complete, and one the transport's own ceiling elides is not, whichever mode chose to show it. Writing the
+ * gate against the mode gets both edges backwards, which is what these cases pin.
  */
 class NotificationsTest {
 
@@ -19,54 +19,84 @@ class NotificationsTest {
     private val long = "SELECT " + "x".repeat(500) + " FROM users"
 
     @Test
-    fun `a statement shorter than the limit is complete under truncated`() {
-        val r = renderStatement(short, StatementDisclosure.TRUNCATED, maxChars = 200)
+    fun `a shown statement under the ceiling is complete`() {
+        val r = renderStatement(short, show = true)
         assertEquals(short, r.text)
         assertTrue(r.complete, "nothing was cut, so the approver has read the whole statement")
     }
 
     @Test
-    fun `a statement longer than the limit is cut and incomplete`() {
-        val r = renderStatement(long, StatementDisclosure.TRUNCATED, maxChars = 200)
-        assertFalse(r.complete)
-        assertTrue(r.text!!.length <= 200, "the ellipsis must fit INSIDE the ceiling, not overrun it")
+    fun `a shown statement within the transport ceiling is complete`() {
+        val r = renderStatement(long, show = true, hardLimit = 2800)
+        assertEquals(long, r.text)
+        assertTrue(r.complete)
+    }
+
+    @Test
+    fun `the transport ceiling cuts an overlong statement and drops completeness`() {
+        val huge = "SELECT " + "y".repeat(4000) + " FROM users"
+        val r = renderStatement(huge, show = true, hardLimit = 2800)
+        assertFalse(r.complete, "elided is elided")
+        assertTrue(r.text!!.length <= 2800, "the ellipsis must fit INSIDE the ceiling, not overrun it")
         assertTrue(r.text!!.endsWith("…"))
     }
 
     @Test
-    fun `full carries the whole statement when the transport can hold it`() {
-        val r = renderStatement(long, StatementDisclosure.FULL, maxChars = 200, hardLimit = 2800)
-        assertEquals(long, r.text)
-        assertTrue(r.complete, "the configured truncation limit does not apply under FULL")
-    }
-
-    /** The edge the mode-based rule got wrong: FULL still loses the button when the transport elides. */
-    @Test
-    fun `full is incomplete when the transport ceiling cuts it`() {
-        val huge = "SELECT " + "y".repeat(4000) + " FROM users"
-        val r = renderStatement(huge, StatementDisclosure.FULL, maxChars = 200, hardLimit = 2800)
-        assertFalse(r.complete, "elided is elided, whoever did it")
-        assertTrue(r.text!!.length <= 2800)
-    }
-
-    @Test
-    fun `omit carries no statement and is never complete`() {
-        val r = renderStatement(short, StatementDisclosure.OMIT, maxChars = 200)
+    fun `a hidden statement carries no text and is never complete`() {
+        val r = renderStatement(short, show = false)
         assertEquals(null, r.text)
         assertFalse(r.complete)
     }
 
     @Test
     fun `a task with no statement is never complete`() {
-        val r = renderStatement(null, StatementDisclosure.FULL, maxChars = 200)
+        val r = renderStatement(null, show = true, hardLimit = 2800)
         assertEquals(null, r.text)
         assertFalse(r.complete)
     }
 
     @Test
-    fun `parse rejects an unrecognized disclosure mode`() {
-        assertEquals(StatementDisclosure.TRUNCATED, StatementDisclosure.parse("truncated"))
+    fun `parse accepts the three modes and rejects anything else`() {
+        assertEquals(StatementDisclosure.OMIT, StatementDisclosure.parse("omit"))
+        assertEquals(StatementDisclosure.AUTO, StatementDisclosure.parse("auto"))
         assertEquals(StatementDisclosure.FULL, StatementDisclosure.parse("FULL"))
+        // `truncated` is removed; the enum does not know it (Config coerces it to auto with a warning).
+        assertEquals(null, StatementDisclosure.parse("truncated"))
         assertEquals(null, StatementDisclosure.parse("sometimes"))
+    }
+
+    @Test
+    fun `omit never shows the statement`() {
+        for (pending in listOf(true, false)) {
+            for (cleared in listOf(true, false)) {
+                assertFalse(discloseStatement(StatementDisclosure.OMIT, pending, cleared))
+            }
+        }
+    }
+
+    @Test
+    fun `auto follows the hint, pending or handled`() {
+        assertTrue(discloseStatement(StatementDisclosure.AUTO, pending = true, cleared = true))
+        assertTrue(discloseStatement(StatementDisclosure.AUTO, pending = false, cleared = true))
+        assertFalse(discloseStatement(StatementDisclosure.AUTO, pending = true, cleared = false))
+        assertFalse(discloseStatement(StatementDisclosure.AUTO, pending = false, cleared = false))
+    }
+
+    @Test
+    fun `full shows a pending statement even when the hint flags it`() {
+        assertTrue(
+            discloseStatement(StatementDisclosure.FULL, pending = true, cleared = false),
+            "a pending approver must be able to read the statement to decide and approve-and-run",
+        )
+        assertTrue(discloseStatement(StatementDisclosure.FULL, pending = true, cleared = true))
+    }
+
+    @Test
+    fun `full falls back to the hint once the task is handled`() {
+        assertFalse(
+            discloseStatement(StatementDisclosure.FULL, pending = false, cleared = false),
+            "a flagged statement is hidden after the decision, so a protected value does not linger",
+        )
+        assertTrue(discloseStatement(StatementDisclosure.FULL, pending = false, cleared = true))
     }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackDecisionHandlerDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackDecisionHandlerDbTest.kt
@@ -50,7 +50,6 @@ class SlackDecisionHandlerDbTest {
             queryResultStore = null,
             webBaseUrl = "https://console.example",
             disclosure = StatementDisclosure.FULL,
-            statementMaxChars = 10_000,
             defaultLocale = "en",
         )
         handler = SlackDecisionHandler(

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackNotificationE2eDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackNotificationE2eDbTest.kt
@@ -72,6 +72,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.slf4j.LoggerFactory
@@ -114,6 +115,13 @@ class SlackNotificationE2eDbTest {
     private var runnerRoleId = 0L
     private val runScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val log = LoggerFactory.getLogger("e2e")
+
+    // The class shares one MockSlack (@BeforeAll), so drop its recorded call log per test — every case then
+    // counts only its own posts, instead of accumulating across the class in method-order-dependent ways.
+    @BeforeEach
+    fun resetSlackLog() {
+        slack.clearRecorded()
+    }
 
     @BeforeAll
     fun setup() {
@@ -159,8 +167,9 @@ class SlackNotificationE2eDbTest {
             accessStore = core.accessStore,
             queryResultStore = resultStore,
             webBaseUrl = "https://console.example",
-            disclosure = StatementDisclosure.FULL,
-            statementMaxChars = 10_000,
+            // `auto`, the default: a cleared statement is shown (approve-and-run offered), a flagged one is
+            // withheld (no button). The two E2E cases below exercise both branches on the real hint path.
+            disclosure = StatementDisclosure.AUTO,
             defaultLocale = "en",
         )
         val handler = SlackDecisionHandler(
@@ -359,6 +368,39 @@ class SlackNotificationE2eDbTest {
         assertTrue(
             post.actionElements().none { it["action_id"]?.jsonPrimitive?.content == SlackTransport.ACTION_APPROVE },
             "a withheld statement offers no approve-and-run — you cannot vouch for what you cannot read",
+        )
+    }
+
+    /**
+     * The mode is a property of the draining service, not the enqueued row, so a FULL-mode drainer renders the
+     * same flagged request the AUTO case above withholds. FULL shows it to a pending approver on purpose — they
+     * must read it to decide — where AUTO never would. The hint reasserts itself once the task is handled
+     * (discloseStatement, unit-tested); the withhold render path is the same one the AUTO case exercises.
+     */
+    @Test
+    fun `under full a pending approver sees even a flagged statement`() = testApplication {
+        val fullSvc = NotificationService(
+            store = NotificationStore(fx.dataSource),
+            recipients = RecipientResolver(core.authz, core.roleResolver) { listOf(approver) },
+            transports = listOf(SlackTransport(http, "xoxb-e2e", "https://console.example", NotificationRenderer(), api = slack.apiBase)),
+            accessStore = core.accessStore,
+            queryResultStore = resultStore,
+            webBaseUrl = "https://console.example",
+            disclosure = StatementDisclosure.FULL,
+            defaultLocale = "en",
+        )
+        val client = wire()
+        assertEquals(HttpStatusCode.Created, client.createApproval("SELECT id FROM users WHERE ssn = '987-65-4320'").status)
+
+        fullSvc.drainOnce()
+        val post = slack.lastRequest("chat.postMessage")!!
+        assertTrue(
+            post.sectionText().contains("987-65-4320"),
+            "full shows a pending approver the whole statement, flagged or not — they must read it to decide",
+        )
+        assertTrue(
+            post.actionElements().any { it["action_id"]?.jsonPrimitive?.content == SlackTransport.ACTION_APPROVE },
+            "a fully-shown statement offers approve-and-run",
         )
     }
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/FakeTransport.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/FakeTransport.kt
@@ -5,6 +5,7 @@ import com.ridi.oss.proxymonster.controlplane.notify.NotificationAction
 import com.ridi.oss.proxymonster.controlplane.notify.NotificationEvent
 import com.ridi.oss.proxymonster.controlplane.notify.NotificationMessage
 import com.ridi.oss.proxymonster.controlplane.notify.NotificationTransport
+import com.ridi.oss.proxymonster.controlplane.notify.RenderedStatement
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.withTimeout
 import java.util.Collections
@@ -36,8 +37,11 @@ class FakeTransport(
         val actions: Set<NotificationAction>,
         // The result-derived fact carried to THIS recipient — null for a non-party (the row-count oracle gate).
         val rowCount: Int? = null,
+        // The disclosure outcome and receipt list, so a drain test can see what actually rendered.
+        val statement: RenderedStatement = RenderedStatement(null, false),
+        val notifiedApprovers: List<String> = emptyList(),
     )
-    data class Updated(val ref: String, val event: NotificationEvent)
+    data class Updated(val ref: String, val event: NotificationEvent, val statement: RenderedStatement = RenderedStatement(null, false))
 
     val delivered: MutableList<Delivered> = Collections.synchronizedList(mutableListOf())
     val updated: MutableList<Updated> = Collections.synchronizedList(mutableListOf())
@@ -51,14 +55,14 @@ class FakeTransport(
     }
 
     override suspend fun deliver(to: String, message: NotificationMessage, locale: String): DeliveryResult {
-        delivered += Delivered(to, message.event, message.actions, message.rowCount)
+        delivered += Delivered(to, message.event, message.actions, message.rowCount, message.statement, message.notifiedApprovers)
         deliverSignal.trySend(Unit)
         deliverThrows?.let { throw it }
         return deliverResult
     }
 
     override suspend fun update(externalRef: String, message: NotificationMessage, locale: String): DeliveryResult {
-        updated += Updated(externalRef, message.event)
+        updated += Updated(externalRef, message.event, message.statement)
         return updateResult
     }
 

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/MockSlack.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/support/MockSlack.kt
@@ -104,6 +104,10 @@ class MockSlack private constructor() : AutoCloseable {
     fun requestsFor(method: String): List<Recorded> = recorded.filter { it.method == method }
     fun lastRequest(method: String): Recorded? = recorded.lastOrNull { it.method == method }
 
+    /** Drop the recorded call log — not the configured users/team — so a shared instance gives each test a
+     *  clean count instead of accumulating posts across the class. */
+    fun clearRecorded() = recorded.clear()
+
     /** The envelope_id acknowledgements the client sent back over the socket. */
     fun acks(): List<JsonObject> = ackFrames.toList()
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -29,10 +29,10 @@ Had Bob tapped **approve and run**, the query runs and the message becomes
 console.
 
 Alice's statement is short, so Bob sees all of it and can approve from the DM.
-Had any of it been elided — too long for the configured limit, too long for
-Slack, or withheld because it carried a protected value — the message would
-offer only `[deny]` and `[open request]`. Nobody approves a statement they have
-not read in full.
+Had any of it been elided — too long for Slack, or withheld because it carried a
+protected value the disclosure mode does not surface — the message would offer
+only `[deny]` and `[open request]`. Nobody approves a statement they have not
+read in full.
 
 Everything below is how that works.
 
@@ -48,11 +48,12 @@ touching the workflow.
 
 ## Events
 
-| Event                                          | When                 | Who hears it                           |
-| ---------------------------------------------- | -------------------- | -------------------------------------- |
-| `task.requested`                               | a request is filed   | everyone who could approve it          |
-| `task.decided`                                 | approved or rejected | the requester, and everyone told above |
-| `task.executed` `task.failed` `task.cancelled` | the run ends         | the requester and the approver         |
+| Event                                          | When                 | Who hears it                                        |
+| ---------------------------------------------- | -------------------- | --------------------------------------------------- |
+| `task.requested`                               | a request is filed   | everyone who could approve it, except the requester |
+| `task.submitted`                               | a request is filed   | the requester — a receipt naming who was asked      |
+| `task.decided`                                 | approved or rejected | the requester, and everyone told above              |
+| `task.executed` `task.failed` `task.cancelled` | the run ends         | the requester and the approver                      |
 
 Anyone told about a request is told how it ended. That is what stops a stale
 "needs your approval" sitting in a DM after someone else already handled it —
@@ -156,30 +157,28 @@ The shipped policies never read `requester_ip` for `task.approve`, so on a
 default deployment either choice is correct. The unknown earns its place the
 moment an operator writes "approvers must be on the office network."
 
-### The one wart: the requester hears about their own request
+### The requester gets a receipt, not an invitation to self-approve
 
-Marking anything unknown costs one wrong notification, and it is worth stating
-plainly because it looks alarming: the requester may be invited to approve their
-own request.
+The requester hears about their own request — as a receipt, never as an approver
+of it. `emitRequested` routes the approver message (`task.requested`) to
+everyone who could approve it _except the requester_, and sends the requester a
+`task.submitted` receipt instead: their request is pending, and here is who was
+asked. So the requester gets exactly one message, and it is never an "approve
+your own request" button.
 
-The cause is a Cedar limitation, not a modelling mistake. Cedar treats the
-context as a single record, and `context has channel` will not reduce while
-_any_ unknown sits in that record — even though `channel` is right there with a
-concrete value, and no address could change whether it exists. Our
-[`system:no-self-approval`] forbid guards its editor/wire escape that way, so it
-goes undecided and the requester reads as "maybe":
+That exclusion is routing, not authorization — the boundary stays Cedar's
+[`system:no-self-approval`] forbid, which denies a requester who reaches an
+approve button by any other path. Cedar's own limitation is unchanged: it treats
+the context as a single record, so `context has channel` will not reduce while
+_any_ unknown sits in that record, even with `channel` right there with a
+concrete value. That still over-notifies by catching a genuine approver
+candidate on the UNKNOWN `requester_ip` row, which is harmless — a click just
+gets a 403:
 
 ```
 channel known, requester_ip omitted  ->  Deny   (correct, forbid resolves)
-channel known, requester_ip UNKNOWN  ->  null   (undecided; the requester is notified)
+channel known, requester_ip UNKNOWN  ->  null   (undecided → over-notified, harmless)
 ```
-
-It is bounded — one person per request, the requester themselves — and it does
-not arise at all on a deployment with no IP-conditioned approval policy, since
-nothing then needs to be unknown. Clicking the button denies exactly as it
-should. Not worth filtering outside Cedar: a hardcoded "skip the requester"
-would move an authorization rule out of the policy engine that owns it, to save
-one message.
 
 ### What this costs, and what it means
 
@@ -296,9 +295,21 @@ left the building.
 
 So `PM_NOTIFY_STATEMENT` picks one of:
 
-- `truncated` (default) — first 200 characters, enough to recognize the query
-- `full` — the whole statement
-- `omit` — no SQL at all; requester, datasource, role, and the link only
+- `omit` — no SQL at all; requester, datasource, role, and the link only.
+- `auto` (default) — show the statement only when the disclosure hint (below)
+  clears it, hide it otherwise. A query that might carry a protected value in
+  its own text never reaches the channel.
+- `full` — show the whole statement while the task is **pending**, so an
+  approver can read it and approve-and-run; once the task is **handled**
+  (decided, executed, failed, or cancelled — by anyone) fall back to `auto`,
+  hiding the statement if the hint flags it, so a protected value does not
+  linger in the channel after the decision.
+
+`truncated` is gone: a first-N-characters cut guarantees nothing — the protected
+value can sit in the first 40 characters as readily as the last — and it
+withheld `[approve and run]` for every statement past the limit. A config that
+still sets `PM_NOTIFY_STATEMENT=truncated` boots as `auto` (the hint-gated show
+it always was beneath the cut) with a warning.
 
 It lives in the environment because that is where all configuration lives here.
 There is no settings table, and adding the first one belongs to its own change.
@@ -309,33 +320,31 @@ There is no settings table, and adding the first one belongs to its own change.
 statement.** The test is what the recipient can actually read, not which mode
 the operator configured:
 
-- `truncated` with a statement shorter than the limit — nothing was cut, so the
-  button appears.
-- `truncated` with a longer one — cut, no button.
-- `full` — usually the button, but not always: a transport has its own length
-  ceiling (a Slack section block's text field caps at 3000 characters), and a
-  statement that overruns it is elided on the way out. Elided is elided, whoever
-  did it.
-- `omit` — no button.
+- a statement shown whole (`auto` on a cleared query, or `full` while pending) —
+  the button appears, unless a transport's own length ceiling (a Slack section
+  block's text field caps at 3000 characters) elided it on the way out. Elided
+  is elided, whoever did it.
+- a hidden statement (`omit`, or `auto`/`full`-once-handled on a flagged query)
+  — no button.
 
 So the flag is an input to rendering, and the button is decided **after**
 rendering, from whether the text survived intact. Writing the gate against the
 mode instead would get both edge cases backwards.
 
-Approving is vouching for a specific statement. A truncated one is worse than
-none: `SELECT id, name FROM users WHERE …` looks harmless and the elided tail is
-exactly where a dangerous predicate would sit. One tap on a query nobody read in
-full is not an approval, it is a rubber stamp with an audit trail.
+Approving is vouching for a specific statement, so a statement nobody could read
+in full never carries the button — the elided tail is exactly where a dangerous
+predicate would sit, and one tap on a query read only in part would be a rubber
+stamp with an audit trail.
 
 `[deny]` stays available throughout — refusing something you have not fully read
 is always safe.
 
-### Hiding a statement that carries the value it asks for
+### The disclosure hint
 
-`PM_NOTIFY_STATEMENT` is a blunt instrument: an operator picks one setting for
-every query, so `full` would send `WHERE ssn = '987-65-4320'` verbatim. The
-protected value is in the query, and masking never sees it because masking acts
-on results. That is the case where `full` needs a floor, and it has one.
+Both `auto` and `full` consult a hint: whether the statement's own text carries
+a value a policy protects. `full` would otherwise send
+`WHERE ssn = '987-65-4320'` verbatim — the protected value is in the query, and
+masking never sees it because masking acts on results.
 
 The analyzer emits a `predicate_literals` fact: for every `WHERE`, `HAVING`,
 `QUALIFY`, and join predicate that compares a **literal** against a column, the
@@ -345,9 +354,9 @@ are followed. A comparison between two columns emits nothing — there is no val
 to leak.
 
 The control plane intersects that against classification: a literal landing on a
-classified column means the statement's own text carries a protected value, so
-the text is withheld whatever the mode, and the message loses
-`[approve and run]` by the rule above.
+classified column means the statement's own text carries a protected value.
+`auto` then hides it from the first message; `full` hides it the moment the task
+is handled. Either way the message loses `[approve and run]` by the rule above.
 
 **The verdict is deliberately reader-independent.** It keys on whether the
 column is classified, not on what the requester may read. A notification goes to
@@ -364,8 +373,11 @@ known clean shows the text, known dirty withholds it, and **never analyzed
 withholds it too**. A from-denied request — which copies a statement nothing
 re-analyzed — is in that third state by construction.
 
-This is an extra layer, not the boundary: `omit` remains the setting for a
-deployment that cannot let query text leave at all.
+Under `full`, a pending message shows the statement whatever the hint says — an
+approver who must decide needs to read it — and the hint reasserts itself the
+moment the task is handled, so the value does not persist. Under `auto` the hint
+governs from the first message. `omit` shows the text under no circumstances,
+the setting for a deployment that cannot let query text leave at all.
 
 ## Slack
 
@@ -447,13 +459,12 @@ may see them.
 
 ## Configuration
 
-| Variable                  | Default     | Meaning                                                                                               |
-| ------------------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
-| `PM_SLACK_BOT_TOKEN`      | unset       | Slack API token; unset = no Slack                                                                     |
-| `PM_SLACK_APP_TOKEN`      | unset       | Socket Mode token; unset = no Slack                                                                   |
-| `PM_NOTIFY_STATEMENT`     | `truncated` | `truncated` · `full` · `omit`. Approve-and-run needs the statement to render whole, whatever the mode |
-| `PM_NOTIFY_STATEMENT_MAX` | `200`       | characters kept when truncating                                                                       |
-| `PM_NOTIFY_LOCALE`        | `en`        | fallback when the recipient has saved no language                                                     |
+| Variable              | Default | Meaning                                                                                                                                                                                         |
+| --------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PM_SLACK_BOT_TOKEN`  | unset   | Slack API token; unset = no Slack                                                                                                                                                               |
+| `PM_SLACK_APP_TOKEN`  | unset   | Socket Mode token; unset = no Slack                                                                                                                                                             |
+| `PM_NOTIFY_STATEMENT` | `auto`  | `omit` · `auto` · `full`. `auto` shows a hint-cleared statement; `full` shows it to pending approvers, then hides a flagged one once handled. Legacy `truncated` boots as `auto` with a warning |
+| `PM_NOTIFY_LOCALE`    | `en`    | fallback when the recipient has saved no language                                                                                                                                               |
 
 ## What this exposes
 


### PR DESCRIPTION
Recut the notification statement-disclosure knob and give the requester a
notification of their own.

## Disclosure modes: `truncated | full | omit` → `omit | auto | full`

Truncation is dropped — a first-N-characters cut is no PII guarantee (the
protected value can sit in the first 40 chars), and it withheld approve-and-run
for every over-limit statement. The decision is now a pure
`discloseStatement(mode, pending, cleared)`:

- **`omit`** — never show the SQL.
- **`auto`** (default) — show only a statement the disclosure hint clears; hide
  one whose predicate compares a literal against a classified column. This is
  what `full`/`truncated` already did beneath the cut.
- **`full`** — show the whole statement to **pending** approvers, bypassing the
  hint so they can read it and approve-and-run, then fall back to `auto` once the
  task is **handled** so a flagged literal does not linger in the channel.

**Config trap:** `PM_NOTIFY_STATEMENT` now takes `omit|auto|full` (default
`auto`), and `PM_NOTIFY_STATEMENT_MAX` is removed. A legacy
`PM_NOTIFY_STATEMENT=truncated` does **not** fail boot — it coerces to `auto`
with a warning.

`pending` is the **live task status** (`req.status == "PENDING"`), not merely the
`task.requested` event: a backed-off request delivered after the decision must
not be the first to surface a flagged statement under `full`.

## The requester is notified at creation

`emitRequested` routes the approver message (`task.requested`) to everyone who
could approve **except the requester**, and sends the requester a new
`task.submitted` receipt naming who was asked (read from the durable outbox rows,
not a fresh eligibility recompute). One message per requester, never an
approve-your-own-request button. The exclusion is routing; `system:no-self-approval`
stays the authorization boundary.

## Verification

Full `:control-plane` suite green (unit + DB + Slack E2E). `discloseStatement` is
exhaustively unit-tested; DB tests cover the requester receipt (content from the
outbox, no statement), `auto` (flagged withheld / clean shown), `full` (flagged
shown while pending, hidden once handled), the eligible-requester exclusion, and
the `truncated→auto` config coercion. Docs (`docs/notifications.md`, `INSTALL.md`)
and en/ko l10n updated; prettier-clean.

Follow-up: the ridi terraform `var.slack.statement` values change to
`omit|auto|full` (dev stays `full`); separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ati9RRaurF1DQ5R4Xz32E
