### PR TITLE
feat(pmon): broker PostgreSQL connections

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -141,7 +141,6 @@ registers itself, and why the control plane holds no target credentials).
   datasource marked as serving wire TLS is refused if the proxy declines the
   upgrade, before the token is sent. A proxy configured without wire TLS is
   brokered in plaintext, which is acceptable only over a trusted network.
-  Brokering is MySQL-only today.
 
 Only the CP's HTTP surface should be public, and only these paths; keep the gRPC
 port internal (nothing in the code enforces either):

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -194,12 +194,10 @@ mechanism). Authoritative: [docs/auth-model.md](docs/auth-model.md).
   binary) runs the OIDC device-auth flow and the control-plane mints a
   short-lived opaque, revocable credential bound to principal + roles.
   - Default — background daemon + local broker: the daemon opens one loopback
-    listener per MySQL datasource on a sticky port as soon as credentials exist
-    (`pmon login` is the only step), so a saved `mysql` or JDBC connection keeps
+    listener per datasource on a sticky port as soon as credentials exist
+    (`pmon login` is the only step), so a saved native or JDBC connection keeps
     a fixed `127.0.0.1:<port>` and a localhost password that never rotates,
-    while the daemon injects the current token on the upstream hop. Only MySQL
-    is brokered — a PostgreSQL datasource is discovered then skipped, so `psql`
-    connects to the proxy directly with a token as its password. The daemon
+    while the daemon injects the current token on the upstream hop. The daemon
     renews the wire token before expiry until the server-side session window
     closes, then requires a fresh `pmon login`.
   - One-shot token: the console's Access page (`/access`) mints a short-lived

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -314,9 +314,6 @@ Fixes for gaps documented in
 - Wire-cert rotation refresh: a rotated proxy leaf cert is only re-advertised on
   the next reconnect resync. Push the new chain on rotation so a verifying
   client is never left with stale trust material.
-- PostgreSQL brokering in `pmon`: the daemon fronts MySQL only, so PostgreSQL
-  datasources are discovered but skipped and their connection strings are
-  rendered without a broker behind them.
 - Bound the native-wire relay by `PM_QUERY_TIMEOUT`. The control-plane-driven
   editor and workflow runs honor it; the wire relay passes no execution guard
   and keeps a fixed socket-inactivity cap, so a direct statement through `pmon`

--- a/docs/datasource-registration.md
+++ b/docs/datasource-registration.md
@@ -91,8 +91,7 @@ certificate and publish nothing (`PM_TLS_NO_ADVERTISE`), so an empty chain does
 NOT mean plaintext. `pmon` refuses to send its token to a proxy that offers no
 TLS whenever this is set — inferring the requirement from the chain instead
 would make an attacker's plaintext greeting indistinguishable from a datasource
-that never had TLS. `pmon` brokers MySQL only today, so a PostgreSQL client
-verifies with the downloaded file instead.
+that never had TLS.
 
 `GET /api/datasources` surfaces all three (`advertiseAddr`,
 `advertiseCertChain`, `advertiseWireTls`). That is how a client finds them:

--- a/pmon/README.md
+++ b/pmon/README.md
@@ -13,6 +13,7 @@ brew install ridi-oss/tap/pmon   # or: go build -o /usr/local/bin/pmon ./pmon
 pmon login                     # device-auth in your browser; starts the daemon + opens the brokers
 pmon status                    # principal, token expiry, every brokered datasource
 pmon show acme-mysql            # mysql://you@example.com:pmlocal_…@127.0.0.1:6100/my_database
+pmon show acme-postgres         # postgresql://you@example.com:pmlocal_…@127.0.0.1:6101/app?sslmode=disable
 ```
 
 Point any SQL client at the address `pmon show` prints. Logging in is the only
@@ -41,6 +42,9 @@ pmon show acme-mysql --jdbc     # jdbc:mysql://127.0.0.1:6100/my_database?user=�
 pmon show acme-mysql --jdbc --jdbc-with-truncation-diagnostics
 pmon show acme-mysql --go-dsn   # user:pw@tcp(127.0.0.1:6100)/my_database?parseTime=true&charset=utf8mb4
 pmon show acme-mysql --cli      # mysql -h 127.0.0.1 -P 6100 -u 'user' -p'pw' 'my_database'
+pmon show acme-postgres --url   # postgresql://user:pw@127.0.0.1:6101/app?sslmode=disable
+pmon show acme-postgres --jdbc  # jdbc:postgresql://127.0.0.1:6101/app?user=…&password=…&sslmode=disable
+pmon show acme-postgres --cli   # psql 'host=127.0.0.1 port=6101 dbname=app user=user password=pw sslmode=disable'
 ```
 
 Output is the bare string, so it pipes straight into a client or an env var.
@@ -55,7 +59,10 @@ The daemon checks that password. It answers `mysql_native_password` and
 `caching_sha2_password` directly, and switches any other plugin to
 `mysql_clear_password` — which the `mysql` CLI only permits with
 `--enable-cleartext-plugin`. A saved connection carrying a stale or blank
-password fails with access denied; re-copy it from `pmon show`.
+password fails with access denied; re-copy it from `pmon show`. PostgreSQL
+clients use the same local password through the protocol's cleartext-password
+exchange on loopback. PostgreSQL cancel requests are forwarded to the proxy, so
+`psql` Ctrl-C keeps working.
 
 `pmon --version` reports the release and the commit it was built from —
 `0.1.1+87d3156f2cb7`, or a `.dirty` suffix when the tree had uncommitted
@@ -111,10 +118,10 @@ pmon CLI ──┐                        ┌── menu-bar app
   localhost TCP port is reachable from any web page. The socket sits in a `0700`
   directory at mode `0600` — filesystem permissions are the authentication, so
   only the same OS user can connect.
-- **Upstream TLS.** When the control plane advertises the proxy's leaf-cert
-  SHA-256, the broker pins exactly that fingerprint (no CA, no system trust) and
-  refuses a pinned datasource whose proxy offers no TLS rather than sending the
-  token in plaintext. The loopback hop stays plaintext by design.
+- **Upstream TLS.** When the control plane advertises the proxy's certificate
+  chain, the broker verifies that chain and the advertised host. A datasource
+  marked as serving wire TLS is refused if the proxy declines TLS, before the
+  token is sent. The loopback hop stays plaintext by design.
 - **Credentials at rest.** `config.json` is written `0600` via an atomic rename,
   so the token and the renewal secret never land in a world-readable inode.
 
@@ -129,8 +136,6 @@ pmon CLI ──┐                        ┌── menu-bar app
 
 ## Not yet
 
-- **Postgres brokering** — PG datasources are discovered and listed with a
-  reason, not fronted.
 - **Notarized menu-bar app** — [`pmontray/`](../pmontray) is built and ad-hoc
   signed; distributing it to other machines needs a Developer ID signature +
   notarization.

--- a/pmon/cli_test.go
+++ b/pmon/cli_test.go
@@ -324,21 +324,48 @@ func TestShowRejectsAnUnknownDatasourceWithTheKnownOnes(t *testing.T) {
 	}
 }
 
