### PR TITLE
build(release): recognize revert-type commits + cut server 0.1.21

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,10 @@
       "section": "Bug Fixes"
     },
     {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
       "type": "perf",
       "section": "Performance"
     },


### PR DESCRIPTION
Adds a `revert` changelog section so a `revert:` commit is releasable (the #202 revert in #227 was not). This file is root-scoped, so the Release-As targets the **server** component.

Release-As: 0.1.21