### PR TITLE
feat(web): list every role a query can run under, auto-discovered in the composer

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
@@ -59,68 +59,55 @@ private val AccessRequest.isWorkflowApproval: Boolean
     get() = kind == "QUERY" && creatorKind == "WORKFLOW"
 
 /**
- * A role the requester could ask to run Q under (approval-workflow.md, "role discovery").
+ * A role the statement can run under (approval-workflow.md, "role discovery").
  *
- * [decision] and [maskedColumns] are what Q returns under this role WHEN EXECUTED BY THE WORKFLOW — the
- * `workflow-executor` channel an approved query actually runs on, which is the only outcome the request
- * can deliver. A role is listed whenever that outcome is not a denial, rather than only when it beats the
- * requester's own roles: "runs, but still masked" is an answer they need in order to stop looking.
- *
- * [unmasksColumns] is the pre-existing summary: columns this role unmasks relative to the baseline.
+ * [decision] and [maskedColumns] are the outcome under this role on the `workflow-executor` channel — the
+ * channel an approved query runs on — PREVIEWED in the requester's current context. Execution runs in the
+ * approver's context and can narrow further (e.g. off a trusted network), so this is the previewed outcome,
+ * not a guaranteed one.
  */
 @Serializable
 data class RoleOption(
     val roleId: Long,
     val roleName: String,
-    val unmasksColumns: List<String>,
     val decision: Decision = Decision.ALLOW,
     val maskedColumns: List<String> = emptyList(),
 )
 
 @Serializable
-data class DiscoverRolesResponse(val baselineAllowed: Boolean, val options: List<RoleOption>)
+data class DiscoverRolesResponse(
+    val options: List<RoleOption>,
+)
 
 /**
- * APPROVAL role discovery (approval-workflow.md — "the requester picks R"): offer every role R the requester
- * does not already hold under which Q runs from SOME network posture, each with its per-posture outcome. R is
- * the elevation unit the request carries (`access_request.role_id`); the workflow adds lifecycle, not
- * authorization.
+ * APPROVAL role discovery (approval-workflow.md — "the requester picks R"): list every role the statement can
+ * run under — one entry per role that is not denied under that role alone. There is no baseline and no
+ * held-vs-not-held concept: a role is offered whether or not the requester already holds it, so a statement
+ * that already runs can still be taken through the workflow for approval/audit.
  *
- * PREVIEW PARITY: each candidate is previewed ALONE — `decide(setOf(role.name), …)`, never unioned with the
- * requester's own roles — because execute-under-R runs with `assumeRoles = setOf(R)` alone. A unioned preview
- * could ALLOW here and DENY at execute, offering a role the requester cannot actually run. Only the baseline
- * and the already-held filter are keyed on the requester's own roles.
- *
- * RESIDUAL GAP: the approver's own identity and address are not known at discovery time, so a policy
- * conditioned on them can still make an offered R deny at execute. The channel and network axes are modeled
- * (candidates preview on the execution channel, across both postures); the approver-identity axis is not.
+ * PREVIEW PARITY: each role is previewed ALONE — `decide(setOf(role.name), …)`, never unioned with the
+ * requester's own roles — because execute-under-R runs with `assumeRoles = setOf(R)` alone, on the
+ * `workflow-executor` channel an approved query actually runs on. A unioned or wrong-channel preview could
+ * ALLOW here and DENY at execute, offering a role the requester cannot actually run.
  *
  * [decide] runs the real decision path and MUST be side-effect-free — discovery is a dry run, no audit write.
  */
 fun discoverRoles(
-    ownRoles: Set<String>,
     allRoles: List<Role>,
     decide: (roles: Set<String>, channel: Channel) -> DecisionContext,
 ): DiscoverRolesResponse {
-    // The baseline answers "what do I get right now", so it decides where the requester is: the editor
-    // channel, under their own roles.
-    val baseline = decide(ownRoles, Channel.EDITOR)
-    val baselineMasked = baseline.masks.map { it.column }.toSet()
-    val baselineDenied = baseline.action == EnfAction.DENY
-
-    val options = allRoles.filterNot { it.name in ownRoles }.mapNotNull { role ->
+    val options = allRoles.mapNotNull { role ->
         val underR = decide(setOf(role.name), Channel.WORKFLOW_EXECUTOR)
         if (underR.action == EnfAction.DENY) return@mapNotNull null
         val masked = underR.masks.map { it.column }.distinct().sorted()
         RoleOption(
             roleId = role.id,
             roleName = role.name,
-            unmasksColumns = (baselineMasked - masked.toSet()).sorted(),
             decision = if (masked.isEmpty()) Decision.ALLOW else Decision.MASK,
             maskedColumns = masked,
         )
     }
-    return DiscoverRolesResponse(baselineAllowed = !baselineDenied, options = options)
+    return DiscoverRolesResponse(options = options)
 }
 
 @Serializable data class ApprovalDetail(
@@ -555,21 +542,19 @@ fun Route.approvalRoutes(
         call.respond(HttpStatusCode.Created, CreateApprovalResponse(request, wouldAllow = decision.action == EnfAction.ALLOW))
     }
 
-    // APPROVAL role discovery (approval-workflow.md — "the requester picks R"): evaluate Q under each
-    // candidate role and offer the ones that return MORE than the requester's own roles. A dry-run — no
-    // audit row is written.
+    // APPROVAL role discovery (approval-workflow.md — "the requester picks R"): evaluate the statement under
+    // each role and list every one it runs under, held or not. A dry-run — no audit row is written.
     post("/api/approvals/discover-roles") {
         val principal = call.requireApi() ?: return@post
         val input = call.receive<DiscoverRolesRequest>()
         val ds = datasourceStore.get(input.datasourceId)
             ?: return@post call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "datasource")))
