### PR TITLE
fix(analyzer): allow VALUES() in INSERT … ON DUPLICATE KEY UPDATE

### DIFF
--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -37,6 +37,18 @@ var safeNoFromFunctions = stringSet(
 	"iif", "if", "typeof", "pg_typeof",
 )
 
+// mysqlOnlySafeFunctions are safe no-FROM function names that exist ONLY on MySQL. `values` is MySQL's
+// INSERT … ON DUPLICATE KEY UPDATE pseudo-function — it names the value that would have been inserted, not a
+// callable function, and its lineage is traced in probe.go. PostgreSQL has no `values` builtin, so keeping
+// it out of the cross-engine set leaves a quoted PostgreSQL `"values"()` (a user function) gated.
+var mysqlOnlySafeFunctions = stringSet("values")
+
+// isSafeNoFromFunction reports whether a bare (unqualified) anonymous function name is a known-safe builtin
+// that needs no no-FROM Function grant — the cross-engine set plus any engine-specific pseudo-functions.
+func isSafeNoFromFunction(name string, eng engine) bool {
+	return safeNoFromFunctions[name] || (eng.Type() == pb.Engine_MYSQL && mysqlOnlySafeFunctions[name])
+}
+
 // userTypeCast returns the name of the first reference to a non-built-in (user) type anywhere in root, or
 // "" if every type reference is a safe built-in. sqlglot resolves a built-in type to a concrete DType and
 // a user type to DTypeUserDefined, so this is a single AST pass over DataType nodes. It covers every way a
@@ -675,7 +687,7 @@ func noFromFunctionGrants(root exp.Expression, eng engine) []*pb.RequireResultRe
 			continue
 		}
 		name := strings.ToLower(fn.Name())
-		if safeNoFromFunctions[name] {
+		if isSafeNoFromFunction(name, eng) {
 			continue
 		}
 		emit(name)
@@ -775,7 +787,7 @@ func hasUnsafeCall(root exp.Expression, eng engine) bool {
 			continue
 		}
 		name := strings.ToLower(fn.Name())
-		if name != "" && name != "*" && !safeNoFromFunctions[name] {
+		if name != "" && name != "*" && !isSafeNoFromFunction(name, eng) {
 			return true
 		}
 	}

--- a/analyzer/probe/function_facts_test.go
+++ b/analyzer/probe/function_facts_test.go
@@ -127,6 +127,76 @@ func TestFormerDangerousFuncsResolveAndEmit(t *testing.T) {
 	}
 }
 
