### PR TITLE
fix(web): reload the page on same-window identity changes

### DIFF
--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -5,7 +5,7 @@
 // the dev-only path. Which affordances render is driven by GET /auth/config.
 
 import { Suspense, useState, type FormEvent } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { ShieldHalf } from 'lucide-react'
 import { API_BASE, ApiError } from '@/lib/api/client'
@@ -32,7 +32,6 @@ function LoginInner() {
     no_access: t('errorNoAccess'),
   }
   const { loginDebug } = useAuth()
-  const router = useRouter()
   const params = useSearchParams()
   const next = params.get('next')
   const callbackUrl = params.get('callbackUrl')
@@ -69,7 +68,9 @@ function LoginInner() {
       await loginDebug(principal.trim(), roles, requesterIp.trim())
       const dest =
         callbackUrl === REAUTH_CALLBACK_PATH ? callbackUrl : (returnTo ?? safeInternalPath(next) ?? '/query')
-      router.replace(dest)
+      // Hard-navigate (not router.replace): a full load brings the app up under the new principal with a
+      // fresh SWR cache, so a debug identity switch cannot serve the previous principal's cached responses.
+      window.location.replace(dest)
     } catch (err) {
       // A 404 means one of two different things, so branch on the code rather than the status: the route
       // itself is absent (PM_AUTH_DEBUG off), or a claimed role does not exist — which answers with

--- a/web/src/components/identity-menu.tsx
+++ b/web/src/components/identity-menu.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { Clock3, LogOut, Network, RefreshCw, User } from 'lucide-react'
 import { useAuth } from '@/lib/auth'
@@ -34,7 +33,6 @@ export function IdentityMenu() {
   const { identity, logout } = useAuth()
   const { absoluteExpiresAt } = useSessionLifecycle()
   const [now, setNow] = useState(() => Date.now())
-  const router = useRouter()
 
   useEffect(() => {
     const ticker = setInterval(() => setNow(Date.now()), 1000)
@@ -42,11 +40,6 @@ export function IdentityMenu() {
   }, [])
 
   if (!identity) return null
-
-  const handleLogout = async () => {
-    await logout()
-    router.push('/login')
-  }
 
   return (
     <DropdownMenu>
@@ -91,7 +84,7 @@ export function IdentityMenu() {
           {t('reauthNow')}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
-        <DropdownMenuItem variant="destructive" onClick={handleLogout}>
+        <DropdownMenuItem variant="destructive" onClick={() => void logout()}>
           <LogOut className="size-3.5" />
           {commonT('signOut')}
         </DropdownMenuItem>

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -76,21 +76,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const loginDebug = useCallback(async (principal: string, roles: string[], requesterIp?: string) => {
-    const me = await debugLogin(principal, roles, requesterIp)
+    await debugLogin(principal, roles, requesterIp)
     sessionStorage.setItem(DEBUG_FLAG_KEY, '1')
-    setDebugMode(true)
-    setIdentity(me)
-    setUnauthReason(null)
-    setStatus('authenticated')
+    // The caller hard-navigates into the app (window.location), so it boots fresh under the new principal
+    // with an empty SWR cache. Flipping identity in place instead would keep the previous principal's cached
+    // responses live in the same heap and serve them to this one.
   }, [])
 
   const logout = useCallback(async () => {
     await apiLogout().catch(() => undefined)
     sessionStorage.removeItem(DEBUG_FLAG_KEY)
-    setDebugMode(false)
-    setIdentity(null)
-    setUnauthReason('none')
-    setStatus('unauthenticated')
+    // Hard-reload to /login rather than a client-side route change: discarding the JS heap drops the SWR
+    // cache and every other in-memory copy of the previous principal's data, so nothing survives to the next
+    // sign-in on a shared browser. A soft navigation would keep the heap — and the cache — alive.
+    window.location.replace('/login')
   }, [])
 
   const hasRole = useCallback(

--- a/web/tests/session-routing.spec.ts
+++ b/web/tests/session-routing.spec.ts
@@ -8,7 +8,11 @@ const SESSION_CONFIG = {
   absoluteCapUnit: 'hours',
 }
 
-async function mockAppBootstrap(page: Page, meResponse: { status: number; body: object }) {
+type MeResponse = { status: number; body: object }
+
+// meResponse may be a function so a test can flip /auth/me from 401 to authenticated once a debug login
+// installs the session — the hard navigation after login re-boots the app and re-fetches /auth/me.
+async function mockAppBootstrap(page: Page, meResponse: MeResponse | (() => MeResponse)) {
   await page.route('**/auth/config', (route) =>
     route.fulfill({
       contentType: 'application/json',
@@ -19,13 +23,14 @@ async function mockAppBootstrap(page: Page, meResponse: { status: number; body: 
       }),
     }),
   )
-  await page.route('**/auth/me', (route) =>
+  await page.route('**/auth/me', (route) => {
+    const me = typeof meResponse === 'function' ? meResponse() : meResponse
     route.fulfill({
-      status: meResponse.status,
+      status: me.status,
       contentType: 'application/json',
-      body: JSON.stringify(meResponse.body),
-    }),
-  )
+      body: JSON.stringify(me.body),
+    })
+  })
 }
 
 test('a displaced session lands on the displacement interstitial', async ({ page }) => {
@@ -57,13 +62,17 @@ test('a displaced device login lands on the displacement interstitial', async ({
 })
 
 test('device login authenticates before showing the verification code', async ({ page }) => {
-  await mockAppBootstrap(page, { status: 401, body: { reason: 'none' } })
-  await page.route('**/auth/debug', (route) =>
+  let authed = false
+  await mockAppBootstrap(page, () =>
+    authed ? { status: 200, body: { principal: 'sam@example.com', roles: [] } } : { status: 401, body: { reason: 'none' } },
+  )
+  await page.route('**/auth/debug', (route) => {
+    authed = true
     route.fulfill({
       contentType: 'application/json',
       body: JSON.stringify({ principal: 'sam@example.com', roles: [] }),
-    }),
-  )
+    })
+  })
 
   await page.goto('/device?user_code=abcd-efgh')
 
@@ -112,13 +121,17 @@ test('device confirmation returns to login when the session expires before submi
 })
 
 test('a bare device URL authenticates before allowing manual code entry', async ({ page }) => {
-  await mockAppBootstrap(page, { status: 401, body: { reason: 'none' } })
-  await page.route('**/auth/debug', (route) =>
+  let authed = false
+  await mockAppBootstrap(page, () =>
+    authed ? { status: 200, body: { principal: 'sam@example.com', roles: [] } } : { status: 401, body: { reason: 'none' } },
+  )
+  await page.route('**/auth/debug', (route) => {
+    authed = true
     route.fulfill({
       contentType: 'application/json',
       body: JSON.stringify({ principal: 'sam@example.com', roles: [] }),
-    }),
-  )
+    })
+  })
 
   await page.goto('/device')
 
@@ -229,3 +242,33 @@ for (const locale of ['en', 'ko'] as const) {
     await expect(page.getByText(copy)).toBeVisible()
   })
 }
+
+test('logout fully reloads the page so no in-memory state survives to the next principal', async ({
+  page,
+}) => {
+  // The #203 fix is that identity changes are hard navigations: a full page load discards the JS heap, and
+  // with it SWR's in-memory cache. A stamp on `window` proves the reload happened — a soft router.push would
+  // keep the same document (and the stamp, and the cache), which is exactly the regression to catch.
+  let authed = true
+  await mockAppBootstrap(page, () =>
+    authed ? { status: 200, body: { principal: 'sam@example.com', roles: [] } } : { status: 401, body: { reason: 'none' } },
+  )
+  await page.route('**/auth/logout', (route) => {
+    authed = false
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ ended: true }) })
+  })
+  // Every other authenticated fetch resolves empty so the app shell (and its identity menu) renders.
+  await page.route('**/api/**', (route) => route.fulfill({ contentType: 'application/json', body: '[]' }))
+
+  await page.goto('/query')
+  const menu = page.getByRole('button', { name: /sam@example\.com/ })
+  await expect(menu).toBeVisible()
+  await page.evaluate(() => ((window as unknown as { __pmHeap?: number }).__pmHeap = 1))
+
+  await menu.click()
+  await page.getByRole('menuitem', { name: /sign out/i }).click()
+
+  await expect(page).toHaveURL(/\/login/)
+  const stamp = await page.evaluate(() => (window as unknown as { __pmHeap?: number }).__pmHeap ?? null)
+  expect(stamp).toBeNull()
+})


### PR DESCRIPTION
Fixes #203.

The web console caches authenticated API responses in SWR's in-memory cache,
keyed without a principal. Within one browser, logout and debug login were
client-side (soft) navigations that kept the JS heap — and that cache — alive,
so the next principal was served the previous one's cached data until each entry
revalidated. Demonstrated: principal B saw principal A's cached workflow request.

## Change

Both transitions become hard navigations (`window.location`), so a full page
load discards the heap and the SWR cache with it:

- `logout()` and debug login reload directly.
- OIDC login/logout were already full-page redirects — unchanged.
- The reauth popup is unchanged: it already reloads the opener on a *different*
  principal (closing the cross-principal case) while keeping the main window's
  work for a same-principal re-auth, which is the point of the popup.

## Scope

- `dest` for the login hard-nav is validated internal-only (`safeInternalPath`),
  so no open redirect.
- The SQL editor's `pm.query.*` localStorage (draft, datasource, expanded
  schemas) is a separate per-browser store — tracked in #206, not fixed here.

## Verify

`mise run lint` (0 errors), `tsc`, `vitest`, `next build`. Playwright asserts the
reload on logout and the device debug-login flow; dual-reviewed (codex + Sol +
grok).

Two pre-existing failures in `session-routing.spec.ts` (`a expired/none session
lands on login`) also fail on `main` — a stale `/login$` assertion vs
auth-guard's `/login?next=…` redirect, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
