### PR TITLE
fix(analyzer): classify MySQL account management and keep its result viewable

### DIFF
--- a/analyzer/go.mod
+++ b/analyzer/go.mod
@@ -8,6 +8,6 @@ module github.com/ridi-oss/proxy-monster/analyzer
 
 go 1.26.0
 
-require github.com/ridi-oss/sqlglot-go v0.23.0
+require github.com/ridi-oss/sqlglot-go v0.24.0
 
 require google.golang.org/protobuf v1.36.11

--- a/analyzer/go.sum
+++ b/analyzer/go.sum
@@ -1,6 +1,6 @@
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/ridi-oss/sqlglot-go v0.23.0 h1:yk4tCVNXOO/2amBKEAK800lvcEITh0ixQbiquvGIhsM=
-github.com/ridi-oss/sqlglot-go v0.23.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
+github.com/ridi-oss/sqlglot-go v0.24.0 h1:dq25mbuMyRk2xMZqrw77WUARppsEMhckbuTGQf6uwMY=
+github.com/ridi-oss/sqlglot-go v0.24.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/analyzer/probe/alter_index_test.go
+++ b/analyzer/probe/alter_index_test.go
@@ -192,17 +192,40 @@ func TestTemporaryDdlIsNotCatalogChanging(t *testing.T) {
 	}
 }
 
+// Account-object DDL (CREATE/ALTER/DROP USER|ROLE) changes accounts/roles, not the column catalog the
+// proxy re-measures — so it must resolve non-catalog-changing and relay as a no-column passthrough. If it
+// were catalog-changing it would fall out of the passthrough, and a result-bearing form (CREATE USER …
+// IDENTIFIED BY RANDOM PASSWORD returns the generated password) would be dropped for a column mismatch on
+// view.
+func TestAccountObjectDdlIsNotCatalogChanging(t *testing.T) {
+	for _, sql := range []string{
+		"CREATE USER 'u'@'h'",
+		"CREATE USER 'u'@'h' IDENTIFIED BY RANDOM PASSWORD",
+		"ALTER USER 'u'@'h' IDENTIFIED BY 'p'",
+		"DROP USER 'u'@'h'",
+		"CREATE ROLE 'r'",
+		"DROP ROLE 'r'",
+	} {
+		f := mysqlFacts(t, sql)
+		if !f.Resolved {
+			t.Fatalf("%q resolved=false: class=%v detail=%q", sql, f.FailureClass, f.Detail)
+		}
+		if f.CatalogChanging {
+			t.Errorf("%q catalog_changing=true — account DDL changes no column catalog, want false", sql)
+		}
+	}
+}
+
 // Classification comes from what sqlglot structurally resolved, never from matching the SQL text.
 //
 // A Command node IS sqlglot reporting "I did not model this statement": the verb survives as a string