+// deniedColumns returns the set of column names emitted as DENY_STATEMENT result-read grants.
+func deniedColumns(f *pb.StatementFacts) map[string]bool {
+	out := map[string]bool{}
+	for _, g := range f.GetResultReads() {
+		if c := g.GetColumn(); c != nil && g.GetMaskedDisposition() == pb.MaskedDisposition_MASKED_DISPOSITION_DENY_STATEMENT {
+			out[c.GetIdentity().GetColumn()] = true
+		}
+	}
+	return out
+}
+
+// TestOdkuValuesIsNotAFunctionGrant locks two things about MySQL's `INSERT … ON DUPLICATE KEY UPDATE
+// col = VALUES(col)`. First, `VALUES()` there is not a callable function — it names the value that would
+// have been inserted — so the upsert must resolve and must NOT emit the deny-by-default Function grant that
+// noFromFunctionGrants gives an unclassified no-FROM call (a regression there re-denies every plain upsert
+// with "dangerous system function is not allowed: 'values'"). Second — and separately — making the
+// pseudo-function safe must NOT weaken write-side gating: every column VALUES() names is still a
+// DENY_STATEMENT grant, so a masked column cannot slip through the write payload unauthorized.
+func TestOdkuValuesIsNotAFunctionGrant(t *testing.T) {
+	sql := "INSERT INTO users (id, email, ssn) VALUES (1, 'x', 'y') ON DUPLICATE KEY UPDATE email = VALUES(email), ssn = VALUES(ssn)"
+	f := mysqlFacts(t, sql)
+	if !f.Resolved {
+		t.Fatalf("upsert did not resolve: detail=%q", f.GetDetail())
+	}
+	for _, g := range f.GetResultReads() {
+		if fn := g.GetFunction(); fn != nil && fn.GetName() == "values" {
+			t.Fatalf("VALUES() emitted a Function grant (control-plane hard-denies it): %q", sql)
+		}
+	}
+	denied := deniedColumns(f)
+	for _, col := range []string{"email", "ssn"} {
+		if !denied[col] {
+			t.Fatalf("VALUES(%s) column is not gated DENY_STATEMENT — masking could be bypassed: reads=%v", col, f.GetResultReads())
+		}
+	}
+}
+
+// TestOdkuInsertSelectRetainsSourceLineage locks that the source of an INSERT … SELECT upsert stays gated
+// even with a `VALUES(col)` in the update clause: a protected source column read by the SELECT must still be
+// a DENY_STATEMENT grant, so the safe pseudo-function never masks the read side of a write-from-select.
+func TestOdkuInsertSelectRetainsSourceLineage(t *testing.T) {
+	sql := "INSERT INTO sink (id, value) SELECT id, ssn FROM users ON DUPLICATE KEY UPDATE value = VALUES(value)"
+	f := mysqlFacts(t, sql)
+	if !f.Resolved {
+		t.Fatalf("insert-select upsert did not resolve: detail=%q", f.GetDetail())
+	}
+	if !deniedColumns(f)["ssn"] {
+		t.Fatalf("protected source column users.ssn is not gated DENY_STATEMENT: reads=%v", f.GetResultReads())
+	}
+}
+
+// TestPostgresQuotedValuesStaysGated locks that `values` is safe ONLY on MySQL. PostgreSQL has no `values`
+// builtin, so a quoted `"values"()` is a user function and must still emit a no-FROM Function grant the
+// control-plane denies — the MySQL ODKU allowance must not leak into PostgreSQL.
+func TestPostgresQuotedValuesStaysGated(t *testing.T) {
+	f := postgresFacts(t, `SELECT "values"()`)
+	if !f.Resolved {
+		t.Fatalf(`SELECT "values"() did not resolve: detail=%q`, f.GetDetail())
+	}
+	gated := false
+	for _, g := range f.GetResultReads() {
+		if fn := g.GetFunction(); fn != nil && fn.GetName() == "values" {
+			gated = true
+		}
+	}
+	if !gated {
+		t.Fatalf(`PostgreSQL "values"() must emit a Function grant (a user function is gated): reads=%v`, f.GetResultReads())
+	}
+}
+
 func probeFunctions(t *testing.T, sql, dialect string, cols []*pb.ColumnSpec, ns *pb.Namespace) ([]string, bool) {
 	t.Helper()
 	engineConfig := &pb.EngineConfig{Engine: pb.Engine_POSTGRES}

--- a/analyzer/probe/parity_test.go
+++ b/analyzer/probe/parity_test.go
@@ -95,7 +95,7 @@ func probeParityCases() []probeParityCase {
 		// not leaks. Listed explicitly rather than silently absent; skipped by the harness
 		// deferred branch.
 		{name: "table valued function source", dialect: "postgres", sql: "SELECT g FROM generate_series(1, 10) g", category: "parser gap", deferredReason: "TVF as standalone FROM source not parsed by the Go parser; Go PARSE-fails=DENY vs Python resolves"},
-		{name: "mysql on duplicate key update", dialect: "mysql", sql: "INSERT INTO sink (id, data) VALUES (1, 'x') ON DUPLICATE KEY UPDATE data = VALUES(data)", category: "parser gap", deferredReason: "MySQL ON DUPLICATE KEY UPDATE ... VALUES(col) not parsed; Go PARSE-fails=DENY vs Python resolves"},
+		{name: "mysql on duplicate key update", dialect: "mysql", sql: "INSERT INTO sink (id, data) VALUES (1, 'x') ON DUPLICATE KEY UPDATE data = VALUES(data)", category: "resolution strictness", deferredReason: "MySQL ODKU VALUES(col) now parses and resolves for known columns (TestOdkuValuesIsNotAFunctionGrant); this case's `data` is absent from the schema, so Go fails closed at VALIDATE where Python resolves the unknown column leniently"},
 		{name: "similar to operator", dialect: "postgres", sql: "SELECT ssn FROM users WHERE ssn SIMILAR TO 'x%'", category: "parser gap", deferredReason: "SIMILAR TO operator not parsed by the Go parser; Go PARSE-fails=DENY vs Python resolves"},
 	}
 }


### PR DESCRIPTION
## What

MySQL `INSERT … ON DUPLICATE KEY UPDATE col = VALUES(col)` was denied with *"dangerous system function is not allowed: 'values'"*.

A literal-`VALUES` INSERT scans no source table, so `noFromFunctionGrants` treated the ODKU `VALUES(col)` pseudo-function (parsed as an anonymous function named `values`) as an unclassified no-FROM call and emitted a deny-by-default Function grant. `VALUES()` there is not a callable function — it names the value that would have been inserted.

## Fix

`values` is added to a new **MySQL-only** safe set (`mysqlOnlySafeFunctions`), so the upsert resolves instead of being denied. It is deliberately *not* cross-engine: PostgreSQL has no `values` builtin, so a quoted `"values"()` user function stays gated there.

The columns `VALUES()` names are still traced and emitted as `DENY_STATEMENT` grants — masking is never bypassed on the write payload. Tests lock: no `values` Function grant, the write columns stay `DENY_STATEMENT` (kills the mutant of dropping the lineage loop), an `INSERT … SELECT` upsert keeps its source lineage, and PostgreSQL `"values"()` stays function-gated.

Also corrects a now-stale `parity_test.go` entry that claimed the Go parser can't parse ODKU `VALUES(col)` (it can — it fails only on an unknown column, fail-closed).

## Verify

`go test ./probe -count=1`, `go vet`, `go build` — all green. Reviewed by dual-review (three reviewers); the MySQL-only scoping and the column-gating test assertions came out of that pass.

Known, out-of-scope residual (unchanged threat model): a same-named user function is the documented same-named-UDF limitation — creating a `SECURITY DEFINER` function is a privileged act already outside proxy-monster's threat model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ati9RRaurF1DQ5R4Xz32E
