### PR TITLE
fix(pgproxy): probe the bound namespace after Bind, not before (GHSA-c99q)

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -162,21 +162,6 @@ analog of MySQL's Prepare-time freeze. No control-plane decision is ever stored.
   against real PostgreSQL). It is `GUC_REPORT`, so a session turning it off is
   observed and the relay fails closed (SQLSTATE `0A000`) rather than proxying
   under a divergent lexer.
-- 🔴 `search_path` mutated _inside_ Bind parameter coercion is untracked
-  (extended path). The bind-time capture probes the namespace immediately before
-  forwarding `Bind`, but `Bind` itself runs parameter input/coercion (input
-  functions, domain `CHECK`s) _before_ it plans the portal. A crafted domain
-  whose check calls `set_config('search_path', <bound value>, false)` moves the
-  path during `Bind`, so the portal resolves under a path the pre-`Bind` probe
-  never saw, and the `Execute` re-decide authorizes under the stale snapshot (a
-  wrong-ALLOW). Reproduced against PG16 by
-  `pgproxy.TestExtendedBindCoercionSetConfigLeaksAcrossSchema` (the proxy
-  decides under the primary path yet the target DB returns the secondary
-  schema's row). The offending domain must already exist, which needs a
-  `CREATE DOMAIN`/`CREATE FUNCTION` grant the masking policy denies read-only
-  principals. A fail-safe close (re-probe _after_ Bind, or bind under a pinned
-  `search_path`) is a follow-up. Tracked:
-  [`docs/backlog.md`](./docs/backlog.md).
 
 ## Catalog freshness
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -209,8 +209,6 @@ Fixes for gaps documented in
   (saved lineage), so an output-name match can no longer release stored
   cleartext under a mask plan computed for a different physical column. High
   priority.
-- Fail-closed close for a `search_path` change made inside Bind parameter
-  coercion: re-probe after `Bind`, or plan under a pinned `search_path`.
 - Fail-closed manifest-completeness guard: deny a touched system schema that has
   no governing manifest, plus a version-independent system-table floor (the
   analog of the dangerous-function floor), so completeness doesn't depend on

--- a/goproxy/pgproxy/extended.go
+++ b/goproxy/pgproxy/extended.go
@@ -33,11 +33,14 @@ type preparedStatement struct {
 	sql string
 }
 
-// boundPortal snapshots the namespace and temporary-column context immediately before its confirmed Bind.
-// Every Execute re-decides the portal SQL against this snapshot, matching PostgreSQL's resolution point.
-// This is the PostgreSQL analog of MySQL's Prepare-time freeze (goproxy/mysqlproxy/stmt.go). Capturing the
-// context at Bind (rather than refusing a Parse-to-Bind path drift) lets the probe-always model authorize
-// the true Bind context with a fail-closed guarantee. No decision is ever stored.
+// boundPortal snapshots the namespace and temporary-column context probed immediately AFTER its confirmed
+// Bind — a Bind-time parameter coercion can move search_path, and PostgreSQL binds the portal's unqualified
+// relations under that post-coercion namespace, so only a post-BindComplete probe captures the context it
+// actually resolved under. Every Execute re-decides the portal SQL against this snapshot, matching
+// PostgreSQL's resolution point. This is the PostgreSQL analog of MySQL's Prepare-time freeze
+// (goproxy/mysqlproxy/stmt.go). Capturing the context at Bind (rather than refusing a Parse-to-Bind path
+// drift) lets the probe-always model authorize the true Bind context with a fail-closed guarantee. No
+// decision is ever stored.
 type boundPortal struct {
 	sql       string
 	namespace []string
@@ -160,18 +163,10 @@ func (s *Server) handleBind(sess *session, message *pgproto3.Bind) error {
 		}
 	}
 
-	// Capture immediately before forwarding: the lockstep single writer guarantees nothing executes on the
-	// target DB between this probe and Bind, so the captured context is exactly the one PostgreSQL binds under.
-	// Probing first also leaves no registry/target DB inconsistency if capture fails. An aborted transaction
-	// fails here before PostgreSQL's equivalent 25P02 Bind, retaining the prior portal snapshot and target DB portal.
-	namespace, temps, err := s.probeBindContext(sess)
-	if err != nil {
-		if errors.Is(err, errClientEncoding) || errors.Is(err, errStdConformingStrings) {
-			return err
-		}
-		return refuseExtended(sess, "58000", "bind-time namespace unavailable")
-	}
-
+	// A parameter coercion runs DURING Bind — a domain CHECK or a cast function can `SET search_path` as a
+	// side effect, and PostgreSQL resolves the portal's unqualified relations under that POST-coercion
+	// namespace. So the authorization context is probed AFTER BindComplete, not before: a pre-Bind probe
+	// captures the namespace the coercion is about to move, and Execute would then decide the wrong schema.
 	sess.targetDb.Send(message)
 	sess.targetDb.Send(&pgproto3.Flush{})
 	if err := sess.targetDb.Flush(); err != nil {
@@ -188,13 +183,30 @@ func (s *Server) handleBind(sess *session, message *pgproto3.Bind) error {
 	if err != nil {
 		return err
 	}
-	if _, complete := terminal.(*pgproto3.BindComplete); complete {
-		sess.portals[message.DestinationPortal] = boundPortal{
-			sql:       statement.sql,
-			namespace: namespace,
-			temps:     temps,
-			binary:    binary,
+	if _, complete := terminal.(*pgproto3.BindComplete); !complete {
+		// Bind errored (a coercion failure, or a 25P02 in an aborted transaction): no portal was bound, so
+		// there is nothing to register or re-decide.
+		return sess.client.Flush()
+	}
+
+	// Bind confirmed: probe the live namespace + temp context the coercion may have moved, and register the
+	// portal against THAT snapshot. The probe's own statement and portal are uniquely named and closed, so it
+	// does not disturb the client's just-bound portal. Fail closed if the probe cannot complete — discard any
+	// prior snapshot at this portal name so a later Execute finds no portal and is denied, never one decided
+	// under stale context.
+	namespace, temps, err := s.probeBindContext(sess)
+	if err != nil {
+		delete(sess.portals, message.DestinationPortal)
+		if errors.Is(err, errClientEncoding) || errors.Is(err, errStdConformingStrings) {
+			return err
 		}
+		return refuseExtended(sess, "58000", "post-bind namespace unavailable")
+	}
+	sess.portals[message.DestinationPortal] = boundPortal{
+		sql:       statement.sql,
+		namespace: namespace,
+		temps:     temps,
+		binary:    binary,
 	}
 	return sess.client.Flush()
 }

--- a/goproxy/pgproxy/extended_test.go
+++ b/goproxy/pgproxy/extended_test.go
@@ -867,15 +867,12 @@ func TestExtendedAbortedTransactionRecoversViaRollback(t *testing.T) {
 	})
 }
 
-// TestExtendedBindCoercionSetConfigLeaksAcrossSchema is a CHARACTERIZATION test for a known, out-of-scope
-// limitation (KNOWN_LIMITATIONS.md, backlog): a domain CHECK that calls set_config('search_path', …) moves
-// the path DURING Bind parameter coercion — after the proxy's pre-Bind probe but before PostgreSQL resolves
-// the portal's table names — so Execute is authorized under the stale probed snapshot while the target DB binds
-// the portal under the mutated path. The bare `people` reads id=10, which exists ONLY in the secondary
-// schema, so a real leak surfaces the secondary row ('secret-2') even though the policy DENIES the secondary
-// path. The proxy tracks search_path by SQL classification and cannot observe a set_config fired from inside
-// coercion, so this is out of scope. If this test ever STOPS leaking, the limitation was closed — update the docs.
-func TestExtendedBindCoercionSetConfigLeaksAcrossSchema(t *testing.T) {
+// TestExtendedBindCoercionSetConfigReprobesNamespace closes GHSA-c99q: a domain CHECK that calls
+// set_config('search_path', …) moves the path DURING Bind parameter coercion — after any pre-Bind probe but
+// before PostgreSQL resolves the portal's table names. handleBind therefore probes the namespace AFTER
+// BindComplete, so Execute is authorized under the path PostgreSQL actually bound (the secondary schema), and
+// the policy DENY on that path blocks the cross-schema read instead of disclosing the secondary row.
+func TestExtendedBindCoercionSetConfigReprobesNamespace(t *testing.T) {
 	h := startBroker(t)
 	var decidedPaths [][]string
 	h.fake.decideFn = func(req *pb.DecisionRequest) (*pb.WireDecision, error) {
@@ -917,6 +914,7 @@ func TestExtendedBindCoercionSetConfigLeaksAcrossSchema(t *testing.T) {
 	)
 
 	leaked := false
+	denied := false
 	for _, f := range frames {
 		switch m := f.(type) {
 		case *pgproto3.DataRow:
@@ -927,24 +925,31 @@ func TestExtendedBindCoercionSetConfigLeaksAcrossSchema(t *testing.T) {
 			}
 			t.Logf("DataRow: %q", m.Values)
 		case *pgproto3.ErrorResponse:
+			if m.Code == "42501" {
+				denied = true
+			}
 			t.Logf("ErrorResponse: %s (%s)", m.Message, m.Code)
-		default:
-			t.Logf("frame: %T", f)
 		}
 	}
 	t.Logf("decision search_paths seen: %v", decidedPaths)
-	t.Logf("LEAKED (secondary secret disclosed under a primary-authorized decision): %v", leaked)
-	if !leaked {
-		t.Fatalf("expected the documented Bind-coercion set_config leak to reproduce (secondary row 'secret-2'); it did not — the leak may no longer reproduce, so revisit KNOWN_LIMITATIONS.md")
+	if leaked {
+		t.Fatalf("Bind coercion changed search_path and disclosed the secondary row 'secret-2' — the post-Bind reprobe did not close the leak")
 	}
-	// The leak is only meaningful if the proxy authorized under the STALE primary path (not the secondary
-	// one the target DB actually bound). Assert no decision was ever made under the secondary schema.
+	if !denied {
+		t.Fatalf("expected a 42501 deny at Execute under the post-Bind secondary path; frames=%v decidedPaths=%v", frames, decidedPaths)
+	}
+	// The deny is only correct if a decision observed the POST-Bind secondary path (the reprobe) rather than
+	// the stale primary snapshot the pre-Bind probe would have captured.
+	sawSecondary := false
 	for _, path := range decidedPaths {
 		for _, schema := range path {
 			if schema == secondarySchema {
-				t.Fatalf("a decision was made under the secondary path %v — not the stale-snapshot leak this test documents", path)
+				sawSecondary = true
 			}
 		}
+	}
+	if !sawSecondary {
+		t.Fatalf("expected an Execute decision under the post-Bind secondary path, saw %v", decidedPaths)
 	}
 }
 


### PR DESCRIPTION
Fixes the GHSA-c99q-3qmj-pwv7 advisory (reported by @archepro84).

## The bug

In PostgreSQL's extended query protocol, a parameter coercion runs **during** Bind — a domain `CHECK` or cast function can `set_config('search_path', …)` as a side effect, and PostgreSQL resolves the portal's unqualified relations under that **post-coercion** namespace. `handleBind` probed the namespace immediately *before* forwarding Bind and stored that snapshot on the portal; `handleExecute` re-decides against it. So Execute authorized under the stale pre-coercion namespace while the backend read a relation in a schema the decision never evaluated — a cross-schema disclosure.

## The fix

Move the namespace + temp-context probe to **after** `BindComplete`. `handleBind` forwards Bind first, then probes the live (post-coercion) namespace and registers the portal against that snapshot. The probe's own statement/portal are uniquely named and closed, so they don't disturb the client's just-bound portal. If the post-Bind probe can't complete, the portal is discarded and the Bind refused (58000) — fail-closed.

## Verification

`mise run verify` green; full `pgproxy` suite passes. The existing Bind-coercion characterization test (which *documented* the leak as an out-of-scope known limitation) is flipped to assert closure: against real PostgreSQL 17, a `CHECK (set_config('search_path', VALUE, false) …)` domain bound to the denied schema now makes the Execute decision observe the secondary path and deny with `42501` — `secret-2` is never disclosed. The KNOWN_LIMITATIONS 🔴 entry and its backlog item are removed.

Dual-reviewed (Sol + Grok + an independent opus standing in for the Codex leg, which aborts on adversarial-security prompts): all three independently confirmed the fix is sound — portal-safe, lockstep-legal, fail-closed on probe failure, no regression to the explicit-`SET` drift case — with no security findings.
