### PR TITLE
fix(control-plane): let a self-approving requester get the approver message

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationService.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationService.kt
@@ -119,13 +119,12 @@ class NotificationService(
                 status = "PENDING",
                 createdAt = "",
             )
-            // The requester hears about their own request as a receipt (TASK_SUBMITTED), never as an approver
-            // of it — so they get exactly one message even where policy would let them approve their own.
-            val approvers = recipients.recipientsFor(subject).filter { it != requester }
+            val approvers = recipients.recipientsFor(subject)
             for (transport in transports) {
                 for (recipient in approvers) {
                     store.enqueue(c, taskId, NotificationEvent.TASK_REQUESTED, transport.name, recipient)
                 }
+                // A requester who can approve is already in `approvers`; the drain dedups this receipt away.
                 store.enqueue(c, taskId, NotificationEvent.TASK_SUBMITTED, transport.name, requester)
             }
         }.onFailure { log.warn("notification emit failed task={} event=task.requested", taskId, it) }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationServiceDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationServiceDbTest.kt
@@ -141,16 +141,19 @@ class NotificationServiceDbTest {
     }
 
     @Test
-    fun `an eligible requester is still dropped from the approver message and only gets the receipt`() {
-        // Make the requester resolve as a genuine approver candidate, so the exclusion filter has something to
-        // drop — without it they would receive both task.requested and task.submitted.
+    fun `an eligible requester is in Cedar's approver set and gets the approver message`() = runBlocking {
+        // Policy lets the requester approve their own request, so recipientsFor (Cedar) returns them — and they
+        // are never post-filtered out. They get the ordinary approver message and can act on it.
         val requester = "self@example.com"
         fx.policyStore.createAssignment(RoleAssignmentInput(requester, adminRoleId()))
         val routing = serviceWith(StatementDisclosure.AUTO, candidates = listOf(requester))
         val task = newTask(principal = requester).id
         fx.dataSource.connection.use { c -> routing.emitRequested(c, task, requester, fx.datasource, roleName = null) }
-        assertEquals(0, countRows(task, NotificationEvent.TASK_REQUESTED, requester))
-        assertEquals("PENDING", statusOf(task, NotificationEvent.TASK_SUBMITTED, requester))
+        assertEquals(1, countRows(task, NotificationEvent.TASK_REQUESTED, requester), "an eligible requester stays in the approver set")
+        // One message per recipient: the actionable approver message wins, the receipt is deduped on delivery.
+        routing.drainOnce()
+        val toRequester = transport.delivered.filter { it.to == "addr:$requester" }.map { it.event }
+        assertEquals(listOf(NotificationEvent.TASK_REQUESTED), toRequester, "the approver message, not the receipt")
     }
 
     @Test

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -48,12 +48,12 @@ touching the workflow.
 
 ## Events
 
-| Event                                          | When                 | Who hears it                                        |
-| ---------------------------------------------- | -------------------- | --------------------------------------------------- |
-| `task.requested`                               | a request is filed   | everyone who could approve it, except the requester |
-| `task.submitted`                               | a request is filed   | the requester — a receipt naming who was asked      |
-| `task.decided`                                 | approved or rejected | the requester, and everyone told above              |
-| `task.executed` `task.failed` `task.cancelled` | the run ends         | the requester and the approver                      |
+| Event                                          | When                 | Who hears it                                                                    |
+| ---------------------------------------------- | -------------------- | ------------------------------------------------------------------------------- |
+| `task.requested`                               | a request is filed   | everyone Cedar says may approve it (the requester too, where policy allows)     |
+| `task.submitted`                               | a request is filed   | the requester, when not themselves an approver — a receipt naming who was asked |
+| `task.decided`                                 | approved or rejected | the requester, and everyone told above                                          |
+| `task.executed` `task.failed` `task.cancelled` | the run ends         | the requester and the approver                                                  |
 
 Anyone told about a request is told how it ended. That is what stops a stale
 "needs your approval" sitting in a DM after someone else already handled it —
@@ -157,28 +157,20 @@ The shipped policies never read `requester_ip` for `task.approve`, so on a
 default deployment either choice is correct. The unknown earns its place the
 moment an operator writes "approvers must be on the office network."
 
-### The requester gets a receipt, not an invitation to self-approve
+### The requester's own message
 
-The requester hears about their own request — as a receipt, never as an approver
-of it. `emitRequested` routes the approver message (`task.requested`) to
-everyone who could approve it _except the requester_, and sends the requester a
-`task.submitted` receipt instead: their request is pending, and here is who was
-asked. So the requester gets exactly one message, and it is never an "approve
-your own request" button.
+`recipientsFor` is Cedar's answer to who may approve, and it is never
+post-filtered. A hard-coded denial or filter in code — dropping the requester,
+skipping an "impossible" approver — is a bug, not a shortcut: it moves a policy
+rule out of the engine that owns it. If the requester is in that set they get
+the ordinary approver message like any approver; if not, they get a
+`task.submitted` receipt — their request is pending, and here is who was asked.
+One message per recipient; which one is Cedar's set, not a branch in code.
 
-That exclusion is routing, not authorization — the boundary stays Cedar's
-[`system:no-self-approval`] forbid, which denies a requester who reaches an
-approve button by any other path. Cedar's own limitation is unchanged: it treats
-the context as a single record, so `context has channel` will not reduce while
-_any_ unknown sits in that record, even with `channel` right there with a
-concrete value. That still over-notifies by catching a genuine approver
-candidate on the UNKNOWN `requester_ip` row, which is harmless — a click just
-gets a 403:
-
-```
-channel known, requester_ip omitted  ->  Deny   (correct, forbid resolves)
-channel known, requester_ip UNKNOWN  ->  null   (undecided → over-notified, harmless)
-```
+The reverse query has one quirk: it treats the context as a single record, so
+`context has channel` will not reduce while _any_ unknown sits in it. That
+over-notifies an approver candidate on the UNKNOWN `requester_ip` row —
+harmless, since the click re-decides and may 403.
 
 ### What this costs, and what it means
 


### PR DESCRIPTION
`emitRequested` post-filtered the requester out of `recipientsFor` with `.filter { it != requester }` — deciding authorization in code. `recipientsFor` **is** Cedar's answer to who may approve, so a requester whom policy lets approve their own request legitimately belongs in it. Filtering them out meant enabling self-approval left the requester with no way to act from Slack (found on dev).

**Fix:** remove the filter (and a follow-on `if (requester !in approvers)` receipt guard — same class of branch-on-a-Cedar-result). The requester is now a plain recipient: the approver message when Cedar puts them in the set, their `task.submitted` receipt otherwise. The drain delivers one message per recipient in id order (`claimDue` is `ORDER BY id`, `task.requested` enqueued first), so the actionable approver message wins and the receipt is deduped when both apply. No branch decides who — Cedar's set does.

Docs state plainly that a hard-coded denial or filter is a bug, not a shortcut; the test flipped to assert an eligible requester stays in the set and receives the approver message.

Verified: `NotificationServiceDbTest` + `SlackNotificationE2eDbTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ati9RRaurF1DQ5R4Xz32E