### PR TITLE
fix(pmon): harden daemon control lifecycle

### DIFF
--- a/pmon/cli_test.go
+++ b/pmon/cli_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -13,11 +14,45 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ridi-oss/proxy-monster/pmon/control"
+	"github.com/ridi-oss/proxy-monster/pmon/singleinstance"
+	"github.com/ridi-oss/proxy-monster/pmon/state"
 )
 
 // End-to-end tests over the REAL binary and a REAL spawned daemon, so the peer-symmetry claims are exercised
 // through the actual control socket rather than an in-process fake: the CLI starts a daemon, logs in through
 // it, reads status, renders connection strings, and stops it.
+
+func daemonRunning(t *testing.T) bool {
+	t.Helper()
+	instance, err := state.DaemonInstance()
+	if err != nil {
+		t.Fatalf("DaemonInstance: %v", err)
+	}
+	running, err := instance.Client().Running(context.Background())
+	if err != nil {
+		t.Fatalf("daemon running: %v", err)
+	}
+	return running
+}
+
+func acquireDaemonLock(t *testing.T) *singleinstance.Daemon {
+	t.Helper()
+	if _, err := state.EnsureDir(); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	instance, err := state.DaemonInstance()
+	if err != nil {
+		t.Fatalf("DaemonInstance: %v", err)
+	}
+	lock, acquired, err := instance.Acquire(context.Background())
+	if err != nil || !acquired {
+		t.Fatalf("Acquire = %t, %v; want true, nil", acquired, err)
+	}
+	t.Cleanup(func() { _ = lock.Close() })
+	return lock
+}
 
 // buildPmon compiles the binary once per test run and returns its path.
 //
@@ -384,6 +419,230 @@ func TestRestartKeepsStickyPortsAndPassword(t *testing.T) {
 	after := strings.TrimSpace(e.mustRun(t, "show", "acme-mysql"))
 	if before != after {
 		t.Errorf("connection string changed across a restart:\n before %q\n after  %q", before, after)
+	}
+}
+
+func TestLifecycleCommandsUsePidLockWhenControlSocketIsUnreachable(t *testing.T) {
+	e := newEnv(t)
+	e.mustRun(t, "start")
+
+	t.Setenv("PMON_CONFIG_DIR", e.stateDir)
+	sock, err := state.SocketPath()
+	if err != nil {
+		t.Fatalf("SocketPath: %v", err)
+	}
+	if err := os.Rename(sock, sock+".unreachable"); err != nil {
+		t.Fatalf("hide daemon socket before restart: %v", err)
+	}
+	if out := e.mustRun(t, "status"); !strings.Contains(out, "running, control socket unreachable") {
+		t.Errorf("status with unreachable socket = %q, want the live daemon reported", out)
+	}
+	if out, err := e.run("start"); err == nil || !strings.Contains(out, "run `pmon restart`") {
+		t.Errorf("start with unreachable socket = %q, %v; want restart guidance", out, err)
+	}
+	if out := e.mustRun(t, "restart"); !strings.Contains(out, "left the daemon running") {
+		t.Errorf("restart without --force = %q, want the daemon preserved", out)
+	}
+	out := e.mustRun(t, "restart", "--force")
+	if !strings.Contains(out, "restarted") {
+		t.Errorf("restart with unreachable socket = %q, want a confirmation", out)
+	}
+
+	if err := os.Rename(sock, sock+".unreachable-after-restart"); err != nil {
+		t.Fatalf("hide daemon socket before stop: %v", err)
+	}
+	if out := e.mustRun(t, "stop"); !strings.Contains(out, "left the daemon running") {
+		t.Errorf("stop without --force = %q, want the daemon preserved", out)
+	}
+	if out := e.mustRun(t, "stop", "--force"); !strings.Contains(out, "stopped") {
+		t.Errorf("stop with unreachable socket = %q, want a confirmation", out)
+	}
+	if out := e.mustRun(t, "status"); !strings.Contains(out, "not running") {
+		t.Errorf("status after stop = %q, want the daemon stopped", out)
+	}
+}
+
+func TestForcedStopRejectsReplacementControlSocketAndUsesPidLock(t *testing.T) {
+	e := newEnv(t)
+	e.mustRun(t, "start")
+
+	t.Setenv("PMON_CONFIG_DIR", e.stateDir)
+	sock, err := state.SocketPath()
+	if err != nil {
+		t.Fatalf("SocketPath: %v", err)
+	}
+	if err := os.Rename(sock, sock+".real"); err != nil {
+		t.Fatalf("hide daemon socket: %v", err)
+	}
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen on replacement control socket: %v", err)
+	}
+	requests := make(chan string, 1)
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	if out := e.mustRun(t, "stop", "--force"); !strings.Contains(out, "stopped") {
+		t.Errorf("forced stop through replacement socket = %q, want stopped", out)
+	}
+	if daemonRunning(t) {
+		t.Fatal("forced stop left the real daemon running")
+	}
+	select {
+	case path := <-requests:
+		t.Fatalf("forced stop sent %q to the replacement control socket", path)
+	default:
+	}
+}
+
+func TestLifecycleCommandsPreserveDaemonWhenStatusCannotBeRead(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		failStatus func(int) bool
+	}{
+		{name: "connect", failStatus: func(int) bool { return true }},
+		{name: "follow-up read", failStatus: func(read int) bool { return read%2 == 0 }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newEnv(t)
+			t.Setenv("PMON_CONFIG_DIR", e.stateDir)
+			acquireDaemonLock(t)
+			sock, err := state.SocketPath()
+			if err != nil {
+				t.Fatalf("SocketPath: %v", err)
+			}
+			ln, err := net.Listen("unix", sock)
+			if err != nil {
+				t.Fatalf("listen on control socket: %v", err)
+			}
+			shutdown := make(chan struct{}, 1)
+			statusReads := 0
+			srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case control.PathStatus:
+					statusReads++
+					if tc.failStatus(statusReads) {
+						http.Error(w, "status unavailable", http.StatusInternalServerError)
+						return
+					}
+					_ = json.NewEncoder(w).Encode(control.Status{})
+				case control.PathShutdown:
+					shutdown <- struct{}{}
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					http.NotFound(w, r)
+				}
+			})}
+			go func() { _ = srv.Serve(ln) }()
+			t.Cleanup(func() { _ = srv.Close() })
+
+			for _, command := range []string{"stop", "restart"} {
+				if out := e.mustRun(t, command); !strings.Contains(out, "left the daemon running") {
+					t.Errorf("%s with unreadable status = %q, want the daemon preserved", command, out)
+				}
+				select {
+				case <-shutdown:
+					t.Fatalf("%s sent shutdown without --force", command)
+				default:
+				}
+			}
+		})
+	}
+}
+
+func TestLifecycleCommandsHandleDaemonExitBetweenStatusReads(t *testing.T) {
+	for _, tc := range []struct {
+		command string
+		want    string
+	}{
+		{command: "stop", want: "not running"},
+		{command: "restart", want: "restarted"},
+	} {
+		t.Run(tc.command, func(t *testing.T) {
+			e := newEnv(t)
+			t.Setenv("PMON_CONFIG_DIR", e.stateDir)
+			lock := acquireDaemonLock(t)
+			sock, err := state.SocketPath()
+			if err != nil {
+				t.Fatalf("SocketPath: %v", err)
+			}
+			ln, err := net.Listen("unix", sock)
+			if err != nil {
+				t.Fatalf("listen on control socket: %v", err)
+			}
+			exitResult := make(chan error, 1)
+			srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != control.PathStatus {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Connection", "close")
+				exitResult <- lock.Close()
+				_ = ln.Close()
+				_ = json.NewEncoder(w).Encode(control.Status{})
+			})}
+			go func() { _ = srv.Serve(ln) }()
+			t.Cleanup(func() { _ = srv.Close() })
+
+			out := e.mustRun(t, tc.command)
+			select {
+			case err := <-exitResult:
+				if err != nil {
+					t.Fatalf("release daemon lock: %v", err)
+				}
+			default:
+				t.Fatal("lifecycle command never reached the daemon status handler")
+			}
+			if !strings.Contains(out, tc.want) {
+				t.Errorf("%s after daemon exit = %q, want %q", tc.command, out, tc.want)
+			}
+			if strings.Contains(out, "left the daemon running") {
+				t.Errorf("%s after daemon exit falsely preserved it: %q", tc.command, out)
+			}
+		})
+	}
+}
+
+func TestLifecycleCommandsPreserveDaemonWhenControlSocketIsReplaced(t *testing.T) {
+	for _, command := range []string{"stop", "restart"} {
+		t.Run(command, func(t *testing.T) {
+			e := newEnv(t)
+			e.mustRun(t, "start")
+
+			t.Setenv("PMON_CONFIG_DIR", e.stateDir)
+			sock, err := state.SocketPath()
+			if err != nil {
+				t.Fatalf("SocketPath: %v", err)
+			}
+			if err := os.Rename(sock, sock+".real"); err != nil {
+				t.Fatalf("hide daemon socket: %v", err)
+			}
+			ln, err := net.Listen("unix", sock)
+			if err != nil {
+				t.Fatalf("listen on replacement control socket: %v", err)
+			}
+			srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != control.PathStatus {
+					http.NotFound(w, r)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(control.Status{})
+			})}
+			go func() { _ = srv.Serve(ln) }()
+			t.Cleanup(func() { _ = srv.Close() })
+
+			out := e.mustRun(t, command)
+			if !strings.Contains(out, "left the daemon running") {
+				t.Errorf("%s with a replacement control socket = %q, want the daemon preserved", command, out)
+			}
+			if !daemonRunning(t) {
+				t.Errorf("%s stopped the daemon without confirmation", command)
+			}
+		})
 	}
 }
 

--- a/pmon/control/client.go
+++ b/pmon/control/client.go
@@ -13,9 +13,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync/atomic"
 	"syscall"
 	"time"
 
+	"github.com/ridi-oss/proxy-monster/pmon/singleinstance"
 	"github.com/ridi-oss/proxy-monster/pmon/state"
 )
 
