### PR TITLE
build(deps): bump mysqlwire to v0.1.3 in goproxy and pmon

### DIFF
--- a/goproxy/go.mod
+++ b/goproxy/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ridi-oss/proxy-monster/analyzer v0.0.0-00010101000000-000000000000
-	github.com/ridi-oss/proxy-monster/mysqlwire v0.1.2
+	github.com/ridi-oss/proxy-monster/mysqlwire v0.1.3
 	github.com/testcontainers/testcontainers-go v0.44.0
 	golang.org/x/crypto v0.54.0
 	google.golang.org/grpc v1.83.0

--- a/pmon/go.mod
+++ b/pmon/go.mod
@@ -2,7 +2,7 @@ module github.com/ridi-oss/proxy-monster/pmon
 
 go 1.26.0
 
-require github.com/ridi-oss/proxy-monster/mysqlwire v0.1.2
+require github.com/ridi-oss/proxy-monster/mysqlwire v0.1.3
 
 require (
 	github.com/alecthomas/kong v1.16.0

--- a/pmon/go.sum
+++ b/pmon/go.sum
@@ -98,6 +98,8 @@ github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/ridi-oss/proxy-monster/mysqlwire v0.1.2 h1:KM/b7PfadLw0drVrTU+/34eTJLLBRbIEfsPhp4+bzds=
 github.com/ridi-oss/proxy-monster/mysqlwire v0.1.2/go.mod h1:yielY+j1TFdAdh9cn7WGFUwUtLwligQEwpO7Xmfvinc=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.3 h1:5y6bdfCt13vpp5LLx5j7e6WgZ9nR3wa0LXTWz1Kh4SQ=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.3/go.mod h1:yielY+j1TFdAdh9cn7WGFUwUtLwligQEwpO7Xmfvinc=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/shirou/gopsutil/v4 v4.26.6 h1:Mzr/npDtQC/xpeEuQKHZt8Zo9CmPvhTj8nkR8w5TLDs=


### PR DESCRIPTION
Picks up the just-released mysqlwire 0.1.3 (the backend→target-DB rename, #165). pmon resolves the tagged module for GOWORK=off release binaries (functional bump); goproxy keeps its `replace => ../mysqlwire` for the image build (require bump is accuracy-only). Verified both GOWORK=off builds compile against v0.1.3.