### PR TITLE
fix: uncorrupt Slack reason links + one Approve & run button

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/i18n/MessageCatalog.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/i18n/MessageCatalog.kt
@@ -21,7 +21,12 @@ class MessageCatalog(
     /** [key] in [locale], falling back to the default locale, then English, then the key itself. */
     fun text(key: String, locale: String, params: Map<String, String> = emptyMap()): String {
         val raw = lookup(locale, key) ?: lookup(defaultLocale, key) ?: lookup(FALLBACK, key) ?: return key
-        return params.entries.fold(raw) { acc, (k, v) -> acc.replace("{$k}", v) }
+        // Single pass over the TEMPLATE: each {placeholder} is resolved from params, and a substituted value is
+        // never re-scanned. A sequential replace would let one field's value smuggle another field's
+        // placeholder — a requester's free-text reason containing "{statementNote}" would expand to that field
+        // (second-order injection into a message rendered beside the real Approve button). An unknown
+        // placeholder is left as written.
+        return PLACEHOLDER.replace(raw) { m -> params[m.groupValues[1]] ?: m.value }
     }
 
     private fun lookup(locale: String, key: String): String? {
@@ -37,6 +42,9 @@ class MessageCatalog(
 
     companion object {
         const val FALLBACK = "en"
+
+        /** One `{placeholder}` token. `[^{}]+` never spans a brace, so a substituted value is not a new token. */
+        private val PLACEHOLDER = Regex("""\{([^{}]+)\}""")
 
         /** The locales every domain must provide a file for — the l10n invariant is enforced by [load]. */
         val LOCALES = listOf("en", "ko")

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationRenderer.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationRenderer.kt
@@ -34,7 +34,10 @@ class NotificationRenderer(private val catalog: MessageCatalog = MessageCatalog(
         // layout (line breaks and field order) rather than code assembling it piece by piece.
         val reason = m.reason
             ?.takeIf { it.isNotBlank() && m.event == NotificationEvent.TASK_REQUESTED }
-            ?.let { "\n" + catalog.text("field.reason", locale, mapOf("reason" to escapeMrkdwn(it.take(REASON_MAX_CHARS)))) }
+            // `field.reason` renders as a Slack blockquote (`> …`); carry the quote onto every wrapped line so a
+            // multi-line reason stays inside it. A blockquote is per line, so — unlike italic — it never glues a
+            // formatting mark onto a bare URL and corrupts the link.
+            ?.let { "\n" + catalog.text("field.reason", locale, mapOf("reason" to escapeMrkdwn(it.take(REASON_MAX_CHARS)).replace("\n", "\n> "))) }
             ?: ""
         // The receipt's approver list is `<@id>` mentions resolved by the transport. In the requester's OWN DM,
         // where no approver is a member, they render as names without pinging anyone — so, like requester and

--- a/control-plane/src/main/resources/messages/en/notifications.json
+++ b/control-plane/src/main/resources/messages/en/notifications.json
@@ -16,7 +16,7 @@
   },
   "field": {
     "role": " as *{role}*",
-    "reason": "_{reason}_",
+    "reason": "> {reason}",
     "statement_hidden": "a query",
     "statement_hidden_note": "_The statement is not shown here. Open the request to read it._",
     "notified": "Notified for approval: {notified}"

--- a/control-plane/src/main/resources/messages/ko/notifications.json
+++ b/control-plane/src/main/resources/messages/ko/notifications.json
@@ -16,7 +16,7 @@
   },
   "field": {
     "role": " (역할: *{role}*)",
-    "reason": "_{reason}_",
+    "reason": "> {reason}",
     "statement_hidden": "쿼리",
     "statement_hidden_note": "_전체 구문은 여기에 표시되지 않습니다. 요청을 열어 확인하세요._",
     "notified": "승인 알림 대상: {notified}"

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationRendererTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationRendererTest.kt
@@ -111,6 +111,54 @@ class NotificationRendererTest {
         assertTrue(summary.count { it == 'Z' } <= 500, "reason contributed ${summary.count { it == 'Z' }} chars, expected ≤ 500")
     }
 
+    /**
+     * A reason that is a bare URL must survive intact. Slack cannot italicize a URL — the enclosing `_…_` would
+     * render literally and glue onto the auto-linked href — so the reason is set off with a blockquote instead.
+     */
+    @Test
+    fun `a url reason is not corrupted by surrounding formatting`() {
+        val url = "https://example.com/pull/1234"
+        // Every locale's field.reason must be a blockquote, so reverting one locale's template to italic fails.
+        for (locale in MessageCatalog.LOCALES) {
+            val summary = renderer.summary(
+                message(NotificationEvent.TASK_REQUESTED, RenderedStatement("SELECT 1", true)).copy(reason = url),
+                locale,
+            )
+            assertTrue(summary.contains("> $url"), "[$locale] the reason is a blockquote with the URL intact: $summary")
+            assertFalse(summary.contains("_$url"), "[$locale] no italic mark glued onto the URL: $summary")
+            assertFalse(summary.contains("${url}_"), "[$locale] no trailing italic mark absorbed into the link: $summary")
+        }
+    }
+
+    /** A multi-line reason stays inside the blockquote — every line carries the `>` marker, in every locale. */
+    @Test
+    fun `a multi-line reason stays quoted on every line`() {
+        for (locale in MessageCatalog.LOCALES) {
+            val summary = renderer.summary(
+                message(NotificationEvent.TASK_REQUESTED, RenderedStatement("SELECT 1", true)).copy(reason = "line one\n\nline two"),
+                locale,
+            )
+            // A blank line in the middle also stays quoted — no un-prefixed line escapes the blockquote.
+            assertTrue(summary.contains("> line one\n> \n> line two"), "[$locale] every line incl. blank is quoted: $summary")
+        }
+    }
+
+    /**
+     * A requester's reason must not smuggle another field's placeholder. With a naive sequential substitution,
+     * a reason containing "{statementNote}" expanded into that field's value — which begins with a newline —
+     * breaking out of the reason's blockquote into unquoted, attacker-controlled mrkdwn beside the real
+     * Approve button. Single-pass substitution keeps the placeholder literal.
+     */
+    @Test
+    fun `a reason cannot expand another field's placeholder`() {
+        val summary = renderer.summary(
+            // A withheld statement makes statementNote non-empty — the field the injection would target.
+            message(NotificationEvent.TASK_REQUESTED, RenderedStatement(null, false)).copy(reason = "INJECT{statementNote}END"),
+            "en",
+        )
+        assertTrue(summary.contains("> INJECT{statementNote}END"), "the placeholder stays literal and quoted: $summary")
+    }
+
     /** A requester's SQL must not close the code fence and inject forged prose beside the real buttons. */
     @Test
     fun `a statement cannot break out of its code fence`() {

--- a/web/messages/en/workflows.json
+++ b/web/messages/en/workflows.json
@@ -5,6 +5,8 @@
     "submitting": "Submitting…",
     "approve": "Approve",
     "approving": "Approving…",
+    "approveAndRun": "Approve & run",
+    "approvingAndRunning": "Approving & running…",
     "reject": "Reject",
     "rejecting": "Rejecting…",
     "revoke": "Revoke",
@@ -176,10 +178,11 @@
   },
   "approveDialog": {
     "approveFailed": "approve failed",
-    "approvedToast": "Approved query request from {principal}",
-    "title": "Approve query request",
-    "descriptionWithPrincipal": "Approve {principal}'s query request.",
-    "descriptionFallback": "Approve this query request.",
+    "approveAndRunToast": "Approved {principal}'s request — running it now.",
+    "approvedRunFailed": "Approved, but the run could not be started. Use Run query to retry.",
+    "title": "Approve & run query request",
+    "descriptionWithPrincipal": "Approve {principal}'s query request and run it under the requested role.",
+    "descriptionFallback": "Approve this query request and run it under the requested role.",
     "executeUnderRNote": "Once approved, an approver runs the query under the requested role and releases the result — the requester never sees more than that role would."
   },
   "tokenDialog": {

--- a/web/messages/ko/workflows.json
+++ b/web/messages/ko/workflows.json
@@ -5,6 +5,8 @@
     "submitting": "제출 중…",
     "approve": "승인",
     "approving": "승인 중…",
+    "approveAndRun": "승인 후 실행",
+    "approvingAndRunning": "승인·실행 중…",
     "reject": "반려",
     "rejecting": "반려 중…",
     "revoke": "회수",
@@ -176,10 +178,11 @@
   },
   "approveDialog": {
     "approveFailed": "승인에 실패했습니다",
-    "approvedToast": "{principal}의 쿼리 요청을 승인했습니다",
-    "title": "쿼리 요청 승인",
-    "descriptionWithPrincipal": "{principal}님의 쿼리 요청을 승인합니다.",
-    "descriptionFallback": "이 쿼리 요청을 승인합니다.",
+    "approveAndRunToast": "{principal}의 요청을 승인하고 실행합니다.",
+    "approvedRunFailed": "승인했지만 실행을 시작하지 못했습니다. 쿼리 실행으로 다시 시도하세요.",
+    "title": "쿼리 요청 승인 후 실행",
+    "descriptionWithPrincipal": "{principal}님의 쿼리 요청을 승인하고 요청된 역할로 실행합니다.",
+    "descriptionFallback": "이 쿼리 요청을 승인하고 요청된 역할로 실행합니다.",
     "executeUnderRNote": "승인되면 승인자가 요청된 역할로 쿼리를 실행하고 결과를 공개합니다. 요청자는 해당 역할이 볼 수 있는 범위 이상을 볼 수 없습니다."
   },
   "tokenDialog": {

--- a/web/src/components/approvals/approval-detail.tsx
+++ b/web/src/components/approvals/approval-detail.tsx
@@ -172,6 +172,10 @@ export function ApprovalDetail({ id }: { id: number }) {
       refresh()
     } catch (err) {
       toast.error(err instanceof Error ? err.message : t('approvalDetail.runFailed'))
+      // A run can commit (APPROVED → EXECUTING) server-side and still fail the response. Refresh so a stale
+      // APPROVED view does not re-enable Run and invite a duplicate submit; the server's CAS is the real
+      // guard, this keeps the UI honest.
+      refresh()
     } finally {
       setBusy(null)
     }
@@ -231,8 +235,12 @@ export function ApprovalDetail({ id }: { id: number }) {
                 >
                   {t('actions.reject')}
                 </Button>
-                <Button onClick={() => setApproveOpen(true)} disabled={busy !== null}>
-                  {t('actions.approve')}
+                <Button
+                  onClick={() => setApproveOpen(true)}
+                  disabled={busy !== null}
+                  className="bg-emerald-600 text-white hover:bg-emerald-700"
+                >
+                  {t('actions.approveAndRun')}
                 </Button>
               </div>
             )}
@@ -299,7 +307,11 @@ export function ApprovalDetail({ id }: { id: number }) {
                   <p className="text-muted-foreground text-sm">
                     {t('approvalDetail.runUnderRole', { principal: request.principal })}
                   </p>
-                  <Button onClick={handleRun} disabled={busy !== null}>
+                  <Button
+                    onClick={handleRun}
+                    disabled={busy !== null}
+                    className="bg-emerald-600 text-white hover:bg-emerald-700"
+                  >
                     {busy === 'run' ? t('actions.running') : t('actions.runQuery')}
                   </Button>
                 </div>

--- a/web/src/components/approvals/approve-query-dialog.tsx
+++ b/web/src/components/approvals/approve-query-dialog.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { mutate } from 'swr'
 import { toast } from 'sonner'
-import { approveApproval, ApiError } from '@/lib/api/client'
+import { approveApproval, executeApproval, ApiError } from '@/lib/api/client'
 import type { AccessRequest } from '@/lib/api/types'
 import { swrKeys } from '@/lib/hooks'
 import { Button } from '@/components/ui/button'
@@ -48,22 +48,36 @@ export function ApproveQueryDialog({
     if (!open && !busy) onClose()
   }
 
-  const handleApprove = async () => {
+  // Approve and run are one action here, mirroring the Slack "Approve and run" button: the approver is
+  // always the executor (the query runs under the requested role, execute-under-R), so approving without
+  // running would just strand the task waiting for a second click. Approval is committed first; if only the
+  // run fails, the request stays APPROVED and the detail's Run button lets the approver retry.
+  const handleApproveAndRun = async () => {
     if (!request) return
     setBusy(true)
     setError(null)
     try {
       await approveApproval(request.id)
-      toast.success(t('approveDialog.approvedToast', { principal: request.principal }))
-      mutate(swrKeys.approvalInbox)
-      mutate(swrKeys.approval(request.id))
-      onApproved?.()
-      onClose()
     } catch (err) {
       setError(errorMessage(err, t))
-    } finally {
       setBusy(false)
+      return
     }
+    try {
+      await executeApproval(request.id)
+      toast.success(t('approveDialog.approveAndRunToast', { principal: request.principal }))
+    } catch (err) {
+      // Approval already committed; surface the run's REAL localized error (e.g. no result store, deleted
+      // datasource) rather than a blanket "retry" line that may not be actionable. The detail refresh below
+      // reflects the true state — the Run button appears only when a retry is actually available.
+      toast.error(err instanceof ApiError ? errorMessage(err, t) : t('approveDialog.approvedRunFailed'))
+    }
+    mutate(swrKeys.approvalInbox)
+    mutate(swrKeys.approval(request.id))
+    mutate(['approval-result', request.id])
+    onApproved?.()
+    onClose()
+    setBusy(false)
   }
 
   return (
@@ -90,8 +104,12 @@ export function ApproveQueryDialog({
           <Button variant="outline" onClick={onClose} disabled={busy}>
             {t('actions.cancel')}
           </Button>
-          <Button onClick={handleApprove} disabled={busy}>
-            {busy ? t('actions.approving') : t('actions.approve')}
+          <Button
+            onClick={handleApproveAndRun}
+            disabled={busy}
+            className="bg-emerald-600 text-white hover:bg-emerald-700"
+          >
+            {busy ? t('actions.approvingAndRunning') : t('actions.approveAndRun')}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## What

Two console/notification fixes for the Slack approval flow.

**1. Slack notification: a URL reason rendered corrupted.** A requester's reason was wrapped in Slack italic (`_…_`); Slack can't italicize a bare URL, so the underscores rendered literally and glued onto the auto-linked href — corrupting the shown text and the link target. The `field.reason` template is now a blockquote (`> {reason}`), applied per line so it never touches a URL.

While there, `MessageCatalog.text` is made **single-pass**: a substituted value is never re-scanned, so a requester's reason can no longer smuggle another field's placeholder (`{statementNote}`) and have it expand into unquoted mrkdwn beside the Approve button.

**2. Web console: one "Approve & run" button.** The approver is always the executor (execute-under-R; there is no requester-exec mode), so the old approve-then-separately-run split just stranded the task on a second click. A single green **"Approve & run"** button mirrors the Slack action (deny in red). A run failure surfaces the real localized error instead of a blanket retry line, and both run paths refresh so a stale view can't re-enable a duplicate submit.

## Review

Dual-reviewed (three reviewers). Acted on the union: the second-order placeholder injection (single-pass), the swallowed run error + false retry promise, the duplicate-run refresh, locale-coverage of the reason tests, and a stale i18n key. Declined, with reasoning: `verbatim: true` on the section (would break the intended `<@id>` mentions *and* URL linking; the real `<!channel>`/`<@U>`/`<url|label>` vectors are already neutralized by escaping `<>`, and the residual is a no-amplification 1:1 DM); a component test for the two-request flow (the repo has no jsdom/RTL env — component state machines are covered by review here, per `pick-role.test.ts`).

## Verify

`:control-plane:test` for NotificationRendererTest + MessageCatalogTest green; the injection regression test fails on the pre-fix sequential fold (verified). i18n key parity holds across en/ko.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ati9RRaurF1DQ5R4Xz32E