@@ -23,42 +25,109 @@ import (
 // failing: a stopped daemon is a normal state, and the peer offers to start one.
 var ErrDaemonNotRunning = errors.New("the pmon daemon is not running")
 
+// ErrDaemonUnreachable reports that the pid lock is held but no daemon answers at the current control socket.
+var ErrDaemonUnreachable = errors.New("the pmon daemon is running but its control socket is unreachable; run `pmon restart`")
+
+// ErrDaemonReplaced reports that the original stop target exited but another daemon took its place.
+var ErrDaemonReplaced = errors.New("the pmon daemon changed while stopping; another daemon is still running")
+
+const controlRequestTimeout = 2 * time.Second
+
 // Client speaks the control API over the daemon's unix socket.
 type Client struct {
-	http *http.Client
+	http      *http.Client
+	loginHTTP *http.Client
 }
 
 // NewClient dials the socket lazily per request — so a Client constructed while the daemon is down starts
 // working the moment one comes up, with no reconstruction.
 func NewClient() (*Client, error) {
+	return newClient(0)
+}
+
+func newClient(expectedOwnerPID int) (*Client, error) {
 	sockets, err := state.SocketPaths()
 	if err != nil {
 		return nil, err
 	}
-	return &Client{http: &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				var dialErr error
-				for _, socket := range sockets {
-					var d net.Dialer
-					conn, err := d.DialContext(ctx, "unix", socket)
-					if err != nil {
-						dialErr = err
-						if ctx.Err() != nil || !isDialFailure(err) {
-							return nil, err
-						}
-						continue
+	transport := &http.Transport{
+		DisableKeepAlives:     true,
+		ResponseHeaderTimeout: controlRequestTimeout,
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var dialErr error
+			for _, socket := range sockets {
+				var d net.Dialer
+				conn, err := d.DialContext(ctx, "unix", socket)
+				if err != nil {
+					dialErr = err
+					if ctx.Err() != nil || !isDialFailure(err) {
+						return nil, err
 					}
-					return conn, nil
+					continue
 				}
-				return nil, dialErr
-			},
+				peerPID, err := verifyDaemonPeer(ctx, conn)
+				if err != nil {
+					return nil, errors.Join(err, conn.Close())
+				}
+				if expectedOwnerPID != 0 && peerPID != expectedOwnerPID {
+					return nil, errors.Join(
+						fmt.Errorf("the daemon changed from pid %d to pid %d", expectedOwnerPID, peerPID),
+						conn.Close(),
+					)
+				}
+				return conn, nil
+			}
+			return nil, dialErr
 		},
-	}}, nil
+	}
+	loginTransport := transport.Clone()
+	loginTransport.ResponseHeaderTimeout = 0
+	return &Client{
+		http:      &http.Client{Transport: transport},
+		loginHTTP: &http.Client{Transport: loginTransport},
+	}, nil
+}
+
+func daemonSingleton() (*singleinstance.Client, error) {
+	instance, err := state.DaemonInstance()
+	if err != nil {
+		return nil, err
+	}
+	return instance.Client(), nil
+}
+
+func verifyDaemonPeer(ctx context.Context, conn net.Conn) (int, error) {
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return 0, fmt.Errorf("control socket returned %T, not a Unix connection", conn)
+	}
+	peerPID, err := socketPeerPID(unixConn)
+	if err != nil {
+		return 0, fmt.Errorf("could not identify the control-socket peer: %w", err)
+	}
+	singleton, err := daemonSingleton()
+	if err != nil {
+		return 0, fmt.Errorf("could not identify the daemon lock owner: %w", err)
+	}
+	owner, err := singleton.Owner(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("could not identify the daemon lock owner: %w", err)
+	}
+	if owner == nil {
+		return 0, ErrDaemonNotRunning
+	}
+	if peerPID != owner.PID() {
+		return 0, fmt.Errorf("control-socket peer pid %d does not own the daemon lock held by pid %d", peerPID, owner.PID())
+	}
+	return peerPID, nil
 }
 
 // do issues a control request. A dial failure becomes [ErrDaemonNotRunning] so callers branch on one error.
 func (c *Client) do(ctx context.Context, method, path string, body any) (*http.Response, error) {
+	return c.doWith(c.http, ctx, method, path, body)
+}
+
+func (c *Client) doWith(client *http.Client, ctx context.Context, method, path string, body any) (*http.Response, error) {
 	var rdr io.Reader
 	if body != nil {
 		buf, err := json.Marshal(body)
@@ -75,9 +144,9 @@ func (c *Client) do(ctx context.Context, method, path string, body any) (*http.R
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := c.http.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
-		if isDialFailure(err) {
+		if errors.Is(err, ErrDaemonNotRunning) || isDialFailure(err) {
 			return nil, ErrDaemonNotRunning
 		}
 		return nil, err
@@ -107,6 +176,8 @@ func isDialFailure(err error) bool {
 
 // Status fetches the daemon's current state.
 func (c *Client) Status(ctx context.Context) (*Status, error) {
+	ctx, cancel := context.WithTimeout(ctx, controlRequestTimeout)
+	defer cancel()
 	resp, err := c.do(ctx, http.MethodGet, PathStatus, nil)
 	if err != nil {
 		return nil, err
@@ -122,7 +193,7 @@ func (c *Client) Status(ctx context.Context) (*Status, error) {
 // Login runs a device-auth flow in the daemon, calling onEvent for each streamed step. It returns when the
 // flow finishes; a "done" event means the daemon is logged in and its brokers are coming up.
 func (c *Client) Login(ctx context.Context, req LoginRequest, onEvent func(LoginEvent)) error {
-	resp, err := c.do(ctx, http.MethodPost, PathLogin, req)
+	resp, err := c.doWith(c.loginHTTP, ctx, http.MethodPost, PathLogin, req)
 	if err != nil {
 		return err
 	}
@@ -150,6 +221,8 @@ func (c *Client) Login(ctx context.Context, req LoginRequest, onEvent func(Login
 
 // Logout clears the stored credentials and closes every broker, leaving the daemon running and idle.
 func (c *Client) Logout(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, controlRequestTimeout)
+	defer cancel()
 	resp, err := c.do(ctx, http.MethodPost, PathLogout, nil)
 	if err != nil {
 		return err
@@ -160,6 +233,8 @@ func (c *Client) Logout(ctx context.Context) error {
 
 // Reload forces an immediate rediscovery instead of waiting for the next cycle.
 func (c *Client) Reload(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, controlRequestTimeout)
+	defer cancel()
 	resp, err := c.do(ctx, http.MethodPost, PathReload, nil)
 	if err != nil {
 		return err
@@ -171,9 +246,19 @@ func (c *Client) Reload(ctx context.Context) error {
 // Shutdown asks the daemon to exit gracefully. The daemon closes the connection as it goes, so a dial/EOF
 // error after the request was accepted is success, not failure.
 func (c *Client) Shutdown(ctx context.Context) error {
+	err := c.shutdown(ctx)
+	if errors.Is(err, ErrDaemonNotRunning) {
+		return nil
+	}
+	return err
+}
+
+func (c *Client) shutdown(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, controlRequestTimeout)
+	defer cancel()
 	resp, err := c.do(ctx, http.MethodPost, PathShutdown, nil)
 	if err != nil {
-		if errors.Is(err, ErrDaemonNotRunning) || errors.Is(err, io.EOF) {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		return err
@@ -182,16 +267,45 @@ func (c *Client) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-// Events streams daemon state changes until ctx ends or the daemon exits, calling onEvent for each. A
-// returning Events means the daemon is gone or shutting down — which is how a peer learns to render "not
-// running" without polling.
+var errEventStreamIdle = errors.New("the daemon event stream stopped responding")
+
+const eventStreamIdleTimeout = 2 * defaultEventKeepalive
+
+type idleTimeoutReader struct {
+	body    io.ReadCloser
+	timeout time.Duration
+}
+
+func (r idleTimeoutReader) Read(p []byte) (int, error) {
+	var timedOut atomic.Bool
+	timerDone := make(chan struct{})
+	timer := time.AfterFunc(r.timeout, func() {
+		timedOut.Store(true)
+		_ = r.body.Close()
+		close(timerDone)
+	})
+	n, err := r.body.Read(p)
+	if !timer.Stop() {
+		<-timerDone
+	}
+	if timedOut.Load() && n == 0 {
+		return 0, fmt.Errorf("%w after %s", errEventStreamIdle, r.timeout)
+	}
+	return n, err
+}
+
+// Events streams daemon state changes until ctx ends or the daemon stops responding.
 func (c *Client) Events(ctx context.Context, onEvent func(Event)) error {
+	return c.events(ctx, onEvent, eventStreamIdleTimeout)
+}
+
+func (c *Client) events(ctx context.Context, onEvent func(Event), idleTimeout time.Duration) error {
 	resp, err := c.do(ctx, http.MethodGet, PathEvents, nil)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	sc := bufio.NewScanner(resp.Body)
+	sc := bufio.NewScanner(idleTimeoutReader{body: resp.Body, timeout: idleTimeout})
 	sc.Buffer(make([]byte, 0, 8192), 1<<20)
 	for sc.Scan() {
 		line := bytes.TrimSpace(sc.Bytes())
@@ -212,6 +326,12 @@ func (c *Client) Events(ctx context.Context, onEvent func(Event)) error {
 // daemonStartTimeout bounds how long a peer waits for a freshly spawned daemon to answer on its socket.
 const daemonStartTimeout = 10 * time.Second
 
+// daemonStartRaceGrace lets a concurrently starting daemon bind before it is reported unreachable.
+const daemonStartRaceGrace = time.Second
+
+const daemonGracefulShutdownTimeout = 10 * time.Second
+const daemonSignalRaceGrace = time.Second
+
 // EnsureDaemon returns a client to a live daemon, starting one if none is running. Both peers call this, so
 // start-if-needed has exactly one implementation.
 //
@@ -223,12 +343,40 @@ func EnsureDaemon(ctx context.Context) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := c.Status(ctx); err == nil {
+	_, statusErr := c.Status(ctx)
+	if statusErr == nil {
 		return c, nil
-	} else if !errors.Is(err, ErrDaemonNotRunning) {
-		return nil, err
 	}
-	if err := StartDaemon(); err != nil {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
+	singleton, err := daemonSingleton()
+	if err != nil {
+		return nil, fmt.Errorf("could not inspect the daemon lock: %w", err)
+	}
+	running, err := singleton.Running(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not inspect the daemon lock: %w", err)
+	}
+	if running {
+		if err := waitForDaemon(ctx, c, daemonStartRaceGrace); err == nil {
+			return c, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		running, err = singleton.Running(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("could not recheck the daemon lock: %w", err)
+		}
+		if running {
+			if errors.Is(statusErr, ErrDaemonNotRunning) {
+				return nil, ErrDaemonUnreachable
+			}
+			return nil, fmt.Errorf("%w: %w", ErrDaemonUnreachable, statusErr)
+		}
+	}
+	if err := StartDaemon(ctx); err != nil {
 		return nil, err
 	}
 	if err := waitForDaemon(ctx, c, daemonStartTimeout); err != nil {
@@ -244,8 +392,37 @@ func Connect(ctx context.Context) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := c.Status(ctx); err != nil {
-		return nil, err
+	if _, statusErr := c.Status(ctx); statusErr != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		singleton, err := daemonSingleton()
+		if err != nil {
+			return nil, fmt.Errorf("could not inspect the daemon lock: %w", err)
+		}
+		running, err := singleton.Running(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("could not inspect the daemon lock: %w", err)
+		}
+		if running {
+			if err := waitForDaemon(ctx, c, daemonStartRaceGrace); err == nil {
+				return c, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			running, err = singleton.Running(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("could not recheck the daemon lock: %w", err)
+			}
+			if running {
+				if errors.Is(statusErr, ErrDaemonNotRunning) {
+					return nil, ErrDaemonUnreachable
+				}
+				return nil, fmt.Errorf("%w: %w", ErrDaemonUnreachable, statusErr)
+			}
+		}
+		return nil, statusErr
 	}
 	return c, nil
 }
@@ -377,7 +554,10 @@ func trustedPathComponent(path, what string) error {
 // [waitForDaemon]). Detached is required, not incidental: the peer that starts the daemon exits immediately
 // (a CLI command returns; a tray may be quit), and the daemon must outlive it. So process-tree death is never
 // the stop mechanism — stopping is always an explicit [Client.Shutdown].
-func StartDaemon() error {
+func StartDaemon(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	exe, err := DaemonBinary()
 	if err != nil {
 		return err
@@ -395,6 +575,9 @@ func StartDaemon() error {
 	// New session: the daemon must not die with the peer's process group, nor take its controlling terminal
 	// signals (a Ctrl-C in the shell that ran `pmon login` must not kill the daemon).
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("could not start the daemon: %w", err)
 	}
@@ -403,59 +586,103 @@ func StartDaemon() error {
 
 // waitForDaemon polls the socket until the daemon answers or the timeout expires.
 func waitForDaemon(ctx context.Context, c *Client, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 	for {
-		if _, err := c.Status(ctx); err == nil {
+		if _, err := c.Status(waitCtx); err == nil {
 			return nil
 		}
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		if time.Now().After(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-waitCtx.Done():
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			logHint := ""
-			if p, e := state.LogPath(); e == nil {
+			if p, err := state.LogPath(); err == nil {
 				logHint = fmt.Sprintf(" (see %s)", p)
 			}
 			return fmt.Errorf("the daemon did not come up within %s%s", timeout, logHint)
+		case <-time.After(50 * time.Millisecond):
 		}
-		time.Sleep(50 * time.Millisecond)
 	}
 }
 
 // StopDaemon stops a running daemon, falling back to SIGTERM when the control socket is unreachable but the
 // pid lock shows a daemon alive (a wedged or half-crashed daemon still has to be stoppable).
 func StopDaemon(ctx context.Context) error {
-	c, err := NewClient()
+	singleton, err := daemonSingleton()
+	if err != nil {
+		return fmt.Errorf("could not identify the running daemon: %w", err)
+	}
+	owner, err := singleton.Owner(ctx)
+	if err != nil {
+		return fmt.Errorf("could not identify the running daemon: %w", err)
+	}
+	if owner == nil {
+		return ErrDaemonNotRunning
+	}
+	c, err := newClient(owner.PID())
 	if err != nil {
 		return err
 	}
-	if err := c.Shutdown(ctx); err == nil {
-		return waitForExit(ctx, 10*time.Second)
-	}
-	if !state.DaemonRunning() {
-		return ErrDaemonNotRunning
-	}
-	pid := state.DaemonPid()
-	if pid <= 0 {
-		return fmt.Errorf("a daemon is running but its pid is unreadable; stop it by hand")
-	}
-	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
-		return fmt.Errorf("could not signal the daemon (pid %d): %w", pid, err)
-	}
-	return waitForExit(ctx, 10*time.Second)
-}
-
-// waitForExit waits for the pid lock to free, which is the daemon's true exit (the socket may linger).
-func waitForExit(ctx context.Context, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
-	for state.DaemonRunning() {
+	graceful := c.shutdown(ctx) == nil
+	if !graceful {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("the daemon did not exit within %s", timeout)
+	}
+	if graceful {
+		err := waitForOwnerExit(ctx, owner, daemonGracefulShutdownTimeout)
+		if err == nil || errors.Is(err, ErrDaemonReplaced) {
+			return err
 		}
-		time.Sleep(50 * time.Millisecond)
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	current, err := owner.Current(ctx)
+	if errors.Is(err, singleinstance.ErrOwnerReplaced) {
+		return ErrDaemonReplaced
+	}
+	if err != nil {
+		return fmt.Errorf("could not revalidate the running daemon: %w", err)
+	}
+	if !current {
+		return nil
+	}
+	if err := owner.Signal(ctx, syscall.SIGTERM); err != nil {
+		if errors.Is(err, singleinstance.ErrOwnerReplaced) {
+			return ErrDaemonReplaced
+		}
+		return handleDaemonSignalError(ctx, owner, fmt.Errorf("could not signal the daemon (pid %d): %w", owner.PID(), err))
+	}
+	return waitForOwnerExit(ctx, owner, daemonGracefulShutdownTimeout)
+}
+
+func handleDaemonSignalError(ctx context.Context, owner *singleinstance.Owner, err error) error {
+	if !errors.Is(err, syscall.ESRCH) {
+		return err
+	}
+	if waitErr := waitForOwnerExit(ctx, owner, daemonSignalRaceGrace); waitErr != nil {
+		return errors.Join(err, waitErr)
 	}
 	return nil
+}
+
+func waitForOwnerExit(ctx context.Context, owner *singleinstance.Owner, timeout time.Duration) error {
+	err := owner.WaitExit(ctx, timeout)
+	switch {
+	case err == nil:
+		return nil
+	case ctx.Err() != nil:
+		return ctx.Err()
+	case errors.Is(err, singleinstance.ErrOwnerReplaced):
+		return ErrDaemonReplaced
+	case errors.Is(err, singleinstance.ErrOwnerExitTimeout):
+		return fmt.Errorf("the daemon did not exit within %s", timeout)
+	default:
+		return fmt.Errorf("could not inspect the daemon lock: %w", err)
+	}
 }

--- a/pmon/control/control_test.go
+++ b/pmon/control/control_test.go
@@ -13,8 +13,32 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ridi-oss/proxy-monster/pmon/singleinstance"
 	"github.com/ridi-oss/proxy-monster/pmon/state"
 )
+
+var daemonLockForTest *singleinstance.Daemon
+
+func acquireDaemonLock(ctx context.Context) (bool, error) {
+	if _, err := state.EnsureDir(); err != nil {
+		return false, err
+	}
+	instance, err := state.DaemonInstance()
+	if err != nil {
+		return false, err
+	}
+	lock, acquired, err := instance.Acquire(ctx)
+	if err == nil && acquired {
+		daemonLockForTest = lock
+	}
+	return acquired, err
+}
+
+func releaseDaemonLock() error {
+	lock := daemonLockForTest
+	daemonLockForTest = nil
+	return lock.Close()
+}
 
 // unixHTTPClient is a raw HTTP client over the control socket, for asserting transport-level behavior the
 // typed Client deliberately hides.
@@ -107,6 +131,15 @@ func (f *fakeBackend) counts() (login, logout, reload, shutdown int) {
 func serve(t *testing.T, backend Backend) *Client {
 	t.Helper()
 	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	held, err := acquireDaemonLock(context.Background())
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
+	}
+	t.Cleanup(func() {
+		if err := releaseDaemonLock(); err != nil {
+			t.Errorf("ReleasePidLock: %v", err)
+		}
+	})
 
 	srv, err := Listen(backend)
 	if err != nil {
@@ -187,11 +220,11 @@ func TestNewClientReachesReleasedDaemonPath(t *testing.T) {
 	if _, err := state.EnsureDir(); err != nil {
 		t.Fatalf("EnsureDir: %v", err)
 	}
-	held, err := state.AcquirePidLock()
+	held, err := acquireDaemonLock(context.Background())
 	if err != nil || !held {
 		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
 	}
-	t.Cleanup(state.ReleasePidLock)
+	t.Cleanup(func() { _ = releaseDaemonLock() })
 	paths, err := state.SocketPaths()
 	if err != nil {
 		t.Fatalf("SocketPaths: %v", err)
@@ -240,11 +273,11 @@ func TestBlockedReleasedPathDoesNotDisableCanonicalSocket(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(paths[1], "blocked"), nil, 0o600); err != nil {
 		t.Fatalf("seed blocked released path: %v", err)
 	}
-	held, err := state.AcquirePidLock()
+	held, err := acquireDaemonLock(context.Background())
 	if err != nil || !held {
 		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
 	}
-	t.Cleanup(state.ReleasePidLock)
+	t.Cleanup(func() { _ = releaseDaemonLock() })
 
 	server, err := Listen(newFakeBackend())
 	if err != nil {
@@ -657,7 +690,7 @@ func TestStartDaemonUsesTheResolvedBinary(t *testing.T) {
 	}
 	t.Setenv(daemonBinaryEnv, stub)
 
-	if err := StartDaemon(); err != nil {
+	if err := StartDaemon(context.Background()); err != nil {
 		t.Fatalf("StartDaemon: %v", err)
 	}
 	deadline := time.Now().Add(5 * time.Second)

--- a/pmon/control/control_test.go
+++ b/pmon/control/control_test.go
@@ -1,11 +1,15 @@
 package control
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -40,6 +44,31 @@ func releaseDaemonLock() error {
 	return lock.Close()
 }
 
+func runningDaemonPID(ctx context.Context) (int, bool, error) {
+	instance, err := state.DaemonInstance()
+	if err != nil {
+		return 0, false, err
+	}
+	owner, err := instance.Client().Owner(ctx)
+	if err != nil || owner == nil {
+		return 0, false, err
+	}
+	return owner.PID(), true, nil
+}
+
+func currentDaemonOwner(t *testing.T) *singleinstance.Owner {
+	t.Helper()
+	instance, err := state.DaemonInstance()
+	if err != nil {
+		t.Fatalf("DaemonInstance: %v", err)
+	}
+	owner, err := instance.Client().Owner(context.Background())
+	if err != nil || owner == nil {
+		t.Fatalf("Owner = %#v, %v; want owner", owner, err)
+	}
+	return owner
+}
+
 // unixHTTPClient is a raw HTTP client over the control socket, for asserting transport-level behavior the
 // typed Client deliberately hides.
 func unixHTTPClient(sock string) *http.Client {
@@ -62,6 +91,8 @@ type fakeBackend struct {
 	shutdowns    int
 	loginEvents  []LoginEvent
 	loginErr     error
+	loginStarted chan struct{}
+	loginRelease <-chan struct{}
 	events       chan Event
 	subscribed   int
 	unsubscribed int
@@ -80,11 +111,22 @@ func (f *fakeBackend) Status() Status {
 	return f.status
 }
 
-func (f *fakeBackend) Login(_ context.Context, _ LoginRequest, onEvent func(LoginEvent)) error {
+func (f *fakeBackend) Login(ctx context.Context, _ LoginRequest, onEvent func(LoginEvent)) error {
 	f.mu.Lock()
 	f.loginCalls++
 	evs, err := f.loginEvents, f.loginErr
+	started, release := f.loginStarted, f.loginRelease
 	f.mu.Unlock()
+	if started != nil {
+		close(started)
+	}
+	if release != nil {
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 	for _, ev := range evs {
 		onEvent(ev)
 	}
@@ -368,8 +410,879 @@ func TestClientReportsDaemonNotRunning(t *testing.T) {
 	}
 }
 
-// TestLoginStreamsPromptBeforeDone is the property that lets both peers show the verification code while the
-// flow is still running: events arrive incrementally, not batched at the end.
+func TestOwnerPinnedClientRejectsReplacementPeerBeforeRequest(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	held, err := acquireDaemonLock(context.Background())
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
+	}
+	t.Cleanup(func() { _ = releaseDaemonLock() })
+	sock, err := state.SocketPath()
+	if err != nil {
+		t.Fatalf("SocketPath: %v", err)
+	}
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	requested := make(chan struct{}, 1)
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requested <- struct{}{}
+		_ = json.NewEncoder(w).Encode(Status{})
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	client, err := newClient(os.Getpid() + 1)
+	if err != nil {
+		t.Fatalf("newClient: %v", err)
+	}
+	if _, err := client.Status(context.Background()); err == nil || !strings.Contains(err.Error(), "daemon changed") {
+		t.Fatalf("Status through a replacement peer = %v, want daemon-changed error", err)
+	}
+	select {
+	case <-requested:
+		t.Fatal("owner-pinned client sent a request to the replacement peer")
+	default:
+	}
+}
+
+func TestStopDaemonHonorsCanceledContextBeforePidFallback(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := StopDaemon(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("StopDaemon with a canceled context = %v, want context.Canceled", err)
+	}
+}
+
+func TestConnectHonorsContextWhilePidPublicationIsStalled(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	if _, err := state.EnsureDir(); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	pidPath, err := state.PidPath()
+	if err != nil {
+		t.Fatalf("PidPath: %v", err)
+	}
+	transitionFile, err := os.OpenFile(pidPath+".transition", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open transition lock: %v", err)
+	}
+	if err := syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		transitionFile.Close()
+		t.Fatalf("lock transition: %v", err)
+	}
+	t.Cleanup(func() {
+		syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_UN)
+		transitionFile.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	if _, err := Connect(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Connect while pid publication is stalled = %v, want context deadline exceeded", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("Connect took %s, want at most 1s", elapsed)
+	}
+}
+
+func TestWaitForOwnerExitHonorsDeadlineWhilePidPublicationIsStalled(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	held, err := acquireDaemonLock(context.Background())
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
+	}
+	t.Cleanup(func() { _ = releaseDaemonLock() })
+	owner := currentDaemonOwner(t)
+	pidPath, err := state.PidPath()
+	if err != nil {
+		t.Fatalf("PidPath: %v", err)
+	}
+	transitionFile, err := os.OpenFile(pidPath+".transition", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open transition lock: %v", err)
+	}
+	if err := syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		transitionFile.Close()
+		t.Fatalf("lock transition: %v", err)
+	}
+	t.Cleanup(func() {
+		syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_UN)
+		transitionFile.Close()
+	})
+
+	const timeout = 100 * time.Millisecond
+	started := time.Now()
+	err = waitForOwnerExit(context.Background(), owner, timeout)
+	if err == nil || !strings.Contains(err.Error(), "did not exit within") {
+		t.Fatalf("waitForOwnerExit while pid publication is stalled = %v, want timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("waitForOwnerExit took %s, want at most 1s", elapsed)
+	}
+}
+
+func TestWaitForOwnerExitRetriesPidLockOperationTimeout(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	held, err := acquireDaemonLock(context.Background())
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
+	}
+	owner := currentDaemonOwner(t)
+	released := false
+	t.Cleanup(func() {
+		if !released {
+			_ = releaseDaemonLock()
+		}
+	})
+	pidPath, err := state.PidPath()
+	if err != nil {
+		t.Fatalf("PidPath: %v", err)
+	}
+	transitionFile, err := os.OpenFile(pidPath+".transition", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open transition lock: %v", err)
+	}
+	if err := syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		transitionFile.Close()
+		t.Fatalf("lock transition: %v", err)
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		result <- waitForOwnerExit(context.Background(), owner, 4*time.Second)
+	}()
+	time.Sleep(2200 * time.Millisecond)
+	if err := syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatalf("unlock transition: %v", err)
+	}
+	if err := transitionFile.Close(); err != nil {
+		t.Fatalf("close transition: %v", err)
+	}
+	if err := releaseDaemonLock(); err != nil {
+		t.Fatalf("ReleasePidLock: %v", err)
+	}
+	released = true
+
+	if err := <-result; err != nil {
+		t.Fatalf("waitForOwnerExit after an internal pid-lock timeout = %v, want nil", err)
+	}
+}
+
+func TestDaemonSignalErrorAcceptsAnExitedDaemon(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	held, err := acquireDaemonLock(context.Background())
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
+	}
+	owner := currentDaemonOwner(t)
+	if err := releaseDaemonLock(); err != nil {
+		t.Fatalf("ReleasePidLock: %v", err)
+	}
+	err = handleDaemonSignalError(context.Background(), owner, fmt.Errorf("signal: %w", syscall.ESRCH))
+	if err != nil {
+		t.Fatalf("handleDaemonSignalError after lock release = %v, want nil", err)
+	}
+}
+
+func TestDaemonSignalErrorDoesNotHideALiveOwner(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	held, err := acquireDaemonLock(context.Background())
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
+	}
+	t.Cleanup(func() { _ = releaseDaemonLock() })
+	owner := currentDaemonOwner(t)
+
+	err = handleDaemonSignalError(context.Background(), owner, fmt.Errorf("signal: %w", syscall.ESRCH))
+	if err == nil || !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("handleDaemonSignalError with a live owner = %v, want ESRCH", err)
+	}
+}
+
+func TestDaemonSignalErrorPreservesOtherFailures(t *testing.T) {
+	want := errors.New("signal failed")
+	if got := handleDaemonSignalError(context.Background(), nil, want); !errors.Is(got, want) {
+		t.Fatalf("handleDaemonSignalError = %v, want %v", got, want)
+	}
+}
+
+const foregroundDaemonHelperEnv = "PMON_CONTROL_FOREGROUND_DAEMON_HELPER"
+
+func TestStopDaemonSignalsForegroundLockOwner(t *testing.T) {
+	configDir := t.TempDir()
+	command := exec.Command(os.Args[0], "-test.run=^TestForegroundDaemonLockHelper$")
+	command.Env = append(os.Environ(),
+		"PMON_CONFIG_DIR="+configDir,
+		foregroundDaemonHelperEnv+"=1",
+	)
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		t.Fatalf("helper stdout: %v", err)
+	}
+	if err := command.Start(); err != nil {
+		t.Fatalf("start foreground daemon helper: %v", err)
+	}
+	waited := false
+	t.Cleanup(func() {
+		if waited {
+			return
+		}
+		_ = command.Process.Kill()
+		_, _ = command.Process.Wait()
+	})
+
+	if line, err := bufio.NewReader(stdout).ReadString('\n'); err != nil || line != "ready\n" {
+		t.Fatalf("foreground daemon helper readiness = %q, %v", line, err)
+	}
+	pid := command.Process.Pid
+	pgid, err := syscall.Getpgid(pid)
+	if err != nil {
+		t.Fatalf("Getpgid(%d): %v", pid, err)
+	}
+	if pgid != pid {
+		t.Fatalf("foreground daemon helper does not lead its process group: pid=%d pgid=%d", pid, pgid)
+	}
+	t.Setenv("PMON_CONFIG_DIR", configDir)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := StopDaemon(ctx); err != nil {
+		t.Fatalf("StopDaemon against a foreground lock owner: %v", err)
+	}
+	_ = command.Wait()
+	waited = true
+}
+
+func TestForegroundDaemonLockHelper(t *testing.T) {
+	if os.Getenv(foregroundDaemonHelperEnv) == "" {
+		return
+	}
+	held, err := acquireDaemonLock(context.Background())
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
+	}
+	if _, err := os.Stdout.WriteString("ready\n"); err != nil {
+		t.Fatalf("write readiness: %v", err)
+	}
+	select {}
+}
+
+const gracefulShutdownHelperEnv = "PMON_CONTROL_GRACEFUL_SHUTDOWN_HELPER"
+
+func TestStopDaemonLetsGracefulShutdownFinish(t *testing.T) {
+	configDir := t.TempDir()
+	command := exec.Command(os.Args[0], "-test.run=^TestGracefulShutdownHelper$")
+	command.Env = append(os.Environ(),
+		"PMON_CONFIG_DIR="+configDir,
+		gracefulShutdownHelperEnv+"=1",
+	)
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		t.Fatalf("helper stdout: %v", err)
+	}
+	if err := command.Start(); err != nil {
+		t.Fatalf("start graceful shutdown helper: %v", err)
+	}
+	waited := false
+	t.Cleanup(func() {
+		if waited {
+			return
+		}
+		_ = command.Process.Kill()
+		_, _ = command.Process.Wait()
+	})
+	if line, err := bufio.NewReader(stdout).ReadString('\n'); err != nil || line != "ready\n" {
+		t.Fatalf("graceful shutdown helper readiness = %q, %v", line, err)
+	}
+
+	t.Setenv("PMON_CONFIG_DIR", configDir)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := StopDaemon(ctx); err != nil {
+		t.Fatalf("StopDaemon during graceful cleanup: %v", err)
+	}
+	if err := command.Wait(); err != nil {
+		t.Fatalf("graceful shutdown helper was signaled before cleanup finished: %v", err)
+	}
+	waited = true
+}
+
+func TestGracefulShutdownHelper(t *testing.T) {
+	if os.Getenv(gracefulShutdownHelperEnv) == "" {
+		return
+	}
+	held, err := acquireDaemonLock(context.Background())
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
+	}
+	sock, err := state.SocketPath()
+	if err != nil {
+		t.Fatalf("SocketPath: %v", err)
+	}
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "stopping"})
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		go func() {
+			time.Sleep(1500 * time.Millisecond)
+			if err := releaseDaemonLock(); err != nil {
+				os.Exit(2)
+			}
+			os.Exit(0)
+		}()
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	if _, err := os.Stdout.WriteString("ready\n"); err != nil {
+		t.Fatalf("write readiness: %v", err)
+	}
+	select {}
+}
+
+const replacementDaemonHelperEnv = "PMON_CONTROL_REPLACEMENT_DAEMON_HELPER"
+const replacementDaemonPathEnv = "PMON_CONTROL_REPLACEMENT_DAEMON_PATH"
+
+func TestStopDaemonDoesNotSignalReplacementOwner(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("PMON_CONFIG_DIR", configDir)
+	if _, err := state.EnsureDir(); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	held, err := acquireDaemonLock(context.Background())
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
+	}
+	t.Cleanup(func() { _ = releaseDaemonLock() })
+
+	pidPath, err := state.PidPath()
+	if err != nil {
+		t.Fatalf("PidPath: %v", err)
+	}
+	sock, err := state.SocketPath()
+	if err != nil {
+		t.Fatalf("SocketPath: %v", err)
+	}
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	command := exec.Command(os.Args[0], "-test.run=^TestReplacementDaemonLockHelper$")
+	command.Env = append(os.Environ(),
+		replacementDaemonHelperEnv+"=1",
+		replacementDaemonPathEnv+"="+pidPath,
+	)
+	stdin, err := command.StdinPipe()
+	if err != nil {
+		t.Fatalf("replacement daemon stdin: %v", err)
+	}
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		t.Fatalf("replacement daemon stdout: %v", err)
+	}
+	if err := command.Start(); err != nil {
+		t.Fatalf("start replacement daemon: %v", err)
+	}
+	stdoutReader := bufio.NewReader(stdout)
+	if line, err := stdoutReader.ReadString('\n'); err != nil || line != "waiting\n" {
+		t.Fatalf("replacement daemon startup = %q, %v", line, err)
+	}
+	waited := false
+	t.Cleanup(func() {
+		if waited {
+			return
+		}
+		_ = command.Process.Kill()
+		_, _ = command.Process.Wait()
+	})
+	handoffErr := make(chan error, 1)
+	handoff := func() error {
+		transitionFile, err := os.OpenFile(pidPath+".transition", os.O_CREATE|os.O_RDWR, 0o600)
+		if err != nil {
+			return err
+		}
+		if err := syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_EX); err != nil {
+			_ = transitionFile.Close()
+			return err
+		}
+		defer func() {
+			_ = syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_UN)
+			_ = transitionFile.Close()
+		}()
+		if err := releaseDaemonLock(); err != nil {
+			return err
+		}
+		if _, err := stdin.Write([]byte("acquire\n")); err != nil {
+			return err
+		}
+		if err := stdin.Close(); err != nil {
+			return err
+		}
+		line, err := stdoutReader.ReadString('\n')
+		if err != nil || line != "ready\n" {
+			return fmt.Errorf("replacement daemon readiness = %q: %v", line, err)
+		}
+		return nil
+	}
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if err := handoff(); err != nil {
+			handoffErr <- err
+			http.Error(w, "handoff failed", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "stopping"})
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+	err = StopDaemon(ctx)
+	select {
+	case handoffErr := <-handoffErr:
+		t.Fatalf("replace daemon owner: %v", handoffErr)
+	default:
+	}
+	if !errors.Is(err, ErrDaemonReplaced) {
+		t.Fatalf("StopDaemon during owner replacement = %v, want ErrDaemonReplaced", err)
+	}
+
+	ownerPID, running, err := runningDaemonPID(context.Background())
+	if err != nil || !running || ownerPID != command.Process.Pid {
+		t.Fatalf("replacement lock owner = %d, %t, %v; want %d, true, nil", ownerPID, running, err, command.Process.Pid)
+	}
+	if err := syscall.Kill(command.Process.Pid, 0); err != nil {
+		_, _ = command.Process.Wait()
+		waited = true
+		t.Fatalf("StopDaemon signaled replacement pid %d: %v", command.Process.Pid, err)
+	}
+}
+
+func TestReplacementDaemonLockHelper(t *testing.T) {
+	if os.Getenv(replacementDaemonHelperEnv) == "" {
+		return
+	}
+	if _, err := os.Stdout.WriteString("waiting\n"); err != nil {
+		t.Fatalf("write startup readiness: %v", err)
+	}
+	if line, err := bufio.NewReader(os.Stdin).ReadString('\n'); err != nil || line != "acquire\n" {
+		t.Fatalf("wait for lock handoff = %q, %v", line, err)
+	}
+	path := os.Getenv(replacementDaemonPathEnv)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open daemon lock: %v", err)
+	}
+	defer file.Close()
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("lock daemon: %v", err)
+	}
+	if err := file.Truncate(0); err != nil {
+		t.Fatalf("truncate daemon pid: %v", err)
+	}
+	if _, err := file.WriteAt([]byte(fmt.Sprintf("%d", os.Getpid())), 0); err != nil {
+		t.Fatalf("write daemon pid: %v", err)
+	}
+	if _, err := os.Stdout.WriteString("ready\n"); err != nil {
+		t.Fatalf("write readiness: %v", err)
+	}
+	select {}
+}
+
+func TestShortControlRequestTimesOutAfterAccept(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	if _, err := state.EnsureDir(); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	held, err := acquireDaemonLock(context.Background())
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
+	}
+	t.Cleanup(func() {
+		if err := releaseDaemonLock(); err != nil {
+			t.Errorf("ReleasePidLock: %v", err)
+		}
+	})
+	sock, err := state.SocketPath()
+	if err != nil {
+		t.Fatalf("SocketPath: %v", err)
+	}
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	release := make(chan struct{})
+	srv := &http.Server{Handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-release
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() {
+		close(release)
+		_ = srv.Close()
+	})
+
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	started := time.Now()
+	if _, err := c.Status(context.Background()); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Status against a silent listener = %v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(started); elapsed > controlRequestTimeout+time.Second {
+		t.Errorf("Status took %s, want at most %s", elapsed, controlRequestTimeout+time.Second)
+	}
+
+	started = time.Now()
+	_, err = Connect(context.Background())
+	if !errors.Is(err, ErrDaemonUnreachable) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Connect against a silent listener = %v, want unreachable with deadline exceeded", err)
+	}
+	maxConnectTime := controlRequestTimeout + daemonStartRaceGrace + time.Second
+	if elapsed := time.Since(started); elapsed > maxConnectTime {
+		t.Errorf("Connect took %s, want at most %s", elapsed, maxConnectTime)
+	}
+}
+
+func TestConnectWaitsForAStartingDaemonSocket(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	held, err := acquireDaemonLock(context.Background())
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
+	}
+	t.Cleanup(func() {
+		if err := releaseDaemonLock(); err != nil {
+			t.Errorf("ReleasePidLock: %v", err)
+		}
+	})
+	sock, err := state.SocketPath()
+	if err != nil {
+		t.Fatalf("SocketPath: %v", err)
+	}
+
+	type serverResult struct {
+		srv *http.Server
+		err error
+	}
+	serverReady := make(chan serverResult, 1)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		ln, err := net.Listen("unix", sock)
+		if err != nil {
+			serverReady <- serverResult{err: err}
+			return
+		}
+		srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(Status{})
+		})}
+		serverReady <- serverResult{srv: srv}
+		_ = srv.Serve(ln)
+	}()
+
+	client, connectErr := Connect(context.Background())
+	result := <-serverReady
+	if result.err != nil {
+		t.Fatalf("delayed listen: %v", result.err)
+	}
+	t.Cleanup(func() { _ = result.srv.Close() })
+	if connectErr != nil || client == nil {
+		t.Fatalf("Connect while the daemon bound its socket = %v, want a client", connectErr)
+	}
+}
+
+const delayedControlHelperEnv = "PMON_CONTROL_DELAYED_HELPER"
+const delayedControlMarkerEnv = "PMON_CONTROL_DELAYED_HELPER_MARKER"
+
+func TestPeersWaitForAStartingDaemonToReplaceTheSocket(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		connect func(context.Context) (*Client, error)
+	}{
+		{name: "Connect", connect: Connect},
+		{name: "EnsureDaemon", connect: EnsureDaemon},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testPeerWaitsForAStartingDaemonToReplaceTheSocket(t, tc.connect)
+		})
+	}
+}
+
+func testPeerWaitsForAStartingDaemonToReplaceTheSocket(
+	t *testing.T,
+	connect func(context.Context) (*Client, error),
+) {
+	t.Helper()
+	configDir := t.TempDir()
+	t.Setenv("PMON_CONFIG_DIR", configDir)
+	if _, err := state.EnsureDir(); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	sock, err := state.SocketPath()
+	if err != nil {
+		t.Fatalf("SocketPath: %v", err)
+	}
+	staleListener, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen on stale socket: %v", err)
+	}
+	t.Cleanup(func() { _ = staleListener.Close() })
+	type acceptResult struct {
+		conn net.Conn
+		err  error
+	}
+	accepted := make(chan acceptResult, 1)
+	go func() {
+		conn, err := staleListener.Accept()
+		accepted <- acceptResult{conn: conn, err: err}
+	}()
+
+	marker := filepath.Join(configDir, "replace-socket")
+	command := exec.Command(os.Args[0], "-test.run=^TestDelayedControlHelper$")
+	command.Env = append(os.Environ(),
+		"PMON_CONFIG_DIR="+configDir,
+		delayedControlHelperEnv+"=1",
+		delayedControlMarkerEnv+"="+marker,
+	)
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		t.Fatalf("helper stdout: %v", err)
+	}
+	if err := command.Start(); err != nil {
+		t.Fatalf("start delayed control helper: %v", err)
+	}
+	waited := false
+	t.Cleanup(func() {
+		if waited {
+			return
+		}
+		_ = command.Process.Kill()
+		_, _ = command.Process.Wait()
+	})
+	if line, err := bufio.NewReader(stdout).ReadString('\n'); err != nil || line != "locked\n" {
+		t.Fatalf("delayed control helper readiness = %q, %v", line, err)
+	}
+
+	result := make(chan struct {
+		client *Client
+		err    error
+	}, 1)
+	go func() {
+		client, err := connect(context.Background())
+		result <- struct {
+			client *Client
+			err    error
+		}{client: client, err: err}
+	}()
+	select {
+	case accepted := <-accepted:
+		if accepted.err != nil {
+			t.Fatalf("accept stale control connection: %v", accepted.err)
+		}
+		defer accepted.conn.Close()
+	case <-time.After(time.Second):
+		t.Fatal("peer did not reach the stale control socket")
+	}
+	if err := os.WriteFile(marker, nil, 0o600); err != nil {
+		t.Fatalf("release delayed control helper: %v", err)
+	}
+	select {
+	case got := <-result:
+		if got.err != nil || got.client == nil {
+			t.Fatalf("peer while the daemon replaced its stale socket = %v, want a client", got.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("peer did not follow the daemon to its replacement socket")
+	}
+	_ = command.Process.Kill()
+	_, _ = command.Process.Wait()
+	waited = true
+}
+
+func TestDelayedControlHelper(t *testing.T) {
+	if os.Getenv(delayedControlHelperEnv) == "" {
+		return
+	}
+	held, err := acquireDaemonLock(context.Background())
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
+	}
+	if _, err := os.Stdout.WriteString("locked\n"); err != nil {
+		t.Fatalf("write readiness: %v", err)
+	}
+	marker := os.Getenv(delayedControlMarkerEnv)
+	for {
+		if _, err := os.Stat(marker); err == nil {
+			break
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("stat release marker: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	srv, err := Listen(newFakeBackend())
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	if err := srv.Serve(context.Background()); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+}
+
+func TestConnectReportsUnreachableDaemonWhenPidLockIsHeld(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	held, err := acquireDaemonLock(context.Background())
+	if err != nil {
+		t.Fatalf("AcquirePidLock: %v", err)
+	}
+	if !held {
+		t.Fatal("AcquirePidLock reported an unexpected live daemon")
+	}
+	t.Cleanup(func() {
+		if err := releaseDaemonLock(); err != nil {
+			t.Errorf("ReleasePidLock: %v", err)
+		}
+	})
+
+	if _, err := Connect(context.Background()); !errors.Is(err, ErrDaemonUnreachable) {
+		t.Errorf("Connect with a held pid lock and no socket = %v, want ErrDaemonUnreachable", err)
+	}
+}
+
+func TestEnsureDaemonReplacesFailingSocketWithoutPidLock(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	if _, err := state.EnsureDir(); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	sock, err := state.SocketPath()
+	if err != nil {
+		t.Fatalf("SocketPath: %v", err)
+	}
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not pmon", http.StatusInternalServerError)
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	binDir := t.TempDir()
+	marker := filepath.Join(binDir, "spawned")
+	stub := filepath.Join(binDir, "pmon")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\n: > \"$PMON_TEST_MARKER\"\n"), 0o755); err != nil {
+		t.Fatalf("write daemon stub: %v", err)
+	}
+	t.Setenv(daemonBinaryEnv, stub)
+	t.Setenv("PMON_TEST_MARKER", marker)
+	type replacementResult struct {
+		server   *http.Server
+		lockHeld bool
+		err      error
+	}
+	replaced := make(chan replacementResult, 1)
+	go func() {
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			if _, err := os.Stat(marker); err == nil {
+				break
+			}
+			if time.Now().After(deadline) {
+				replaced <- replacementResult{err: errors.New("daemon stub did not start")}
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		held, err := acquireDaemonLock(context.Background())
+		if err != nil || !held {
+			replaced <- replacementResult{err: errors.New("replacement daemon could not acquire the pid lock")}
+			return
+		}
+		result := replacementResult{lockHeld: true}
+		if err := os.Remove(sock); err != nil {
+			result.err = err
+			replaced <- result
+			return
+		}
+		realListener, err := net.Listen("unix", sock)
+		if err != nil {
+			result.err = err
+			replaced <- result
+			return
+		}
+		result.server = &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(Status{})
+		})}
+		go func() { _ = result.server.Serve(realListener) }()
+		replaced <- result
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	client, ensureErr := EnsureDaemon(ctx)
+	result := <-replaced
+	if result.lockHeld {
+		t.Cleanup(func() {
+			if err := releaseDaemonLock(); err != nil {
+				t.Errorf("ReleasePidLock: %v", err)
+			}
+		})
+	}
+	if result.server != nil {
+		t.Cleanup(func() { _ = result.server.Close() })
+	}
+	if result.err != nil {
+		t.Fatalf("replace stale control socket: %v", result.err)
+	}
+	if ensureErr != nil || client == nil {
+		t.Fatalf("EnsureDaemon through a replaced socket = %v, want a client", ensureErr)
+	}
+}
+
+func TestPeersReportUnreachableDaemonWhenStatusFails(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	held, err := acquireDaemonLock(context.Background())
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
+	}
+	t.Cleanup(func() {
+		if err := releaseDaemonLock(); err != nil {
+			t.Errorf("ReleasePidLock: %v", err)
+		}
+	})
+	sock, err := state.SocketPath()
+	if err != nil {
+		t.Fatalf("SocketPath: %v", err)
+	}
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "status unavailable", http.StatusInternalServerError)
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	for name, connect := range map[string]func(context.Context) (*Client, error){
+		"Connect":      Connect,
+		"EnsureDaemon": EnsureDaemon,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := connect(context.Background()); !errors.Is(err, ErrDaemonUnreachable) {
+				t.Errorf("%s with a held pid lock and failing status = %v, want ErrDaemonUnreachable", name, err)
+			}
+		})
+	}
+}
+
 func TestLoginStreamsPromptBeforeDone(t *testing.T) {
 	backend := newFakeBackend()
 	backend.loginEvents = []LoginEvent{
@@ -392,7 +1305,116 @@ func TestLoginStreamsPromptBeforeDone(t *testing.T) {
 	}
 }
 
-// TestLoginSurfacesAnError: a failed flow must reach the peer as an error, not a silent empty stream.
+func TestLoginFlushesHeadersBeforeTheDeviceFlowResponds(t *testing.T) {
+	backend := newFakeBackend()
+	backend.loginStarted = make(chan struct{})
+	release := make(chan struct{})
+	backend.loginRelease = release
+	c := serve(t, backend)
+	const headerTimeout = 100 * time.Millisecond
+	c.loginHTTP.Transport.(*http.Transport).ResponseHeaderTimeout = headerTimeout
+
+	result := make(chan error, 1)
+	go func() {
+		result <- c.Login(context.Background(), LoginRequest{}, nil)
+	}()
+	select {
+	case <-backend.loginStarted:
+	case <-time.After(time.Second):
+		t.Fatal("login did not reach the backend")
+	}
+	select {
+	case err := <-result:
+		t.Fatalf("Login returned before the device flow completed: %v", err)
+	case <-time.After(2 * headerTimeout):
+	}
+	close(release)
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Login did not finish after the device flow completed")
+	}
+}
+
+func TestLoginWaitsForReleasedDaemonResponseHeaders(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	if _, err := state.EnsureDir(); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	held, err := acquireDaemonLock(context.Background())
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %t, %v; want true, nil", held, err)
+	}
+	t.Cleanup(func() {
+		if err := releaseDaemonLock(); err != nil {
+			t.Errorf("ReleasePidLock: %v", err)
+		}
+	})
+	sock, err := state.SocketPath()
+	if err != nil {
+		t.Fatalf("SocketPath: %v", err)
+	}
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != PathLogin {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+		close(started)
+		<-release
+		_ = json.NewEncoder(w).Encode(LoginEvent{Kind: "done"})
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+		_ = srv.Close()
+	})
+
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	const shortHeaderTimeout = 50 * time.Millisecond
+	c.http.Transport.(*http.Transport).ResponseHeaderTimeout = shortHeaderTimeout
+	result := make(chan error, 1)
+	go func() {
+		result <- c.Login(context.Background(), LoginRequest{}, nil)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("login did not reach the released-style handler")
+	}
+	select {
+	case err := <-result:
+		t.Fatalf("Login returned before released daemon responded: %v", err)
+	case <-time.After(2 * shortHeaderTimeout):
+	}
+	close(release)
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Login did not finish after released daemon responded")
+	}
+}
+
 func TestLoginSurfacesAnError(t *testing.T) {
 	backend := newFakeBackend()
 	backend.loginErr = errors.New("device poll failed")
@@ -441,8 +1463,6 @@ func TestShutdownDrivesTheBackend(t *testing.T) {
 	t.Error("the backend never saw a shutdown")
 }
 
-// TestEventsSendsCurrentStateFirst means a peer renders correctly the moment it subscribes, with no separate
-// /status call and no blank window.
 func TestEventsSendsCurrentStateFirst(t *testing.T) {
 	backend := newFakeBackend()
 	c := serve(t, backend)
@@ -462,7 +1482,6 @@ func TestEventsSendsCurrentStateFirst(t *testing.T) {
 		t.Fatal("no initial status event within 3s")
 	}
 
-	// A subsequent backend event reaches the peer on the same stream.
 	backend.events <- Event{Kind: "reauth", Message: "the session window has closed"}
 	select {
 	case ev := <-got:
@@ -474,8 +1493,26 @@ func TestEventsSendsCurrentStateFirst(t *testing.T) {
 	}
 }
 
-// sameFile compares two paths by identity rather than by string: on macOS /tmp is a symlink to /private/tmp and
-// resolution deliberately calls EvalSymlinks, so equal files have unequal path strings.
+func TestEventsFailsWhenHeartbeatsStop(t *testing.T) {
+	c := serve(t, newFakeBackend())
+	const idleTimeout = 100 * time.Millisecond
+
+	var got []Event
+	started := time.Now()
+	err := c.events(context.Background(), func(ev Event) {
+		got = append(got, ev)
+	}, idleTimeout)
+	if !errors.Is(err, errEventStreamIdle) {
+		t.Fatalf("Events error = %v, want event-stream idle timeout", err)
+	}
+	if len(got) != 1 || got[0].Kind != "status" {
+		t.Fatalf("events before timeout = %+v, want the initial status only", got)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("event stream took %s to detect a %s idle timeout", elapsed, idleTimeout)
+	}
+}
+
 func sameFile(t *testing.T, a, b string) bool {
 	t.Helper()
 	ai, err := os.Stat(a)
@@ -489,10 +1526,6 @@ func sameFile(t *testing.T, a, b string) bool {
 	return os.SameFile(ai, bi)
 }
 
-// TestDaemonBinaryPrefersASiblingPmon is the regression for a bug that made the menu-bar app's Start and Log in
-// unusable: resolving the daemon as os.Executable() meant a peer that is NOT pmon re-exec'd ITSELF with a
-// `daemon` argument, launching a second copy of that app instead of a daemon, and every start died on the
-// readiness timeout. A non-pmon host must resolve the sibling pmon that ships beside it in the .app bundle.
 func TestDaemonBinaryPrefersASiblingPmon(t *testing.T) {
 	dir := t.TempDir()
 	host := filepath.Join(dir, "pmontray")
@@ -503,7 +1536,6 @@ func TestDaemonBinaryPrefersASiblingPmon(t *testing.T) {
 		}
 	}
 
-	// Simulate being run as the tray: resolution must pick the sibling, never the host.
 	got, err := daemonBinaryFrom(host, "", false)
 	if err != nil {
 		t.Fatalf("daemonBinaryFrom: %v", err)
@@ -516,8 +1548,6 @@ func TestDaemonBinaryPrefersASiblingPmon(t *testing.T) {
 	}
 }
 
-// TestDaemonBinaryUsesItselfWhenItIsPmon: the CLI's own case stays a direct self-exec, with no PATH lookup that
-// could pick up a different pmon than the one the user invoked.
 func TestDaemonBinaryUsesItselfWhenItIsPmon(t *testing.T) {
 	dir := t.TempDir()
 	self := filepath.Join(dir, "pmon")
@@ -533,7 +1563,6 @@ func TestDaemonBinaryUsesItselfWhenItIsPmon(t *testing.T) {
 	}
 }
 
-// TestDaemonBinaryHonorsTheOverride covers the dev loop: an explicit binary wins over any search.
 func TestDaemonBinaryHonorsTheOverride(t *testing.T) {
 	dir := t.TempDir()
 	override := filepath.Join(dir, "pmon-dev")
@@ -547,28 +1576,23 @@ func TestDaemonBinaryHonorsTheOverride(t *testing.T) {
 	if got != override {
 		t.Errorf("resolved %q, want the override %q", got, override)
 	}
-	// A non-runnable override is an error, not a silent fallback that would start the wrong binary.
 	if _, err := daemonBinaryFrom(filepath.Join(dir, "pmontray"), filepath.Join(dir, "missing"), false); err == nil {
 		t.Error("a missing override was accepted; it must fail rather than fall back")
 	}
 }
 
-// TestDaemonBinaryFailsWhenNoPmonExists: with no sibling and nothing on PATH, resolution must return a clear
-// error rather than a path that cannot serve.
 func TestDaemonBinaryFailsWhenNoPmonExists(t *testing.T) {
 	dir := t.TempDir()
 	host := filepath.Join(dir, "pmontray")
 	if err := os.WriteFile(host, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	t.Setenv("PATH", dir) // no pmon here
+	t.Setenv("PATH", dir)
 	if got, err := daemonBinaryFrom(host, "", false); err == nil {
 		t.Errorf("resolved %q with no pmon available; want an error", got)
 	}
 }
 
-// TestMutationsRejectGET is a small hardening check: the control socket can start a login, so a route that
-// mutates must not be reachable by a bare GET.
 func TestMutationsRejectGET(t *testing.T) {
 	serve(t, newFakeBackend())
 	sock, _ := state.SocketPath()
@@ -586,9 +1610,6 @@ func TestMutationsRejectGET(t *testing.T) {
 	}
 }
 
-// TestIsDialFailureCoversAnyDialError: a peer branches on ErrDaemonNotRunning to decide whether to offer a start.
-// Keying on an essno allow-list meant an unlisted failure — a stale non-socket file at the path, a permission
-// problem — looked like a LIVE daemon and blocked auto-start entirely. Any dial-op error must read as "no daemon".
 func TestIsDialFailureCoversAnyDialError(t *testing.T) {
 	tests := []struct {
 		name string
@@ -597,11 +1618,9 @@ func TestIsDialFailureCoversAnyDialError(t *testing.T) {
 	}{
 		{"ENOENT", &net.OpError{Op: "dial", Err: syscall.ENOENT}, true},
 		{"ECONNREFUSED", &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}, true},
-		// The cases the allow-list missed:
 		{"EACCES on dial", &net.OpError{Op: "dial", Err: syscall.EACCES}, true},
 		{"ECONNABORTED on dial", &net.OpError{Op: "dial", Err: syscall.ECONNABORTED}, true},
 		{"a non-socket file", &net.OpError{Op: "dial", Err: syscall.ENOTSOCK}, true},
-		// Not a dial: a mid-request failure against a live daemon must NOT read as "not running".
 		{"read error", &net.OpError{Op: "read", Err: syscall.EINVAL}, false},
 	}
 	for _, tc := range tests {
@@ -611,18 +1630,15 @@ func TestIsDialFailureCoversAnyDialError(t *testing.T) {
 	}
 }
 
-// TestDaemonBinaryTrustsSelfDeclarationNotFilename covers the install layouts a filename check broke: a release
-// artifact (pmon_0.3.0_darwin_arm64) and a symlinked install (Homebrew / /usr/local/bin) are genuine pmon
-// binaries under another name, and must be able to start their own daemon.
 func TestDaemonBinaryTrustsSelfDeclarationNotFilename(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("PATH", dir) // no pmon on PATH, so a wrong answer fails rather than silently working
+	t.Setenv("PATH", dir)
 	for _, name := range []string{"pmon_0.3.0_darwin_arm64", "pmon2", "pmon"} {
 		p := filepath.Join(dir, name)
 		if err := os.WriteFile(p, []byte("#!/bin/sh\n"), 0o755); err != nil {
 			t.Fatalf("WriteFile: %v", err)
 		}
-		got, err := daemonBinaryFrom(p, "", true) // it declares itself the daemon host
+		got, err := daemonBinaryFrom(p, "", true)
 		if err != nil {
 			t.Errorf("%s: %v", name, err)
 			continue
@@ -633,8 +1649,6 @@ func TestDaemonBinaryTrustsSelfDeclarationNotFilename(t *testing.T) {
 	}
 }
 
-// TestDaemonBinaryRejectsANonRegularSibling: a FIFO, socket, or device node with an execute bit was accepted as
-// the daemon binary and exec'd, hanging or failing opaquely.
 func TestDaemonBinaryRejectsANonRegularSibling(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("PATH", dir)
@@ -651,9 +1665,6 @@ func TestDaemonBinaryRejectsANonRegularSibling(t *testing.T) {
 	}
 }
 
-// TestDaemonBinaryRejectsAGroupWritableTarget: a found-by-search target runs with this user's privileges and
-// inherits the wire token and control socket, so one another user could replace must be refused. Installs under
-// a group-writable prefix (a single-admin Mac's /usr/local/bin is staff-writable) are the real case.
 func TestDaemonBinaryRejectsAGroupWritableTarget(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("PATH", dir)
@@ -667,7 +1678,7 @@ func TestDaemonBinaryRejectsAGroupWritableTarget(t *testing.T) {
 	if _, err := daemonBinaryFrom(host, "", false); err != nil {
 		t.Fatalf("precondition: a 0755 sibling should be accepted: %v", err)
 	}
-	if err := os.Chmod(sibling, 0o775); err != nil { // group-writable
+	if err := os.Chmod(sibling, 0o775); err != nil {
 		t.Fatalf("Chmod: %v", err)
 	}
 	if got, err := daemonBinaryFrom(host, "", false); err == nil {
@@ -675,13 +1686,46 @@ func TestDaemonBinaryRejectsAGroupWritableTarget(t *testing.T) {
 	}
 }
 
-// TestStartDaemonUsesTheResolvedBinary pins the ACTUAL bug the resolution exists for: StartDaemon must exec the
-// resolved pmon, not os.Executable(). Without this, reverting StartDaemon to os.Executable() — the original
-// tray-launches-itself bug — leaves the suite green because only DaemonBinary is covered.
+type cancelAfterFirstErrContext struct {
+	context.Context
+	cancel context.CancelFunc
+	checks int
+}
+
+func (c *cancelAfterFirstErrContext) Err() error {
+	c.checks++
+	if c.checks == 1 {
+		c.cancel()
+		return nil
+	}
+	return c.Context.Err()
+}
+
+func TestStartDaemonHonorsCancellationBeforeSpawn(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "spawned.txt")
+	stub := filepath.Join(dir, "pmon")
+	script := "#!/bin/sh\ntouch " + marker + "\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv(daemonBinaryEnv, stub)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelCtx := &cancelAfterFirstErrContext{Context: ctx, cancel: cancel}
+
+	if err := StartDaemon(cancelCtx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("StartDaemon after cancellation during setup = %v, want context.Canceled", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("spawn marker after canceled StartDaemon = %v, want not found", err)
+	}
+}
+
 func TestStartDaemonUsesTheResolvedBinary(t *testing.T) {
 	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
 	dir := t.TempDir()
-	// A stub that records the argv it was invoked with, standing in for the real pmon daemon.
 	marker := filepath.Join(dir, "spawned.txt")
 	stub := filepath.Join(dir, "pmon")
 	script := "#!/bin/sh\necho \"$0 $*\" > " + marker + "\n"
@@ -707,9 +1751,6 @@ func TestStartDaemonUsesTheResolvedBinary(t *testing.T) {
 	t.Error("StartDaemon never executed the resolved binary; it likely re-exec'd the test binary instead")
 }
 
-// TestDaemonBinaryRejectsALooseDirectory closes the loop log's review found: unlink permission on Unix comes from
-// the parent DIRECTORY, not the file, so a 0755 binary we own inside a 0777 directory is still swappable by any
-// local user — a file-only check asserted a trust it did not establish.
 func TestDaemonBinaryRejectsALooseDirectory(t *testing.T) {
 	parent := t.TempDir()
 	dir := filepath.Join(parent, "bin")
@@ -728,7 +1769,6 @@ func TestDaemonBinaryRejectsALooseDirectory(t *testing.T) {
 		t.Fatalf("precondition: a 0755 sibling in a 0755 dir should be accepted: %v", err)
 	}
 
-	// The file stays 0755 and ours; only the directory loosens.
 	if err := os.Chmod(dir, 0o777); err != nil {
 		t.Fatalf("Chmod: %v", err)
 	}

--- a/pmon/control/control_test.go
+++ b/pmon/control/control_test.go
@@ -1388,6 +1388,9 @@ func TestLoginWaitsForReleasedDaemonResponseHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
+	if got := c.loginHTTP.Transport.(*http.Transport).ResponseHeaderTimeout; got != 0 {
+		t.Fatalf("Login response-header timeout = %s, want no timeout for released daemons", got)
+	}
 	const shortHeaderTimeout = 50 * time.Millisecond
 	c.http.Transport.(*http.Transport).ResponseHeaderTimeout = shortHeaderTimeout
 	result := make(chan error, 1)
@@ -1490,6 +1493,70 @@ func TestEventsSendsCurrentStateFirst(t *testing.T) {
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("no reauth event within 3s")
+	}
+}
+
+type dataOnCloseReader struct {
+	once   sync.Once
+	closed chan struct{}
+}
+
+func (reader *dataOnCloseReader) Read(p []byte) (int, error) {
+	<-reader.closed
+	return copy(p, "x"), nil
+}
+
+func (reader *dataOnCloseReader) Close() error {
+	reader.once.Do(func() { close(reader.closed) })
+	return nil
+}
+
+func TestIdleTimeoutReaderReturnsDataAvailableAtTimeout(t *testing.T) {
+	body := &dataOnCloseReader{closed: make(chan struct{})}
+	buf := make([]byte, 1)
+	n, err := (idleTimeoutReader{body: body, timeout: 10 * time.Millisecond}).Read(buf)
+	if err != nil || n != 1 || string(buf) != "x" {
+		t.Fatalf("Read = %q, %d, %v; want x, 1, nil", buf, n, err)
+	}
+}
+
+func TestEventsHeartbeatsKeepStreamAlive(t *testing.T) {
+	previousKeepalive := eventKeepalive
+	eventKeepalive = 10 * time.Millisecond
+	t.Cleanup(func() { eventKeepalive = previousKeepalive })
+	c := serve(t, newFakeBackend())
+	const idleTimeout = 200 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	gotStatus := make(chan struct{}, 1)
+	go func() {
+		result <- c.events(ctx, func(ev Event) {
+			if ev.Kind == "status" {
+				select {
+				case gotStatus <- struct{}{}:
+				default:
+				}
+			}
+		}, idleTimeout)
+	}()
+	select {
+	case <-gotStatus:
+	case err := <-result:
+		t.Fatalf("Events returned before the initial status: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("Events did not receive the initial status")
+	}
+	select {
+	case err := <-result:
+		t.Fatalf("Events returned while server heartbeats were active: %v", err)
+	case <-time.After(3 * idleTimeout):
+	}
+	cancel()
+	select {
+	case <-result:
+	case <-time.After(time.Second):
+		t.Fatal("Events did not stop after cancellation")
 	}
 }
 

--- a/pmon/control/peer_pid_darwin.go
+++ b/pmon/control/peer_pid_darwin.go
@@ -1,0 +1,24 @@
+//go:build darwin
+
+package control
+
+import (
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+func socketPeerPID(conn *net.UnixConn) (int, error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+	var pid int
+	var socketErr error
+	if err := raw.Control(func(fd uintptr) {
+		pid, socketErr = unix.GetsockoptInt(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERPID)
+	}); err != nil {
+		return 0, err
+	}
+	return pid, socketErr
+}

--- a/pmon/control/peer_pid_linux.go
+++ b/pmon/control/peer_pid_linux.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package control
+
+import (
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+func socketPeerPID(conn *net.UnixConn) (int, error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+	var credentials *unix.Ucred
+	var socketErr error
+	if err := raw.Control(func(fd uintptr) {
+		credentials, socketErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	}); err != nil {
+		return 0, err
+	}
+	if socketErr != nil {
+		return 0, socketErr
+	}
+	return int(credentials.Pid), nil
+}

--- a/pmon/control/server.go
+++ b/pmon/control/server.go
@@ -150,6 +150,9 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/x-ndjson")
 	w.WriteHeader(http.StatusOK)
 	flusher, _ := w.(http.Flusher)
+	if flusher != nil {
+		flusher.Flush()
+	}
 
 	var mu sync.Mutex
 	emit := func(ev LoginEvent) {
@@ -196,7 +199,9 @@ func (s *Server) handleShutdown(w http.ResponseWriter, r *http.Request) {
 }
 
 // eventKeepalive bounds how long /events can sit silent, so a peer notices a dead socket promptly.
-const eventKeepalive = 30 * time.Second
+const defaultEventKeepalive = 30 * time.Second
+
+var eventKeepalive = defaultEventKeepalive
 
 func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	if !requireMethod(w, r, http.MethodGet) {

--- a/pmon/go.mod
+++ b/pmon/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/moby/moby/api v1.55.0
 	github.com/testcontainers/testcontainers-go v0.44.0
+	golang.org/x/sys v0.47.0
 )
 
 require (
@@ -61,6 +62,5 @@ require (
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pmon/internal/daemon/daemon.go
+++ b/pmon/internal/daemon/daemon.go
@@ -125,15 +125,24 @@ func New(version string) *Daemon {
 //
 // Missing credentials are NOT a startup failure: the daemon comes up idle and waits for a login, because a
 // peer must be able to launch it on a fresh machine and then log in through it.
-func (d *Daemon) Run(ctx context.Context) error {
-	held, err := state.AcquirePidLock()
+func (d *Daemon) Run(ctx context.Context) (err error) {
+	if _, err := state.EnsureDir(); err != nil {
+		return fmt.Errorf("pid lock: %w", err)
+	}
+	instance, err := state.DaemonInstance()
 	if err != nil {
 		return fmt.Errorf("pid lock: %w", err)
 	}
-	if !held {
+	owner, acquired, err := instance.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("pid lock: %w", err)
+	}
+	if !acquired {
 		return errors.New("another pmon daemon is already running")
 	}
-	defer state.ReleasePidLock()
+	defer func() {
+		err = errors.Join(err, owner.Close())
+	}()
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pmon/lifecycle_cmd.go
+++ b/pmon/lifecycle_cmd.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/ridi-oss/proxy-monster/pmon/control"
+	"github.com/ridi-oss/proxy-monster/pmon/state"
 )
 
 // startCmd starts the daemon if none is running. Symmetric with the menu-bar app's Start: both call the same
@@ -44,22 +45,45 @@ type stopCmd struct {
 	Force bool `short:"f" help:"Stop without asking, even with connections open."`
 }
 
+func daemonMayBeRunning(ctx context.Context) bool {
+	instance, err := state.DaemonInstance()
+	if err != nil {
+		return true
+	}
+	running, err := instance.Client().Running(ctx)
+	return err != nil || running
+}
+
 func (c *stopCmd) Run() error {
 	ctx := context.Background()
-	client, err := control.Connect(ctx)
-	if err != nil {
-		fmt.Println("the daemon is not running")
-		return nil
-	}
+	shouldStop := true
 	if !c.Force {
-		if s, err := client.Status(ctx); err == nil {
-			if n := s.TotalLiveConns(); n > 0 {
+		client, err := control.Connect(ctx)
+		if err == nil {
+			s, statusErr := client.Status(ctx)
+			if statusErr != nil {
+				if errors.Is(statusErr, control.ErrDaemonNotRunning) && !daemonMayBeRunning(ctx) {
+					shouldStop = false
+				} else if !confirm("the daemon status cannot be read, so its connections cannot be checked. Stop anyway?") {
+					fmt.Println("left the daemon running")
+					return nil
+				}
+			} else if n := s.TotalLiveConns(); n > 0 {
 				if !confirm(fmt.Sprintf("%d active connection(s) will be dropped. Stop anyway?", n)) {
 					fmt.Println("left the daemon running")
 					return nil
 				}
 			}
+		} else if errors.Is(err, control.ErrDaemonNotRunning) {
+			shouldStop = false
+		} else if !confirm("the daemon status cannot be read, so its connections cannot be checked. Stop anyway?") {
+			fmt.Println("left the daemon running")
+			return nil
 		}
+	}
+	if !shouldStop {
+		fmt.Println("the daemon is not running")
+		return nil
 	}
 	if err := control.StopDaemon(ctx); err != nil {
 		if errors.Is(err, control.ErrDaemonNotRunning) {
@@ -79,18 +103,35 @@ type restartCmd struct {
 
 func (c *restartCmd) Run() error {
 	ctx := context.Background()
-	if client, err := control.Connect(ctx); err == nil {
-		if !c.Force {
-			if s, err := client.Status(ctx); err == nil {
-				if n := s.TotalLiveConns(); n > 0 {
-					if !confirm(fmt.Sprintf("%d active connection(s) will be dropped. Restart anyway?", n)) {
-						fmt.Println("left the daemon running")
-						return nil
-					}
+	shouldStop := true
+	if !c.Force {
+		client, err := control.Connect(ctx)
+		if err == nil {
+			s, statusErr := client.Status(ctx)
+			if statusErr != nil {
+				if errors.Is(statusErr, control.ErrDaemonNotRunning) && !daemonMayBeRunning(ctx) {
+					shouldStop = false
+				} else if !confirm("the daemon status cannot be read, so its connections cannot be checked. Restart anyway?") {
+					fmt.Println("left the daemon running")
+					return nil
+				}
+			} else if n := s.TotalLiveConns(); n > 0 {
+				if !confirm(fmt.Sprintf("%d active connection(s) will be dropped. Restart anyway?", n)) {
+					fmt.Println("left the daemon running")
+					return nil
 				}
 			}
+		} else if errors.Is(err, control.ErrDaemonNotRunning) {
+			shouldStop = false
+		} else if !confirm("the daemon status cannot be read, so its connections cannot be checked. Restart anyway?") {
+			fmt.Println("left the daemon running")
+			return nil
 		}
-		if err := control.StopDaemon(ctx); err != nil && !errors.Is(err, control.ErrDaemonNotRunning) {
+	}
+	if shouldStop {
+		if err := control.StopDaemon(ctx); err != nil &&
+			!errors.Is(err, control.ErrDaemonNotRunning) &&
+			!errors.Is(err, control.ErrDaemonReplaced) {
 			return err
 		}
 	}
@@ -116,9 +157,12 @@ type logoutCmd struct{}
 func (logoutCmd) Run() error {
 	ctx := context.Background()
 	client, err := control.Connect(ctx)
-	if err != nil {
+	if errors.Is(err, control.ErrDaemonNotRunning) {
 		fmt.Println("the daemon is not running — nothing to log out of")
 		return nil
+	}
+	if err != nil {
+		return err
 	}
 	if err := client.Logout(ctx); err != nil {
 		return err

--- a/pmon/show_cmd.go
+++ b/pmon/show_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -35,8 +36,11 @@ func (c *showCmd) Run() error {
 
 	ctx := context.Background()
 	client, err := control.Connect(ctx)
-	if err != nil {
+	if errors.Is(err, control.ErrDaemonNotRunning) {
 		return fmt.Errorf("the daemon is not running — run `pmon login` (or `pmon start` if you are already logged in)")
+	}
+	if err != nil {
+		return err
 	}
 	s, err := client.Status(ctx)
 	if err != nil {

--- a/pmon/singleinstance/instance.go
+++ b/pmon/singleinstance/instance.go
@@ -1,0 +1,153 @@
+package singleinstance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const ownerPollGap = 50 * time.Millisecond
+
+var (
+	ErrOwnerReplaced    = errors.New("single-instance owner changed")
+	ErrOwnerExitTimeout = errors.New("single-instance owner did not exit")
+)
+
+type Instance struct {
+	path             string
+	operationTimeout time.Duration
+}
+
+func New(path string, operationTimeout time.Duration) *Instance {
+	return &Instance{path: path, operationTimeout: operationTimeout}
+}
+
+func (instance *Instance) Acquire(ctx context.Context) (*Daemon, bool, error) {
+	ctx, cancel := instance.operationContext(ctx)
+	defer cancel()
+	lock, acquired, err := acquireLock(ctx, instance.path)
+	if err != nil || !acquired {
+		return nil, acquired, err
+	}
+	return &Daemon{lock: lock}, true, nil
+}
+
+func (instance *Instance) Client() *Client {
+	return &Client{instance: instance}
+}
+
+func (instance *Instance) operationContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, instance.operationTimeout)
+}
+
+type Daemon struct {
+	mu   sync.Mutex
+	lock *fileLock
+}
+
+func (daemon *Daemon) Close() error {
+	if daemon == nil {
+		return nil
+	}
+	daemon.mu.Lock()
+	defer daemon.mu.Unlock()
+	if daemon.lock == nil {
+		return nil
+	}
+	lock := daemon.lock
+	daemon.lock = nil
+	return lock.Close()
+}
+
+type Client struct {
+	instance *Instance
+}
+
+func (client *Client) Running(ctx context.Context) (bool, error) {
+	ctx, cancel := client.instance.operationContext(ctx)
+	defer cancel()
+	return lockHeld(ctx, client.instance.path)
+}
+
+func (client *Client) Owner(ctx context.Context) (*Owner, error) {
+	ctx, cancel := client.instance.operationContext(ctx)
+	defer cancel()
+	pid, held, err := lockOwnerPID(ctx, client.instance.path)
+	if err != nil || !held {
+		return nil, err
+	}
+	return &Owner{pid: pid, client: client}, nil
+}
+
+type Owner struct {
+	pid    int
+	client *Client
+}
+
+func (owner *Owner) PID() int {
+	return owner.pid
+}
+
+func (owner *Owner) Current(ctx context.Context) (bool, error) {
+	current, err := owner.client.Owner(ctx)
+	if err != nil {
+		return false, err
+	}
+	if current == nil {
+		return false, nil
+	}
+	if current.pid != owner.pid {
+		return false, ErrOwnerReplaced
+	}
+	return true, nil
+}
+
+func (owner *Owner) Signal(ctx context.Context, signal syscall.Signal) error {
+	current, err := owner.Current(ctx)
+	if err != nil || !current {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return syscall.Kill(owner.pid, signal)
+}
+
+func (owner *Owner) WaitExit(ctx context.Context, timeout time.Duration) error {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	for {
+		current, err := owner.Current(waitCtx)
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			if errors.Is(err, ErrOwnerReplaced) {
+				return err
+			}
+			if waitCtx.Err() != nil {
+				return fmt.Errorf("%w: pid %d after %s", ErrOwnerExitTimeout, owner.pid, timeout)
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				continue
+			}
+			return err
+		}
+		if !current {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-waitCtx.Done():
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			return fmt.Errorf("%w: pid %d after %s", ErrOwnerExitTimeout, owner.pid, timeout)
+		case <-time.After(ownerPollGap):
+		}
+	}
+}

--- a/pmon/singleinstance/instance_test.go
+++ b/pmon/singleinstance/instance_test.go
@@ -1,0 +1,135 @@
+package singleinstance
+
+import (
+	"context"
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestDaemonClientLifecycle(t *testing.T) {
+	instance := New(t.TempDir()+"/instance.lock", time.Second)
+	client := instance.Client()
+	if running, err := client.Running(context.Background()); err != nil || running {
+		t.Fatalf("Running before acquire = %t, %v; want false, nil", running, err)
+	}
+
+	daemon, acquired, err := instance.Acquire(context.Background())
+	if err != nil || !acquired {
+		t.Fatalf("Acquire = %t, %v; want true, nil", acquired, err)
+	}
+	owner, err := client.Owner(context.Background())
+	if err != nil || owner == nil || owner.PID() != os.Getpid() {
+		t.Fatalf("Owner = %#v, %v; want pid %d", owner, err, os.Getpid())
+	}
+	if current, err := owner.Current(context.Background()); err != nil || !current {
+		t.Fatalf("Current = %t, %v; want true, nil", current, err)
+	}
+	if err := owner.Signal(context.Background(), 0); err != nil {
+		t.Fatalf("Signal(0): %v", err)
+	}
+	if other, acquired, err := instance.Acquire(context.Background()); err != nil || acquired || other != nil {
+		t.Fatalf("second Acquire = %#v, %t, %v; want nil, false, nil", other, acquired, err)
+	}
+
+	if err := daemon.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := daemon.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if err := owner.WaitExit(context.Background(), time.Second); err != nil {
+		t.Fatalf("WaitExit: %v", err)
+	}
+	if running, err := client.Running(context.Background()); err != nil || running {
+		t.Fatalf("Running after close = %t, %v; want false, nil", running, err)
+	}
+}
+
+func TestPinnedOwnerDetectsReplacement(t *testing.T) {
+	instance := New(t.TempDir()+"/instance.lock", time.Second)
+	client := instance.Client()
+	first, acquired, err := instance.Acquire(context.Background())
+	if err != nil || !acquired {
+		t.Fatalf("first Acquire = %t, %v; want true, nil", acquired, err)
+	}
+	owner, err := client.Owner(context.Background())
+	if err != nil || owner == nil {
+		t.Fatalf("Owner = %#v, %v; want owner", owner, err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first owner: %v", err)
+	}
+
+	path := instance.path
+	file, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open lock: %v", err)
+	}
+	transitionFile, err := lockTransition(context.Background(), path, syscall.LOCK_EX)
+	if err != nil {
+		file.Close()
+		t.Fatalf("lock transition: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = unlockAndClose(file)
+		_ = unlockAndClose(transitionFile)
+	})
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatalf("lock replacement: %v", err)
+	}
+	if err := writePID(file, owner.PID()+1); err != nil {
+		t.Fatalf("write replacement pid: %v", err)
+	}
+	if err := syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatalf("publish replacement: %v", err)
+	}
+
+	if current, err := owner.Current(context.Background()); !errors.Is(err, ErrOwnerReplaced) || current {
+		t.Fatalf("Current after replacement = %t, %v; want false, ErrOwnerReplaced", current, err)
+	}
+	if err := owner.Signal(context.Background(), 0); !errors.Is(err, ErrOwnerReplaced) {
+		t.Fatalf("Signal after replacement = %v, want ErrOwnerReplaced", err)
+	}
+	if err := owner.WaitExit(context.Background(), time.Second); !errors.Is(err, ErrOwnerReplaced) {
+		t.Fatalf("WaitExit after replacement = %v, want ErrOwnerReplaced", err)
+	}
+}
+
+func TestPinnedOwnerWaitExitTimesOut(t *testing.T) {
+	instance := New(t.TempDir()+"/instance.lock", time.Second)
+	daemon, acquired, err := instance.Acquire(context.Background())
+	if err != nil || !acquired {
+		t.Fatalf("Acquire = %t, %v; want true, nil", acquired, err)
+	}
+	t.Cleanup(func() { _ = daemon.Close() })
+	owner, err := instance.Client().Owner(context.Background())
+	if err != nil || owner == nil {
+		t.Fatalf("Owner = %#v, %v; want owner", owner, err)
+	}
+
+	err = owner.WaitExit(context.Background(), 50*time.Millisecond)
+	if !errors.Is(err, ErrOwnerExitTimeout) {
+		t.Fatalf("WaitExit = %v, want ErrOwnerExitTimeout", err)
+	}
+}
+
+func TestClientBoundsTransitionWait(t *testing.T) {
+	path := t.TempDir() + "/instance.lock"
+	transitionFile, err := os.OpenFile(transitionPath(path), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open transition lock: %v", err)
+	}
+	if err := syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		transitionFile.Close()
+		t.Fatalf("lock transition: %v", err)
+	}
+	t.Cleanup(func() { _ = unlockAndClose(transitionFile) })
+
+	client := New(path, 50*time.Millisecond).Client()
+	if _, err := client.Running(context.Background()); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Running = %v, want context deadline exceeded", err)
+	}
+}

--- a/pmon/singleinstance/lock.go
+++ b/pmon/singleinstance/lock.go
@@ -1,0 +1,194 @@
+// Package singleinstance coordinates one daemon process and its clients.
+package singleinstance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	maxPIDBytes       = 64
+	transitionPollGap = 10 * time.Millisecond
+)
+
+type fileLock struct {
+	file *os.File
+}
+
+func acquireLock(ctx context.Context, path string) (*fileLock, bool, error) {
+	transitionFile, err := lockTransition(ctx, path, syscall.LOCK_EX)
+	if err != nil {
+		return nil, false, err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, false, errors.Join(err, unlockAndClose(transitionFile))
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		closeErr := errors.Join(file.Close(), unlockAndClose(transitionFile))
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, false, closeErr
+		}
+		return nil, false, errors.Join(err, closeErr)
+	}
+	// The transition lock makes retained metadata unreadable until this replacement completes.
+	if err := writePID(file, os.Getpid()); err != nil {
+		return nil, false, errors.Join(err, unlockAndClose(file), unlockAndClose(transitionFile))
+	}
+	if err := unlockAndClose(transitionFile); err != nil {
+		return nil, false, errors.Join(err, unlockAndClose(file))
+	}
+	return &fileLock{file: file}, true, nil
+}
+
+func (lock *fileLock) Close() error {
+	if lock == nil || lock.file == nil {
+		return nil
+	}
+	file := lock.file
+	lock.file = nil
+	return unlockAndClose(file)
+}
+
+func lockHeld(ctx context.Context, path string) (held bool, err error) {
+	transitionFile, err := lockTransition(ctx, path, syscall.LOCK_SH)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	file, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, unlockAndClose(transitionFile)
+	}
+	if err != nil {
+		return false, errors.Join(err, unlockAndClose(transitionFile))
+	}
+	defer func() {
+		err = errors.Join(err, file.Close(), unlockAndClose(transitionFile))
+	}()
+	return fileHeld(file)
+}
+
+func lockOwnerPID(ctx context.Context, path string) (pid int, held bool, err error) {
+	transitionFile, err := lockTransition(ctx, path, syscall.LOCK_SH)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	file, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, false, unlockAndClose(transitionFile)
+	}
+	if err != nil {
+		return 0, false, errors.Join(err, unlockAndClose(transitionFile))
+	}
+	defer func() {
+		err = errors.Join(err, file.Close(), unlockAndClose(transitionFile))
+	}()
+	held, err = fileHeld(file)
+	if err != nil || !held {
+		return 0, held, err
+	}
+	pid, err = readPID(file)
+	if err != nil {
+		return 0, true, err
+	}
+	held, err = fileHeld(file)
+	if err != nil || !held {
+		return 0, held, err
+	}
+	return pid, true, nil
+}
+
+func writePID(file *os.File, pid int) error {
+	if err := file.Truncate(0); err != nil {
+		return err
+	}
+	data := fmt.Appendf(nil, "%d", pid)
+	written, err := file.WriteAt(data, 0)
+	if err != nil {
+		return err
+	}
+	if written != len(data) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+func readPID(file *os.File) (int, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return 0, err
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxPIDBytes+1))
+	if err != nil {
+		return 0, err
+	}
+	if len(data) > maxPIDBytes {
+		return 0, errors.New("owner pid is too long")
+	}
+	pid, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 32)
+	if err != nil || pid <= 0 {
+		return 0, fmt.Errorf("invalid owner pid %q", data)
+	}
+	return int(pid), nil
+}
+
+func transitionPath(path string) string {
+	return path + ".transition"
+}
+
+func lockTransition(ctx context.Context, path string, mode int) (*os.File, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(transitionPath(path), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	for {
+		err := syscall.Flock(int(file.Fd()), mode|syscall.LOCK_NB)
+		if err == nil {
+			return file, nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			return nil, errors.Join(err, file.Close())
+		}
+		select {
+		case <-ctx.Done():
+			return nil, errors.Join(fmt.Errorf("wait for lock transition: %w", ctx.Err()), file.Close())
+		case <-time.After(transitionPollGap):
+		}
+	}
+}
+
+func fileHeld(file *os.File) (bool, error) {
+	err := syscall.Flock(int(file.Fd()), syscall.LOCK_SH|syscall.LOCK_NB)
+	if err == nil {
+		if err := syscall.Flock(int(file.Fd()), syscall.LOCK_UN); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+		return true, nil
+	}
+	return false, err
+}
+
+func unlockAndClose(file *os.File) error {
+	return errors.Join(
+		syscall.Flock(int(file.Fd()), syscall.LOCK_UN),
+		file.Close(),
+	)
+}

--- a/pmon/singleinstance/lock_test.go
+++ b/pmon/singleinstance/lock_test.go
@@ -1,0 +1,434 @@
+package singleinstance
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func acquire(path string) (*fileLock, bool, error) {
+	return acquireLock(context.Background(), path)
+}
+
+func held(path string) (bool, error) {
+	return lockHeld(context.Background(), path)
+}
+
+func ownerPID(path string) (int, bool, error) {
+	return lockOwnerPID(context.Background(), path)
+}
+
+func transitionLock(path string, mode int) (*os.File, error) {
+	return lockTransition(context.Background(), path, mode)
+}
+
+type transitionWaitContext struct {
+	context.Context
+	once    sync.Once
+	waiting chan struct{}
+}
+
+func (ctx *transitionWaitContext) Done() <-chan struct{} {
+	ctx.once.Do(func() { close(ctx.waiting) })
+	return ctx.Context.Done()
+}
+
+func TestLockLifecycle(t *testing.T) {
+	path := t.TempDir() + "/instance.lock"
+
+	if held, err := held(path); err != nil || held {
+		t.Fatalf("Held before acquire = %v, %v; want false, nil", held, err)
+	}
+	lock, acquired, err := acquire(path)
+	if err != nil || !acquired {
+		t.Fatalf("Acquire = %v, %v; want lock, true, nil", acquired, err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat acquired lock: %v", err)
+	}
+	transitionBefore, err := os.Stat(transitionPath(path))
+	if err != nil {
+		t.Fatalf("stat acquired transition lock: %v", err)
+	}
+	if held, err := held(path); err != nil || !held {
+		t.Fatalf("Held after acquire = %v, %v; want true, nil", held, err)
+	}
+	if pid, held, err := ownerPID(path); err != nil || !held || pid != os.Getpid() {
+		t.Fatalf("OwnerPID = %d, %v, %v; want %d, true, nil", pid, held, err, os.Getpid())
+	}
+	if other, acquired, err := acquire(path); err != nil || acquired || other != nil {
+		t.Fatalf("second Acquire = %v, %v, %v; want nil, false, nil", other, acquired, err)
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if held, err := held(path); err != nil || held {
+		t.Fatalf("Held after close = %v, %v; want false, nil", held, err)
+	}
+	if pid, held, err := ownerPID(path); err != nil || held || pid != 0 {
+		t.Fatalf("OwnerPID after close = %d, %v, %v; want 0, false, nil", pid, held, err)
+	}
+
+	lock, acquired, err = acquire(path)
+	if err != nil || !acquired {
+		t.Fatalf("reacquire = %v, %v; want lock, true, nil", acquired, err)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat reacquired lock: %v", err)
+	}
+	transitionAfter, err := os.Stat(transitionPath(path))
+	if err != nil {
+		t.Fatalf("stat reacquired transition lock: %v", err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("reacquire replaced the lock inode")
+	}
+	if !os.SameFile(transitionBefore, transitionAfter) {
+		t.Fatal("reacquire replaced the transition-lock inode")
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatalf("close reacquired lock: %v", err)
+	}
+}
+
+func TestSharedProbeLockDoesNotReportAnOwner(t *testing.T) {
+	path := t.TempDir() + "/instance.lock"
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open lock: %v", err)
+	}
+	t.Cleanup(func() {
+		syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		file.Close()
+	})
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_SH|syscall.LOCK_NB); err != nil {
+		t.Fatalf("take shared probe lock: %v", err)
+	}
+
+	if held, err := held(path); err != nil || held {
+		t.Fatalf("Held behind another probe = %v, %v; want false, nil", held, err)
+	}
+	if pid, held, err := ownerPID(path); err != nil || held || pid != 0 {
+		t.Fatalf("OwnerPID behind another probe = %d, %v, %v; want 0, false, nil", pid, held, err)
+	}
+}
+
+func TestProbesWithMissingParent(t *testing.T) {
+	path := t.TempDir() + "/missing/instance.lock"
+	if held, err := held(path); err != nil || held {
+		t.Fatalf("Held = %v, %v; want false, nil", held, err)
+	}
+	if pid, held, err := ownerPID(path); err != nil || held || pid != 0 {
+		t.Fatalf("OwnerPID = %d, %v, %v; want 0, false, nil", pid, held, err)
+	}
+}
+
+func TestOperationsHonorDeadlineWhileTransitionIslockHeld(t *testing.T) {
+	path := t.TempDir() + "/instance.lock"
+	transitionFile, err := os.OpenFile(transitionPath(path), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open transition lock: %v", err)
+	}
+	if err := syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		transitionFile.Close()
+		t.Fatalf("lock transition: %v", err)
+	}
+	t.Cleanup(func() {
+		syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_UN)
+		transitionFile.Close()
+	})
+
+	operations := map[string]func(context.Context) error{
+		"Acquire": func(ctx context.Context) error {
+			lock, _, err := acquireLock(ctx, path)
+			if lock != nil {
+				_ = lock.Close()
+			}
+			return err
+		},
+		"Held": func(ctx context.Context) error {
+			_, err := lockHeld(ctx, path)
+			return err
+		},
+		"OwnerPID": func(ctx context.Context) error {
+			_, _, err := lockOwnerPID(ctx, path)
+			return err
+		},
+	}
+	for name, operation := range operations {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			started := time.Now()
+			if err := operation(ctx); !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("operation error = %v, want context deadline exceeded", err)
+			}
+			if elapsed := time.Since(started); elapsed > time.Second {
+				t.Fatalf("operation took %s, want at most 1s", elapsed)
+			}
+		})
+	}
+}
+
+func TestLockAcrossProcesses(t *testing.T) {
+	path := t.TempDir() + "/instance.lock"
+	lock, acquired, err := acquire(path)
+	if err != nil || !acquired {
+		t.Fatalf("Acquire = %v, %v; want lock, true, nil", acquired, err)
+	}
+	runLockHelper(t, path, "blocked")
+	if err := lock.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	runLockHelper(t, path, "acquired")
+	lock, acquired, err = acquire(path)
+	if err != nil || !acquired {
+		t.Fatalf("Acquire after helper exit = %v, %v; want lock, true, nil", acquired, err)
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatalf("final Close: %v", err)
+	}
+}
+
+func TestLockHelperProcess(t *testing.T) {
+	path := os.Getenv("PM_SINGLEINSTANCE_HELPER_PATH")
+	if path == "" {
+		return
+	}
+	want := os.Getenv("PM_SINGLEINSTANCE_HELPER_WANT")
+	lock, acquired, err := acquire(path)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	switch want {
+	case "blocked":
+		if acquired || lock != nil {
+			_ = lock.Close()
+			t.Fatal("Acquire succeeded while the parent held the lock")
+		}
+	case "acquired":
+		if !acquired || lock == nil {
+			t.Fatal("Acquire did not succeed after the parent released the lock")
+		}
+	default:
+		t.Fatalf("unknown expectation %q", want)
+	}
+}
+
+func runLockHelper(t *testing.T, path, want string) {
+	t.Helper()
+	command := exec.Command(os.Args[0], "-test.run=^TestLockHelperProcess$")
+	command.Env = append(os.Environ(),
+		"PM_SINGLEINSTANCE_HELPER_PATH="+path,
+		"PM_SINGLEINSTANCE_HELPER_WANT="+want,
+	)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("helper expecting %s: %v\n%s", want, err, output)
+	}
+}
+
+func TestProbesWaitForOwnershipPublication(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		probe func(context.Context, string) (bool, error)
+	}{
+		{name: "Held", probe: lockHeld},
+		{name: "OwnerPID", probe: func(ctx context.Context, path string) (bool, error) {
+			pid, held, err := lockOwnerPID(ctx, path)
+			if err == nil && held && pid != os.Getpid() {
+				return false, errors.New("OwnerPID returned the wrong pid")
+			}
+			return held, err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := t.TempDir() + "/instance.lock"
+			file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+			if err != nil {
+				t.Fatalf("open lock: %v", err)
+			}
+			transitionFile, err := transitionLock(path, syscall.LOCK_EX)
+			if err != nil {
+				file.Close()
+				t.Fatalf("lock transition: %v", err)
+			}
+			t.Cleanup(func() {
+				syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+				syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_UN)
+				file.Close()
+				transitionFile.Close()
+			})
+			if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+				t.Fatalf("lock: %v", err)
+			}
+			if err := writePID(file, 1); err != nil {
+				t.Fatalf("write retained metadata: %v", err)
+			}
+
+			waitCtx := &transitionWaitContext{Context: context.Background(), waiting: make(chan struct{})}
+			result := make(chan error, 1)
+			go func() {
+				held, err := tc.probe(waitCtx, path)
+				if err == nil && !held {
+					err = errors.New("probe did not report the held lock")
+				}
+				result <- err
+			}()
+			select {
+			case <-waitCtx.waiting:
+			case <-time.After(time.Second):
+				t.Fatal("probe never reached transition-lock contention")
+			}
+			select {
+			case err := <-result:
+				t.Fatalf("probe returned before ownership was published: %v", err)
+			default:
+			}
+
+			if err := writePID(file, os.Getpid()); err != nil {
+				t.Fatalf("publish pid: %v", err)
+			}
+			if err := syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_UN); err != nil {
+				t.Fatalf("unlock transition: %v", err)
+			}
+			select {
+			case err := <-result:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("probe did not resume after ownership was published")
+			}
+		})
+	}
+}
+
+func TestProbesWaitForFirstOwnershipPublication(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		probe func(context.Context, string) (bool, error)
+	}{
+		{name: "Held", probe: lockHeld},
+		{name: "OwnerPID", probe: func(ctx context.Context, path string) (bool, error) {
+			pid, held, err := lockOwnerPID(ctx, path)
+			if err == nil && held && pid != os.Getpid() {
+				return false, errors.New("OwnerPID returned the wrong pid")
+			}
+			return held, err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := t.TempDir() + "/instance.lock"
+			transitionFile, err := transitionLock(path, syscall.LOCK_EX)
+			if err != nil {
+				t.Fatalf("lock transition: %v", err)
+			}
+			var file *os.File
+			t.Cleanup(func() {
+				if file != nil {
+					syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+					file.Close()
+				}
+				syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_UN)
+				transitionFile.Close()
+			})
+
+			waitCtx := &transitionWaitContext{Context: context.Background(), waiting: make(chan struct{})}
+			result := make(chan error, 1)
+			go func() {
+				held, err := tc.probe(waitCtx, path)
+				if err == nil && !held {
+					err = errors.New("probe did not report the held lock")
+				}
+				result <- err
+			}()
+			select {
+			case <-waitCtx.waiting:
+			case <-time.After(time.Second):
+				t.Fatal("probe never reached first-publication contention")
+			}
+			select {
+			case err := <-result:
+				t.Fatalf("probe returned before first ownership was published: %v", err)
+			default:
+			}
+
+			file, err = os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+			if err != nil {
+				t.Fatalf("open lock: %v", err)
+			}
+			if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+				t.Fatalf("lock: %v", err)
+			}
+			if err := writePID(file, os.Getpid()); err != nil {
+				t.Fatalf("publish pid: %v", err)
+			}
+			if err := syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_UN); err != nil {
+				t.Fatalf("unlock transition: %v", err)
+			}
+			select {
+			case err := <-result:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("probe did not resume after first ownership was published")
+			}
+		})
+	}
+}
+
+func TestOwnerPIDRejectsInvalidMetadata(t *testing.T) {
+	for name, contents := range map[string]string{
+		"empty":              "",
+		"not-pid":            "pmon",
+		"zero":               "0",
+		"negative":           "-1",
+		"pid-t-overflow":     "2147483648",
+		"kill-all-wrap":      "4294967295",
+		"process-group-wrap": "4294967296",
+		"too-long":           strings.Repeat("1", maxPIDBytes+1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := t.TempDir() + "/instance.lock"
+			file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+			if err != nil {
+				t.Fatalf("open lock: %v", err)
+			}
+			transitionFile, err := os.OpenFile(transitionPath(path), os.O_CREATE|os.O_RDWR, 0o600)
+			if err != nil {
+				file.Close()
+				t.Fatalf("open transition lock: %v", err)
+			}
+			t.Cleanup(func() {
+				syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_UN)
+				syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+				transitionFile.Close()
+				file.Close()
+			})
+			if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+				t.Fatalf("lock: %v", err)
+			}
+			if _, err := file.WriteString(contents); err != nil {
+				t.Fatalf("write metadata: %v", err)
+			}
+
+			pid, held, err := ownerPID(path)
+			if err == nil || !held || pid != 0 {
+				t.Fatalf("OwnerPID = %d, %v, %v; want 0, true, error", pid, held, err)
+			}
+		})
+	}
+}

--- a/pmon/state/pidlock.go
+++ b/pmon/state/pidlock.go
@@ -1,92 +1,17 @@
 package state
 
 import (
-	"fmt"
-	"os"
-	"strconv"
-	"strings"
-	"syscall"
+	"time"
+
+	"github.com/ridi-oss/proxy-monster/pmon/singleinstance"
 )
 
-// pidLock is the open, flocked pid file the daemon holds while it runs; [ReleasePidLock] closes it.
-var pidLock *os.File
+const pidLockOperationTimeout = 2 * time.Second
 
-// AcquirePidLock takes the exclusive pid lock that makes the daemon single-instance. It returns held=false
-// (no error) when another live daemon already holds it, so two peers racing to start one can't produce two.
-// A crashed daemon's lock is auto-released by the OS, which is why this is an flock rather than a
-// kill(pid,0) check — the latter is defeated by PID reuse and by the TOCTOU between check and start.
-func AcquirePidLock() (held bool, err error) {
-	if _, err := EnsureDir(); err != nil {
-		return false, err
-	}
-	p, err := PidPath()
+func DaemonInstance() (*singleinstance.Instance, error) {
+	path, err := PidPath()
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		return false, err
-	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		f.Close()
-		return false, nil // already held by a live daemon
-	}
-	_ = f.Truncate(0)
-	_, _ = f.WriteAt(fmt.Appendf(nil, "%d", os.Getpid()), 0)
-	pidLock = f // keep the fd (and its lock) for the process lifetime
-	return true, nil
-}
-
-// ReleasePidLock drops the lock, leaving the pid file in place.
-//
-// The file is deliberately NOT removed. Unlocking and then unlinking opens a window in which a second daemon
-// opens and locks that same inode, the first daemon unlinks it, and a third creates and locks a FRESH inode —
-// leaving two daemons each believing it is the singleton, and each entitled to unlink the other's control
-// socket. Keeping one stable inode makes the flock the single arbiter; stale file CONTENTS are harmless,
-// because liveness is decided by whether the lock can be taken, never by the pid written inside.
-func ReleasePidLock() {
-	if pidLock == nil {
-		return
-	}
-	syscall.Flock(int(pidLock.Fd()), syscall.LOCK_UN)
-	pidLock.Close()
-	pidLock = nil
-}
-
-// DaemonRunning reports whether a daemon is alive, by probing the pid lock: if the flock can't be taken, a
-// daemon holds it. Robust against PID reuse, and it needs no cooperation from the daemon — so it is also how
-// a peer distinguishes "socket file is stale" from "a daemon is listening".
-func DaemonRunning() bool {
-	p, err := PidPath()
-	if err != nil {
-		return false
-	}
-	f, err := os.OpenFile(p, os.O_RDWR, 0o600)
-	if err != nil {
-		return false // no pid file -> not running
-	}
-	defer f.Close()
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		return true // lock held elsewhere -> a daemon is alive
-	}
-	syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-	return false
-}
-
-// DaemonPid reads the pid the running daemon recorded, for a signal-based stop when the control socket is
-// unreachable. Returns 0 when the file is absent or unparseable.
-func DaemonPid() int {
-	p, err := PidPath()
-	if err != nil {
-		return 0
-	}
-	data, err := os.ReadFile(p)
-	if err != nil {
-		return 0
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil {
-		return 0
-	}
-	return pid
+	return singleinstance.New(path, pidLockOperationTimeout), nil
 }

--- a/pmon/state/state_test.go
+++ b/pmon/state/state_test.go
@@ -1,14 +1,18 @@
 package state
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
+	"time"
 )
 
 // isolate points the state directory at a temp dir, so a test never touches the real user config.
@@ -17,6 +21,47 @@ func isolate(t *testing.T) string {
 	dir := t.TempDir()
 	t.Setenv(dirEnv, dir)
 	return dir
+}
+
+func TestDaemonRunningTimesOutWhenPidPublicationStalls(t *testing.T) {
+	isolate(t)
+	if _, err := EnsureDir(); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	pidPath, err := PidPath()
+	if err != nil {
+		t.Fatalf("PidPath: %v", err)
+	}
+	transitionFile, err := os.OpenFile(pidPath+".transition", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open transition lock: %v", err)
+	}
+	if err := syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		transitionFile.Close()
+		t.Fatalf("lock transition: %v", err)
+	}
+	t.Cleanup(func() {
+		syscall.Flock(int(transitionFile.Fd()), syscall.LOCK_UN)
+		transitionFile.Close()
+	})
+
+	instance, err := DaemonInstance()
+	if err != nil {
+		t.Fatalf("DaemonInstance: %v", err)
+	}
+	result := make(chan error, 1)
+	go func() {
+		_, err := instance.Client().Running(context.Background())
+		result <- err
+	}()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("DaemonRunning error = %v, want context deadline exceeded", err)
+		}
+	case <-time.After(pidLockOperationTimeout + time.Second):
+		t.Fatal("DaemonRunning did not stop at the pid-lock operation deadline")
+	}
 }
 
 func TestAssignPortIsStickyAndCompact(t *testing.T) {
@@ -406,56 +451,4 @@ func TestSocketPathUsesProductionRoot(t *testing.T) {
 	if got := filepath.Dir(sock); got != want {
 		t.Errorf("socket directory = %q, want %q", got, want)
 	}
-}
-
-// TestPidLockIsExclusiveAndReportsLiveness covers the daemon's single-instance guard: while the lock is held
-// DaemonRunning is true and a second acquire fails without error (so a racing peer's spawn loses gracefully
-// rather than producing two daemons); after release both invert.
-func TestPidLockIsExclusiveAndReportsLiveness(t *testing.T) {
-	isolate(t)
-
-	if DaemonRunning() {
-		t.Fatal("DaemonRunning() true before any lock was taken")
-	}
-	held, err := AcquirePidLock()
-	if err != nil || !held {
-		t.Fatalf("AcquirePidLock() = %v, %v; want true, nil", held, err)
-	}
-	if !DaemonRunning() {
-		t.Error("DaemonRunning() false while the lock is held")
-	}
-	if pid := DaemonPid(); pid != os.Getpid() {
-		t.Errorf("DaemonPid() = %d, want this process %d", pid, os.Getpid())
-	}
-
-	ReleasePidLock()
-	if DaemonRunning() {
-		t.Error("DaemonRunning() true after release")
-	}
-}
-
-// TestReleasePidLockKeepsTheFile locks the reason the pid file is NOT unlinked on release: unlock-then-unlink let
-// a second daemon lock the same inode before the first removed it, after which a third created and locked a fresh
-// one — two daemons each believing it was the singleton, each entitled to unlink the other's control socket.
-// Liveness comes from whether the flock can be taken, never from the pid inside, so stale contents are harmless.
-func TestReleasePidLockKeepsTheFile(t *testing.T) {
-	isolate(t)
-	if _, err := AcquirePidLock(); err != nil {
-		t.Fatalf("AcquirePidLock: %v", err)
-	}
-	p, err := PidPath()
-	if err != nil {
-		t.Fatalf("PidPath: %v", err)
-	}
-	ReleasePidLock()
-
-	if _, err := os.Stat(p); err != nil {
-		t.Errorf("the pid file was removed on release (%v); one stable inode must remain so the flock is the sole arbiter", err)
-	}
-	// And it is re-lockable, so a later daemon still starts.
-	held, err := AcquirePidLock()
-	if err != nil || !held {
-		t.Errorf("AcquirePidLock after release = %v, %v; want true, nil", held, err)
-	}
-	ReleasePidLock()
 }

--- a/pmon/status_cmd.go
+++ b/pmon/status_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -18,9 +19,16 @@ type statusCmd struct{}
 func (statusCmd) Run() error {
 	ctx := context.Background()
 	client, err := control.Connect(ctx)
-	if err != nil {
+	if errors.Is(err, control.ErrDaemonUnreachable) {
+		fmt.Println("daemon:    running, control socket unreachable (run `pmon restart`)")
+		return nil
+	}
+	if errors.Is(err, control.ErrDaemonNotRunning) {
 		fmt.Println("daemon:    not running (run `pmon start`, or `pmon login` to start it and log in)")
 		return nil
+	}
+	if err != nil {
+		return err
 	}
 	s, err := client.Status(ctx)
 	if err != nil {

--- a/pmontray/actions.go
+++ b/pmontray/actions.go
@@ -1,13 +1,30 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"fyne.io/systray"
 
 	"github.com/ridi-oss/proxy-monster/pmon/control"
+	"github.com/ridi-oss/proxy-monster/pmon/state"
 )
+
+var (
+	connectForConfirmation       = control.Connect
+	statusForConfirmation        = (*control.Client).Status
+	daemonRunningForConfirmation = daemonIsRunning
+	confirmConnectionDrop        = confirmDialog
+)
+
+func daemonIsRunning(ctx context.Context) (bool, error) {
+	instance, err := state.DaemonInstance()
+	if err != nil {
+		return false, err
+	}
+	return instance.Client().Running(ctx)
+}
 
 // The tray's actions. Each is the SAME control-API call `pmon` makes — no privileged path, no tray-only
 // behavior — so the two front ends cannot diverge in what they do or in what they protect.
@@ -26,6 +43,7 @@ func (a *app) doLogin() {
 	client, err := control.EnsureDaemon(a.ctx)
 	a.unlockAction()
 	if err != nil {
+		a.renderControlError(err)
 		notify("proxy-monster", fmt.Sprintf("could not start the daemon: %v", err))
 		return
 	}
@@ -66,8 +84,18 @@ func (a *app) doLogout() {
 	defer a.unlockAction()
 
 	client, err := control.Connect(a.ctx)
-	if err != nil {
+	if errors.Is(err, control.ErrDaemonUnreachable) {
+		a.renderUnreachable()
+		notify("proxy-monster", "the daemon control socket is unreachable — restart it before logging out")
+		return
+	}
+	if errors.Is(err, control.ErrDaemonNotRunning) {
 		a.render(nil)
+		return
+	}
+	if err != nil {
+		a.renderControlError(err)
+		notify("proxy-monster", fmt.Sprintf("could not read the daemon status: %v", err))
 		return
 	}
 	// Logging out closes the brokers, which drops live sessions — the same warning the CLI gives.
@@ -93,6 +121,7 @@ func (a *app) doStart() {
 	}
 	client, err := control.EnsureDaemon(a.ctx)
 	if err != nil {
+		a.renderControlError(err)
 		notify("proxy-monster", fmt.Sprintf("could not start the daemon: %v", err))
 		return
 	}
@@ -109,14 +138,17 @@ func (a *app) doRestart() {
 	if !a.confirmDroppingConns("Restart") {
 		return
 	}
-	if err := control.StopDaemon(a.ctx); err != nil && !errors.Is(err, control.ErrDaemonNotRunning) {
+	if err := control.StopDaemon(a.ctx); err != nil &&
+		!errors.Is(err, control.ErrDaemonNotRunning) &&
+		!errors.Is(err, control.ErrDaemonReplaced) {
+		a.renderControlError(err)
 		notify("proxy-monster", fmt.Sprintf("could not stop the daemon: %v", err))
 		return
 	}
 	client, err := control.EnsureDaemon(a.ctx)
 	if err != nil {
 		notify("proxy-monster", fmt.Sprintf("could not restart the daemon: %v", err))
-		a.render(nil)
+		a.renderControlError(err)
 		return
 	}
 	a.refresh(client)
@@ -133,6 +165,7 @@ func (a *app) doStop() {
 		return
 	}
 	if err := control.StopDaemon(a.ctx); err != nil && !errors.Is(err, control.ErrDaemonNotRunning) {
+		a.renderControlError(err)
 		notify("proxy-monster", fmt.Sprintf("could not stop the daemon: %v", err))
 		return
 	}
@@ -148,36 +181,45 @@ func (a *app) doQuit() {
 		return
 	}
 	if err := control.StopDaemon(a.ctx); err != nil && !errors.Is(err, control.ErrDaemonNotRunning) {
-		// Quitting is meant to stop the daemon; if that failed the daemon is still brokering. Under `open
-		// pmontray.app` there is no stderr to read, so say so where the user will see it — otherwise the menu
-		// vanishes and a daemon keeps running with no indication.
+		// The tray has no visible stderr, so report a daemon left running before it exits.
 		a.setErr(fmt.Errorf("could not stop the daemon: %w", err))
 		notify("proxy-monster", fmt.Sprintf("quitting, but the daemon is still running: %v — stop it with `pmon stop`", err))
 	}
 	systray.Quit()
 }
 
-// confirmDroppingConns asks before an action that would cut live database sessions. The daemon is shared — the
-// CLI may have started it, another window may be mid-query — so the honest guard is telling the user what
-// breaks, exactly as `pmon stop` does, rather than tracking who started it.
-// It asks the DAEMON for the count rather than trusting the last render: the cached status can be stale (a
-// reconnect in progress, or a render(nil) that raced an in-flight refresh), and a stale nil would silently skip
-// the dialog and drop someone's in-flight query. Only a daemon that is genuinely unreachable — nothing to
-// disturb — proceeds without asking.
+// confirmDroppingConns reads live status before warning because the tray's cached status may be stale.
 func (a *app) confirmDroppingConns(action string) bool {
-	client, err := control.Connect(a.ctx)
-	if err != nil {
-		return true // no daemon reachable: there are no sessions to cut
-	}
-	s, err := client.Status(a.ctx)
-	if err != nil {
+	client, err := connectForConfirmation(a.ctx)
+	if errors.Is(err, control.ErrDaemonNotRunning) {
 		return true
+	}
+	if err != nil {
+		return confirmConnectionDrop(
+			fmt.Sprintf("%s proxy-monster?", action),
+			"The daemon status cannot be read, so active database connections cannot be checked.",
+			action,
+		)
+	}
+	s, err := statusForConfirmation(client, a.ctx)
+	if errors.Is(err, control.ErrDaemonNotRunning) {
+		running, runningErr := daemonRunningForConfirmation(a.ctx)
+		if runningErr == nil && !running {
+			return true
+		}
+	}
+	if err != nil {
+		return confirmConnectionDrop(
+			fmt.Sprintf("%s proxy-monster?", action),
+			"The daemon status cannot be read, so active database connections cannot be checked.",
+			action,
+		)
 	}
 	n := s.TotalLiveConns()
 	if n == 0 {
 		return true
 	}
-	return confirmDialog(
+	return confirmConnectionDrop(
 		fmt.Sprintf("%s proxy-monster?", action),
 		fmt.Sprintf("%d active database connection(s) will be dropped.", n),
 		action,

--- a/pmontray/actions_test.go
+++ b/pmontray/actions_test.go
@@ -1,9 +1,110 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/ridi-oss/proxy-monster/pmon/control"
 )
+
+func TestConnectionDropConfirmationFailsClosedWhenStatusIsUnknown(t *testing.T) {
+	originalConnect := connectForConfirmation
+	originalStatus := statusForConfirmation
+	originalDaemonRunning := daemonRunningForConfirmation
+	originalConfirm := confirmConnectionDrop
+	t.Cleanup(func() {
+		connectForConfirmation = originalConnect
+		statusForConfirmation = originalStatus
+		daemonRunningForConfirmation = originalDaemonRunning
+		confirmConnectionDrop = originalConfirm
+	})
+
+	unknownErr := errors.New("status unavailable")
+	for _, tc := range []struct {
+		name             string
+		connectErr       error
+		status           *control.Status
+		statusErr        error
+		daemonRunning    bool
+		daemonRunningErr error
+		confirmResult    bool
+		wantConfirm      bool
+		wantResult       bool
+		wantMessage      string
+	}{
+		{name: "not running", connectErr: control.ErrDaemonNotRunning, wantResult: true},
+		{name: "unreachable", connectErr: control.ErrDaemonUnreachable, wantConfirm: true, wantMessage: "cannot be read"},
+		{
+			name:          "unreachable approved",
+			connectErr:    control.ErrDaemonUnreachable,
+			confirmResult: true,
+			wantConfirm:   true,
+			wantResult:    true,
+			wantMessage:   "cannot be read",
+		},
+		{name: "unexpected connect error", connectErr: unknownErr, wantConfirm: true, wantMessage: "cannot be read"},
+		{name: "daemon exits before status", statusErr: control.ErrDaemonNotRunning, wantResult: true},
+		{
+			name:          "status closes while pid lock is held",
+			statusErr:     control.ErrDaemonNotRunning,
+			daemonRunning: true,
+			wantConfirm:   true,
+			wantMessage:   "cannot be read",
+		},
+		{
+			name:             "status closes while pid lock cannot be inspected",
+			statusErr:        control.ErrDaemonNotRunning,
+			daemonRunningErr: unknownErr,
+			wantConfirm:      true,
+			wantMessage:      "cannot be read",
+		},
+		{name: "status read error", statusErr: unknownErr, wantConfirm: true, wantMessage: "cannot be read"},
+		{name: "no live connections", status: &control.Status{}, wantResult: true},
+		{
+			name:        "live connections",
+			status:      &control.Status{Datasources: []control.Datasource{{LiveConns: 2}}},
+			wantConfirm: true,
+			wantMessage: "2 active database connection(s)",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			connectForConfirmation = func(context.Context) (*control.Client, error) {
+				return &control.Client{}, tc.connectErr
+			}
+			statusForConfirmation = func(*control.Client, context.Context) (*control.Status, error) {
+				if tc.status != nil {
+					return tc.status, tc.statusErr
+				}
+				return &control.Status{}, tc.statusErr
+			}
+			daemonRunningForConfirmation = func(context.Context) (bool, error) {
+				return tc.daemonRunning, tc.daemonRunningErr
+			}
+			confirmCalls := 0
+			confirmConnectionDrop = func(title, message, label string) bool {
+				confirmCalls++
+				if title != "Stop proxy-monster?" || label != "Stop" {
+					t.Errorf("confirmation = title %q label %q", title, label)
+				}
+				if !strings.Contains(message, tc.wantMessage) {
+					t.Errorf("confirmation message = %q, want %q", message, tc.wantMessage)
+				}
+				return tc.confirmResult
+			}
+
+			got := (&app{ctx: context.Background()}).confirmDroppingConns("Stop")
+			if got != tc.wantResult {
+				t.Errorf("confirmDroppingConns = %t, want %t", got, tc.wantResult)
+			}
+			if gotConfirm := confirmCalls > 0; gotConfirm != tc.wantConfirm {
+				t.Errorf("confirmation called = %t, want %t", gotConfirm, tc.wantConfirm)
+			}
+		})
+	}
+}
 
 // TestALongActionCannotWedgeTheMenu is the guard for a real wedge: the lifecycle lock used to be a plain mutex
 // held across the whole device-auth flow, which runs until the control plane's device TTL (~10 min) if the user

--- a/pmontray/app.go
+++ b/pmontray/app.go
@@ -37,8 +37,9 @@ type app struct {
 	actionBusy sync.Mutex
 	actionHeld bool
 
-	mu     sync.Mutex
-	status *control.Status // nil means "no daemon reachable"
+	mu          sync.Mutex
+	status      *control.Status
+	unreachable bool
 	// dsItems are the reusable datasource rows, in a fixed order established at startup.
 	dsItems []*dsItem
 
@@ -188,8 +189,7 @@ func (a *app) watchCopy(d *dsItem) {
 	}
 }
 
-// watchDaemon keeps the menu in sync with the daemon, and is also how the tray learns the daemon is gone: the
-// event stream ending means no daemon, which renders as the stopped state rather than a stale last-known one.
+// watchDaemon keeps the menu in sync with the daemon, and is also how the tray learns the daemon is gone.
 //
 // It deliberately does NOT start a daemon. A tray launching at login must not force one up — that is an
 // explicit action (Start / Log in), symmetric with the CLI.
@@ -200,13 +200,14 @@ func (a *app) watchDaemon() {
 		}
 		client, err := control.Connect(a.ctx)
 		if err != nil {
-			a.render(nil)
+			a.renderControlError(err)
 			if !a.sleep(reconnectDelay) {
 				return
 			}
 			continue
 		}
 		// The stream's first event is the current status, so the menu is correct as soon as it opens.
+		shuttingDown := false
 		streamErr := client.Events(a.ctx, func(ev control.Event) {
 			switch ev.Kind {
 			case "status":
@@ -217,15 +218,20 @@ func (a *app) watchDaemon() {
 				a.refresh(client)
 				notify("proxy-monster", "your session expired — log in again from the menu")
 			case "shutdown":
-				a.render(nil)
+				shuttingDown = true
 			default:
 				a.refresh(client)
 			}
 		})
-		if streamErr != nil && !errors.Is(streamErr, context.Canceled) {
-			a.render(nil)
-		} else {
-			a.render(nil) // the stream ended: the daemon is gone until proven otherwise
+		switch {
+		case a.ctx.Err() != nil:
+			return
+		case shuttingDown:
+			a.renderAfterDisconnect(true)
+		case streamErr != nil && !errors.Is(streamErr, context.Canceled):
+			a.renderControlError(streamErr)
+		default:
+			a.renderAfterDisconnect(false)
 		}
 		if !a.sleep(reconnectDelay) {
 			return
@@ -237,10 +243,62 @@ func (a *app) watchDaemon() {
 func (a *app) refresh(client *control.Client) {
 	s, err := client.Status(a.ctx)
 	if err != nil {
-		a.render(nil)
+		a.renderControlError(err)
 		return
 	}
 	a.render(s)
+}
+
+func (a *app) renderAfterDisconnect(shuttingDown bool) {
+	deadline := time.Now()
+	if shuttingDown {
+		deadline = deadline.Add(reconnectDelay)
+	}
+	for {
+		if a.ctx.Err() != nil {
+			return
+		}
+		running, err := daemonIsRunning(a.ctx)
+		if err != nil {
+			a.renderUnreachable()
+			return
+		}
+		if !running {
+			a.render(nil)
+			return
+		}
+		if !shuttingDown || time.Now().After(deadline) {
+			if a.renderConnectedDaemon() {
+				return
+			}
+			a.renderUnreachable()
+			return
+		}
+		if !a.sleep(25 * time.Millisecond) {
+			return
+		}
+	}
+}
+
+func (a *app) renderConnectedDaemon() bool {
+	client, err := control.Connect(a.ctx)
+	if err != nil {
+		return false
+	}
+	status, err := client.Status(a.ctx)
+	if err != nil {
+		return false
+	}
+	a.render(status)
+	return true
+}
+
+func (a *app) renderControlError(err error) {
+	if errors.Is(err, control.ErrDaemonNotRunning) {
+		a.renderAfterDisconnect(false)
+		return
+	}
+	a.renderUnreachable()
 }
 
 // sleep waits d, returning false if the app is shutting down.

--- a/pmontray/render.go
+++ b/pmontray/render.go
@@ -12,37 +12,42 @@ import (
 
 // menuItem wrappers for the FIXED items, nil-safe for the same reason as the row ones: render() must be
 // exercisable in a test, so the shipped function is what is verified rather than a parallel copy.
-func setTitleOf(m *systray.MenuItem, title string) {
+var setTitleOf = func(m *systray.MenuItem, title string) {
 	if m != nil {
 		m.SetTitle(title)
 	}
 }
 
-func showItem(m *systray.MenuItem) {
+var showItem = func(m *systray.MenuItem) {
 	if m != nil {
 		m.Show()
 	}
 }
 
-func hideItem(m *systray.MenuItem) {
+var hideItem = func(m *systray.MenuItem) {
 	if m != nil {
 		m.Hide()
 	}
 }
 
-func enableItem(m *systray.MenuItem) {
+var enableItem = func(m *systray.MenuItem) {
 	if m != nil {
 		m.Enable()
 	}
 }
 
-// render mirrors one daemon state into the menu. A nil status means no daemon is reachable, which is a normal
-// state to display — never a stale last-known one, since a menu bar claiming "connected" after the daemon died
-// is worse than one that says nothing.
-//
+// render mirrors one daemon state into the menu. A nil status means the daemon is stopped.
+func (a *app) render(s *control.Status) {
+	a.renderState(s, false)
+}
+
+func (a *app) renderUnreachable() {
+	a.renderState(nil, true)
+}
+
 // Only ever updates or hides existing items: systray cannot remove an item, so a menu rebuilt per update would
 // accumulate rows forever.
-func (a *app) render(s *control.Status) {
+func (a *app) renderState(s *control.Status, unreachable bool) {
 	// One render at a time, start to finish. render is reachable from the event watcher AND from every action
 	// goroutine (via refresh), and it assigns a LABEL and a CONNECTION STRING to each row in separate steps —
 	// so two interleaved renders could leave a row displaying one datasource while its click copied another
@@ -52,9 +57,12 @@ func (a *app) render(s *control.Status) {
 
 	a.mu.Lock()
 	a.status = s
+	a.unreachable = unreachable
 	a.mu.Unlock()
 
 	switch {
+	case unreachable:
+		a.renderUnreachableState()
 	case s == nil:
 		a.renderStopped()
 	case !s.LoggedIn:
@@ -62,6 +70,24 @@ func (a *app) render(s *control.Status) {
 	default:
 		a.renderLoggedIn(s)
 	}
+}
+
+func (a *app) renderUnreachableState() {
+	if a.mHeader != nil {
+		systray.SetTooltip("proxy-monster — daemon needs restart")
+	}
+	setTitleOf(a.mHeader, "daemon needs restart")
+	setTitleOf(a.mDetail, "control socket unreachable")
+	showItem(a.mDetail)
+	a.hideDatasourcesFrom(0)
+
+	hideItem(a.mLogin)
+	hideItem(a.mLogout)
+	hideItem(a.mStart)
+	showItem(a.mRestart)
+	enableItem(a.mRestart)
+	showItem(a.mStop)
+	enableItem(a.mStop)
 }
 
 func (a *app) renderStopped() {
@@ -73,6 +99,7 @@ func (a *app) renderStopped() {
 	a.hideDatasourcesFrom(0)
 
 	setTitleOf(a.mLogin, "Log in…") // starts the daemon on the way
+	showItem(a.mLogin)
 	enableItem(a.mLogin)
 	hideItem(a.mLogout)
 	showItem(a.mStart)
@@ -91,6 +118,7 @@ func (a *app) renderIdle(s *control.Status) {
 	a.hideDatasourcesFrom(0)
 
 	setTitleOf(a.mLogin, "Log in…")
+	showItem(a.mLogin)
 	enableItem(a.mLogin)
 	hideItem(a.mLogout)
 	hideItem(a.mStart)
@@ -113,6 +141,7 @@ func (a *app) renderLoggedIn(s *control.Status) {
 		setTitleOf(a.mHeader, fmt.Sprintf("%s — %s", s.Principal, expiry))
 		setTitleOf(a.mLogin, "Re-authenticate…")
 	}
+	showItem(a.mLogin)
 	enableItem(a.mLogin)
 	showItem(a.mLogout)
 	hideItem(a.mStart)

--- a/pmontray/render_test.go
+++ b/pmontray/render_test.go
@@ -1,12 +1,36 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
+	"time"
+
+	"fyne.io/systray"
 
 	"github.com/ridi-oss/proxy-monster/pmon/control"
+	"github.com/ridi-oss/proxy-monster/pmon/singleinstance"
+	"github.com/ridi-oss/proxy-monster/pmon/state"
 )
+
+func acquireDaemonLock(t *testing.T) *singleinstance.Daemon {
+	t.Helper()
+	if _, err := state.EnsureDir(); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	instance, err := state.DaemonInstance()
+	if err != nil {
+		t.Fatalf("DaemonInstance: %v", err)
+	}
+	lock, acquired, err := instance.Acquire(context.Background())
+	if err != nil || !acquired {
+		t.Fatalf("Acquire = %t, %v; want true, nil", acquired, err)
+	}
+	t.Cleanup(func() { _ = lock.Close() })
+	return lock
+}
 
 // The menu-item plumbing is macOS-only, so these tests exercise the row-assignment model directly: what a row
 // DISPLAYS and what it COPIES must always describe the same datasource. That pairing is the security-relevant
@@ -14,7 +38,7 @@ import (
 
 // newTestApp builds an app with the row pool but no systray, so row bookkeeping can be tested off-screen.
 func newTestApp(rows int) *app {
-	a := &app{}
+	a := &app{ctx: context.Background()}
 	for range rows {
 		a.dsItems = append(a.dsItems, &dsItem{})
 	}
@@ -29,6 +53,274 @@ func statusWith(names ...string) *control.Status {
 		})
 	}
 	return s
+}
+
+type statusBackend struct {
+	status control.Status
+}
+
+func (backend statusBackend) Status() control.Status {
+	return backend.status
+}
+
+func (statusBackend) Login(context.Context, control.LoginRequest, func(control.LoginEvent)) error {
+	return nil
+}
+
+func (statusBackend) Logout() error {
+	return nil
+}
+
+func (statusBackend) Reload() {}
+
+func (statusBackend) Subscribe() (<-chan control.Event, func()) {
+	return nil, func() {}
+}
+
+func (statusBackend) Shutdown() {}
+
+func TestUnreachableDaemonShowsRecoveryActions(t *testing.T) {
+	originalSetTitle := setTitleOf
+	originalShow := showItem
+	originalHide := hideItem
+	originalEnable := enableItem
+	t.Cleanup(func() {
+		setTitleOf = originalSetTitle
+		showItem = originalShow
+		hideItem = originalHide
+		enableItem = originalEnable
+	})
+
+	a := newTestApp(2)
+	a.mDetail = new(systray.MenuItem)
+	a.mLogin = new(systray.MenuItem)
+	a.mLogout = new(systray.MenuItem)
+	a.mStart = new(systray.MenuItem)
+	a.mRestart = new(systray.MenuItem)
+	a.mStop = new(systray.MenuItem)
+
+	titles := make(map[*systray.MenuItem]string)
+	visible := map[*systray.MenuItem]bool{
+		a.mLogin: true, a.mLogout: true, a.mStart: true,
+	}
+	enabled := make(map[*systray.MenuItem]bool)
+	setTitleOf = func(item *systray.MenuItem, title string) {
+		if item != nil {
+			titles[item] = title
+		}
+	}
+	showItem = func(item *systray.MenuItem) { visible[item] = true }
+	hideItem = func(item *systray.MenuItem) { visible[item] = false }
+	enableItem = func(item *systray.MenuItem) { enabled[item] = true }
+
+	a.renderUnreachable()
+
+	if titles[a.mDetail] != "control socket unreachable" || !visible[a.mDetail] {
+		t.Errorf("detail = %q visible=%t", titles[a.mDetail], visible[a.mDetail])
+	}
+	for name, item := range map[string]*systray.MenuItem{
+		"login": a.mLogin, "logout": a.mLogout, "start": a.mStart,
+	} {
+		if visible[item] {
+			t.Errorf("%s action is visible while the daemon needs restart", name)
+		}
+	}
+	for name, item := range map[string]*systray.MenuItem{"restart": a.mRestart, "stop": a.mStop} {
+		if !visible[item] || !enabled[item] {
+			t.Errorf("%s action visible=%t enabled=%t", name, visible[item], enabled[item])
+		}
+	}
+}
+
+func TestRecoveredStatesShowLoginAfterUnreachable(t *testing.T) {
+	originalSetTitle := setTitleOf
+	originalShow := showItem
+	originalHide := hideItem
+	originalEnable := enableItem
+	t.Cleanup(func() {
+		setTitleOf = originalSetTitle
+		showItem = originalShow
+		hideItem = originalHide
+		enableItem = originalEnable
+	})
+
+	a := newTestApp(1)
+	a.mLogin = new(systray.MenuItem)
+	visible := true
+	setTitleOf = func(*systray.MenuItem, string) {}
+	showItem = func(item *systray.MenuItem) {
+		if item == a.mLogin {
+			visible = true
+		}
+	}
+	hideItem = func(item *systray.MenuItem) {
+		if item == a.mLogin {
+			visible = false
+		}
+	}
+	enableItem = func(*systray.MenuItem) {}
+
+	states := map[string]*control.Status{
+		"stopped":   nil,
+		"idle":      {},
+		"logged-in": {LoggedIn: true, Principal: "you@example.com"},
+	}
+	for name, status := range states {
+		t.Run(name, func(t *testing.T) {
+			a.renderUnreachable()
+			if visible {
+				t.Fatal("Login is visible in the unreachable state")
+			}
+			a.render(status)
+			if !visible {
+				t.Fatal("Login stayed hidden after recovery")
+			}
+		})
+	}
+}
+
+func TestUnreachableDaemonIsDistinctFromStopped(t *testing.T) {
+	a := newTestApp(2)
+	a.render(statusWith("acme"))
+	a.renderUnreachable()
+
+	a.mu.Lock()
+	unreachable, status := a.unreachable, a.status
+	a.mu.Unlock()
+	if !unreachable || status != nil {
+		t.Fatalf("unreachable render stored unreachable=%t status=%v", unreachable, status)
+	}
+	if a.dsItems[0].name != "" || a.dsItems[0].connString != "" {
+		t.Errorf("unreachable render retained datasource state: %+v", a.dsItems[0])
+	}
+
+	a.render(nil)
+	a.mu.Lock()
+	unreachable = a.unreachable
+	a.mu.Unlock()
+	if unreachable {
+		t.Error("stopped render retained the unreachable state")
+	}
+}
+
+func TestControlErrorsRenderStoppedOnlyWhenDaemonIsKnownAbsent(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	a := newTestApp(1)
+	a.renderControlError(errors.New("could not inspect daemon lock"))
+
+	a.mu.Lock()
+	unreachable := a.unreachable
+	a.mu.Unlock()
+	if !unreachable {
+		t.Error("an unknown daemon-state error rendered as stopped")
+	}
+
+	a.renderControlError(control.ErrDaemonNotRunning)
+	a.mu.Lock()
+	unreachable = a.unreachable
+	a.mu.Unlock()
+	if unreachable {
+		t.Error("ErrDaemonNotRunning rendered as unreachable")
+	}
+}
+
+func TestDisconnectRendersStoppedOnlyAfterPidLockReleased(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	lock := acquireDaemonLock(t)
+
+	a := newTestApp(1)
+	a.render(statusWith("acme"))
+	a.renderAfterDisconnect(false)
+
+	a.mu.Lock()
+	unreachable := a.unreachable
+	a.mu.Unlock()
+	if !unreachable {
+		t.Error("a disconnected daemon holding the pid lock rendered as stopped")
+	}
+
+	a.render(statusWith("acme"))
+	a.renderControlError(control.ErrDaemonNotRunning)
+	a.mu.Lock()
+	unreachable = a.unreachable
+	a.mu.Unlock()
+	if !unreachable {
+		t.Error("a dial failure with the pid lock held rendered as stopped")
+	}
+
+	if err := lock.Close(); err != nil {
+		t.Fatalf("release daemon lock: %v", err)
+	}
+	a.renderControlError(control.ErrDaemonNotRunning)
+
+	a.mu.Lock()
+	unreachable, status := a.unreachable, a.status
+	a.mu.Unlock()
+	if unreachable || status != nil {
+		t.Errorf("released daemon rendered unreachable=%t status=%v; want stopped", unreachable, status)
+	}
+}
+
+func TestDisconnectKeepsHealthyReplacementVisible(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	acquireDaemonLock(t)
+	replacement := statusWith("replacement")
+	server, err := control.Listen(statusBackend{status: *replacement})
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- server.Serve(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		server.Close()
+		<-done
+	})
+
+	a := newTestApp(1)
+	a.render(statusWith("old"))
+	a.renderAfterDisconnect(false)
+
+	a.mu.Lock()
+	unreachable, status := a.unreachable, a.status
+	a.mu.Unlock()
+	if unreachable || status == nil || len(status.Datasources) != 1 || status.Datasources[0].Name != "replacement" {
+		t.Errorf("healthy replacement rendered unreachable=%t status=%v", unreachable, status)
+	}
+}
+
+func TestShutdownDisconnectWaitsForPidLockRelease(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	lock := acquireDaemonLock(t)
+
+	a := newTestApp(1)
+	a.render(statusWith("acme"))
+	done := make(chan struct{})
+	go func() {
+		a.renderAfterDisconnect(true)
+		close(done)
+	}()
+	select {
+	case <-done:
+		t.Fatal("shutdown disconnect rendered before the pid lock was released")
+	case <-time.After(50 * time.Millisecond):
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatalf("release daemon lock: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown disconnect did not render after the pid lock was released")
+	}
+
+	a.mu.Lock()
+	unreachable, status := a.unreachable, a.status
+	a.mu.Unlock()
+	if unreachable || status != nil {
+		t.Errorf("clean shutdown rendered unreachable=%t status=%v; want stopped", unreachable, status)
+	}
 }
 
 // TestConcurrentRendersNeverLeaveAMixedPool is the invariant serializing renders exists for. render is reachable


### PR DESCRIPTION
## Summary
- add an independently tested `pmon/singleinstance` package for stable-inode daemon ownership
- pin control requests and shutdown to the verified Unix peer and lock owner
- keep CLI and tray states fail-closed when daemon ownership or the control socket is uncertain

## Risk
Daemon start, stop, restart, replacement, login, and event-stream liveness.

## Verification
- every commit: `go test -count=1 ./pmon/... ./pmontray/...`
- `CI=true PM_TEST_POSTGRES_IMAGE=postgres:16 mise run verify`
- race tests, vet, and Linux amd64/arm64 builds