### PR TITLE
fix(control-plane): deliver both the requester's receipt AND the approver message

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationService.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationService.kt
@@ -76,19 +76,24 @@ class NotificationService(
     fun emit(c: Connection, event: NotificationEvent, req: AccessRequest) {
         if (!enabled) return
         runCatching {
-            val targets = when (event) {
-                // Only a pending request goes to the freshly-computed eligible approvers.
-                NotificationEvent.TASK_REQUESTED -> recipients.recipientsFor(req)
-                // Every later event edits the messages of exactly the people who were TOLD about the request.
-                // Recomputing eligibility would skip an approver whose role was revoked since, leaving their
-                // live "needs approval" buttons in place forever — and address someone who never saw it. Plus
-                // the parties, told how their own request ended regardless of approval authority.
-                else -> store.recipientsOfRequest(c, req.id) +
-                    listOfNotNull(req.principal, req.decidedBy, req.executedBy).filter { it.isNotBlank() }
+            val targets: List<Pair<String, NotificationKind>> = when (event) {
+                // emit() only carries later events; a pending request is enqueued by emitRequested. Kept total.
+                NotificationEvent.TASK_REQUESTED -> recipients.recipientsFor(req).map { it to NotificationKind.APPROVER }
+                // Every later event edits the threads of exactly the people who were TOLD about the request —
+                // the approver side is those who got it (recomputing eligibility would skip an approver whose
+                // role was revoked since, stranding their live buttons), the requester side is the requester's
+                // own receipt. A self-approving requester holds both threads and both are updated.
+                else -> buildList {
+                    for (r in store.recipientsOfRequest(c, req.id)) add(r to NotificationKind.APPROVER)
+                    for (r in listOfNotNull(req.decidedBy, req.executedBy).filter { it.isNotBlank() }) {
+                        add(r to NotificationKind.APPROVER)
+                    }
+                    add(req.principal to NotificationKind.REQUESTER)
+                }
             }
             for (transport in transports) {
-                for (recipient in targets) {
-                    store.enqueue(c, req.id, event, transport.name, recipient)
+                for ((recipient, kind) in targets) {
+                    store.enqueue(c, req.id, event, transport.name, recipient, kind)
                 }
             }
         }.onFailure { log.warn("notification emit failed task={} event={}", req.id, event.wire, it) }
@@ -122,10 +127,11 @@ class NotificationService(
             val approvers = recipients.recipientsFor(subject)
             for (transport in transports) {
                 for (recipient in approvers) {
-                    store.enqueue(c, taskId, NotificationEvent.TASK_REQUESTED, transport.name, recipient)
+                    store.enqueue(c, taskId, NotificationEvent.TASK_REQUESTED, transport.name, recipient, NotificationKind.APPROVER)
                 }
-                // A requester who can approve is already in `approvers`; the drain dedups this receipt away.
-                store.enqueue(c, taskId, NotificationEvent.TASK_SUBMITTED, transport.name, requester)
+                // The requester always gets their own receipt. When they are also an approver it is a separate
+                // thread from their approver message (distinct kind), so both are delivered, not deduped.
+                store.enqueue(c, taskId, NotificationEvent.TASK_SUBMITTED, transport.name, requester, NotificationKind.REQUESTER)
             }
         }.onFailure { log.warn("notification emit failed task={} event=task.requested", taskId, it) }
     }
@@ -178,7 +184,7 @@ class NotificationService(
 
         val locale = store.localeOf(row.recipient) ?: defaultLocale
         val message = buildMessage(row, req, transport)
-        val existingRef = store.externalRef(row.taskId, transport.name, row.recipient)
+        val existingRef = store.externalRef(row.taskId, transport.name, row.recipient, row.kind)
 
         // A non-update row that already left a ref was delivered by a prior attempt whose markSent did not
         // commit (the post succeeded, then the bookkeeping failed). Re-posting would double-send and strand
@@ -205,7 +211,7 @@ class NotificationService(
 
         when (result) {
             is DeliveryResult.Sent -> {
-                store.rememberMessage(row.taskId, transport.name, row.recipient, result.externalRef)
+                store.rememberMessage(row.taskId, transport.name, row.recipient, row.kind, result.externalRef)
                 store.markSent(row.id)
             }
             is DeliveryResult.Drop -> store.markDead(row.id, result.reason)

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStore.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStore.kt
@@ -12,6 +12,7 @@ data class OutboxRow(
     val event: NotificationEvent,
     val transport: String,
     val recipient: String,
+    val kind: NotificationKind,
     val attempts: Int,
 )
 
@@ -26,8 +27,9 @@ data class OutboxRow(
 class NotificationStore(private val dataSource: DataSource) {
 
     /**
-     * Queue one delivery, in the caller's transaction. Idempotent per (task, event, transport, recipient):
-     * an event emitted twice for one recipient collapses onto the existing row rather than sending twice.
+     * Queue one delivery, in the caller's transaction. Idempotent per (task, event, transport, recipient,
+     * kind): an event emitted twice for one recipient+kind collapses onto the existing row rather than sending
+     * twice — but the same recipient's requester-side and approver-side threads ([kind]) stay separate.
      */
     fun enqueue(
         c: Connection,
@@ -35,16 +37,18 @@ class NotificationStore(private val dataSource: DataSource) {
         event: NotificationEvent,
         transport: String,
         recipient: String,
+        kind: NotificationKind,
     ) {
         c.prepareStatement(
-            """INSERT INTO notification_outbox (task_id, event, transport, recipient)
-               VALUES (?, ?, ?, ?)
-               ON CONFLICT (task_id, event, transport, recipient) DO NOTHING""",
+            """INSERT INTO notification_outbox (task_id, event, transport, recipient, kind)
+               VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT (task_id, event, transport, recipient, kind) DO NOTHING""",
         ).use { ps ->
             ps.setLong(1, taskId)
             ps.setString(2, event.wire)
             ps.setString(3, transport)
             ps.setString(4, recipient)
+            ps.setString(5, kind.wire)
             ps.executeUpdate()
         }
     }
@@ -59,7 +63,7 @@ class NotificationStore(private val dataSource: DataSource) {
      */
     fun claimDue(limit: Int): List<OutboxRow> = dataSource.inTxLocal { c ->
         c.prepareStatement(
-            """SELECT id, task_id, event, transport, recipient, attempts
+            """SELECT id, task_id, event, transport, recipient, kind, attempts
                FROM notification_outbox
                WHERE status = 'PENDING' AND next_attempt_at <= now()
                ORDER BY id
@@ -85,6 +89,7 @@ class NotificationStore(private val dataSource: DataSource) {
                         event = event,
                         transport = rs.getString("transport"),
                         recipient = rs.getString("recipient"),
+                        kind = NotificationKind.fromWire(rs.getString("kind")),
                         attempts = rs.getInt("attempts"),
                     )
                 }
@@ -153,26 +158,28 @@ class NotificationStore(private val dataSource: DataSource) {
     fun hasEarlierPending(row: OutboxRow): Boolean = dataSource.connection.use { c ->
         c.prepareStatement(
             """SELECT 1 FROM notification_outbox
-               WHERE task_id = ? AND transport = ? AND recipient = ? AND status = 'PENDING' AND id < ?
+               WHERE task_id = ? AND transport = ? AND recipient = ? AND kind = ? AND status = 'PENDING' AND id < ?
                LIMIT 1""",
         ).use { ps ->
             ps.setLong(1, row.taskId)
             ps.setString(2, row.transport)
             ps.setString(3, row.recipient)
-            ps.setLong(4, row.id)
+            ps.setString(4, row.kind.wire)
+            ps.setLong(5, row.id)
             ps.executeQuery().use { it.next() }
         }
     }
 
-    /** The handle a delivered message left behind, or null when nothing has been delivered yet. */
-    fun externalRef(taskId: Long, transport: String, recipient: String): String? =
+    /** The handle a delivered message left behind for this thread, or null when nothing has been delivered. */
+    fun externalRef(taskId: Long, transport: String, recipient: String, kind: NotificationKind): String? =
         dataSource.connection.use { c ->
             c.prepareStatement(
-                "SELECT external_ref FROM notification_message WHERE task_id = ? AND transport = ? AND recipient = ?",
+                "SELECT external_ref FROM notification_message WHERE task_id = ? AND transport = ? AND recipient = ? AND kind = ?",
             ).use { ps ->
                 ps.setLong(1, taskId)
                 ps.setString(2, transport)
                 ps.setString(3, recipient)
+                ps.setString(4, kind.wire)
                 ps.executeQuery().use { if (it.next()) it.getString(1) else null }
             }
         }
@@ -198,19 +205,20 @@ class NotificationStore(private val dataSource: DataSource) {
     fun recipientsOfRequest(taskId: Long): Set<String> =
         dataSource.connection.use { c -> recipientsOfRequest(c, taskId) }
 
-    /** Record where a message landed, so a later event edits it in place. */
-    fun rememberMessage(taskId: Long, transport: String, recipient: String, externalRef: String) {
+    /** Record where a message landed, so a later event edits that thread in place. */
+    fun rememberMessage(taskId: Long, transport: String, recipient: String, kind: NotificationKind, externalRef: String) {
         dataSource.connection.use { c ->
             c.prepareStatement(
-                """INSERT INTO notification_message (task_id, transport, recipient, external_ref)
-                   VALUES (?, ?, ?, ?)
-                   ON CONFLICT (task_id, transport, recipient)
+                """INSERT INTO notification_message (task_id, transport, recipient, kind, external_ref)
+                   VALUES (?, ?, ?, ?, ?)
+                   ON CONFLICT (task_id, transport, recipient, kind)
                    DO UPDATE SET external_ref = EXCLUDED.external_ref, updated_at = now()""",
             ).use { ps ->
                 ps.setLong(1, taskId)
                 ps.setString(2, transport)
                 ps.setString(3, recipient)
-                ps.setString(4, externalRef)
+                ps.setString(4, kind.wire)
+                ps.setString(5, externalRef)
                 ps.executeUpdate()
             }
         }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/Notifications.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/Notifications.kt
@@ -38,6 +38,21 @@ enum class NotificationEvent(val wire: String) {
 }
 
 /**
+ * Which side of a request a message serves. One person can hold both for the same task — a requester whom
+ * policy lets approve their own request is [REQUESTER] (their receipt) AND [APPROVER] (the actionable copy).
+ * The two are independent threads, keyed apart so neither deduplicates or overwrites the other.
+ */
+enum class NotificationKind(val wire: String) {
+    APPROVER("approver"),
+    REQUESTER("requester"),
+    ;
+
+    companion object {
+        fun fromWire(wire: String): NotificationKind = entries.firstOrNull { it.wire == wire } ?: APPROVER
+    }
+}
+
+/**
  * How much of the requester's statement may leave the building (docs/notifications.md, "The statement in the
  * message"). A statement's literals can be the very values a policy protects — `WHERE ssn = '…'` leaks a
  * value masking never sees, because masking acts on results. The disclosure hint

--- a/control-plane/src/main/resources/db/migration/V22__notification_kind.sql
+++ b/control-plane/src/main/resources/db/migration/V22__notification_kind.sql
@@ -1,0 +1,15 @@
+-- A recipient can relate to one task both as its requester (a task.submitted receipt) and as an approver (a
+-- task.requested message) — self-approval. Each is its own thread that is delivered and later edited
+-- independently, so the outbox and the delivered-message record are keyed by `kind` ('requester' |
+-- 'approver'), not by recipient alone. Without this the second message to a shared recipient is deduped away
+-- on delivery. Rows created before this migration are approver-side — the only kind that existed.
+ALTER TABLE notification_outbox ADD COLUMN kind TEXT NOT NULL DEFAULT 'approver';
+ALTER TABLE notification_message ADD COLUMN kind TEXT NOT NULL DEFAULT 'approver';
+
+ALTER TABLE notification_outbox DROP CONSTRAINT notification_outbox_unique;
+ALTER TABLE notification_outbox ADD CONSTRAINT notification_outbox_unique
+    UNIQUE (task_id, event, transport, recipient, kind);
+
+ALTER TABLE notification_message DROP CONSTRAINT notification_message_unique;
+ALTER TABLE notification_message ADD CONSTRAINT notification_message_unique
+    UNIQUE (task_id, transport, recipient, kind);

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationServiceDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationServiceDbTest.kt
@@ -69,8 +69,14 @@ class NotificationServiceDbTest {
             denyReason = null, sourceDecisionId = null, reason = "r", title = "t", evaluatedDecision = "ALLOW",
         )
 
-    private fun enqueue(task: Long, event: NotificationEvent, recipient: String, transportName: String = "fake") {
-        fx.dataSource.connection.use { c -> store.enqueue(c, task, event, transportName, recipient) }
+    private fun enqueue(
+        task: Long,
+        event: NotificationEvent,
+        recipient: String,
+        kind: NotificationKind = NotificationKind.APPROVER,
+        transportName: String = "fake",
+    ) {
+        fx.dataSource.connection.use { c -> store.enqueue(c, task, event, transportName, recipient, kind) }
     }
 
     private fun statusOf(task: Long, event: NotificationEvent, recipient: String): String =
@@ -141,19 +147,40 @@ class NotificationServiceDbTest {
     }
 
     @Test
-    fun `an eligible requester is in Cedar's approver set and gets the approver message`() = runBlocking {
-        // Policy lets the requester approve their own request, so recipientsFor (Cedar) returns them — and they
-        // are never post-filtered out. They get the ordinary approver message and can act on it.
+    fun `a self-approving requester gets BOTH the approver message and their own receipt`() = runBlocking {
+        // Policy lets the requester approve their own request, so recipientsFor (Cedar) returns them — never
+        // post-filtered. They are a plain recipient of both threads, and both are delivered, not deduped.
         val requester = "self@example.com"
         fx.policyStore.createAssignment(RoleAssignmentInput(requester, adminRoleId()))
         val routing = serviceWith(StatementDisclosure.AUTO, candidates = listOf(requester))
         val task = newTask(principal = requester).id
         fx.dataSource.connection.use { c -> routing.emitRequested(c, task, requester, fx.datasource, roleName = null) }
-        assertEquals(1, countRows(task, NotificationEvent.TASK_REQUESTED, requester), "an eligible requester stays in the approver set")
-        // One message per recipient: the actionable approver message wins, the receipt is deduped on delivery.
         routing.drainOnce()
-        val toRequester = transport.delivered.filter { it.to == "addr:$requester" }.map { it.event }
-        assertEquals(listOf(NotificationEvent.TASK_REQUESTED), toRequester, "the approver message, not the receipt")
+        val toRequester = transport.delivered.filter { it.to == "addr:$requester" }.map { it.event }.toSet()
+        assertEquals(
+            setOf(NotificationEvent.TASK_REQUESTED, NotificationEvent.TASK_SUBMITTED),
+            toRequester,
+            "the requester receives BOTH the approver message and their receipt — neither is deduped away",
+        )
+    }
+
+    @Test
+    fun `a terminal event updates both threads of a self-approving requester`() = runBlocking {
+        val requester = "self@example.com"
+        fx.policyStore.createAssignment(RoleAssignmentInput(requester, adminRoleId()))
+        val routing = serviceWith(StatementDisclosure.AUTO, candidates = listOf(requester))
+        val task = newTask(principal = requester).id
+        fx.dataSource.connection.use { c -> routing.emitRequested(c, task, requester, fx.datasource, roleName = null) }
+        routing.drainOnce() // both threads delivered, both refs remembered
+        transport.updated.clear()
+        val req = fx.accessStore.getRequest(task)!!
+        fx.dataSource.connection.use { c -> routing.emit(c, NotificationEvent.TASK_DECIDED, req) }
+        routing.drainOnce()
+        assertEquals(
+            2,
+            transport.updated.count { it.event == NotificationEvent.TASK_DECIDED },
+            "the decision edits both the approver-side message and the requester's receipt",
+        )
     }
 
     @Test
@@ -164,7 +191,7 @@ class NotificationServiceDbTest {
         // recomputed eligibility would list nobody — asserting bob+carol proves it reads the outbox instead.
         enqueue(task, NotificationEvent.TASK_REQUESTED, "bob@x")
         enqueue(task, NotificationEvent.TASK_REQUESTED, "carol@x")
-        enqueue(task, NotificationEvent.TASK_SUBMITTED, "req@example.com")
+        enqueue(task, NotificationEvent.TASK_SUBMITTED, "req@example.com", NotificationKind.REQUESTER)
         svc.drainOnce()
         val receipt = transport.delivered.single { it.event == NotificationEvent.TASK_SUBMITTED }
         assertEquals(listOf("bob@x", "carol@x"), receipt.notifiedApprovers, "the receipt names who was actually asked")
@@ -198,7 +225,7 @@ class NotificationServiceDbTest {
         assertEquals("addr:sam@x", transport.delivered.first().to)
         assertEquals(NotificationEvent.TASK_REQUESTED, transport.delivered.first().event)
         assertEquals("SENT", statusOf(task, NotificationEvent.TASK_REQUESTED, "sam@x"))
-        assertEquals("ref-fake", store.externalRef(task, "fake", "sam@x"), "the handle is remembered for later edits")
+        assertEquals("ref-fake", store.externalRef(task, "fake", "sam@x", NotificationKind.APPROVER), "the handle is remembered for later edits")
     }
 
     @Test
@@ -268,12 +295,12 @@ class NotificationServiceDbTest {
         enqueue(task, NotificationEvent.TASK_REQUESTED, "sam@x")
         // A prior attempt posted (ref recorded) but its markSent did not commit: the row is still PENDING, yet
         // a delivery handle already exists. Re-posting would double-send and strand the first message's buttons.
-        store.rememberMessage(task, "fake", "sam@x", "ref-prior")
+        store.rememberMessage(task, "fake", "sam@x", NotificationKind.APPROVER, "ref-prior")
         svc.drainOnce()
 
         assertTrue(transport.delivered.isEmpty(), "the existing ref is adopted; the message is not sent again")
         assertEquals("SENT", statusOf(task, NotificationEvent.TASK_REQUESTED, "sam@x"), "the row is finished, not left pending")
-        assertEquals("ref-prior", store.externalRef(task, "fake", "sam@x"), "the original handle is kept for later edits")
+        assertEquals("ref-prior", store.externalRef(task, "fake", "sam@x", NotificationKind.APPROVER), "the original handle is kept for later edits")
     }
 
     @Test

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStoreTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStoreTest.kt
@@ -65,8 +65,8 @@ class NotificationStoreTest {
     fun `enqueue is idempotent per task-event-transport-recipient`() {
         val task = newTask()
         fx.dataSource.connection.use { c ->
-            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "a@x")
-            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "a@x")
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "a@x", NotificationKind.APPROVER)
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "a@x", NotificationKind.APPROVER)
         }
         assertEquals(1, store.claimDue(10).count { it.taskId == task }, "the second enqueue collapsed onto the first")
     }
@@ -75,9 +75,9 @@ class NotificationStoreTest {
     fun `claimDue returns due pending rows in id order up to the limit`() {
         val task = newTask()
         fx.dataSource.connection.use { c ->
-            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "one@x")
-            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "two@x")
-            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "three@x")
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "one@x", NotificationKind.APPROVER)
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "two@x", NotificationKind.APPROVER)
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "three@x", NotificationKind.APPROVER)
         }
         val claimed = store.claimDue(2).filter { it.taskId == task }
         assertEquals(2, claimed.size, "the limit is honored")
@@ -92,8 +92,8 @@ class NotificationStoreTest {
     fun `claimDue skips a row another transaction holds locked`() {
         val task = newTask()
         fx.dataSource.connection.use { c ->
-            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "locked@x")
-            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "free@x")
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "locked@x", NotificationKind.APPROVER)
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "free@x", NotificationKind.APPROVER)
         }
         val rows = store.claimDue(10).filter { it.taskId == task }.sortedBy { it.id }
         val lockedId = rows.first().id
@@ -117,7 +117,7 @@ class NotificationStoreTest {
     @Test
     fun `markSent is terminal and increments attempts`() {
         val task = newTask()
-        fx.dataSource.connection.use { c -> store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "s@x") }
+        fx.dataSource.connection.use { c -> store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "s@x", NotificationKind.APPROVER) }
         val row = store.claimDue(10).first { it.taskId == task }
         store.markSent(row.id)
         assertEquals("SENT", statusOf(row.id))
@@ -128,7 +128,7 @@ class NotificationStoreTest {
     @Test
     fun `markRetry keeps the row pending but out of the claim until it is due`() {
         val task = newTask()
-        fx.dataSource.connection.use { c -> store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "r@x") }
+        fx.dataSource.connection.use { c -> store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "r@x", NotificationKind.APPROVER) }
         val row = store.claimDue(10).first { it.taskId == task }
 
         store.markRetry(row.id, "ratelimited", Duration.ofHours(1))
@@ -143,7 +143,7 @@ class NotificationStoreTest {
     @Test
     fun `markDead is terminal`() {
         val task = newTask()
-        fx.dataSource.connection.use { c -> store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "d@x") }
+        fx.dataSource.connection.use { c -> store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "d@x", NotificationKind.APPROVER) }
         val row = store.claimDue(10).first { it.taskId == task }
         store.markDead(row.id, "channel_not_found")
         assertEquals("DEAD", statusOf(row.id))
@@ -154,8 +154,8 @@ class NotificationStoreTest {
     fun `an update waits while an earlier event for the same recipient is still pending`() {
         val task = newTask()
         fx.dataSource.connection.use { c ->
-            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "u@x")
-            store.enqueue(c, task, NotificationEvent.TASK_DECIDED, "slack", "u@x")
+            store.enqueue(c, task, NotificationEvent.TASK_REQUESTED, "slack", "u@x", NotificationKind.APPROVER)
+            store.enqueue(c, task, NotificationEvent.TASK_DECIDED, "slack", "u@x", NotificationKind.APPROVER)
         }
         val rows = store.claimDue(10).filter { it.taskId == task }.sortedBy { it.id }
         val requested = rows.first { it.event == NotificationEvent.TASK_REQUESTED }
@@ -169,11 +169,11 @@ class NotificationStoreTest {
     @Test
     fun `rememberMessage upserts the external ref`() {
         val task = newTask()
-        assertNull(store.externalRef(task, "slack", "m@x"), "nothing delivered yet")
-        store.rememberMessage(task, "slack", "m@x", "C1:100")
-        assertEquals("C1:100", store.externalRef(task, "slack", "m@x"))
-        store.rememberMessage(task, "slack", "m@x", "C1:200")
-        assertEquals("C1:200", store.externalRef(task, "slack", "m@x"), "a later delivery overwrites the handle")
+        assertNull(store.externalRef(task, "slack", "m@x", NotificationKind.APPROVER), "nothing delivered yet")
+        store.rememberMessage(task, "slack", "m@x", NotificationKind.APPROVER, "C1:100")
+        assertEquals("C1:100", store.externalRef(task, "slack", "m@x", NotificationKind.APPROVER))
+        store.rememberMessage(task, "slack", "m@x", NotificationKind.APPROVER, "C1:200")
+        assertEquals("C1:200", store.externalRef(task, "slack", "m@x", NotificationKind.APPROVER), "a later delivery overwrites the handle")
     }
 
     @Test

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackNotificationE2eDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackNotificationE2eDbTest.kt
@@ -403,4 +403,57 @@ class SlackNotificationE2eDbTest {
             "a fully-shown statement offers approve-and-run",
         )
     }
+
+    /**
+     * The one person who is BOTH requester and approver (self-approval) gets both messages, and a decision
+     * edits both — over the real Slack wire, not just the store. The delivery model keyed each message and its
+     * handle by (task, transport, recipient), so this person's own receipt used to dedup against their approver
+     * message and never post; this exercises that end to end (real Cedar routing, real Postgres, real
+     * SlackTransport → mock Slack). The approver is already a system:admin registered in mock Slack, so a
+     * request they file themselves is a self-approver with no extra setup.
+     */
+    @Test
+    fun `a self-approving requester gets both the approver message and their own receipt over Slack`() {
+        val selfSvc = NotificationService(
+            store = NotificationStore(fx.dataSource),
+            recipients = RecipientResolver(core.authz, core.roleResolver) { listOf(approver) },
+            transports = listOf(SlackTransport(http, "xoxb-e2e", "https://console.example", NotificationRenderer(), api = slack.apiBase)),
+            accessStore = core.accessStore,
+            queryResultStore = resultStore,
+            webBaseUrl = "https://console.example",
+            disclosure = StatementDisclosure.AUTO,
+            defaultLocale = "en",
+        )
+        val task = core.accessStore.createQueryRequest(
+            principal = approver,
+            datasourceId = fx.datasource.id,
+            sql = "SELECT id FROM users",
+            denyReason = null,
+            sourceDecisionId = null,
+            reason = "audit",
+            title = "read",
+            evaluatedDecision = "ALLOW",
+            roleId = runnerRoleId,
+            carriesProtectedLiteral = false,
+        )
+        runBlocking {
+            fx.dataSource.connection.use { c -> selfSvc.emitRequested(c, task.id, approver, fx.datasource, task.roleName) }
+            selfSvc.drainOnce()
+        }
+        val posts = slack.requestsFor("chat.postMessage")
+        assertEquals(2, posts.size, "the self-approver gets BOTH the approver message and their own receipt, not one deduped into the other")
+        assertEquals(
+            1,
+            posts.count { p -> p.actionElements().any { it["action_id"]?.jsonPrimitive?.content == SlackTransport.ACTION_APPROVE } },
+            "exactly one carries approve-and-run — the approver copy; the receipt has no buttons",
+        )
+
+        // A decision edits BOTH threads in place — again over the wire, not one update swallowing the other.
+        slack.clearRecorded()
+        runBlocking {
+            fx.dataSource.connection.use { c -> selfSvc.emit(c, NotificationEvent.TASK_DECIDED, core.accessStore.getRequest(task.id)!!) }
+            selfSvc.drainOnce()
+        }
+        assertEquals(2, slack.requestsFor("chat.update").size, "the decision edits both the approver message and the receipt")
+    }
 }

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -48,12 +48,12 @@ touching the workflow.
 
 ## Events
 
-| Event                                          | When                 | Who hears it                                                                    |
-| ---------------------------------------------- | -------------------- | ------------------------------------------------------------------------------- |
-| `task.requested`                               | a request is filed   | everyone Cedar says may approve it (the requester too, where policy allows)     |
-| `task.submitted`                               | a request is filed   | the requester, when not themselves an approver — a receipt naming who was asked |
-| `task.decided`                                 | approved or rejected | the requester, and everyone told above                                          |
-| `task.executed` `task.failed` `task.cancelled` | the run ends         | the requester and the approver                                                  |
+| Event                                          | When                 | Who hears it                                                                                  |
+| ---------------------------------------------- | -------------------- | --------------------------------------------------------------------------------------------- |
+| `task.requested`                               | a request is filed   | everyone Cedar says may approve it (the requester too, where policy allows)                   |
+| `task.submitted`                               | a request is filed   | the requester — their own receipt (plus the approver message above, if they may also approve) |
+| `task.decided`                                 | approved or rejected | the requester, and everyone told above                                                        |
+| `task.executed` `task.failed` `task.cancelled` | the run ends         | the requester and the approver                                                                |
 
 Anyone told about a request is told how it ended. That is what stops a stale
 "needs your approval" sitting in a DM after someone else already handled it —
@@ -162,10 +162,14 @@ moment an operator writes "approvers must be on the office network."
 `recipientsFor` is Cedar's answer to who may approve, and it is never
 post-filtered. A hard-coded denial or filter in code — dropping the requester,
 skipping an "impossible" approver — is a bug, not a shortcut: it moves a policy
-rule out of the engine that owns it. If the requester is in that set they get
-the ordinary approver message like any approver; if not, they get a
-`task.submitted` receipt — their request is pending, and here is who was asked.
-One message per recipient; which one is Cedar's set, not a branch in code.
+rule out of the engine that owns it.
+
+The requester always gets their own `task.submitted` receipt — their request is
+pending, and here is who was asked. If Cedar also puts them in the approver set
+(policy lets them approve their own request), they get the ordinary approver
+message too. Those are two independent threads (message `kind` requester vs
+approver), both delivered and both updated on the decision — neither deduped
+into the other, and no branch in code deciding which they "should" get.
 
 The reverse query has one quirk: it treats the context as a single record, so
 `context has channel` will not reduce while _any_ unknown sits in it. That


### PR DESCRIPTION
When one person is both the requester and an approver (self-approval), they only received the approver message. The delivery model keys each message and its remembered handle by `(task, transport, recipient)`, so the requester's `task.submitted` receipt hit the "already delivered" dedup against their `task.requested` and was **dropped without posting**. The model assumed one message per person per task.

**Fix:** add a `kind` (`requester` | `approver`) so the two are independent threads. The outbox row, the retry-dedup, and the remembered handle are all keyed by `(task, transport, recipient, kind)`, so neither dedups nor overwrites the other, and a terminal event edits **both** threads (the requester side always; the approver side for everyone who was asked). No branch in code decides who gets what — `recipientsFor` is Cedar's set, and the requester always gets their own receipt.

`V22` adds the column and reworks the two unique constraints (append-only; existing rows default to approver-side).

**Tested (honestly, this time):** the prior test asserted the *buggy* single-message behavior as correct and the E2E used distinct requester/approver principals, so nothing exercised self-approval. Now `NotificationServiceDbTest` (real Postgres + V22) asserts a **self-approving requester receives BOTH messages** and that **a decision edits both threads**. Full `:control-plane` suite green. The Slack render itself is unchanged and covered by the existing E2E; final confirmation is on dev after redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ati9RRaurF1DQ5R4Xz32E