-// TestShowExplainsAnUnbrokeredDatasource: a PG datasource is discovered but not fronted, so show must say why
-// rather than emit a connection string that cannot work.
-func TestShowExplainsAnUnbrokeredDatasource(t *testing.T) {
+func TestPostgresShowFormats(t *testing.T) {
 	e := newEnv(t)
 	cp := fakeCP(t, []map[string]any{
-		{"name": "pg", "engine": "postgres", "dbName": "app", "advertiseAddr": dummyProxy(t)},
+		{"name": "acme-postgres", "engine": "postgres", "dbName": "app", "advertiseAddr": dummyProxy(t)},
+	})
+	if out := e.mustRun(t, "login", "--url", cp.URL); !strings.Contains(out, "1 datasource(s) brokered") {
+		t.Fatalf("login = %q, want the PostgreSQL broker to open", out)
+	}
+
+	cases := []struct {
+		flag string
+		want string
+	}{
+		{"", "postgresql://"},
+		{"--jdbc", "jdbc:postgresql://"},
+		{"--go-dsn", "host=127.0.0.1"},
+		{"--cli", "psql 'host=127.0.0.1"},
+	}
+	for _, tc := range cases {
+		args := []string{"show", "acme-postgres"}
+		if tc.flag != "" {
+			args = append(args, tc.flag)
+		}
+		if got := strings.TrimSpace(e.mustRun(t, args...)); !strings.HasPrefix(got, tc.want) {
+			t.Errorf("pmon %s = %q, want prefix %q", strings.Join(args, " "), got, tc.want)
+		}
+	}
+}
+
+func TestShowExplainsAnUnsupportedDatasource(t *testing.T) {
+	e := newEnv(t)
+	cp := fakeCP(t, []map[string]any{
+		{"name": "unsupported", "engine": "sqlite", "dbName": "app", "advertiseAddr": dummyProxy(t)},
 	})
 	e.mustRun(t, "login", "--url", cp.URL)
 
-	out, err := e.run("show", "pg")
+	out, err := e.run("show", "unsupported")
 	if err == nil {
-		t.Fatal("show for an unbrokered datasource succeeded")
+		t.Fatal("show for an unsupported datasource succeeded")
 	}
-	if !strings.Contains(out, "postgres") {
-		t.Errorf("show error = %q, want the reason it is not brokered", out)
+	if !strings.Contains(out, "sqlite") {
+		t.Errorf("show error = %q, want the unsupported engine named", out)
 	}
 }
 

--- a/pmon/conn/conn.go
+++ b/pmon/conn/conn.go
@@ -83,22 +83,34 @@ func mysql(format Format, t Target, opts Options) string {
 }
 
 func postgres(format Format, t Target) string {
+	dbPath := url.PathEscape(t.DbName)
+	keywordUser := postgresKeywordValue(t.User)
+	keywordPassword := postgresKeywordValue(t.Password)
+	keywordDB := postgresKeywordValue(t.DbName)
 	switch format {
 	case JDBC:
-		return fmt.Sprintf("jdbc:postgresql://%s:%d/%s?user=%s&password=%s",
-			Host, t.Port, t.DbName, url.QueryEscape(t.User), url.QueryEscape(t.Password))
+		return fmt.Sprintf("jdbc:postgresql://%s:%d/%s?user=%s&password=%s&sslmode=disable",
+			Host, t.Port, dbPath, url.QueryEscape(t.User), url.QueryEscape(t.Password))
 	case GoDSN:
 		// lib/pq keyword form. sslmode=disable for the same reason MySQL's DSN carries no TLS: the loopback
 		// hop is plaintext by design.
 		return fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
-			Host, t.Port, t.User, t.Password, t.DbName)
+			Host, t.Port, keywordUser, keywordPassword, keywordDB)
 	case CLI:
-		return fmt.Sprintf("psql %s", shellQuote(fmt.Sprintf("host=%s port=%d dbname=%s user=%s password=%s",
-			Host, t.Port, t.DbName, t.User, t.Password)))
+		return fmt.Sprintf("psql %s", shellQuote(fmt.Sprintf("host=%s port=%d dbname=%s user=%s password=%s sslmode=disable",
+			Host, t.Port, keywordDB, keywordUser, keywordPassword)))
 	default:
-		return fmt.Sprintf("postgresql://%s:%s@%s:%d/%s",
-			url.QueryEscape(t.User), url.QueryEscape(t.Password), Host, t.Port, t.DbName)
+		return fmt.Sprintf("postgresql://%s@%s:%d/%s?sslmode=disable",
+			url.UserPassword(t.User, t.Password), Host, t.Port, dbPath)
 	}
+}
+
+func postgresKeywordValue(s string) string {
+	if s != "" && !strings.ContainsAny(s, " \t\r\n'\\") {
+		return s
+	}
+	escaped := strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(s)
+	return "'" + escaped + "'"
 }
 
 // shellQuote wraps s in single quotes for safe copy-paste into a POSIX shell, escaping any embedded single

