### PR TITLE
build: bump mysqlwire to v0.1.4 in goproxy and pmon

### DIFF
--- a/goproxy/go.mod
+++ b/goproxy/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/ridi-oss/proxy-monster/analyzer v0.0.0-00010101000000-000000000000
-	github.com/ridi-oss/proxy-monster/mysqlwire v0.1.3
+	github.com/ridi-oss/proxy-monster/mysqlwire v0.1.4
 	github.com/testcontainers/testcontainers-go v0.44.0
 	golang.org/x/crypto v0.54.0
 	google.golang.org/grpc v1.83.0

--- a/pmon/go.mod
+++ b/pmon/go.mod
@@ -2,13 +2,13 @@ module github.com/ridi-oss/proxy-monster/pmon
 
 go 1.26.0
 
-require github.com/ridi-oss/proxy-monster/mysqlwire v0.1.3
+require github.com/ridi-oss/proxy-monster/mysqlwire v0.1.4
 
 require (
 	github.com/alecthomas/kong v1.16.0
 	github.com/docker/docker v27.1.1+incompatible
-	github.com/docker/go-connections v0.8.1
 	github.com/go-sql-driver/mysql v1.10.0
+	github.com/moby/moby/api v1.55.0
 	github.com/testcontainers/testcontainers-go v0.44.0
 )
 
@@ -26,6 +26,7 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/go-connections v0.8.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.1 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
@@ -38,7 +39,6 @@ require (
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
-	github.com/moby/moby/api v1.55.0 // indirect
 	github.com/moby/moby/client v0.5.0 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/sys/sequential v0.7.0 // indirect

--- a/pmon/go.sum
+++ b/pmon/go.sum
@@ -96,10 +96,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/ridi-oss/proxy-monster/mysqlwire v0.1.2 h1:KM/b7PfadLw0drVrTU+/34eTJLLBRbIEfsPhp4+bzds=
-github.com/ridi-oss/proxy-monster/mysqlwire v0.1.2/go.mod h1:yielY+j1TFdAdh9cn7WGFUwUtLwligQEwpO7Xmfvinc=
-github.com/ridi-oss/proxy-monster/mysqlwire v0.1.3 h1:5y6bdfCt13vpp5LLx5j7e6WgZ9nR3wa0LXTWz1Kh4SQ=
-github.com/ridi-oss/proxy-monster/mysqlwire v0.1.3/go.mod h1:yielY+j1TFdAdh9cn7WGFUwUtLwligQEwpO7Xmfvinc=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.4 h1:bVwRAl9ant7hGM2fZtcONKTzsZQ0kOZeRpOGjUNLMso=
+github.com/ridi-oss/proxy-monster/mysqlwire v0.1.4/go.mod h1:yielY+j1TFdAdh9cn7WGFUwUtLwligQEwpO7Xmfvinc=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/shirou/gopsutil/v4 v4.26.6 h1:Mzr/npDtQC/xpeEuQKHZt8Zo9CmPvhTj8nkR8w5TLDs=


### PR DESCRIPTION
Bumps the `mysqlwire` dependency to `v0.1.4` (released in #218, carrying the `ColumnDefinition` parsing from #205) in the server (`goproxy`) and client (`pmon`) modules.

- **pmon** resolves the published module directly (no `replace`), so its `GOWORK=off` release build needs the `require` + `go.sum` bump — done via `go get`.
- **goproxy** sources mysqlwire from a local `replace => ../mysqlwire`; the `require` is aligned to the released version for documentation.

Verify: `GOWORK=off go build ./...` passes in both `pmon` and `goproxy`; `go test ./goproxy/mysqlproxy` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)