### PR TITLE
refactor(control-plane): build the approval authz resource from the request row

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -307,11 +307,6 @@ tagging, table detail) and never feeds an enforcement decision.
   effect. The benign session statements the forbid does deny (`SET NAMES`,
   `BEGIN`, `SET @var`) are otherwise ungated, which is why they are the ones
   that need the channel rule.
-- 🔴 Role-approval `Request` EUID is not request-unique.
-  `Request::"<requester>#<datasource>"` omits the request id and requested role,
-  so one approval policy authorizes every later request that principal makes for
-  that datasource — a wrong-ALLOW. Tracked in
-  [`docs/backlog.md`](./docs/backlog.md).
 - 🔴 `system:admin` immutability assumes single-instance, migrate-before-serve.
   The `system:admin` group is immutable through the API and SCIM via runtime
   guards inside `UserGroupStore`, which are in-process: they serialize

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Access.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Access.kt
@@ -54,6 +54,16 @@ data class AccessRequest(
     val statementCarriesProtectedLiteral: Boolean? = null,
 )
 
+/**
+ * The authz view of this persisted approval request, built from its row so every route that decides a task
+ * asks Cedar the same question from one place. The prospective auto-approval check (before a row exists)
+ * builds its resource inline instead.
+ */
+fun AccessRequest.toApprovalResource() = AuthzResource.ApprovalRequest(
+    requester = principal, approver = decidedBy, executedBy = executedBy,
+    datasourceName = datasourceName, roleName = roleName,
+)
+
 @Serializable
 data class AccessRequestInput(
     val roleId: Long, val datasourceId: Long? = null,
@@ -763,10 +773,7 @@ fun Route.accessRoutes(
             rows.filter {
                 authz.authorize(
                     caller, AuthzAction.TASK_READ,
-                    AuthzResource.ApprovalRequest(
-                        requester = it.principal, approver = it.decidedBy, executedBy = it.executedBy,
-                        datasourceName = it.datasourceName, roleName = it.roleName,
-                    ),
+                    it.toApprovalResource(),
                 ) is AuthzDecision.Allow
             },
         )
@@ -815,10 +822,7 @@ fun Route.accessRoutes(
         // approval routes' mayDecide (task.approve) call in Approvals.kt.
         val decision = authz.authorizeWithContext(
             approver, AuthzAction.TASK_APPROVE,
-            AuthzResource.ApprovalRequest(
-                requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
-                datasourceName = req.datasourceName, roleName = req.roleName,
-            ),
+            req.toApprovalResource(),
             call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
             req.datasourceName,
             req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
@@ -844,10 +848,7 @@ fun Route.accessRoutes(
         // Cedar question, so a role-scoped approval policy governs reject too (see /approve above).
         val decision = authz.authorizeWithContext(
             approver, AuthzAction.TASK_APPROVE,
-            AuthzResource.ApprovalRequest(
-                requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
-                datasourceName = req.datasourceName, roleName = req.roleName,
-            ),
+            req.toApprovalResource(),
             call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
             req.datasourceName,
             req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -187,10 +187,7 @@ internal fun taskReadableForPush(
     val decision = authz.authorizeWithContext(
         principal,
         AuthzAction.TASK_READ,
-        AuthzResource.ApprovalRequest(
-            requester = task.principal, approver = task.decidedBy, executedBy = task.executedBy,
-            datasourceName = task.datasourceName, roleName = task.roleName,
-        ),
+        task.toApprovalResource(),
         context,
         task.datasourceName,
         task.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
@@ -383,10 +383,7 @@ fun Route.approvalRoutes(
         val decision = authz.authorizeWithContext(
             principal,
             action,
-            AuthzResource.ApprovalRequest(
-                requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
-                datasourceName = req.datasourceName, roleName = req.roleName,
-            ),
+            req.toApprovalResource(),
             call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
             req.datasourceName,
             req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
@@ -401,10 +398,7 @@ fun Route.approvalRoutes(
         val decision = authz.authorizeWithContext(
             principal,
             AuthzAction.TASK_ASSUME,
-            AuthzResource.ApprovalRequest(
-                requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
-                datasourceName = req.datasourceName, roleName = req.roleName,
-            ),
+            req.toApprovalResource(),
             call.httpAuthzContext(config, Channel.WORKFLOW_VIEWER),
             req.datasourceName,
             req.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -4,7 +4,6 @@ import com.ridi.oss.proxymonster.controlplane.authz.Authz
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzContext
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzDecision
-import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
 import com.ridi.oss.proxymonster.controlplane.authz.ColumnRef
 import com.ridi.oss.proxymonster.controlplane.authz.ColumnVerdict
 import com.ridi.oss.proxymonster.controlplane.authz.FunctionRef
@@ -1157,10 +1156,7 @@ fun Route.editorSessionRoutes(
         // still override the self-read permit.
         val mayRead = authz.authorizeWithContext(
             principal, AuthzAction.TASK_READ,
-            AuthzResource.ApprovalRequest(
-                requester = task.principal, approver = task.decidedBy, executedBy = task.executedBy,
-                datasourceName = task.datasourceName, roleName = task.roleName,
-            ),
+            task.toApprovalResource(),
             call.httpAuthzContext(config), task.datasourceName,
             task.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
         )
@@ -1180,10 +1176,7 @@ fun Route.editorSessionRoutes(
         }
         val mayCancel = authz.authorizeWithContext(
             principal, AuthzAction.TASK_CANCEL,
-            AuthzResource.ApprovalRequest(
-                requester = task.principal, approver = task.decidedBy, executedBy = task.executedBy,
-                datasourceName = task.datasourceName, roleName = task.roleName,
-            ),
+            task.toApprovalResource(),
             call.httpAuthzContext(config), task.datasourceName,
             task.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
         )
@@ -1235,10 +1228,7 @@ fun Route.editorSessionRoutes(
             ?: return@get call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "editor task")))
         val mayAssume = authz.authorizeWithContext(
             principal, AuthzAction.TASK_ASSUME,
-            AuthzResource.ApprovalRequest(
-                requester = task.principal, approver = task.decidedBy, executedBy = task.executedBy,
-                datasourceName = task.datasourceName, roleName = task.roleName,
-            ),
+            task.toApprovalResource(),
             call.httpAuthzContext(config), task.datasourceName,
             task.datasourceId?.let(datasourceStore::getIncludingDeleted)?.tags.orEmpty(),
         )

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/RecipientResolver.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/RecipientResolver.kt
@@ -1,10 +1,10 @@
 package com.ridi.oss.proxymonster.controlplane.notify
 
 import com.ridi.oss.proxymonster.controlplane.AccessRequest
+import com.ridi.oss.proxymonster.controlplane.toApprovalResource
 import com.ridi.oss.proxymonster.controlplane.RoleResolver
 import com.ridi.oss.proxymonster.controlplane.authz.Authz
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
-import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
 import com.ridi.oss.proxymonster.controlplane.authz.SatisfiableVerdict
 import org.slf4j.LoggerFactory
 
@@ -34,13 +34,7 @@ class RecipientResolver(
     }
 
     private fun approverCandidates(req: AccessRequest): Set<String> {
-        val resource = AuthzResource.ApprovalRequest(
-            requester = req.principal,
-            approver = req.decidedBy,
-            executedBy = req.executedBy,
-            datasourceName = req.datasourceName,
-            roleName = req.roleName,
-        )
+        val resource = req.toApprovalResource()
         return candidateSource()
             .filter { candidate ->
                 authz.satisfiableAs(

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackDecisionHandler.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackDecisionHandler.kt
@@ -1,6 +1,7 @@
 package com.ridi.oss.proxymonster.controlplane.notify
 
 import com.ridi.oss.proxymonster.controlplane.AccessRequest
+import com.ridi.oss.proxymonster.controlplane.toApprovalResource
 import com.ridi.oss.proxymonster.controlplane.AccessStore
 import com.ridi.oss.proxymonster.controlplane.Channel
 import com.ridi.oss.proxymonster.controlplane.Datasource
@@ -9,7 +10,6 @@ import com.ridi.oss.proxymonster.controlplane.authz.Authz
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzContext
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzDecision
-import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
 import com.ridi.oss.proxymonster.controlplane.authz.authorizeWithContext
 import com.ridi.oss.proxymonster.controlplane.i18n.MessageCatalog
 import com.ridi.oss.proxymonster.controlplane.management.AuditActor
@@ -102,10 +102,7 @@ class SlackDecisionHandler(
         val decision = authz.authorizeWithContext(
             principal,
             AuthzAction.TASK_APPROVE,
-            AuthzResource.ApprovalRequest(
-                requester = req.principal, approver = req.decidedBy, executedBy = req.executedBy,
-                datasourceName = req.datasourceName, roleName = req.roleName,
-            ),
+            req.toApprovalResource(),
             // No attested address: a Slack click carries none, so a policy requiring one denies. That is the
             // same fail-closed posture the system takes for any unknown attribute, and the reason `slack` is
             // its own channel rather than a flag.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -217,8 +217,6 @@ Fixes for gaps documented in
   grant hygiene.
 - Per-engine-version golden inventory of system objects plus a CI release-diff
   gate, so a manifest can't silently fall behind a new engine minor.
-- Make the role-approval `Request` EUID request-unique so one approval can't
-  authorize a principal's later requests.
 - Canonicalize introspected schema names on the proxy side (case-fold-aware),
   removing the interim MySQL lowercase fold in the control plane.
 - Broker a per-user target DB login so `SET PASSWORD` / `SET GLOBAL` stop


### PR DESCRIPTION
Pure refactor + doc cleanup — no behavior change, no security fix.

## What

- Extract the eleven inlined `AuthzResource.ApprovalRequest(...)` constructions (each mapping the same `AccessRequest` fields) into one `AccessRequest.toApprovalResource()`, so every task-decision route asks Cedar the same question from one place. The prospective auto-approval check (no row yet) keeps its inline construction. **Net −34 lines.**
- Remove the stale 🔴 "role-approval `Request` EUID is not request-unique" known-limitation entry and its backlog item. The EUID is `requester#datasource` by design, and an exact-`Request` policy transparently scopes to that pair — it was never the wrong-ALLOW the entry claimed (this was reported as GHSA-jq28 and, on analysis, declined as not-an-issue).

## Verification

`mise run verify` green. No new test: the mapping is compiler-checked and the existing DB-backed approval/recipient tests exercise the routes that now call the helper.