--- a/pmon/conn/conn_test.go
+++ b/pmon/conn/conn_test.go
@@ -31,15 +31,46 @@ func TestMySQLJDBCTruncationDiagnostics(t *testing.T) {
 func TestPostgresFormats(t *testing.T) {
 	target := Target{Engine: "postgres", DbName: "app", Port: 6101, User: "you@example.com", Password: "pw"}
 	cases := map[Format]string{
-		URL:   "postgresql://you%40example.com:pw@127.0.0.1:6101/app",
-		JDBC:  "jdbc:postgresql://127.0.0.1:6101/app?user=you%40example.com&password=pw",
+		URL:   "postgresql://you%40example.com:pw@127.0.0.1:6101/app?sslmode=disable",
+		JDBC:  "jdbc:postgresql://127.0.0.1:6101/app?user=you%40example.com&password=pw&sslmode=disable",
 		GoDSN: "host=127.0.0.1 port=6101 user=you@example.com password=pw dbname=app sslmode=disable",
-		CLI:   `psql 'host=127.0.0.1 port=6101 dbname=app user=you@example.com password=pw'`,
+		CLI:   `psql 'host=127.0.0.1 port=6101 dbname=app user=you@example.com password=pw sslmode=disable'`,
 	}
 	for format, want := range cases {
 		if got := String(format, target); got != want {
 			t.Errorf("String(%s) = %q, want %q", format, got, want)
 		}
+	}
+}
+
+func TestPostgresEscapesURLPathAndUserInfo(t *testing.T) {
+	target := Target{
+		Engine: "postgres", DbName: "team / reports", Port: 6101,
+		User: "user name", Password: "pw/secret",
+	}
+	cases := map[Format]string{
+		URL:  "postgresql://user%20name:pw%2Fsecret@127.0.0.1:6101/team%20%2F%20reports?sslmode=disable",
+		JDBC: "jdbc:postgresql://127.0.0.1:6101/team%20%2F%20reports?user=user+name&password=pw%2Fsecret&sslmode=disable",
+	}
+	for format, want := range cases {
+		if got := String(format, target); got != want {
+			t.Errorf("String(%s) = %q, want %q", format, got, want)
+		}
+	}
+}
+
+func TestPostgresEscapesKeywordValues(t *testing.T) {
+	target := Target{
+		Engine: "postgres", DbName: "team / reports", Port: 6101,
+		User: "user name", Password: `pw'\secret`,
+	}
+	wantDSN := `host=127.0.0.1 port=6101 user='user name' password='pw\'\\secret' dbname='team / reports' sslmode=disable`
+	if got := String(GoDSN, target); got != wantDSN {
+		t.Errorf("String(%s) = %q, want %q", GoDSN, got, wantDSN)
+	}
+	wantCLIFields := `host=127.0.0.1 port=6101 dbname='team / reports' user='user name' password='pw\'\\secret' sslmode=disable`
+	if got, want := String(CLI, target), "psql "+shellQuote(wantCLIFields); got != want {
+		t.Errorf("String(%s) = %q, want %q", CLI, got, want)
 	}
 }
 

--- a/pmon/control/control_test.go
+++ b/pmon/control/control_test.go
@@ -132,7 +132,7 @@ func TestStatusRoundTrips(t *testing.T) {
 	backend := newFakeBackend()
 	backend.status.Datasources = []Datasource{
 		{Name: "acme-mysql", Engine: "mysql", DbName: "app", LocalPort: 6100, Brokered: true, LiveConns: 2},
-		{Name: "pg", Engine: "postgres", Brokered: false, Reason: "postgres brokering not yet supported"},
+		{Name: "unsupported", Engine: "sqlite", Brokered: false, Reason: "engine \"sqlite\" not brokered"},
 	}
 	c := serve(t, backend)
 

--- a/pmon/internal/daemon/daemon.go
+++ b/pmon/internal/daemon/daemon.go
@@ -462,6 +462,14 @@ func (d *Daemon) closeSubscribers() {
 
 // ---- brokering ----------------------------------------------------------------------------------
 
+func postgresBrokerRouteChanged(previous, current Datasource) bool {
+	return previous.Engine == "postgres" &&
+		current.Engine == "postgres" &&
+		(previous.AdvertiseAddr != current.AdvertiseAddr ||
+			previous.WireTLS != current.WireTLS ||
+			previous.CertChainPEM != current.CertChainPEM)
+}
+
 // openListeners discovers datasources, refreshes each one's current form (so a re-advertised address is
 // picked up), assigns a sticky loopback port to any new brokerable one, and starts its listener. Discovery
 // failures are recorded and surfaced, never fatal.
@@ -502,6 +510,7 @@ func (d *Daemon) openListeners(ctx context.Context) {
 	brokerableNow := make(map[string]bool, len(dss))
 	needsListener := make([]Datasource, 0, len(dss))
 	var stale []net.Listener
+	var closeSessions []string
 
 	d.mu.Lock()
 	d.lastDiscoveryErr = ""
@@ -513,8 +522,17 @@ func (d *Daemon) openListeners(ctx context.Context) {
 			continue
 		}
 		brokerableNow[ds.Name] = true
+		previous := d.datasources[ds.Name]
+		ln, already := d.listeners[ds.Name]
 		d.datasources[ds.Name] = ds
-		if _, already := d.listeners[ds.Name]; !already {
+		restart := already && (previous.Engine != ds.Engine || postgresBrokerRouteChanged(previous, ds))
+		if restart {
+			stale = append(stale, ln)
+			closeSessions = append(closeSessions, ds.Name)
+			delete(d.listeners, ds.Name)
+			needsListener = append(needsListener, ds)
+			fmt.Fprintf(os.Stderr, "broker for %q restarting for updated route or protocol\n", ds.Name)
+		} else if !already {
 			needsListener = append(needsListener, ds)
 		}
 	}
@@ -523,11 +541,10 @@ func (d *Daemon) openListeners(ctx context.Context) {
 	// daemon would keep handing the wire token to a stale/unauthorized address. Close its listener (its serve
 	// loop exits on the closed listener) and forget its current form. The sticky port in the config is kept,
 	// so a later re-grant reuses the same local port + saved connection string.
-	var revoked []string
 	for name, ln := range d.listeners {
 		if !brokerableNow[name] {
 			stale = append(stale, ln)
-			revoked = append(revoked, name)
+			closeSessions = append(closeSessions, name)
 			delete(d.listeners, name)
 			delete(d.datasources, name)
 			fmt.Fprintf(os.Stderr, "broker for %q closed (no longer connectable)\n", name)
@@ -537,10 +554,10 @@ func (d *Daemon) openListeners(ctx context.Context) {
 	for _, ln := range stale {
 		ln.Close()
 	}
-	// End sessions already established on a revoked datasource too: a closed listener stops new accepts, but an
-	// open session would otherwise keep piping to an address this principal is no longer authorized for.
-	if len(revoked) > 0 {
-		d.closeConns(revoked...)
+	// End sessions already established on a revoked or protocol-changed datasource too: a closed listener stops
+	// new accepts, but an open session would otherwise keep piping through the old broker.
+	if len(closeSessions) > 0 {
+		d.closeConns(closeSessions...)
 	}
 
 	ports := map[string]int{}
@@ -597,7 +614,7 @@ func (d *Daemon) openListeners(ctx context.Context) {
 			continue
 		}
 		fmt.Printf("broker %s -> %s (%s)\n", addr, ds.AdvertiseAddr, ds.Engine)
-		go d.serve(ctx, ln, ds.Name)
+		go d.serve(ctx, ln, ds.Name, ds.Engine)
 	}
 	if len(needsListener) > 0 || len(stale) > 0 {
 		d.publishStatus()
@@ -617,7 +634,7 @@ func (d *Daemon) closeAllListeners() {
 	}
 }
 
-func (d *Daemon) serve(ctx context.Context, ln net.Listener, name string) {
+func (d *Daemon) serve(ctx context.Context, ln net.Listener, name, engine string) {
 	for {
 		c, err := ln.Accept()
 		if err != nil {
@@ -632,7 +649,7 @@ func (d *Daemon) serve(ctx context.Context, ln net.Listener, name string) {
 				continue
 			}
 		}
-		go d.broker(c, name)
+		go d.broker(c, name, engine)
 	}
 }
 
@@ -648,23 +665,34 @@ func (d *Daemon) current(name string) (Datasource, bool) {
 // that re-registered from A to B is followed without a daemon restart), speaks its wire protocol to the local
 // client, and dials the proxy with the current token. The local client is checked against the sticky
 // local password before the proxy is dialed.
-func (d *Daemon) broker(local net.Conn, name string) {
+func (d *Daemon) broker(local net.Conn, name, engine string) {
 	defer local.Close()
 	// Register now (so a logout/revocation mid-session can close this socket) and deregister on return.
 	deregister := d.addConn(name, local)
 	defer deregister()
 
 	ds, ok := d.current(name)
-	if !ok || ds.Engine != "mysql" || ds.AdvertiseAddr == "" {
+	if !ok || ds.Engine != engine || ds.AdvertiseAddr == "" {
 		// Deleted, lost its advertised address, or no longer brokerable since the listener opened — reject
 		// rather than dial a stale/empty address.
-		_ = mysqlwire.WritePacket(local, 2, mysqlwire.ErrPacket(1045, "proxy-monster: datasource no longer available"))
+		if engine == "postgres" {
+			_ = rejectPostgresUnavailable(local)
+		} else {
+			_ = mysqlwire.WritePacket(local, 2, mysqlwire.ErrPacket(1045, "proxy-monster: datasource no longer available"))
+		}
 		return
 	}
 	cfg := d.snapshot()
 	// cfg.LocalPassword is the same value `pmon show` puts in its connection strings, so the client is
 	// checked against the password it was handed.
-	if err := brokerMySQL(local, ds.AdvertiseAddr, ds.CertChainPEM, ds.WireTLS, cfg.Principal, cfg.Token, cfg.LocalPassword); err != nil {
+	var err error
+	switch ds.Engine {
+	case "mysql":
+		err = brokerMySQL(local, ds.AdvertiseAddr, ds.CertChainPEM, ds.WireTLS, cfg.Principal, cfg.Token, cfg.LocalPassword)
+	case "postgres":
+		err = brokerPostgres(local, ds.AdvertiseAddr, ds.CertChainPEM, ds.WireTLS, cfg.Token, cfg.LocalPassword)
+	}
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "broker %q: %v\n", name, err)
 	}
 }

--- a/pmon/internal/daemon/daemon_test.go
+++ b/pmon/internal/daemon/daemon_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -168,12 +169,12 @@ func TestBrokeringImpliesALocalPassword(t *testing.T) {
 	}
 }
 
-// TestStatusReportsUnbrokerableDatasourcesWithAReason: a PG or address-less datasource must still appear, with
-// an explanation — a silently short list would read as "you have no access".
+// TestStatusReportsUnbrokerableDatasourcesWithAReason: an unsupported or address-less datasource must still
+// appear with an explanation rather than silently shortening the list.
 func TestStatusReportsUnbrokerableDatasourcesWithAReason(t *testing.T) {
 	isolate(t)
 	cp := newFakeCP(t, []Datasource{
-		{Name: "pg", Engine: "postgres", DbName: "app", AdvertiseAddr: freePort(t)},
+		{Name: "unsupported", Engine: "sqlite", DbName: "app", AdvertiseAddr: freePort(t)},
 		{Name: "no-addr", Engine: "mysql", DbName: "app"},
 	})
 
@@ -245,6 +246,196 @@ func TestRediscoveryClosesARevokedDatasource(t *testing.T) {
 	}
 	if cfg.Ports["acme-mysql"] != port {
 		t.Errorf("sticky port for a revoked datasource = %d, want it kept at %d", cfg.Ports["acme-mysql"], port)
+	}
+}
+
+func TestRediscoveryReplacesListenerWhenEngineChanges(t *testing.T) {
+	isolate(t)
+	cp := newFakeCP(t, []Datasource{
+		{Name: "acme", Engine: "mysql", DbName: "app", AdvertiseAddr: freePort(t)},
+	})
+
+	d := New("test")
+	ctx := context.Background()
+	if err := d.Login(ctx, control.LoginRequest{ControlPlane: cp.URL}, func(control.LoginEvent) {}); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	defer d.closeAllListeners()
+
+	before := d.Status().Datasources[0]
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	deregister := d.addConn("acme", server)
+	defer deregister()
+
+	cp.datasources = []Datasource{
+		{Name: "acme", Engine: "postgres", DbName: "app", AdvertiseAddr: freePort(t)},
+	}
+	d.openListeners(ctx)
+
+	if _, err := server.Read(make([]byte, 1)); err == nil {
+		t.Error("a session using the old engine survived the listener replacement")
+	}
+	after := d.Status().Datasources[0]
+	if after.Engine != "postgres" || !after.Brokered {
+		t.Fatalf("datasource after engine change = %+v, want a brokered PostgreSQL datasource", after)
+	}
+	if after.LocalPort != before.LocalPort {
+		t.Errorf("local port changed from %d to %d with the engine; saved connections must keep the sticky port",
+			before.LocalPort, after.LocalPort)
+	}
+
+	c, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", after.LocalPort), 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial replacement broker: %v", err)
+	}
+	defer c.Close()
+	if err := c.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	if _, err := c.Write(postgresStartupPacket(pgSSLRequest)); err != nil {
+		t.Fatalf("write PostgreSQL SSLRequest: %v", err)
+	}
+	var response [1]byte
+	if _, err := c.Read(response[:]); err != nil {
+		t.Fatalf("read PostgreSQL SSL response: %v", err)
+	}
+	if response[0] != 'N' {
+		t.Fatalf("replacement broker answered %#x, want PostgreSQL SSL response 'N'", response[0])
+	}
+}
+
+func TestRediscoveryRestartsPostgresWhenProxyRouteChanges(t *testing.T) {
+	isolate(t)
+	oldAddr := freePort(t)
+	newAddr := freePort(t)
+	cp := newFakeCP(t, []Datasource{
+		{Name: "acme", Engine: "postgres", DbName: "app", AdvertiseAddr: oldAddr},
+	})
+
+	d := New("test")
+	ctx := context.Background()
+	if err := d.Login(ctx, control.LoginRequest{ControlPlane: cp.URL}, func(control.LoginEvent) {}); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	defer d.closeAllListeners()
+
+	before := d.Status().Datasources[0]
+
+	client, server := net.Pipe()
+	defer client.Close()
+	deregister := d.addConn("acme", server)
+	defer deregister()
+
+	cp.datasources = []Datasource{
+		{Name: "acme", Engine: "postgres", DbName: "app", AdvertiseAddr: newAddr},
+	}
+	d.openListeners(ctx)
+
+	if _, err := server.Read(make([]byte, 1)); err == nil {
+		t.Error("a PostgreSQL session tied to the old proxy route survived rediscovery")
+	}
+	after := d.Status().Datasources[0]
+	if !after.Brokered || after.AdvertiseAddr != newAddr {
+		t.Fatalf("datasource after route change = %+v, want the replacement PostgreSQL route", after)
+	}
+	if after.LocalPort != before.LocalPort {
+		t.Errorf("local port changed from %d to %d with the proxy route", before.LocalPort, after.LocalPort)
+	}
+}
+
+func TestPostgresBrokerRouteIdentity(t *testing.T) {
+	base := Datasource{
+		Name: "acme", Engine: "postgres", AdvertiseAddr: "proxy-a:5432", WireTLS: true, CertChainPEM: "cert-a",
+	}
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*Datasource)
+		changed bool
+	}{
+		{name: "address", mutate: func(ds *Datasource) { ds.AdvertiseAddr = "proxy-b:5432" }, changed: true},
+		{name: "TLS mode", mutate: func(ds *Datasource) { ds.WireTLS = false }, changed: true},
+		{name: "certificate chain", mutate: func(ds *Datasource) { ds.CertChainPEM = "cert-b" }, changed: true},
+		{name: "database name", mutate: func(ds *Datasource) { ds.DbName = "other" }, changed: false},
+		{name: "MySQL route", mutate: func(ds *Datasource) { ds.Engine = "mysql" }, changed: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			current := base
+			tc.mutate(&current)
+			if got := postgresBrokerRouteChanged(base, current); got != tc.changed {
+				t.Errorf("postgresBrokerRouteChanged() = %v, want %v", got, tc.changed)
+			}
+		})
+	}
+}
+
+func TestBrokerBoundsAndClearsUpstreamStartup(t *testing.T) {
+	proxyAddr, proxyDone := postgresProxyStub(t, func(c net.Conn) error {
+		if _, code, err := readPostgresStartup(c); err != nil || code != pgSSLRequest {
+			return fmt.Errorf("SSL request code = %d, err %v", code, err)
+		}
+		if _, err := c.Write([]byte{'N'}); err != nil {
+			return err
+		}
+		if _, _, err := readPostgresStartup(c); err != nil {
+			return err
+		}
+		if err := writePostgresFrame(c, 'R', uint32Bytes(3)); err != nil {
+			return err
+		}
+		if _, _, _, err := readPostgresFrame(c, maxPGAuthBody); err != nil {
+			return err
+		}
+		if err := writePostgresFrame(c, 'R', uint32Bytes(0)); err != nil {
+			return err
+		}
+		return writePostgresFrame(c, 'Z', []byte{'I'})
+	})
+
+	d := New("test")
+	d.mu.Lock()
+	d.cfg.ControlPlane = "https://cp.example"
+	d.cfg.Token = "pmk_token"
+	d.cfg.LocalPassword = "pmlocal_test"
+	d.datasources["pg"] = Datasource{
+		Name: "pg", Engine: "postgres", DbName: "app", AdvertiseAddr: proxyAddr,
+	}
+	d.mu.Unlock()
+
+	client, server := net.Pipe()
+	defer client.Close()
+	tracked := &deadlineRecordingConn{Conn: server}
+	done := make(chan struct{})
+	go func() {
+		d.broker(tracked, "pg", "postgres")
+		close(done)
+	}()
+
+	if _, err := client.Write(postgresStartup("alice", "app")); err != nil {
+		t.Fatal(err)
+	}
+	assertPostgresAuthCode(t, client, 3)
+	if err := writePostgresFrame(client, 'p', []byte("pmlocal_test\x00")); err != nil {
+		t.Fatal(err)
+	}
+	assertPostgresAuthCode(t, client, 0)
+	if typ, body, _, err := readPostgresFrame(client, maxPGAuthBody); err != nil || typ != 'Z' || !bytes.Equal(body, []byte{'I'}) {
+		t.Fatalf("ready frame = %q %x, err %v", typ, body, err)
+	}
+	<-done
+	if err := <-proxyDone; err != nil {
+		t.Fatal(err)
+	}
+
+	if len(tracked.deadlines) < 2 {
+		t.Fatalf("local deadline changes = %v, want upstream startup bound, then clear", tracked.deadlines)
+	}
+	if tracked.deadlines[0].IsZero() {
+		t.Errorf("local deadline during upstream startup = zero, want bounded")
+	}
+	if !tracked.deadlines[len(tracked.deadlines)-1].IsZero() {
+		t.Errorf("deadline after ReadyForQuery = %s, want cleared", tracked.deadlines[len(tracked.deadlines)-1])
 	}
 }
 
@@ -860,6 +1051,16 @@ func TestAPortCollisionIsVisibleNotSilent(t *testing.T) {
 	if !strings.Contains(ds.Reason, "in use") {
 		t.Errorf("Reason = %q, want it to name the port collision", ds.Reason)
 	}
+}
+
+type deadlineRecordingConn struct {
+	net.Conn
+	deadlines []time.Time
+}
+
+func (c *deadlineRecordingConn) SetDeadline(deadline time.Time) error {
+	c.deadlines = append(c.deadlines, deadline)
+	return c.Conn.SetDeadline(deadline)
 }
 
 // TestSnapshotDoesNotAliasThePortsMap: a bare struct copy shares the map header, so a caller reading Ports off a

--- a/pmon/internal/daemon/discovery.go
+++ b/pmon/internal/daemon/discovery.go
@@ -27,22 +27,18 @@ type Datasource struct {
 	WireTLS bool `json:"advertiseWireTls"`
 }
 
-// Brokerable reports whether this datasource can be fronted by a local broker: it needs an advertised proxy
-// address (so the daemon knows where to dial) and a wire protocol the broker speaks. Only MySQL is brokered
-// today — Postgres brokering is backlogged, so PG datasources are discovered but skipped.
+// Brokerable reports whether this datasource has an address and a wire protocol the local broker speaks.
 func (d Datasource) Brokerable() bool {
-	return d.AdvertiseAddr != "" && d.Engine == "mysql"
+	return d.AdvertiseAddr != "" && (d.Engine == "mysql" || d.Engine == "postgres")
 }
 
 // UnbrokerableReason explains why a discovered datasource has no local listener, for a peer to show in place
 // of a connection string.
 func (d Datasource) UnbrokerableReason() string {
 	switch {
-	case d.Engine == "postgres":
-		return "postgres brokering not yet supported"
 	case d.AdvertiseAddr == "":
 		return "no advertised proxy address"
-	case d.Engine != "mysql":
+	case d.Engine != "mysql" && d.Engine != "postgres":
 		return fmt.Sprintf("engine %q not brokered", d.Engine)
 	default:
 		return ""

--- a/pmon/internal/daemon/mysql_test.go
+++ b/pmon/internal/daemon/mysql_test.go
@@ -70,9 +70,8 @@ func TestLocalServerGreetAdvertisesConnectWithDB(t *testing.T) {
 	}
 }
 
-// selfSignedServer builds a server TLS config with a fresh self-signed leaf and returns it alongside the
-// leaf DER — the exact bytes a client receives as rawCerts[0] and the proxy would advertise as its SHA-256
-// Self-signed on purpose: it is its own trust anchor, which is the ordinary proxy case.
+// selfSignedServer builds a server TLS config with a fresh self-signed leaf and returns its DER for the
+// advertised trust pool. The leaf covers both test host forms and is its own trust anchor.
 func selfSignedServer(t *testing.T) (*tls.Config, []byte) {
 	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -80,10 +79,10 @@ func selfSignedServer(t *testing.T) (*tls.Config, []byte) {
 		t.Fatalf("GenerateKey: %v", err)
 	}
 	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "proxy.example"},
-		// A DNS SAN is required now that verification checks the hostname — the pin it replaced did not.
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "proxy.example"},
 		DNSNames:              []string{"proxy.example"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
 		NotBefore:             time.Now().Add(-time.Hour),
 		NotAfter:              time.Now().Add(time.Hour),
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,

--- a/pmon/internal/daemon/postgres.go
+++ b/pmon/internal/daemon/postgres.go
@@ -1,0 +1,398 @@
+package daemon
+
+import (
+	"bytes"
+	"crypto/subtle"
+	"crypto/tls"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+)
+
+const (
+	pgProtocolVersion30      = 196608
+	pgProtocolVersion32      = 196610
+	pgCancelRequest          = 80877102
+	pgSSLRequest             = 80877103
+	pgGSSENCRequest          = 80877104
+	maxPGStartupPacket       = 4 + 10_000
+	minPGCancelPacket        = 16
+	maxPGCancelPacket        = 268
+	maxPGAuthBody            = 8192
+	maxPGStartupResponseBody = 1 << 20
+)
+
+var errPostgresLocalAuth = errors.New("access denied")
+
+func brokerPostgres(local net.Conn, proxyAddr, certChainPEM string, wireTLS bool, token, localPassword string) error {
+	startup, cancel, err := localPostgresHandshake(local, localPassword)
+	if err != nil {
+		if errors.Is(err, errPostgresLocalAuth) {
+			_ = writePostgresError(local, "28P01", "proxy-monster: access denied")
+		}
+		return err
+	}
+	if cancel != nil {
+		return forwardPostgresCancel(proxyAddr, certChainPEM, wireTLS, cancel)
+	}
+	if err := local.SetDeadline(time.Now().Add(handshakeTimeout)); err != nil {
+		return err
+	}
+
+	raw, err := net.DialTimeout("tcp", proxyAddr, dialTimeout)
+	if err != nil {
+		_ = writePostgresError(local, "08001", "proxy-monster: cannot reach proxy")
+		return err
+	}
+	defer raw.Close()
+	if err := raw.SetDeadline(time.Now().Add(handshakeTimeout)); err != nil {
+		return err
+	}
+
+	up, responded, err := postgresProxyConnect(raw, hostOf(proxyAddr), certChainPEM, wireTLS, startup, token, local)
+	if err != nil {
+		if !responded {
+			_ = writePostgresError(local, "08001", "proxy-monster: "+err.Error())
+		}
+		return err
+	}
+	if err := up.SetDeadline(time.Time{}); err != nil {
+		return err
+	}
+	if err := local.SetDeadline(time.Time{}); err != nil {
+		return err
+	}
+	pipe(up, local)
+	return nil
+}
+
+func postgresProtocolNegotiationBody(unrecognized []string) []byte {
+	body := binary.BigEndian.AppendUint32(nil, 0)
+	body = binary.BigEndian.AppendUint32(body, uint32(len(unrecognized)))
+	for _, name := range unrecognized {
+		body = append(body, name...)
+		body = append(body, 0)
+	}
+	return body
+}
+
+func normalizePostgresStartup(packet []byte) ([]byte, []string, error) {
+	if len(packet) < 9 {
+		return nil, nil, errors.New("invalid postgres startup parameters")
+	}
+	code := binary.BigEndian.Uint32(packet[4:8])
+	body := packet[8:]
+	params := make([]byte, 0, len(body))
+	unrecognized := []string{}
+	for len(body) > 1 {
+		nameEnd := bytes.IndexByte(body, 0)
+		if nameEnd <= 0 {
+			return nil, nil, errors.New("invalid postgres startup parameter name")
+		}
+		name := string(body[:nameEnd])
+		body = body[nameEnd+1:]
+		valueEnd := bytes.IndexByte(body, 0)
+		if valueEnd < 0 {
+			return nil, nil, errors.New("invalid postgres startup parameter value")
+		}
+		value := body[:valueEnd]
+		body = body[valueEnd+1:]
+		if strings.HasPrefix(name, "_pq_.") {
+			unrecognized = append(unrecognized, name)
+			continue
+		}
+		params = append(params, name...)
+		params = append(params, 0)
+		params = append(params, value...)
+		params = append(params, 0)
+	}
+	if len(body) != 1 || body[0] != 0 {
+		return nil, nil, errors.New("invalid postgres startup terminator")
+	}
+	if code == pgProtocolVersion30 && len(unrecognized) == 0 {
+		return packet, nil, nil
+	}
+	out := binary.BigEndian.AppendUint32(nil, uint32(4+4+len(params)+1))
+	out = binary.BigEndian.AppendUint32(out, pgProtocolVersion30)
+	out = append(out, params...)
+	out = append(out, 0)
+	return out, unrecognized, nil
+}
+
+func localPostgresHandshake(local net.Conn, localPassword string) (startup, cancel []byte, err error) {
+	for {
+		packet, code, err := readPostgresStartup(local)
+		if err != nil {
+			return nil, nil, err
+		}
+		switch code {
+		case pgSSLRequest, pgGSSENCRequest:
+			if _, err := local.Write([]byte{'N'}); err != nil {
+				return nil, nil, err
+			}
+		case pgCancelRequest:
+			if len(packet) < minPGCancelPacket || len(packet) > maxPGCancelPacket {
+				return nil, nil, fmt.Errorf("invalid postgres cancel request length %d", len(packet))
+			}
+			return nil, packet, nil
+		case pgProtocolVersion30, pgProtocolVersion32:
+			startup, unrecognized, err := normalizePostgresStartup(packet)
+			if err != nil {
+				return nil, nil, err
+			}
+			if code == pgProtocolVersion32 || len(unrecognized) > 0 {
+				if err := writePostgresFrame(local, 'v', postgresProtocolNegotiationBody(unrecognized)); err != nil {
+					return nil, nil, err
+				}
+			}
+			if err := writePostgresFrame(local, 'R', uint32Bytes(3)); err != nil {
+				return nil, nil, err
+			}
+			typ, body, _, err := readPostgresFrame(local, maxPGAuthBody)
+			if err != nil {
+				return nil, nil, err
+			}
+			if typ != 'p' || len(body) == 0 || body[len(body)-1] != 0 || localPassword == "" {
+				return nil, nil, errPostgresLocalAuth
+			}
+			password := body[:len(body)-1]
+			if subtle.ConstantTimeCompare(password, []byte(localPassword)) != 1 {
+				return nil, nil, errPostgresLocalAuth
+			}
+			return startup, nil, nil
+		default:
+			_ = writePostgresError(local, "08P01", "proxy-monster: unsupported startup packet")
+			return nil, nil, fmt.Errorf("unsupported postgres startup code %d", code)
+		}
+	}
+}
+
+func postgresProxyConnect(
+	raw net.Conn,
+	serverName, certChainPEM string,
+	wireTLS bool,
+	startup []byte,
+	token string,
+	local io.Writer,
+) (net.Conn, bool, error) {
+	up, err := postgresUpgrade(raw, serverName, certChainPEM, wireTLS)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := writePostgresBytes(up, startup); err != nil {
+		return nil, false, err
+	}
+	var typ byte
+	var body, rawFrame []byte
+	for {
+		typ, body, rawFrame, err = readPostgresFrame(up, maxPGStartupResponseBody)
+		if err != nil {
+			return nil, false, err
+		}
+		if typ != 'v' {
+			break
+		}
+	}
+	if typ == 'E' {
+		return nil, true, forwardPostgresResponse(local, rawFrame, "proxy rejected postgres startup")
+	}
+	if typ != 'R' || len(body) != 4 || binary.BigEndian.Uint32(body) != 3 {
+		return nil, false, fmt.Errorf("unexpected authentication request from proxy")
+	}
+	password := append([]byte(token), 0)
+	if err := writePostgresFrame(up, 'p', password); err != nil {
+		return nil, false, err
+	}
+	typ, body, rawFrame, err = readPostgresFrame(up, maxPGStartupResponseBody)
+	if err != nil {
+		return nil, false, err
+	}
+	if typ == 'E' {
+		return nil, true, forwardPostgresResponse(local, rawFrame, "proxy rejected postgres authentication")
+	}
+	if typ != 'R' || len(body) != 4 || binary.BigEndian.Uint32(body) != 0 {
+		return nil, false, fmt.Errorf("unexpected authentication result from proxy")
+	}
+	if err := writePostgresBytes(local, rawFrame); err != nil {
+		return nil, true, err
+	}
+
+	for {
+		typ, body, rawFrame, err = readPostgresFrame(up, maxPGStartupResponseBody)
+		if err != nil {
+			return nil, true, err
+		}
+		if err := writePostgresBytes(local, rawFrame); err != nil {
+			return nil, true, err
+		}
+		if typ == 'E' {
+			return nil, true, errors.New("proxy rejected postgres startup")
+		}
+		if typ == 'Z' {
+			if len(body) != 1 {
+				return nil, true, fmt.Errorf("invalid ReadyForQuery from proxy")
+			}
+			return up, true, nil
+		}
+	}
+}
+
+func forwardPostgresResponse(w io.Writer, frame []byte, message string) error {
+	if err := writePostgresBytes(w, frame); err != nil {
+		return err
+	}
+	return errors.New(message)
+}
+
+func writePostgresBytes(w io.Writer, p []byte) error {
+	for len(p) > 0 {
+		n, err := w.Write(p)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+		p = p[n:]
+	}
+	return nil
+}
+
+func postgresUpgrade(raw net.Conn, serverName, certChainPEM string, wireTLS bool) (net.Conn, error) {
+	if _, err := raw.Write(postgresStartupPacket(pgSSLRequest)); err != nil {
+		return nil, err
+	}
+	var response [1]byte
+	if _, err := io.ReadFull(raw, response[:]); err != nil {
+		return nil, err
+	}
+	switch response[0] {
+	case 'S':
+		tlsCfg, err := upstreamTLSConfig(serverName, certChainPEM)
+		if err != nil {
+			return nil, err
+		}
+		tlsConn := tls.Client(raw, tlsCfg)
+		if err := tlsConn.Handshake(); err != nil {
+			return nil, fmt.Errorf("TLS handshake with proxy failed: %w", err)
+		}
+		return tlsConn, nil
+	case 'N':
+		if wireTLS {
+			return nil, fmt.Errorf("the control plane says this datasource's proxy serves TLS but it refused the SSL request — refusing to send credentials in plaintext")
+		}
+		return raw, nil
+	default:
+		return nil, fmt.Errorf("unexpected SSL response from proxy: %q", response[0])
+	}
+}
+
+func forwardPostgresCancel(proxyAddr, certChainPEM string, wireTLS bool, packet []byte) error {
+	raw, err := net.DialTimeout("tcp", proxyAddr, dialTimeout)
+	if err != nil {
+		return err
+	}
+	defer raw.Close()
+	if err := raw.SetDeadline(time.Now().Add(handshakeTimeout)); err != nil {
+		return err
+	}
+	up, err := postgresUpgrade(raw, hostOf(proxyAddr), certChainPEM, wireTLS)
+	if err != nil {
+		return err
+	}
+	_, err = up.Write(packet)
+	return err
+}
+
+func rejectPostgresUnavailable(local net.Conn) error {
+	for {
+		_, code, err := readPostgresStartup(local)
+		if err != nil {
+			return err
+		}
+		switch code {
+		case pgSSLRequest, pgGSSENCRequest:
+			if _, err := local.Write([]byte{'N'}); err != nil {
+				return err
+			}
+		case pgCancelRequest:
+			return nil
+		default:
+			return writePostgresError(local, "08004", "proxy-monster: datasource no longer available")
+		}
+	}
+}
+
+func readPostgresStartup(r io.Reader) ([]byte, uint32, error) {
+	var header [4]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return nil, 0, err
+	}
+	length := int(binary.BigEndian.Uint32(header[:]))
+	if length < 8 || length > maxPGStartupPacket {
+		return nil, 0, fmt.Errorf("invalid postgres startup packet length %d", length)
+	}
+	packet := make([]byte, length)
+	copy(packet, header[:])
+	if _, err := io.ReadFull(r, packet[4:]); err != nil {
+		return nil, 0, err
+	}
+	return packet, binary.BigEndian.Uint32(packet[4:8]), nil
+}
+
+func readPostgresFrame(r io.Reader, maxBody int) (byte, []byte, []byte, error) {
+	var header [5]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return 0, nil, nil, err
+	}
+	length := int(binary.BigEndian.Uint32(header[1:]))
+	if length < 4 || length-4 > maxBody {
+		return 0, nil, nil, fmt.Errorf("invalid postgres frame length %d", length)
+	}
+	body := make([]byte, length-4)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return 0, nil, nil, err
+	}
+	raw := make([]byte, 0, len(header)+len(body))
+	raw = append(raw, header[:]...)
+	raw = append(raw, body...)
+	return header[0], body, raw, nil
+}
+
+func writePostgresFrame(w io.Writer, typ byte, body []byte) error {
+	frame := make([]byte, 0, 5+len(body))
+	frame = append(frame, typ)
+	frame = binary.BigEndian.AppendUint32(frame, uint32(4+len(body)))
+	frame = append(frame, body...)
+	_, err := w.Write(frame)
+	return err
+}
+
+func writePostgresError(w io.Writer, code, message string) error {
+	body := make([]byte, 0, len(code)+len(message)+32)
+	for _, field := range []struct {
+		typ   byte
+		value string
+	}{{'S', "FATAL"}, {'V', "FATAL"}, {'C', code}, {'M', message}} {
+		body = append(body, field.typ)
+		body = append(body, field.value...)
+		body = append(body, 0)
+	}
+	body = append(body, 0)
+	return writePostgresFrame(w, 'E', body)
+}
+
+func postgresStartupPacket(code uint32) []byte {
+	packet := make([]byte, 0, 8)
+	packet = binary.BigEndian.AppendUint32(packet, 8)
+	packet = binary.BigEndian.AppendUint32(packet, code)
+	return packet
+}
+
+func uint32Bytes(v uint32) []byte {
+	return binary.BigEndian.AppendUint32(nil, v)
+}

--- a/pmon/internal/daemon/postgres_test.go
+++ b/pmon/internal/daemon/postgres_test.go
@@ -1,0 +1,682 @@
+package daemon
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/binary"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBrokerPostgresAuthenticatesLocallyAndInjectsToken(t *testing.T) {
+	const localPassword = "pmlocal_test"
+	const token = "pmk_token"
+	startup := postgresStartup("alice", "app")
+	query := postgresFrame('Q', append([]byte("select 1"), 0))
+
+	proxyAddr, proxyDone := postgresProxyStub(t, func(c net.Conn) error {
+		packet, code, err := readPostgresStartup(c)
+		if err != nil {
+			return err
+		}
+		if code != pgSSLRequest {
+			return fmt.Errorf("first startup code = %d, want SSLRequest", code)
+		}
+		if !bytes.Equal(packet, postgresStartupPacket(pgSSLRequest)) {
+			return fmt.Errorf("unexpected SSL request: %x", packet)
+		}
+		if _, err := c.Write([]byte{'N'}); err != nil {
+			return err
+		}
+		gotStartup, code, err := readPostgresStartup(c)
+		if err != nil {
+			return err
+		}
+		if code != pgProtocolVersion30 || !bytes.Equal(gotStartup, startup) {
+			return fmt.Errorf("startup was not preserved: %x", gotStartup)
+		}
+		if err := writePostgresFrame(c, 'v', postgresProtocolNegotiationBody(nil)); err != nil {
+			return err
+		}
+		if err := writePostgresFrame(c, 'R', uint32Bytes(3)); err != nil {
+			return err
+		}
+		typ, body, _, err := readPostgresFrame(c, maxPGAuthBody)
+		if err != nil {
+			return err
+		}
+		if typ != 'p' || string(body) != token+"\x00" {
+			return fmt.Errorf("token frame = %q %q", typ, body)
+		}
+
+		var ready bytes.Buffer
+		_ = writePostgresFrame(&ready, 'R', uint32Bytes(0))
+		parameter := append(append([]byte("application_name"), 0), append([]byte(strings.Repeat("x", maxPGAuthBody)), 0)...)
+		_ = writePostgresFrame(&ready, 'S', parameter)
+		_ = writePostgresFrame(&ready, 'Z', []byte{'I'})
+		if _, err := c.Write(ready.Bytes()); err != nil {
+			return err
+		}
+		gotQuery := make([]byte, len(query))
+		if _, err := io.ReadFull(c, gotQuery); err != nil {
+			return err
+		}
+		if !bytes.Equal(gotQuery, query) {
+			return fmt.Errorf("query = %x, want %x", gotQuery, query)
+		}
+		return writePostgresFrame(c, 'C', append([]byte("SELECT 1"), 0))
+	})
+
+	client, broker := net.Pipe()
+	brokerDone := make(chan error, 1)
+	go func() { brokerDone <- brokerPostgres(broker, proxyAddr, "", false, token, localPassword) }()
+
+	if _, err := client.Write(postgresStartupPacket(pgSSLRequest)); err != nil {
+		t.Fatal(err)
+	}
+	var sslResponse [1]byte
+	if _, err := io.ReadFull(client, sslResponse[:]); err != nil || sslResponse[0] != 'N' {
+		t.Fatalf("local SSL response = %q, err %v", sslResponse[0], err)
+	}
+	if _, err := client.Write(startup); err != nil {
+		t.Fatal(err)
+	}
+	assertPostgresAuthCode(t, client, 3)
+	if err := writePostgresFrame(client, 'p', append([]byte(localPassword), 0)); err != nil {
+		t.Fatal(err)
+	}
+	assertPostgresAuthCode(t, client, 0)
+	if typ, body, _, err := readPostgresFrame(client, maxPGStartupResponseBody); err != nil || typ != 'S' || len(body) <= maxPGAuthBody {
+		t.Fatalf("large parameter status = %q len %d, err %v", typ, len(body), err)
+	}
+	if typ, body, _, err := readPostgresFrame(client, maxPGAuthBody); err != nil || typ != 'Z' || !bytes.Equal(body, []byte{'I'}) {
+		t.Fatalf("ready frame = %q %x, err %v", typ, body, err)
+	}
+	if _, err := client.Write(query); err != nil {
+		t.Fatal(err)
+	}
+	if typ, body, _, err := readPostgresFrame(client, maxPGAuthBody); err != nil || typ != 'C' || string(body) != "SELECT 1\x00" {
+		t.Fatalf("command frame = %q %q, err %v", typ, body, err)
+	}
+	client.Close()
+	broker.Close()
+	if err := <-proxyDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-brokerDone; err != nil {
+		t.Fatalf("brokerPostgres: %v", err)
+	}
+}
+
+func TestBrokerPostgresRejectsWrongLocalPasswordBeforeDial(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	client, broker := net.Pipe()
+	defer client.Close()
+	defer broker.Close()
+	done := make(chan error, 1)
+	go func() { done <- brokerPostgres(broker, ln.Addr().String(), "", false, "pmk_token", "correct") }()
+
+	if _, err := client.Write(postgresStartup("alice", "app")); err != nil {
+		t.Fatal(err)
+	}
+	assertPostgresAuthCode(t, client, 3)
+	if err := writePostgresFrame(client, 'p', append([]byte("wrong"), 0)); err != nil {
+		t.Fatal(err)
+	}
+	typ, body, _, err := readPostgresFrame(client, maxPGAuthBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if typ != 'E' || !bytes.Contains(body, []byte("28P01")) {
+		t.Fatalf("auth rejection = %q %q", typ, body)
+	}
+	if err := <-done; !errors.Is(err, errPostgresLocalAuth) {
+		t.Fatalf("brokerPostgres error = %v, want local auth failure", err)
+	}
+	if err := ln.(*net.TCPListener).SetDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	if c, err := ln.Accept(); err == nil {
+		c.Close()
+		t.Fatal("wrong local password dialed the proxy")
+	} else if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() {
+		t.Fatalf("accept after wrong password: %v", err)
+	}
+}
+
+func TestBrokerPostgresReturnsLocalAuthenticationWriteError(t *testing.T) {
+	const localPassword = "pmlocal_test"
+	proxyAddr, proxyDone := postgresProxyStub(t, func(c net.Conn) error {
+		if _, code, err := readPostgresStartup(c); err != nil || code != pgSSLRequest {
+			return fmt.Errorf("SSL request code = %d, err %v", code, err)
+		}
+		if _, err := c.Write([]byte{'N'}); err != nil {
+			return err
+		}
+		if _, _, err := readPostgresStartup(c); err != nil {
+			return err
+		}
+		if err := writePostgresFrame(c, 'R', uint32Bytes(3)); err != nil {
+			return err
+		}
+		if _, _, _, err := readPostgresFrame(c, maxPGAuthBody); err != nil {
+			return err
+		}
+		return writePostgresFrame(c, 'R', uint32Bytes(0))
+	})
+
+	client, pipeBroker := net.Pipe()
+	defer client.Close()
+	defer pipeBroker.Close()
+	writeErr := errors.New("local write failed")
+	broker := &failNthWriteConn{Conn: pipeBroker, failAt: 2, err: writeErr}
+	done := make(chan error, 1)
+	go func() {
+		done <- brokerPostgres(broker, proxyAddr, "", false, "pmk_token", localPassword)
+	}()
+	if _, err := client.Write(postgresStartup("alice", "app")); err != nil {
+		t.Fatal(err)
+	}
+	assertPostgresAuthCode(t, client, 3)
+	if err := writePostgresFrame(client, 'p', []byte(localPassword+"\x00")); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-done; !errors.Is(err, writeErr) {
+		t.Fatalf("brokerPostgres error = %v, want local write failure", err)
+	}
+	if err := <-proxyDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPostgresProxyConnectRefusesTLSDowngradeBeforeStartup(t *testing.T) {
+	proxyAddr, proxyDone := postgresProxyStub(t, func(c net.Conn) error {
+		_, code, err := readPostgresStartup(c)
+		if err != nil {
+			return err
+		}
+		if code != pgSSLRequest {
+			return fmt.Errorf("startup code = %d, want SSLRequest", code)
+		}
+		if _, err := c.Write([]byte{'N'}); err != nil {
+			return err
+		}
+		_ = c.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		var one [1]byte
+		n, err := c.Read(one[:])
+		if n != 0 {
+			return fmt.Errorf("client sent %d bytes after TLS refusal", n)
+		}
+		if err == nil {
+			return errors.New("client kept the plaintext connection open")
+		}
+		return nil
+	})
+
+	raw, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = postgresProxyConnect(raw, "proxy.example", "", true, postgresStartup("alice", "app"), "sekrit-token", io.Discard)
+	raw.Close()
+	if err == nil || !strings.Contains(err.Error(), "refused the SSL request") {
+		t.Fatalf("postgresProxyConnect error = %v, want downgrade refusal", err)
+	}
+	if err := <-proxyDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPostgresProxyConnectRejectsUnsupportedAuthBeforeToken(t *testing.T) {
+	const token = "sekrit-token"
+	proxyAddr, proxyDone := postgresProxyStub(t, func(c net.Conn) error {
+		if _, code, err := readPostgresStartup(c); err != nil || code != pgSSLRequest {
+			return fmt.Errorf("SSL request code = %d, err %v", code, err)
+		}
+		if _, err := c.Write([]byte{'N'}); err != nil {
+			return err
+		}
+		if _, _, err := readPostgresStartup(c); err != nil {
+			return err
+		}
+		if err := writePostgresFrame(c, 'R', append(uint32Bytes(5), 1, 2, 3, 4)); err != nil {
+			return err
+		}
+		_ = c.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		buf := make([]byte, len(token)+16)
+		n, err := c.Read(buf)
+		if n != 0 {
+			return fmt.Errorf("client sent %d bytes after unsupported authentication: %x", n, buf[:n])
+		}
+		if err == nil {
+			return errors.New("client kept the unsupported authentication connection open")
+		}
+		return nil
+	})
+
+	raw, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = postgresProxyConnect(raw, "proxy.example", "", false, postgresStartup("alice", "app"), token, io.Discard)
+	raw.Close()
+	if err == nil || !strings.Contains(err.Error(), "unexpected authentication request") {
+		t.Fatalf("postgresProxyConnect error = %v, want unsupported authentication rejection", err)
+	}
+	if err := <-proxyDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPostgresProxyConnectWaitsForReadyForQuery(t *testing.T) {
+	proxyAddr, proxyDone := postgresProxyStub(t, func(c net.Conn) error {
+		if _, code, err := readPostgresStartup(c); err != nil || code != pgSSLRequest {
+			return fmt.Errorf("SSL request code = %d, err %v", code, err)
+		}
+		if _, err := c.Write([]byte{'N'}); err != nil {
+			return err
+		}
+		if _, _, err := readPostgresStartup(c); err != nil {
+			return err
+		}
+		if err := writePostgresFrame(c, 'R', uint32Bytes(3)); err != nil {
+			return err
+		}
+		if _, _, _, err := readPostgresFrame(c, maxPGAuthBody); err != nil {
+			return err
+		}
+		if err := writePostgresFrame(c, 'R', uint32Bytes(0)); err != nil {
+			return err
+		}
+		var one [1]byte
+		if _, err := c.Read(one[:]); err == nil {
+			return errors.New("client entered relay before ReadyForQuery")
+		}
+		return nil
+	})
+
+	raw, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := raw.SetDeadline(time.Now().Add(200 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	var local bytes.Buffer
+	_, responded, err := postgresProxyConnect(
+		raw,
+		"proxy.example",
+		"",
+		false,
+		postgresStartup("alice", "app"),
+		"sekrit-token",
+		&local,
+	)
+	raw.Close()
+	if netErr, ok := err.(net.Error); !ok || !netErr.Timeout() {
+		t.Fatalf("postgresProxyConnect error = %v, want ReadyForQuery timeout", err)
+	}
+	if !responded {
+		t.Fatal("postgresProxyConnect did not report the forwarded AuthenticationOk")
+	}
+	if want := postgresFrame('R', uint32Bytes(0)); !bytes.Equal(local.Bytes(), want) {
+		t.Fatalf("local startup response = %x, want %x", local.Bytes(), want)
+	}
+	if err := <-proxyDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPostgresProxyConnectUsesAdvertisedTLSChain(t *testing.T) {
+	serverCfg, leafDER := selfSignedServer(t)
+	chain := certificatePEM(leafDER)
+	client, server := net.Pipe()
+	deadline := time.Now().Add(3 * time.Second)
+	_ = client.SetDeadline(deadline)
+	_ = server.SetDeadline(deadline)
+
+	serverDone := make(chan error, 1)
+	go func() {
+		_, code, err := readPostgresStartup(server)
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		if code != pgSSLRequest {
+			serverDone <- fmt.Errorf("startup code = %d, want SSLRequest", code)
+			return
+		}
+		if _, err := server.Write([]byte{'S'}); err != nil {
+			serverDone <- err
+			return
+		}
+		tlsServer := tls.Server(server, serverCfg)
+		if err := tlsServer.Handshake(); err != nil {
+			serverDone <- err
+			return
+		}
+		if _, _, err := readPostgresStartup(tlsServer); err != nil {
+			serverDone <- err
+			return
+		}
+		if err := writePostgresFrame(tlsServer, 'R', uint32Bytes(3)); err != nil {
+			serverDone <- err
+			return
+		}
+		typ, body, _, err := readPostgresFrame(tlsServer, maxPGAuthBody)
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		if typ != 'p' || string(body) != "sekrit-token\x00" {
+			serverDone <- fmt.Errorf("token frame = %q %q", typ, body)
+			return
+		}
+		if err := writePostgresFrame(tlsServer, 'R', uint32Bytes(0)); err != nil {
+			serverDone <- err
+			return
+		}
+		serverDone <- writePostgresFrame(tlsServer, 'Z', []byte{'I'})
+	}()
+
+	up, _, err := postgresProxyConnect(client, "proxy.example", chain, true, postgresStartup("alice", "app"), "sekrit-token", io.Discard)
+	if err != nil {
+		t.Fatalf("postgresProxyConnect: %v", err)
+	}
+	up.Close()
+	server.Close()
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBrokerPostgresForwardsCancelRequest(t *testing.T) {
+	cancel := postgresCancelPacket(123, uint32Bytes(456))
+	proxyAddr, proxyDone := postgresProxyStub(t, func(c net.Conn) error {
+		if _, code, err := readPostgresStartup(c); err != nil || code != pgSSLRequest {
+			return fmt.Errorf("SSL request code = %d, err %v", code, err)
+		}
+		if _, err := c.Write([]byte{'N'}); err != nil {
+			return err
+		}
+		return expectPostgresCancel(c, cancel)
+	})
+	client, broker := net.Pipe()
+	done := make(chan error, 1)
+	go func() { done <- brokerPostgres(broker, proxyAddr, "", false, "", "") }()
+	if _, err := client.Write(cancel); err != nil {
+		t.Fatal(err)
+	}
+	client.Close()
+	broker.Close()
+	if err := <-done; err != nil {
+		t.Fatalf("brokerPostgres cancel: %v", err)
+	}
+	if err := <-proxyDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBrokerPostgresForwardsCancelRequestOverTLS(t *testing.T) {
+	cancel := postgresCancelPacket(123, uint32Bytes(456))
+	serverCfg, leafDER := selfSignedServer(t)
+	proxyAddr, proxyDone := postgresProxyStub(t, func(c net.Conn) error {
+		if _, code, err := readPostgresStartup(c); err != nil || code != pgSSLRequest {
+			return fmt.Errorf("SSL request code = %d, err %v", code, err)
+		}
+		if _, err := c.Write([]byte{'S'}); err != nil {
+			return err
+		}
+		tlsServer := tls.Server(c, serverCfg)
+		if err := tlsServer.Handshake(); err != nil {
+			return err
+		}
+		return expectPostgresCancel(tlsServer, cancel)
+	})
+	client, broker := net.Pipe()
+	done := make(chan error, 1)
+	go func() {
+		done <- brokerPostgres(broker, proxyAddr, certificatePEM(leafDER), true, "", "")
+	}()
+	if _, err := client.Write(cancel); err != nil {
+		t.Fatal(err)
+	}
+	client.Close()
+	broker.Close()
+	if err := <-done; err != nil {
+		t.Fatalf("brokerPostgres cancel: %v", err)
+	}
+	if err := <-proxyDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBrokerPostgresRefusesCancelTLSDowngrade(t *testing.T) {
+	cancel := postgresCancelPacket(123, uint32Bytes(456))
+	proxyAddr, proxyDone := postgresProxyStub(t, func(c net.Conn) error {
+		if _, code, err := readPostgresStartup(c); err != nil || code != pgSSLRequest {
+			return fmt.Errorf("SSL request code = %d, err %v", code, err)
+		}
+		if _, err := c.Write([]byte{'N'}); err != nil {
+			return err
+		}
+		_ = c.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		var one [1]byte
+		n, err := c.Read(one[:])
+		if n != 0 {
+			return fmt.Errorf("client sent %d cancel bytes after TLS refusal", n)
+		}
+		if err == nil {
+			return errors.New("client kept the plaintext cancel connection open")
+		}
+		return nil
+	})
+	client, broker := net.Pipe()
+	done := make(chan error, 1)
+	go func() { done <- brokerPostgres(broker, proxyAddr, "", true, "", "") }()
+	if _, err := client.Write(cancel); err != nil {
+		t.Fatal(err)
+	}
+	client.Close()
+	broker.Close()
+	if err := <-done; err == nil || !strings.Contains(err.Error(), "refused the SSL request") {
+		t.Fatalf("brokerPostgres cancel error = %v, want downgrade refusal", err)
+	}
+	if err := <-proxyDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLocalPostgresHandshakeNegotiatesProtocol32(t *testing.T) {
+	startup := postgresStartupParams(
+		pgProtocolVersion32,
+		"user", "alice",
+		"_pq_.traceparent", "ignored",
+		"database", "app",
+		"_pq_.feature", "ignored",
+	)
+	client, broker := net.Pipe()
+	defer client.Close()
+	defer broker.Close()
+	type result struct {
+		startup []byte
+		err     error
+	}
+	done := make(chan result, 1)
+	go func() {
+		got, _, err := localPostgresHandshake(broker, "correct")
+		done <- result{startup: got, err: err}
+	}()
+	if _, err := client.Write(startup); err != nil {
+		t.Fatal(err)
+	}
+	typ, body, _, err := readPostgresFrame(client, maxPGAuthBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if typ != 'v' || !bytes.Equal(
+		body,
+		postgresProtocolNegotiationBody([]string{"_pq_.traceparent", "_pq_.feature"}),
+	) {
+		t.Fatalf("protocol negotiation = %q %x", typ, body)
+	}
+	assertPostgresAuthCode(t, client, 3)
+	if err := writePostgresFrame(client, 'p', []byte("correct\x00")); err != nil {
+		t.Fatal(err)
+	}
+	got := <-done
+	if got.err != nil {
+		t.Fatalf("localPostgresHandshake: %v", got.err)
+	}
+	want := postgresStartup("alice", "app")
+	if !bytes.Equal(got.startup, want) {
+		t.Fatalf("startup = %x, want sanitized protocol 3.0 %x", got.startup, want)
+	}
+}
+
+func TestReadPostgresStartupPacketLengthBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		length int
+		valid  bool
+	}{
+		{length: 10_004, valid: true},
+		{length: 10_005, valid: false},
+	} {
+		t.Run(fmt.Sprintf("length_%d", tc.length), func(t *testing.T) {
+			packet := make([]byte, tc.length)
+			binary.BigEndian.PutUint32(packet, uint32(tc.length))
+			binary.BigEndian.PutUint32(packet[4:], pgProtocolVersion30)
+			_, _, err := readPostgresStartup(bytes.NewReader(packet))
+			if tc.valid && err != nil {
+				t.Fatalf("readPostgresStartup: %v", err)
+			}
+			if !tc.valid && (err == nil || !strings.Contains(err.Error(), "invalid postgres startup packet length")) {
+				t.Fatalf("readPostgresStartup error = %v, want invalid length", err)
+			}
+		})
+	}
+}
+
+func TestLocalPostgresHandshakeRejectsInvalidCancelLength(t *testing.T) {
+	for _, length := range []int{minPGCancelPacket - 1, maxPGCancelPacket + 1} {
+		t.Run(fmt.Sprintf("length_%d", length), func(t *testing.T) {
+			packet := make([]byte, length)
+			binary.BigEndian.PutUint32(packet, uint32(length))
+			binary.BigEndian.PutUint32(packet[4:], pgCancelRequest)
+			client, broker := net.Pipe()
+			defer client.Close()
+			defer broker.Close()
+			done := make(chan error, 1)
+			go func() {
+				_, _, err := localPostgresHandshake(broker, "")
+				done <- err
+			}()
+			if _, err := client.Write(packet); err != nil {
+				t.Fatal(err)
+			}
+			if err := <-done; err == nil || !strings.Contains(err.Error(), "invalid postgres cancel request length") {
+				t.Fatalf("localPostgresHandshake error = %v, want invalid cancel length", err)
+			}
+		})
+	}
+}
+
+type failNthWriteConn struct {
+	net.Conn
+	writes int
+	failAt int
+	err    error
+}
+
+func (c *failNthWriteConn) Write(p []byte) (int, error) {
+	c.writes++
+	if c.writes == c.failAt {
+		return 0, c.err
+	}
+	return c.Conn.Write(p)
+}
+
+func postgresProxyStub(t *testing.T, serve func(net.Conn) error) (string, <-chan error) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		defer ln.Close()
+		c, err := ln.Accept()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer c.Close()
+		done <- serve(c)
+	}()
+	return ln.Addr().String(), done
+}
+
+func postgresCancelPacket(processID uint32, secretKey []byte) []byte {
+	packet := make([]byte, 0, 12+len(secretKey))
+	packet = binary.BigEndian.AppendUint32(packet, uint32(12+len(secretKey)))
+	packet = binary.BigEndian.AppendUint32(packet, pgCancelRequest)
+	packet = binary.BigEndian.AppendUint32(packet, processID)
+	return append(packet, secretKey...)
+}
+
+func expectPostgresCancel(r io.Reader, want []byte) error {
+	got := make([]byte, len(want))
+	if _, err := io.ReadFull(r, got); err != nil {
+		return err
+	}
+	if !bytes.Equal(got, want) {
+		return fmt.Errorf("cancel = %x, want %x", got, want)
+	}
+	return nil
+}
+
+func postgresStartup(user, database string) []byte {
+	return postgresStartupParams(pgProtocolVersion30, "user", user, "database", database)
+}
+
+func postgresStartupParams(version uint32, params ...string) []byte {
+	body := uint32Bytes(version)
+	for _, value := range params {
+		body = append(body, value...)
+		body = append(body, 0)
+	}
+	body = append(body, 0)
+	packet := binary.BigEndian.AppendUint32(nil, uint32(4+len(body)))
+	return append(packet, body...)
+}
+
+func postgresFrame(typ byte, body []byte) []byte {
+	var out bytes.Buffer
+	_ = writePostgresFrame(&out, typ, body)
+	return out.Bytes()
+}
+
+func assertPostgresAuthCode(t *testing.T, r io.Reader, want uint32) {
+	t.Helper()
+	typ, body, _, err := readPostgresFrame(r, maxPGAuthBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if typ != 'R' || len(body) != 4 || binary.BigEndian.Uint32(body) != want {
+		t.Fatalf("authentication frame = %q %x, want code %d", typ, body, want)
+	}
+}
+
+func certificatePEM(der []byte) string {
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}

--- a/pmontray/README.md
+++ b/pmontray/README.md
@@ -22,7 +22,7 @@ item, and the daemon's lifetime is an explicit choice, never an init system's.
   ─────────
   acme-mysql    ·  127.0.0.1:6100        ← click to copy the connection string
   acme-orders   ·  127.0.0.1:6101  (2)   ← (2) = live connections
-  acme-target   ·  postgres brokering not yet supported
+  acme-target   ·  127.0.0.1:6102
   ─────────
   Re-authenticate…
   Log out

--- a/pmontray/render_test.go
+++ b/pmontray/render_test.go
@@ -71,18 +71,18 @@ func TestConcurrentRendersNeverLeaveAMixedPool(t *testing.T) {
 	}
 }
 
-// TestUnbrokeredRowCarriesNoPayload: a row for a datasource that is not brokered (Postgres, no advertised
-// address) must be un-clickable rather than copying an empty or bogus string.
+// TestUnbrokeredRowCarriesNoPayload: a row without an advertised address must be un-clickable rather than
+// copying an empty or bogus string.
 func TestUnbrokeredRowCarriesNoPayload(t *testing.T) {
 	a := newTestApp(4)
 	s := &control.Status{Principal: "you@example.com", LoggedIn: true, LocalPassword: "pw"}
 	s.Datasources = []control.Datasource{
-		{Name: "pg", Engine: "postgres", Brokered: false, Reason: "postgres brokering not yet supported"},
+		{Name: "no-addr", Engine: "postgres", Brokered: false, Reason: "no advertised proxy address"},
 	}
 	a.applyRows(s)
 
-	if a.dsItems[0].name != "pg" {
-		t.Fatalf("row 0 = %q, want pg", a.dsItems[0].name)
+	if a.dsItems[0].name != "no-addr" {
+		t.Fatalf("row 0 = %q, want no-addr", a.dsItems[0].name)
 	}
 	if a.dsItems[0].connString != "" {
 		t.Errorf("unbrokered row carries a payload %q; a click must copy nothing", a.dsItems[0].connString)


### PR DESCRIPTION
## Summary
- add sticky loopback listeners and stable local credentials for PostgreSQL datasources
- replace the local password with the current wire token upstream
- handle PostgreSQL startup, TLS, authentication, cancellation, and connection rendering

## Risk
PostgreSQL wire framing, TLS downgrade refusal, and cancellation forwarding.

## Verification
- `mise run verify`