-        val ownRoles = roleResolver.resolve(principal)
-        // Resolve requester_ip ONCE here (the closure runs decideQuery per candidate role and posture).
+        // Resolve requester_ip ONCE here (the closure runs decideQuery per candidate role).
         val discoverContext = call.httpAuthzContext(config)
         // Candidates preview on WORKFLOW_EXECUTOR, the channel an approved query actually runs on. A grant
         // scoped to that channel — the shipped -259 PII unmask — is invisible from any other, so previewing
         // candidates elsewhere hides roles that would in fact work.
-        val response = discoverRoles(ownRoles, policyStore.listRoles()) { roles, channel ->
+        val response = discoverRoles(policyStore.listRoles()) { roles, channel ->
             decideQuery(
                 principal = principal, ds = ds, sql = input.sql, channel = channel,
                 catalog = datasourceStore.catalog(ds.id), policyStore = policyStore, accessStore = accessStore,

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalDiscoverPickSubmitRouteDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalDiscoverPickSubmitRouteDbTest.kt
@@ -35,16 +35,16 @@ import kotlin.test.assertTrue
  * coverage, driven at the HTTP layer against a real introspected catalog + real Cedar grants
  * ([EnforcementFixture.postgres]).
  *
- * It also carries ROUTE-level teeth for the R-ALONE preview, in the case that actually distinguishes
- * it: the requester here HOLDS an own role (`base-reader`, which runs `select id, ssn from users` with
- * `ssn` masked). Two candidates are seeded so the union and R-alone decisions genuinely diverge:
- *   * `full-reader` unmasks `ssn` ON ITS OWN → offered under both models (the positive round-trip pick);
- *   * `unmask-only` grants unmasked-`ssn` but NO datasource.connect/sql.select, so ALONE it DENYs, while
- *     `{base-reader, unmask-only}` would connect (via base-reader) and unmask `ssn`. A unioned
- *     preview would offer `unmask-only`; under R-alone it must NOT be — this test catches the union
- *     bug, unlike a no-own-roles fixture where `ownRoles + R == {R}` makes the two implementations equal.
- * The pure [RoleDiscoveryTest] covers the union-vs-alone logic directly; this pins the ROUTE wiring
- * (ownRoles resolution + per-candidate decideQuery through real Cedar) to the same behavior end to end.
+ * It also carries ROUTE-level teeth for the R-ALONE preview: each candidate is previewed under `{R}` ALONE
+ * (never unioned with any other role), on the `workflow-executor` channel. Three roles are seeded so a
+ * union would diverge from the R-alone decision the route makes:
+ *   * `base-reader` runs `select id, ssn from users` with `ssn` masked → offered, outcome MASK;
+ *   * `full-reader` unmasks `ssn` ON ITS OWN → offered, outcome ALLOW (the positive round-trip pick);
+ *   * `unmask-only` grants unmasked-`ssn` but NO datasource.connect/sql.select, so ALONE it DENYs and must
+ *     NOT be offered — a unioned preview `{base-reader, unmask-only}` would connect (via base-reader) and
+ *     wrongly offer it. That divergence is the R-alone teeth.
+ * The pure [RoleDiscoveryTest] covers the listing logic directly; this pins the ROUTE wiring — per-candidate
+ * `decideQuery` under `{R}` alone on `workflow-executor`, through real Cedar — to the same behavior end to end.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ApprovalDiscoverPickSubmitRouteDbTest {
@@ -80,7 +80,7 @@ class ApprovalDiscoverPickSubmitRouteDbTest {
     }
 
     /**
-     * Seed the own-role + two candidates whose union and R-alone previews diverge (see the class kdoc).
+     * Seed three roles whose R-alone previews diverge from a union preview (see the class kdoc).
      * Mirrors [EnforcementFixture.seedPolicy]'s pattern (the `users` Table EUID + connect/select + read
      * grants). [com.ridi.oss.proxymonster.controlplane.authz.CedarEngine] rebuilds its cached PolicySet on
      * the next stateVersion, so grants created here (before the first request) are live for the test.
@@ -93,7 +93,7 @@ class ApprovalDiscoverPickSubmitRouteDbTest {
         fun grant(name: String, src: String) =
             fx.cedarPolicyStore.create(CedarPolicyInput(name = name, cedarSrc = src), updatedBy = "discover-pick-submit-test")
 
-        // The requester's OWN role: connects + selects, cleartext except pii, pii (ssn) masked → baseline MASK.
+        // base-reader: connects + selects, cleartext except pii, pii (ssn) masked → runs Q with ssn MASKed.
         val baseReader = fx.policyStore.createRole(RoleInput("base-reader"))
         fx.policyStore.createAssignment(RoleAssignmentInput(requester, baseReader.id))
         grant("base-reader-connect-select", """permit(principal in Role::"base-reader", action in [Action::"datasource.connect", Action::"stmt.cat.read"], resource in Datasource::"${ds.name}");""")
@@ -145,10 +145,6 @@ class ApprovalDiscoverPickSubmitRouteDbTest {
         }
         assertEquals(HttpStatusCode.OK, discoverResponse.status)
         val discovered = discoverResponse.body<DiscoverRolesResponse>()
-        assertTrue(
-            discovered.baselineAllowed,
-            "the requester holds base-reader, which runs the query with ssn masked -> the baseline is a masked ALLOW",
-        )
 
         val offered = discovered.options.map { it.roleName }.toSet()
         // The teeth: `unmask-only` alone can't even connect (DENY), so R-alone must not offer it. A
@@ -161,9 +157,9 @@ class ApprovalDiscoverPickSubmitRouteDbTest {
         val fullReader = discovered.options.singleOrNull { it.roleName == "full-reader" }
         assertTrue(
             fullReader != null,
-            "full-reader unmasks ssn ON ITS OWN, improving on the masked baseline -> it must be offered. Offered: $offered",
+            "full-reader runs the query and returns ssn cleartext ON ITS OWN -> it must be offered. Offered: $offered",
         )
-        assertEquals(listOf("ssn"), fullReader!!.unmasksColumns, "the offered role must report ssn as newly unmasked over the baseline")
+        assertEquals(Decision.ALLOW, fullReader!!.decision, "full-reader returns ssn cleartext, so its outcome is ALLOW")
 
         val submitResponse = client.post("/api/approvals") {
             contentType(ContentType.Application.Json)

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DdlEnforcementDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/DdlEnforcementDbTest.kt
@@ -191,7 +191,7 @@ class DdlEnforcementDbTest {
      */
     @Test
     fun `role discovery offers the ddl role for a DDL statement`() {
-        val response = discoverRoles(ownRoles = emptySet(), allRoles = fx.policyStore.listRoles()) { roles, channel ->
+        val response = discoverRoles(allRoles = fx.policyStore.listRoles()) { roles, channel ->
             decideQuery(
                 principal = noRole,
                 ds = fx.datasourceStore.get(fx.datasource.id)!!,

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/RoleDiscoveryTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/RoleDiscoveryTest.kt
@@ -4,17 +4,15 @@ import com.ridi.oss.proxymonster.grpc.EnfAction
 import com.ridi.oss.proxymonster.grpc.columnMask
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * APPROVAL role discovery (approval-workflow.md) — pure logic, exercised through a stub `decide` closure
- * that stands in for the real decideQuery.
+ * APPROVAL role discovery (approval-workflow.md) — pure logic, exercised through a stub `decide` closure that
+ * stands in for the real decideQuery.
  *
- * Candidates are previewed on WORKFLOW_EXECUTOR, the channel an approved query actually runs on, and each
- * option carries the outcome it would deliver there. Previewing on the requester's own channel hid roles a
- * channel-scoped grant would have unlocked, and offering only roles that beat the requester's own dropped
- * ones that run the query while still masking — an answer the requester needs.
+ * The model is deliberately flat: list every role the statement runs under. No baseline and no held-vs-not
+ * concept — a role is offered whether or not the requester holds it. Each role is previewed under {R} ALONE
+ * on WORKFLOW_EXECUTOR, the channel an approved query actually runs on and the role set it runs under.
  */
 class RoleDiscoveryTest {
     private fun ctx(action: EnfAction, maskedCols: List<String> = emptyList()) = DecisionContext(
@@ -31,94 +29,59 @@ class RoleDiscoveryTest {
     private val roles = listOf(Role(1, "analyst"), Role(2, "pii-reader"), Role(3, "auditor"))
 
     @Test
-    fun `a role that unmasks a baseline-masked column is offered with the unmasked column`() {
-        // own role analyst masks ssn; pii-reader unmasks it; auditor still masks it (no improvement).
-        val decide = { r: Set<String>, _: Channel ->
-            when {
-                "pii-reader" in r -> ctx(EnfAction.ALLOW) // ssn unmasked → no masks
-                else -> ctx(EnfAction.MASK, listOf("ssn"))
-            }
-        }
-        val res = discoverRoles(setOf("analyst"), roles, decide)
-        assertTrue(res.baselineAllowed, "a MASK baseline is 'allowed' (not denied)")
-        // Both candidates run Q, so both are listed; what distinguishes them is the reported gain.
-        assertEquals(listOf("pii-reader", "auditor"), res.options.map { it.roleName })
-        assertEquals(listOf("ssn"), res.options.single { it.roleName == "pii-reader" }.unmasksColumns)
-        assertEquals(emptyList(), res.options.single { it.roleName == "auditor" }.unmasksColumns)
+    fun `every role that runs the statement is listed`() {
+        val decide = { _: Set<String>, _: Channel -> ctx(EnfAction.ALLOW) }
+        val res = discoverRoles(roles, decide)
+        assertEquals(listOf("analyst", "pii-reader", "auditor"), res.options.map { it.roleName })
     }
 
     @Test
-    fun `a role that denies the query is not offered`() {
-        val decide = { r: Set<String>, _: Channel -> if ("auditor" in r) ctx(EnfAction.DENY) else ctx(EnfAction.MASK, listOf("ssn")) }
-        val res = discoverRoles(setOf("analyst"), roles, decide)
-        assertTrue(res.options.none { it.roleName == "auditor" }, "a role that denies Q cannot be the answer")
-        assertTrue(res.options.any { it.roleName == "pii-reader" }, "a role that CAN run Q is still listed")
-    }
-
-    @Test
-    fun `when baseline is denied, a role that makes Q runnable is offered`() {
-        // requester's own roles can't run Q at all (no read grant); pii-reader can.
-        val decide = { r: Set<String>, _: Channel -> if ("pii-reader" in r) ctx(EnfAction.ALLOW) else ctx(EnfAction.DENY) }
-        val res = discoverRoles(setOf("analyst"), roles, decide)
-        assertFalse(res.baselineAllowed, "baseline is denied")
-        assertEquals(listOf("pii-reader"), res.options.map { it.roleName }, "a role that makes a denied Q runnable is offered")
-    }
-
-    @Test
-    fun `a role the requester already holds is never offered`() {
+    fun `a role that runs but still masks is listed, marked masked`() {
         val decide = { _: Set<String>, _: Channel -> ctx(EnfAction.MASK, listOf("ssn")) }
-        val res = discoverRoles(setOf("analyst", "pii-reader"), roles, decide)
-        assertTrue(res.options.none { it.roleName in setOf("analyst", "pii-reader") }, "already-held roles are filtered out")
+        val res = discoverRoles(roles, decide)
+        val option = res.options.first()
+        assertEquals(Decision.MASK, option.decision)
+        assertEquals(listOf("ssn"), option.maskedColumns)
+    }
+
+    @Test
+    fun `a role that returns cleartext is marked ALLOW`() {
+        val decide = { r: Set<String>, _: Channel ->
+            if ("pii-reader" in r) ctx(EnfAction.ALLOW) else ctx(EnfAction.MASK, listOf("ssn"))
+        }
+        val res = discoverRoles(roles, decide)
+        val option = res.options.single { it.roleName == "pii-reader" }
+        assertEquals(Decision.ALLOW, option.decision)
+        assertEquals(emptyList(), option.maskedColumns)
+    }
+
+    @Test
+    fun `a role that denies the statement is not listed`() {
+        val decide = { r: Set<String>, _: Channel -> if ("auditor" in r) ctx(EnfAction.DENY) else ctx(EnfAction.ALLOW) }
+        val res = discoverRoles(roles, decide)
+        assertTrue(res.options.none { it.roleName == "auditor" }, "a role that denies cannot run the statement")
+        assertEquals(listOf("analyst", "pii-reader"), res.options.map { it.roleName })
     }
 
     @Test
     fun `a candidate is previewed on the channel an approved query executes on`() {
         // The shipped -259 unmasks production PII for a pii-accessor on WORKFLOW_EXECUTOR alone. Previewed on
-        // the requester's own channel that grant never fires, so the role reads as no better than baseline
-        // and was filtered out — leaving a requester who asked to see ssn told that no role would help.
+        // any other channel that grant never fires, so the role would read as denied/masked and be dropped.
         val decide = { r: Set<String>, channel: Channel ->
-            if ("pii-reader" in r && channel == Channel.WORKFLOW_EXECUTOR) ctx(EnfAction.ALLOW)
-            else ctx(EnfAction.MASK, listOf("ssn"))
+            if ("pii-reader" in r && channel == Channel.WORKFLOW_EXECUTOR) ctx(EnfAction.ALLOW) else ctx(EnfAction.DENY)
         }
-        val res = discoverRoles(setOf("analyst"), roles, decide)
-
-        val option = res.options.single { it.roleName == "pii-reader" }
-        assertEquals(Decision.ALLOW, option.decision)
-        assertEquals(emptyList(), option.maskedColumns)
-        assertEquals(listOf("ssn"), option.unmasksColumns)
-    }
-
-    @Test
-    fun `the baseline is decided on the requester's own channel, never the executor's`() {
-        // The baseline answers "what do I get right now", so previewing it as the workflow would overstate
-        // what the requester already has and understate what an elevation buys them.
-        val seen = mutableListOf<Channel>()
-        val decide = { r: Set<String>, channel: Channel ->
-            if (r == setOf("analyst")) seen.add(channel)
-            ctx(EnfAction.MASK, listOf("ssn"))
-        }
-        discoverRoles(setOf("analyst"), roles, decide)
-        assertEquals(listOf(Channel.EDITOR), seen)
-    }
-
-    @Test
-    fun `a role that runs the query but still masks is offered, marked masked`() {
-        val decide = { _: Set<String>, _: Channel -> ctx(EnfAction.MASK, listOf("ssn")) }
-        val res = discoverRoles(setOf("analyst"), roles, decide)
-        val option = res.options.first()
-        assertEquals(Decision.MASK, option.decision)
-        assertEquals(listOf("ssn"), option.maskedColumns)
-        assertEquals(emptyList(), option.unmasksColumns, "it unmasks nothing relative to the baseline")
+        val res = discoverRoles(roles, decide)
+        assertEquals(listOf("pii-reader"), res.options.map { it.roleName })
+        assertEquals(Decision.ALLOW, res.options.single().decision)
     }
 
     @Test
     fun `a candidate is previewed under R ALONE, not unioned with the requester's own roles`() {
-        // decide ALLOWs only when BOTH "analyst" (the requester's own role) AND "pii-reader" (the candidate)
-        // are present together — modeling a policy whose grant only fires on the union. A unioned
-        // preview would compute decide({analyst, pii-reader}) = ALLOW and offer pii-reader — but
-        // execution decides under {pii-reader} ALONE and would DENY there, so offering it would be a lie.
+        // decide ALLOWs only when BOTH "analyst" AND "pii-reader" are present — a policy whose grant only fires
+        // on the union. A unioned preview would offer pii-reader, but execution decides under {pii-reader}
+        // ALONE and would DENY there, so offering it would be a lie.
         val decide = { r: Set<String>, _: Channel -> if ("analyst" in r && "pii-reader" in r) ctx(EnfAction.ALLOW) else ctx(EnfAction.DENY) }
-        val res = discoverRoles(setOf("analyst"), roles, decide)
-        assertTrue(res.options.isEmpty(), "R-alone preview must DENY (analyst is not in {pii-reader} alone) → pii-reader must not be offered")
+        val res = discoverRoles(roles, decide)
+        assertTrue(res.options.isEmpty(), "R-alone preview must DENY, so no role is offered")
     }
 }

--- a/docs/approval-workflow.md
+++ b/docs/approval-workflow.md
@@ -39,13 +39,18 @@ task exists but no rows.
 
 1. Compose. The requester writes Q + datasource, or arrives from a denied
    decision (auto-filled).
-2. Role discovery. `POST /api/approvals/discover-roles` evaluates Q under
-   candidate roles (preview via `decideQuery` on the `editor` channel in the
-   requester's HTTP context) and offers the roles under which Q is not denied
-   _and_ that return more than the requester's own roles (e.g. `ssn` unmasked).
-   The requester picks R. Role-set parity with execute is `assumeRoles={R}`
-   alone; channel/context can still diverge at run (execute uses
-   `workflow-executor` in the approver's context).
+2. Role discovery. `POST /api/approvals/discover-roles` previews Q under each
+   role on the `workflow-executor` channel — the channel an approved query
+   actually executes on — with `assumeRoles={R}` alone, so the preview matches
+   execution's role set. It lists every role Q runs under (not denied), each
+   with the outcome it previews in the requester's context (cleartext, or which
+   columns it still masks) — execution in the approver's context can narrow it.
+   There is no baseline and no held-vs-not-held distinction: a role is listed
+   whether or not the requester holds it, so a statement that already runs can
+   still go through the workflow for approval/audit. The console re-lists
+   automatically as the query changes (debounced) and defaults to the first
+   role; the requester can pick another. Channel/context can still diverge at
+   run (execute uses the approver's context).
 3. Route + approve. Eligibility is exactly
    `authorize(approver, task.approve, request, context)` — the request is
    `in Role::R`, so approvers-of-R match. Single approval. Self-approval is not
@@ -84,8 +89,8 @@ anywhere, `read.unmasked` pii `when trusted-network`. Requester `alice` holds
 `analyst` (masks ssn); she needs ssn.
 
 - Compose: `SELECT id, name, ssn FROM users`.
-- Discovery: under `analyst`, ssn masks; under `pii-reader`, ssn unmasks from a
-  망분리 node. Offer `pii-reader`; alice picks it.
+- Discovery lists every role Q runs under: `analyst` (ssn masked) and
+  `pii-reader` (ssn unmasked from a 망분리 node). alice picks `pii-reader`.
 - Approve: approvers of `pii-reader` (Cedar). `bob` approves (`bob ≠ alice`).
 - Execute: bob runs it under `pii-reader`, off-망분리. Off-network, R's verdict
   for `ssn` is MASK, so the encrypted stored result holds `ssn` masked — the
@@ -146,9 +151,9 @@ Verified on the real Cedar engine in [docs/cedar-sim/](./cedar-sim/)
   channel (via `RunExecService.run` + proxy `Decide`) → R's enforced result. A
   column R cannot read at all ⇒ Q-under-R denied ⇒ pick another role / narrow Q.
 - Role discovery: the same `decideQuery(under candidate role, Q)`, one per
-  candidate, with `assumeRoles={R}` alone — matching execute's role set (no
-  offer-then-DENY skew on the role axis). Preview channel is `editor`, not
-  `workflow-executor`.
+  candidate, with `assumeRoles={R}` alone AND on the `workflow-executor` channel
+  — matching execute on both axes, so a channel-scoped grant fires the same way
+  in the preview as at run (no offer-then-DENY skew).
 - View: `task.assume` gates whether the viewer may act as R, then R's
   `result.read.*` grants mask each column as exactly `{R}` in the viewer's
   context.

--- a/web/messages/en/workflows.json
+++ b/web/messages/en/workflows.json
@@ -120,14 +120,11 @@
     "titleRequired": "Title (required)",
     "titlePlaceholder": "Incident triage / support investigation / monthly report",
     "reasonPlaceholder": "Why do you need this query reviewed?",
-    "discoverRoles": "Check available roles",
     "discovering": "Checking…",
-    "discoverFailed": "Couldn't check roles — you can still submit without one.",
-    "selectRole": "Select an elevation role",
-    "noRolesFound": "No role would change the outcome for this query.",
-    "staleDiscovery": "The query changed since these roles were checked. Check available roles again.",
-    "alreadyAllowed": "This query is already allowed without an elevated role.",
-    "unmasksHint": "Unmasks: {columns}",
+    "discoverFailed": "Couldn't check roles.",
+    "retry": "Retry",
+    "selectRole": "Select a role",
+    "noRolesFound": "No role can run this query.",
     "outcome": {
       "ALLOW": "cleartext",
       "MASK": "masked"

--- a/web/messages/ko/workflows.json
+++ b/web/messages/ko/workflows.json
@@ -120,14 +120,11 @@
     "titleRequired": "제목 (필수)",
     "titlePlaceholder": "장애 대응 / 지원 조사 / 월간 리포트",
     "reasonPlaceholder": "이 쿼리를 검토받아야 하는 이유는 무엇인가요?",
-    "discoverRoles": "사용 가능한 역할 확인",
     "discovering": "확인 중…",
-    "discoverFailed": "역할을 확인하지 못했습니다 — 역할 없이도 제출할 수 있습니다.",
-    "selectRole": "권한 상승 역할 선택",
-    "noRolesFound": "이 쿼리의 결과를 바꿀 수 있는 역할이 없습니다.",
-    "staleDiscovery": "역할을 확인한 뒤 쿼리가 변경되었습니다. 사용 가능한 역할을 다시 확인해 주세요.",
-    "alreadyAllowed": "이 쿼리는 이미 역할 상승 없이 허용되어 있습니다.",
-    "unmasksHint": "마스킹 해제: {columns}",
+    "discoverFailed": "역할을 확인하지 못했습니다.",
+    "retry": "다시 시도",
+    "selectRole": "역할 선택",
+    "noRolesFound": "이 쿼리를 실행할 수 있는 역할이 없습니다.",
     "outcome": {
       "ALLOW": "평문",
       "MASK": "마스킹"

--- a/web/src/components/workflows/pick-role.test.ts
+++ b/web/src/components/workflows/pick-role.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { pickRole } from './pick-role'
+import type { RoleOption } from '@/lib/api/types'
+
+// pickRole is the pure selection rule the composer applies each render with the CURRENT options and the
+// user's persisted `userChoice`. The composer's async discovery state machine (debounce / seq-guarded
+// `discovering` / retry) lives in the component; the repo has no jsdom + testing-library env, so it is
+// exercised through this pure helper plus review, not a full component render.
+
+const opt = (roleId: number, roleName: string): RoleOption => ({
+  roleId,
+  roleName,
+  decision: 'ALLOW',
+  maskedColumns: [],
+})
+
+describe('pickRole', () => {
+  const analyst = opt(1, 'analyst')
+  const piiReader = opt(2, 'pii-reader')
+  const auditor = opt(3, 'auditor')
+
+  it('selects the first offered role when nothing was picked', () => {
+    expect(pickRole([analyst, piiReader], null)).toBe('1')
+  })
+
+  it('keeps the user pick while it is still offered', () => {
+    expect(pickRole([analyst, piiReader, auditor], '2')).toBe('2')
+  })
+
+  it('recovers the pick across a query change that drops then re-offers it', () => {
+    // The component holds `userChoice` = '2' throughout; only the options list changes as the query is
+    // re-discovered. pickRole must keep '2' while offered, fall back to the first when it is dropped, and
+    // recover '2' when it is offered again — without the caller ever forgetting the pick.
+    const choice = '2'
+    expect(pickRole([analyst, piiReader, auditor], choice)).toBe('2') // offered → kept
+    expect(pickRole([analyst, auditor], choice)).toBe('1') // dropped → first
+    expect(pickRole([analyst, piiReader, auditor], choice)).toBe('2') // re-offered → recovered
+  })
+
+  it('returns null when no role is offered', () => {
+    expect(pickRole([], '2')).toBeNull()
+    expect(pickRole([], null)).toBeNull()
+  })
+})

--- a/web/src/components/workflows/pick-role.ts
+++ b/web/src/components/workflows/pick-role.ts
@@ -1,0 +1,12 @@
+import type { RoleOption } from '@/lib/api/types'
+
+/**
+ * The role to select from a discovery: the user's explicit pick while it is still offered — recovered when it
+ * reappears after a query change had dropped it — else the first offered role; null when nothing is offered.
+ * Pure so the recover/fallback behavior is unit-tested without the component.
+ */
+export function pickRole(options: RoleOption[], userChoice: string | null): string | null {
+  if (options.length === 0) return null
+  if (userChoice != null && options.some((o) => String(o.roleId) === userChoice)) return userChoice
+  return String(options[0].roleId)
+}

--- a/web/src/components/workflows/query-request-composer.tsx
+++ b/web/src/components/workflows/query-request-composer.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { useRef, useState, type FormEvent } from 'react'
+import { useRef, useState, useEffect, useMemo, type FormEvent } from 'react'
 import { useTranslations } from 'next-intl'
 import { mutate } from 'swr'
 import { toast } from 'sonner'
 import { createApproval, discoverApprovalRoles, ApiError } from '@/lib/api/client'
 import type { AccessRequest, DiscoverRolesResponse } from '@/lib/api/types'
+import { pickRole } from './pick-role'
 import { swrKeys, useAuditEvent, useDatasources } from '@/lib/hooks'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -27,6 +28,9 @@ const OUTCOME_TONE: Record<string, string> = {
   ALLOW: 'text-emerald-600 dark:text-emerald-400',
   MASK: 'text-amber-600 dark:text-amber-400',
 }
+
+/** Wait this long after the query stops changing before re-listing roles, so it is not fetched per keystroke. */
+const DISCOVER_DEBOUNCE_MS = 400
 
 function errorMessage(err: unknown): string {
   if (err instanceof ApiError) {
@@ -64,14 +68,22 @@ export function QueryRequestComposer({
   const [reason, setReason] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
-  const [roleId, setRoleId] = useState<string | null>(null)
-  // The discovery result, tagged with the inputs it was resolved FOR — that pairing is what makes a
-  // stale selection detectable without throwing the selection away on every derived-value flicker.
+  // The role the user explicitly picked, remembered across query changes so it can be RECOVERED when it is
+  // offered again. null = never overridden → the first offered role is selected by default.
+  const [userChoice, setUserChoice] = useState<string | null>(null)
+  // The discovery result, tagged with the inputs it was resolved FOR — that pairing is what makes a stale
+  // result detectable without throwing it away on every derived-value flicker.
   const [discovery, setDiscovery] = useState<
     (DiscoverRolesResponse & { forSql: string; forDatasourceId: number }) | null
   >(null)
-  const [discovering, setDiscovering] = useState(false)
   const [discoverError, setDiscoverError] = useState<string | null>(null)
+  // True while a discovery fetch for the CURRENT query is in flight (debounce + request). It gates a PRIOR
+  // same-query result from reactivating before the fresh fetch lands (a query edited A→B→A back to A would
+  // otherwise show A's earlier options while A is being re-listed), and drives the "checking…" copy.
+  const [discovering, setDiscovering] = useState(false)
+  // Bumped by the Retry control so a discovery that failed for the UNCHANGED query re-runs — the effect's
+  // other deps have not moved, so without this a transient failure would leave the form permanently stuck.
+  const [retryNonce, setRetryNonce] = useState(0)
 
   const fromDenied = sourceDecisionId != null
 
@@ -82,50 +94,70 @@ export function QueryRequestComposer({
     : datasourceId
   const canDiscover = effectiveDatasourceId != null && !!effectiveSql
 
-  // Every discovery bumps this generation counter, so a response is applied only if its generation is
-  // still current — an in-flight request that resolves after a newer one started cannot repopulate options.
+  // Each discovery bumps this generation counter, so a response is applied only if its generation is still
+  // current — an in-flight request that resolves after a newer one (or after the query cleared) cannot
+  // repopulate the list.
   const discoverSeq = useRef(0)
 
-  // Staleness guard: a role may be submitted ONLY if it was discovered for the query being submitted.
-  // Enforced by comparing the discovery's own inputs against the current ones, rather than by resetting
-  // the picker whenever those inputs change — `effectiveSql`/`effectiveDatasourceId` are derived from
-  // fetched data on the from-denied branch, so they legitimately transition through null while SWR
-  // resolves or revalidates, and a reset keyed on them wiped the user's selection for reasons that had
-  // nothing to do with the query changing. Comparing is also the stronger check: it holds even if a
-  // reset were missed, where the reset alone only held if it always fired.
-  const staleDiscovery =
-    discovery != null &&
-    (discovery.forSql !== effectiveSql || discovery.forDatasourceId !== effectiveDatasourceId)
-
-  // A query approval always runs under an elevation role R (execute-under-R), so a role must be picked from
-  // discovery before submitting — there is no requester-run / no-elevation mode.
-  const canSubmit = roleId != null && !staleDiscovery && (fromDenied
-    ? reason.trim().length > 0 && record?.decision === 'DENY'
-    : datasourceId != null && sql.trim().length > 0 && title.trim().length > 0 && reason.trim().length > 0)
-
-  const handleDiscover = async () => {
-    if (!canDiscover) return
-    // Start a fresh generation; drop any prior selection so it can't be submitted against the reload.
+  // Roles are re-listed automatically whenever the query changes, debounced. No manual "check roles" step.
+  useEffect(() => {
+    if (!canDiscover) {
+      discoverSeq.current += 1 // cancel any in-flight response; the render guard already ignores a stale one
+      setDiscovering(false)
+      // Drop the stale list too: restoring the SAME query (A → cleared → A) would otherwise re-offer A's
+      // prior options on the render BEFORE the fresh fetch marks itself in flight — a brief submit window on
+      // outdated options. userChoice is preserved, so the pick recovers when the re-fetch lands.
+      setDiscovery(null)
+      return
+    }
+    const forDatasourceId = effectiveDatasourceId
+    const forSql = effectiveSql
     const seq = (discoverSeq.current += 1)
-    setDiscovery(null)
-    setRoleId(null)
+    // Mark this query's fetch in flight and clear a stale error up front: until it lands, a prior result for
+    // the same query text is not usable, and a leftover error must not mask the fresh "checking…".
     setDiscovering(true)
     setDiscoverError(null)
-    const forDatasourceId = effectiveDatasourceId!
-    const forSql = effectiveSql!
-    try {
-      const res = await discoverApprovalRoles({ datasourceId: forDatasourceId, sql: forSql })
-      if (seq !== discoverSeq.current) return // a newer discovery started → this response is stale
-      setDiscovery({ ...res, forSql, forDatasourceId })
-    } catch {
-      if (seq !== discoverSeq.current) return
-      // Discovery is a non-blocking helper — surface a friendly, actionable message
-      // (you can still submit with no elevation) rather than the raw API error.
-      setDiscoverError(t('queryComposer.discoverFailed'))
-    } finally {
-      if (seq === discoverSeq.current) setDiscovering(false)
-    }
-  }
+    const timer = setTimeout(() => {
+      discoverApprovalRoles({ datasourceId: forDatasourceId, sql: forSql })
+        .then((res) => {
+          if (seq !== discoverSeq.current) return // a newer generation started → this response is stale
+          setDiscovery({ ...res, forSql, forDatasourceId })
+          setDiscovering(false)
+        })
+        .catch(() => {
+          if (seq !== discoverSeq.current) return
+          setDiscovery(null)
+          setDiscoverError(t('queryComposer.discoverFailed'))
+          setDiscovering(false)
+        })
+    }, DISCOVER_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [canDiscover, effectiveSql, effectiveDatasourceId, retryNonce, t])
+
+  // The discovery is usable only if it was resolved FOR the query now being composed. On the from-denied
+  // branch effectiveSql/effectiveDatasourceId transition through null while SWR resolves, so comparing —
+  // rather than resetting on change — is what keeps a valid list from being wiped by a derived-value flicker.
+  const discoveryFresh =
+    discovery != null &&
+    discovery.forSql === effectiveSql &&
+    discovery.forDatasourceId === effectiveDatasourceId
+  // The list is usable only when it matches the current query AND no fetch for it is in flight — the latter is
+  // what stops a prior same-query result from being offered while it is being re-listed.
+  const resolved = discoveryFresh && !discovering
+  const options = useMemo(
+    () => (resolved && discovery ? discovery.options : []),
+    [resolved, discovery],
+  )
+
+  // The selected role: the user's explicit pick while it is still offered (recovered), else the first offered
+  // role. A query change that drops the picked role falls back to the first, without forgetting the pick.
+  const selectedRoleId = useMemo(() => pickRole(options, userChoice), [options, userChoice])
+
+  // A query approval always runs under an elevation role R (execute-under-R), so a role must be selected
+  // before submitting — there is no requester-run / no-elevation mode.
+  const canSubmit = selectedRoleId != null && (fromDenied
+    ? reason.trim().length > 0 && record?.decision === 'DENY'
+    : datasourceId != null && sql.trim().length > 0 && title.trim().length > 0 && reason.trim().length > 0)
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -133,7 +165,7 @@ export function QueryRequestComposer({
     setSubmitting(true)
     setSubmitError(null)
     try {
-      const pickedRoleId = roleId != null ? Number(roleId) : undefined
+      const pickedRoleId = selectedRoleId != null ? Number(selectedRoleId) : undefined
       const res = fromDenied
         ? await createApproval({
             sourceDecisionId: sourceDecisionId!,
@@ -254,49 +286,45 @@ export function QueryRequestComposer({
                 <CardTitle>{t('fields.role')}</CardTitle>
               </CardHeader>
               <CardContent className="space-y-3">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={handleDiscover}
-                  disabled={!canDiscover || discovering}
-                >
-                  {discovering ? t('queryComposer.discovering') : t('queryComposer.discoverRoles')}
-                </Button>
-
-                {discoverError && (
-                  <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-500">
-                    {discoverError}
+                {discoverError ? (
+                  // A failed discovery is not a dead end: since a role must be picked to submit, offer an
+                  // explicit retry for the unchanged query (editing the query re-runs discovery on its own).
+                  <div className="flex items-center justify-between gap-2 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-500">
+                    <span>{discoverError}</span>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setRetryNonce((n) => n + 1)}
+                    >
+                      {t('queryComposer.retry')}
+                    </Button>
                   </div>
-                )}
-
-                {discovery && (
+                ) : options.length > 0 ? (
                   <div className="space-y-1.5">
                     <Label htmlFor="approval-role">{t('fields.role')}</Label>
-                    {/* `value` must be the state itself, INCLUDING null. Passing `undefined` for the
-                        empty case makes the Select uncontrolled, and it then discards every selection —
-                        the picker snapped straight back to its placeholder and nothing could be
-                        submitted. `null` is "controlled, nothing selected"; `undefined` is "not
-                        controlled at all". */}
-                    <Select value={roleId} onValueChange={(value: string | null) => setRoleId(value)}>
+                    {/* `value` must be the state itself, INCLUDING null. Passing `undefined` for the empty
+                        case makes the Select uncontrolled, and it then discards every selection. `null` is
+                        "controlled, nothing selected"; `undefined` is "not controlled at all". */}
+                    <Select value={selectedRoleId} onValueChange={(value: string | null) => setUserChoice(value)}>
                       <SelectTrigger id="approval-role" className="w-full">
-                        {/* The trigger renders the raw value unless given this mapping, which would show
-                            the role's numeric id — the one thing the approver must not misread, since the
-                            request is submitted to run under whichever role this names. */}
+                        {/* The trigger renders the raw value unless given this mapping, which would show the
+                            role's numeric id — the one thing the requester must not misread, since the request
+                            is submitted to run under whichever role this names. */}
                         <SelectValue placeholder={t('queryComposer.selectRole')}>
                           {(value: string | null) =>
-                            discovery.options.find((option) => String(option.roleId) === value)?.roleName ??
+                            options.find((option) => String(option.roleId) === value)?.roleName ??
                             t('queryComposer.selectRole')
                           }
                         </SelectValue>
                       </SelectTrigger>
                       <SelectContent>
-                        {discovery.options.map((option) => (
+                        {options.map((option) => (
                           <SelectItem key={option.roleId} value={String(option.roleId)}>
                             <span className="flex flex-col gap-0.5">
                               <span>{option.roleName}</span>
-                              {/* What the query returns under this role when the workflow executes it —
-                                  the only outcome the request can actually deliver. */}
+                              {/* The outcome under this role, previewed in your context; the approver's
+                                  execution context can narrow it further. */}
                               <span className="text-muted-foreground text-xs">
                                 <span className={OUTCOME_TONE[option.decision]}>
                                   {t(`queryComposer.outcome.${option.decision}`)}
@@ -310,20 +338,11 @@ export function QueryRequestComposer({
                         ))}
                       </SelectContent>
                     </Select>
-
-                    {staleDiscovery ? (
-                      // Submitting is blocked here; say why, so a disabled button is not a dead end.
-                      <p className="text-sm text-amber-500">{t('queryComposer.staleDiscovery')}</p>
-                    ) : (
-                      discovery.options.length === 0 && (
-                        <p className="text-muted-foreground text-sm">
-                          {discovery.baselineAllowed
-                            ? t('queryComposer.alreadyAllowed')
-                            : t('queryComposer.noRolesFound')}
-                        </p>
-                      )
-                    )}
                   </div>
+                ) : (
+                  <p className="text-muted-foreground text-sm">
+                    {resolved ? t('queryComposer.noRolesFound') : t('queryComposer.discovering')}
+                  </p>
                 )}
               </CardContent>
             </Card>

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -389,15 +389,14 @@ export interface DiscoverRolesRequest {
 export interface RoleOption {
   roleId: number
   roleName: string
-  unmasksColumns: string[]
-  /** What the query returns under this role when executed by the workflow — the only outcome the request
-   *  can deliver. `maskedColumns` is empty on a plain ALLOW. */
+  /** What the query returns under this role, PREVIEWED under `{R}` on workflow-executor in the requester's
+   *  context. Execution runs in the approver's context and can mask further, so this is the previewed
+   *  outcome, not a guaranteed one. `maskedColumns` is empty on a plain ALLOW. */
   decision: 'ALLOW' | 'MASK'
   maskedColumns: string[]
 }
 
 export interface DiscoverRolesResponse {
-  baselineAllowed: boolean
   options: RoleOption[]
 }
 


### PR DESCRIPTION
## What

The query-approval composer requires picking an elevation role, but role discovery only
offered roles that beat the requester's own — so a statement already runnable under a held
role offered nothing to pick, and couldn't be taken through the workflow at all.

**List every role the statement runs under.** One entry per role that is not denied under
that role alone, previewed on the `workflow-executor` channel it actually runs on, each
carrying the outcome it delivers (cleartext, or which columns it still masks). No baseline,
no held-vs-not-held concept — assume nothing about the requester's own roles and just list
what can run it.

**Auto-discovered in the console.** The manual "check roles" button is gone. Roles re-list
automatically as the query changes (400ms debounce), the first is selected by default, and
an explicit pick is remembered — if a query change drops that role it falls back to the
first, and it's recovered when the role is offered again.

## Verify

`RoleDiscoveryTest` + the discover→pick→submit route DB test; web eslint / tsc / vitest and
en↔ko i18n parity. Net −68 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Session: https://claude.ai/code/session_017ati9RRaurF1DQ5R4Xz32E