-// and the rest is unparsed text. Granting sql.ddl off that verb would hand a schema-DDL grant to
-// privilege management — `DROP USER`, `RENAME USER` — which are not schema changes and must stay
-// denied. Some genuine table DDL degrades to Command too (`RENAME TABLE a TO b`) and is denied along
-// with it; over-denying an unmodeled statement is the correct side to fail on, and the fix is for
-// sqlglot to model the form, not for this layer to guess from a prefix.
+// and the rest is unparsed text. Classifying off that verb would hand an authorization off a prefix —
+// `RENAME USER`, which is account management, not a schema change. Some genuine table DDL degrades to
+// Command too (`RENAME TABLE a TO b`) and is denied along with it; over-denying an unmodeled statement
+// is the correct side to fail on, and the fix is for sqlglot to model the form, not for this layer to
+// guess from a prefix.
 func TestUnmodeledCommandStatementsStayDenied(t *testing.T) {
 	for _, sql := range []string{
-		"DROP USER 'x'@'%'",
 		"RENAME USER 'a'@'%' TO 'b'@'%'",
 		// Table DDL that also degrades to Command — denied, deliberately.
 		"RENAME TABLE users TO users2",

--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -959,9 +959,22 @@ func ddlFacts(root exp.Expression, eng engine) *pb.StatementFacts {
 		Resolved:     true,
 		FailureClass: pb.FailureClass_FAILURE_CLASS_UNSPECIFIED,
 		// A temp-scoped DDL target is session-local, so it changes no shared catalog and must not force
-		// every other connection to re-measure.
-		CatalogChanging: !isTemporaryDDL(root, eng),
+		// every other connection to re-measure. Account-object DDL (CREATE/ALTER/DROP USER|ROLE) changes
+		// accounts/roles, not the column catalog the proxy re-measures for masking, so it is not
+		// catalog-changing either — it relays as a no-column passthrough, which keeps a statement result
+		// like CREATE USER … IDENTIFIED BY RANDOM PASSWORD viewable rather than dropped for column mismatch.
+		CatalogChanging: !isTemporaryDDL(root, eng) && !isAccountObjectDDL(root),
 	}
+}
+
+// isAccountObjectDDL is true for CREATE/ALTER/DROP of a USER or ROLE — account management that touches no
+// table or column, so unlike schema DDL it changes no catalog the proxy re-measures.
+func isAccountObjectDDL(root exp.Expression) bool {
+	switch objectKindText(root) {
+	case "USER", "ROLE":
+		return true
+	}
+	return false
 }
 
 func schemaQualifierCandidates(root exp.Expression) []string {

--- a/analyzer/probe/mysql_statement_coverage_test.go
+++ b/analyzer/probe/mysql_statement_coverage_test.go
@@ -260,12 +260,15 @@ var mysqlStatements = []mysqlStatement{
 	{"RESET BINARY LOGS AND GTIDS", "RESET BINARY LOGS AND GTIDS", "INADMISSIBLE-deny", pb.StatementKind_STATEMENT_KIND_STMT_UNKNOWN}, // 8.4 replacement for RESET MASTER
 
 	// ---- Account management (§15.7.1) — privileged, must fail closed ----
-	{"CREATE USER", "CREATE USER 'u'@'h'", "unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_STMT_UNKNOWN},
-	{"ALTER USER", "ALTER USER 'u'@'h' IDENTIFIED BY 'p'", "unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_STMT_UNKNOWN},
-	{"DROP USER", "DROP USER 'u'@'h'", "unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_STMT_UNKNOWN},
+	{"CREATE USER", "CREATE USER 'u'@'h'", "stmt.kind.create_user", pb.StatementKind_STATEMENT_KIND_CREATE_USER},
+	{"CREATE USER RANDOM PASSWORD", "CREATE USER 'u'@'h' IDENTIFIED BY RANDOM PASSWORD", "stmt.kind.create_user", pb.StatementKind_STATEMENT_KIND_CREATE_USER},
+	{"ALTER USER", "ALTER USER 'u'@'h' IDENTIFIED BY 'p'", "stmt.kind.alter_user", pb.StatementKind_STATEMENT_KIND_ALTER_USER},
+	{"DROP USER", "DROP USER 'u'@'h'", "stmt.kind.drop_user", pb.StatementKind_STATEMENT_KIND_DROP_USER},
+	// RENAME USER is the one account-mgmt form sqlglot-go leaves as an opaque Command, so it stays
+	// unanalyzable where its CREATE/ALTER/DROP siblings resolve to a classified kind.
 	{"RENAME USER", "RENAME USER 'u'@'h' TO 'v'@'h'", "unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_STMT_UNKNOWN},
-	{"CREATE ROLE", "CREATE ROLE 'r'", "unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_STMT_UNKNOWN},
-	{"DROP ROLE", "DROP ROLE 'r'", "unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_STMT_UNKNOWN},
+	{"CREATE ROLE", "CREATE ROLE 'r'", "stmt.kind.create_role", pb.StatementKind_STATEMENT_KIND_CREATE_ROLE},
+	{"DROP ROLE", "DROP ROLE 'r'", "stmt.kind.drop_role", pb.StatementKind_STATEMENT_KIND_DROP_ROLE},
 	{"GRANT (priv)", "GRANT SELECT ON *.* TO 'u'@'h'", "stmt.kind.grant_priv + unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_GRANT_PRIV},
 	{"GRANT (role)", "GRANT 'r' TO 'u'@'h'", "stmt.kind.grant_priv + unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_GRANT_PRIV},
 	{"REVOKE (priv)", "REVOKE SELECT ON *.* FROM 'u'@'h'", "stmt.kind.revoke_priv + unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_REVOKE_PRIV},
@@ -422,7 +425,7 @@ var privilegedNeedingGate = map[string]bool{
 	"RESET REPLICA": true, "RESET SLAVE": true, "RESET MASTER": true, "RESET BINARY LOGS AND GTIDS": true,
 	"START GROUP_REPLICATION": true, "STOP GROUP_REPLICATION": true, "PURGE BINARY LOGS": true,
 	"CHANGE REPLICATION SOURCE TO": true, "CHANGE MASTER TO": true, "CHANGE REPLICATION FILTER": true,
-	"CREATE USER": true, "ALTER USER": true, "DROP USER": true, "RENAME USER": true, "CREATE ROLE": true,
+	"CREATE USER": true, "CREATE USER RANDOM PASSWORD": true, "ALTER USER": true, "DROP USER": true, "RENAME USER": true, "CREATE ROLE": true,
 	"DROP ROLE": true, "GRANT (priv)": true, "GRANT (role)": true, "REVOKE (priv)": true, "REVOKE (role)": true,
 	"ANALYZE TABLE": true, "CHECK TABLE": true, "CHECKSUM TABLE": true, "OPTIMIZE TABLE": true, "REPAIR TABLE": true,
 	"INSTALL PLUGIN": true, "UNINSTALL PLUGIN": true, "INSTALL COMPONENT": true, "UNINSTALL COMPONENT": true,
@@ -458,10 +461,25 @@ var knownConnectOnlyGaps = map[string]bool{
 	"SHOW SLAVE HOSTS":   true,
 }
 
+// gatedBareKinds are privileged kinds whose bare stmt.kind.<k> term IS the gate, not an under-gating.
+// Account management (CREATE/ALTER/DROP USER|ROLE) touches no data, so it emits no utility grant and no
+// lineage — a lone stmt.kind.<k>. But the CP schema maps these kinds into stmt.cat.admin.account, a
+// deny-by-default category with no benign passthrough, so a bare admin-category term denies unless an
+// admin grant is present. This is the opposite of knownConnectOnlyGaps, which are genuinely under-gated
+// (a benign category). The map key is the resolve() output.
+var gatedBareKinds = map[string]bool{
+	"stmt.kind.create_user": true,
+	"stmt.kind.alter_user":  true,
+	"stmt.kind.drop_user":   true,
+	"stmt.kind.create_role": true,
+	"stmt.kind.drop_role":   true,
+}
+
 // TestPrivilegedStatementsAreGated is the security invariant: every privileged or data-exposing MySQL
-// statement must be gated — a datasource verb, a utility grant, or a fail-closed deny — never a bare
-// connect-only passthrough. The known gaps are enumerated, so this stays green today AND fails the moment a
-// new privileged kind falls through the analyzer's dispatch to a bare stmt.kind passthrough.
+// statement must be gated — a datasource verb, a utility grant, a gated-category kind, or a fail-closed
+// deny — never a bare connect-only passthrough. The known gaps are enumerated, so this stays green today
+// AND fails the moment a new privileged kind falls through the analyzer's dispatch to a bare stmt.kind
+// passthrough.
 func TestPrivilegedStatementsAreGated(t *testing.T) {
 	for _, s := range mysqlStatements {
 		if !privilegedNeedingGate[s.name] {
@@ -471,9 +489,10 @@ func TestPrivilegedStatementsAreGated(t *testing.T) {
 		// A bare connect-only passthrough now shows as a lone stmt.kind.<k> term (or the zero-grant
 		// sentinel): resolved, asking nothing beyond the kind — no utility grant, no result.read, and not
 		// a fail-closed deny. A privileged statement landing there is authorized by its benign-category
-		// kind alone, the same under-gating the METADATA/SESSION passthrough classes used to represent.
+		// kind alone, the same under-gating the METADATA/SESSION passthrough classes used to represent —
+		// UNLESS the kind's own category gates it (gatedBareKinds), which the account-mgmt kinds do.
 		bareKind := strings.HasPrefix(got, "stmt.kind.") && !strings.Contains(got, " + ")
-		connectOnly := bareKind || got == "allow(connect-only)"
+		connectOnly := (bareKind && !gatedBareKinds[got]) || got == "allow(connect-only)"
 		if connectOnly && !knownConnectOnlyGaps[s.name] {
 			t.Errorf("%s is privileged but resolves connect-only (%s) — it must be gated; verify %q", s.name, got, s.sql)
 		}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AccountManagementEnforcementDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AccountManagementEnforcementDbTest.kt
@@ -1,0 +1,151 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.controlplane.authz.AuthzContext
+import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
+import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import com.ridi.oss.proxymonster.grpc.EnfAction
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Account management (CREATE/ALTER/DROP USER|ROLE) is authorized by its `stmt.cat.admin.account` grant and
+ * relayed as a no-column passthrough — so a result-bearing form (`CREATE USER … IDENTIFIED BY RANDOM
+ * PASSWORD` returns the generated password) stays viewable rather than dropped for a column mismatch.
+ *
+ * These go through the real decideQuery/decideResultView against a live MySQL, so they fail if the analyzer
+ * classifies account DDL as STMT_UNKNOWN again (it would deny under a mere admin grant), or if it marks it
+ * catalog-changing again (its result would leave the passthrough and the stored view would refuse it).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AccountManagementEnforcementDbTest {
+    private lateinit var fx: EnforcementFixture
+    private lateinit var datasource: Datasource
+    private var roleId = 0L
+
+    private val admin = "useradmin@example.com"
+    private val connector = "connector@example.com"
+    private val createUserRandom = "CREATE USER 'books-frontend'@'10.23.0.0/255.255.0.0' IDENTIFIED BY RANDOM PASSWORD"
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        fx = EnforcementFixture.mysql()
+        fx.dataSource.connection.use { c ->
+            c.prepareStatement("UPDATE datasource SET tags = '[\"system:production\"]'::jsonb WHERE id = ?").use { ps ->
+                ps.setLong(1, fx.datasource.id)
+                ps.executeUpdate()
+            }
+        }
+        datasource = checkNotNull(fx.datasourceStore.get(fx.datasource.id))
+        // The account-admin: stmt.cat.admin.account + datasource.connect on production-tagged datasources.
+        roleId = fx.policyStore.createRole(RoleInput("account-admin")).id
+        fx.policyStore.createAssignment(RoleAssignmentInput(admin, roleId))
+        fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "account-admin-account",
+                cedarSrc = """permit(principal in Role::"account-admin", action in [Action::"stmt.cat.admin.account"], resource) when { resource in Tag::"system:production" };""",
+            ),
+            updatedBy = "test-fixture",
+        )
+        fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "account-admin-connect",
+                cedarSrc = """permit(principal in Role::"account-admin", action == Action::"datasource.connect", resource) when { resource in Tag::"system:production" };""",
+            ),
+            updatedBy = "test-fixture",
+        )
+        // A principal that may CONNECT but holds no stmt.cat.admin.account, so a deny isolates the missing
+        // account grant rather than passing at the earlier datasource.connect gate.
+        val connectRole = fx.policyStore.createRole(RoleInput("account-connect-only"))
+        fx.policyStore.createAssignment(RoleAssignmentInput(connector, connectRole.id))
+        fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "account-connect-only-connect",
+                cedarSrc = """permit(principal in Role::"account-connect-only", action == Action::"datasource.connect", resource) when { resource in Tag::"system:production" };""",
+            ),
+            updatedBy = "test-fixture",
+        )
+    }
+
+    private fun decide(sql: String, who: String) = decideQuery(
+        principal = who,
+        ds = datasource,
+        sql = sql,
+        channel = Channel.WIRE,
+        catalog = fx.datasourceStore.catalog(datasource.id),
+        policyStore = fx.policyStore,
+        accessStore = fx.accessStore,
+        userGroupStore = fx.userGroupStore,
+        roleResolver = fx.roleResolver,
+        authz = fx.authz,
+    )
+
+    private fun request() = AccessRequest(
+        id = 1,
+        principal = admin,
+        roleId = roleId,
+        roleName = "account-admin",
+        datasourceId = datasource.id,
+        datasourceName = datasource.name,
+        requestedDurationSec = 3600,
+        status = "EXECUTED",
+        decidedBy = admin,
+        executedBy = admin,
+        createdAt = "2026-08-14T00:00:00Z",
+        kind = "QUERY",
+        sql = createUserRandom,
+        executeAs = listOf("account-admin"),
+        creatorKind = "WORKFLOW",
+    )
+
+    @Test
+    fun `an admin-account holder runs CREATE USER RANDOM PASSWORD as a passthrough and views its generated password`() {
+        val ctx = decide(createUserRandom, admin)
+        assertEquals(
+            EnfAction.ALLOW,
+            ctx.action,
+            "CREATE USER denied for the stmt.cat.admin.account holder: ${ctx.denyReason} (stage=${ctx.failedStage})",
+        )
+        assertTrue(ctx.passthrough, "account DDL must relay as a no-column passthrough, not fall through the DDL/re-measure path")
+        assertFalse(ctx.catalogChanging, "CREATE USER changes accounts, not the column catalog the proxy re-measures")
+
+        // MySQL returns the generated password in a result set; the stored workflow result must be viewable,
+        // not dropped because the analyzer emitted no output columns for it.
+        val stored = DecryptedResult(
+            columns = listOf("user", "host", "generated password", "auth_factor"),
+            rows = listOf(listOf("books-frontend", "10.23.0.0/255.255.0.0", "}q7=x!P2b0Kd", "1")),
+        )
+        val view = decideResultView(
+            viewer = admin,
+            req = request(),
+            childSql = createUserRandom,
+            ds = datasource,
+            decrypted = stored,
+            callerContext = AuthzContext(requesterIp = "10.23.1.1"),
+            datasourceStore = fx.datasourceStore,
+            policyStore = fx.policyStore,
+            accessStore = fx.accessStore,
+            userGroupStore = fx.userGroupStore,
+            roleResolver = fx.roleResolver,
+            authz = fx.authz,
+            systemClassification = null,
+            channel = Channel.WIRE,
+        )
+        val allowed = assertIs<ResultViewDecision.Allowed>(view)
+        assertEquals(stored.columns, allowed.columns, "the generated-password result is released with its columns intact")
+        assertEquals(stored.rows, allowed.rows, "the generated password itself is released, not withheld")
+        assertTrue(allowed.maskedColumns.isEmpty(), "a passthrough view masks nothing")
+    }
+
+    @Test
+    fun `a connect-only role is denied CREATE USER at the account-kind gate`() {
+        val ctx = decide("CREATE USER 'x'@'%'", connector)
+        assertEquals(EnfAction.DENY, ctx.action, "CREATE USER must stay denied without stmt.cat.admin.account")
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DdlEnforcementDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DdlEnforcementDbTest.kt
@@ -126,11 +126,11 @@ class DdlEnforcementDbTest {
     }
 
     /**
-     * A `stmt.cat.ddl` grant authorizes schema DDL, not everything DDL-adjacent. RENAME TABLE is a Command
-     * sqlglot does not model — unanalyzable, so it denies at the unanalyzable gate (no `exception.unanalyzable`
-     * hatch here). DROP USER / RENAME USER classify as `stmt.cat.admin.account` (privilege management, not
-     * schema DDL), so their kind gate demands admin, which the architect lacks. None is reachable by the
-     * ddl grant alone — over-denying is the correct side to fail on.
+     * A `stmt.cat.ddl` grant authorizes schema DDL, not everything DDL-adjacent. RENAME TABLE and RENAME USER
+     * are Commands sqlglot does not model — unanalyzable, so they deny at the `exception.unanalyzable` gate the
+     * architect does not hold. DROP USER is account management (`stmt.cat.admin.account`, not schema DDL), so
+     * its kind gate demands admin, which the architect also lacks. None is reachable by the ddl grant alone —
+     * over-denying is the correct side to fail on.
      */
     @Test
     fun `a statement outside schema DDL stays denied even with the ddl grant`() {

--- a/goproxy/go.mod
+++ b/goproxy/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/ridi-oss/sqlglot-go v0.23.0 // indirect
+	github.com/ridi-oss/sqlglot-go v0.24.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.6 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect

--- a/goproxy/go.sum
+++ b/goproxy/go.sum
@@ -107,6 +107,8 @@ github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/ridi-oss/sqlglot-go v0.23.0 h1:yk4tCVNXOO/2amBKEAK800lvcEITh0ixQbiquvGIhsM=
 github.com/ridi-oss/sqlglot-go v0.23.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
+github.com/ridi-oss/sqlglot-go v0.24.0 h1:dq25mbuMyRk2xMZqrw77WUARppsEMhckbuTGQf6uwMY=
+github.com/ridi-oss/sqlglot-go v0.24.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/shirou/gopsutil/v4 v4.26.6 h1:Mzr/npDtQC/xpeEuQKHZt8Zo9CmPvhTj8nkR8w5TLDs=


### PR DESCRIPTION
A production `CREATE USER 'books-frontend'@'…' IDENTIFIED BY RANDOM PASSWORD` was DENY'd: sqlglot-go ≤0.23 parsed MySQL `CREATE/ALTER/DROP USER|ROLE` as opaque `Command` nodes, so the probe classified them `STMT_UNKNOWN` → gated by the broad `exception.unanalyzable` escape hatch instead of their own account grant.

**Fix.** Bump `analyzer` to **sqlglot-go v0.24.0**, which structures those into typed `Create`/`Alter`/`Drop` nodes. The probe's existing `createKind`/`dropKind`/`alterKind` `USER`/`ROLE` cases (dead until now) then classify them to `stmt.kind.{create,alter,drop}_{user,role}` → `stmt.cat.admin.account` (deny-by-default). The classification half is a pure dep bump — zero probe-logic change.

Account-object DDL changes accounts/roles, **not** the column catalog the proxy re-measures for masking, so `ddlFacts` no longer marks it catalog-changing. It now relays as a no-column **passthrough**, which keeps `CREATE USER … RANDOM PASSWORD`'s generated-password result **viewable** (previously dropped for a column mismatch on the stored view) and drops a needless re-measure.

**Where it could bite:** authorization is *stricter* — a principal holding only `exception.unanalyzable` can no longer run account management; it now requires `stmt.cat.admin.account`. The `admin.account` kind gate runs before the passthrough, so authorization is otherwise unchanged. `RENAME USER` stays an unmodeled `Command` (sqlglot-go doesn't structure it) → `exception.unanalyzable`.

**Verification.** Analyzer suite (coverage rows + a not-catalog-changing check) + a control-plane `decideQuery`/`decideResultView` test against live MySQL proving `CREATE USER … RANDOM PASSWORD` is ALLOW + passthrough for an `admin.account` holder, its password is released, and a connect-only role denies at the gate. Reviewed by Codex + Sol + Grok — sound, no auth flaw, and stricter than before.

**Known follow-ups (not this PR):** `gatedBareKinds` in the coverage test is a Go-side mirror of the Cedar schema (drift risk, same class as the existing `privilegedNeedingGate`); `alterKind` has no `ROLE` case (dead today — MySQL has no `ALTER ROLE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ati9RRaurF1DQ5R4Xz32E