### PR TITLE
build(deps): bump CI actions (checkout/setup-node/setup-go v7, setup-buildx v4, release-please v5)

### DIFF
--- a/.github/workflows/commit-convention.yml
+++ b/.github/workflows/commit-convention.yml
@@ -25,11 +25,11 @@ jobs:
 
     steps:
       # Full history: the commit range is diffed against the merge base with the PR's base branch.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/pmon-release-binaries.yml
+++ b/.github/workflows/pmon-release-binaries.yml
@@ -20,11 +20,11 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version-file: pmon/go.mod
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/server-images.yml
+++ b/.github/workflows/server-images.yml
@@ -90,9 +90,9 @@ jobs:
       SCOPE: ${{ matrix.image.name }}-${{ matrix.arch }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - uses: docker/login-action@v3
         with:
@@ -165,7 +165,7 @@ jobs:
           path: /tmp/digests
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Combines Dependabot #25, #26, #27, #105, #106. Branch protection requires up-to-date branches, so five independent action bumps would each need a full re-run; grouping lands them in one gate. Pure `.github/workflows` version bumps — CI is the test surface. Will close the five superseded Dependabot PRs on merge.