### PR TITLE
fix(analyzer): resolve PostgreSQL hidden columns

### DIFF
--- a/analyzer/probe/columnfirst_test.go
+++ b/analyzer/probe/columnfirst_test.go
@@ -68,3 +68,39 @@ func TestColumnFirstCanonical(t *testing.T) {
 		})
 	}
 }
+
+func TestWriteCorrelatedColumnAmbiguityRemainsUnresolved(t *testing.T) {
+	catalog := append([]*pb.ColumnSpec{}, canonicalPostgresCatalog...)
+	catalog = append(catalog, columnSpec("acme", "public", "orders", "ssn", "VARCHAR"))
+	result := analyzeProbe(t, &pb.AnalyzeRequest{
+		Sql:          "DELETE FROM users u USING orders ssn WHERE u.id = ssn.user_id RETURNING (SELECT ssn)",
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+		Namespace:    canonicalPostgresNamespace,
+		Catalog:      catalog,
+	})
+	if result.Resolved {
+		t.Fatalf("ambiguous correlated column must fail closed: %+v", result)
+	}
+}
+
+func TestWriteCorrelatedColumnIgnoresUnselectedCTE(t *testing.T) {
+	catalog := append([]*pb.ColumnSpec{}, canonicalPostgresCatalog...)
+	catalog = append(catalog, columnSpec("acme", "public", "orders", "ssn", "VARCHAR"))
+	result := analyzeProbe(t, &pb.AnalyzeRequest{
+		Sql:          "WITH d AS (SELECT ssn FROM orders) DELETE FROM users u WHERE u.id = 1 RETURNING (SELECT ssn)",
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+		Namespace:    canonicalPostgresNamespace,
+		Catalog:      catalog,
+	})
+	if !result.Resolved {
+		t.Fatalf("unselected CTE must not compete with a correlated column: %+v", result)
+	}
+	for _, columns := range result.References {
+		for _, column := range columns {
+			if column == canonicalUsersSSNKey {
+				return
+			}
+		}
+	}
+	t.Fatalf("correlated users.ssn read was not surfaced: %+v", result)
+}

--- a/analyzer/probe/engine.go
+++ b/analyzer/probe/engine.go
@@ -18,7 +18,6 @@ import (
 // sqlglot-go Dialect built from them) is captured at construction, so nothing downstream re-derives
 // it from a namespace or re-parses it from a bare wire-name string.
 type engine interface {
-	Type() pb.Engine
 	// WireName is the canonical lowercase sqlglot-go dialect name ("mysql" | "postgres").
 	WireName() string
 	// Dialect is the single *dialects.Dialect built once from this engine's config — reused for
@@ -43,6 +42,27 @@ type engine interface {
 	// RewriteStatement optionally rewrites a parsed statement into the SQL the proxy should relay to the
 	// target DB, returning "" to leave it unchanged.
 	RewriteStatement(root exp.Expression) string
+	// FinalizeStatementIdentity is the engine's post-classification pass over a resolved statement:
+	// it may pin identities the target DB would otherwise resolve live (mutating facts.RewrittenSql)
+	// or overwrite facts with a fail-closed denial when an identity cannot be pinned. root is the
+	// folded statement, sql the client's original text. Runs once per statement, after the kind
+	// switch in EmitFacts.
+	FinalizeStatementIdentity(root exp.Expression, sql string, facts *pb.StatementFacts, namespace NamespaceConfig) *pb.StatementFacts
+	// IsSafeNoFromFunction reports whether a bare (unqualified) anonymous function name is a
+	// known-safe builtin that needs no no-FROM Function grant — the cross-engine set plus this
+	// engine's own pseudo-functions.
+	IsSafeNoFromFunction(name string) bool
+	// IsTrustedInformationSchemaCall reports whether a schema-qualified call is one of this engine's
+	// trusted information_schema helper builtins, needing no Function grant.
+	IsTrustedInformationSchemaCall(qualifier exp.Expression, leaf string) bool
+	// CommandPassthrough reports whether a statement that DEGRADED to an unstructured Command (the
+	// structured node forms never reach it) may relay as a benign session/metadata passthrough for
+	// this engine. False = fail closed.
+	CommandPassthrough(command string) bool
+	// RejectsDuplicateDerivedLabels reports whether this engine's target DB rejects a derived-table
+	// or CTE body whose output labels collide (MySQL ER_DUP_FIELDNAME; PostgreSQL allows duplicate
+	// OUTPUT labels and rejects only a reference to one).
+	RejectsDuplicateDerivedLabels() bool
 	// NativeOutputLabel computes the output label THIS engine's target DB natively assigns to an
 	// unaliased projection: PostgreSQL derives it from the resolved expression (parse_target.c
 	// FigureColname, written function names from the parse-time SpanText); MySQL uses the
@@ -131,7 +151,6 @@ func newMySQLEngine(config *pb.EngineConfig) (*mysqlEngine, error) {
 	return &mysqlEngine{dialect: dialect}, nil
 }
 
-func (e *mysqlEngine) Type() pb.Engine            { return pb.Engine_MYSQL }
 func (e *mysqlEngine) WireName() string           { return "mysql" }
 func (e *mysqlEngine) Dialect() *dialects.Dialect { return e.dialect }
 
@@ -227,6 +246,27 @@ func (e *mysqlEngine) DiagnosticLeakKeys(report ProbeResult, _ schema.Schema) ma
 	return referencedColumnKeys(report)
 }
 
+// MySQL resolves statement identities at parse time against a fixed namespace — nothing to pin.
+func (e *mysqlEngine) FinalizeStatementIdentity(_ exp.Expression, _ string, facts *pb.StatementFacts, _ NamespaceConfig) *pb.StatementFacts {
+	return facts
+}
+
+// `values` is MySQL's INSERT … ON DUPLICATE KEY UPDATE pseudo-function — it names the value that
+// would have been inserted, not a callable function; its lineage is traced in probe.go.
+func (e *mysqlEngine) IsSafeNoFromFunction(name string) bool {
+	return safeNoFromFunctions[name] || name == "values"
+}
+
+// MySQL's information_schema holds tables only — a function call qualified by it is user code.
+func (e *mysqlEngine) IsTrustedInformationSchemaCall(exp.Expression, string) bool { return false }
+
+// A statement that degrades to an unstructured Command is one the analyzer cannot vouch for on
+// MySQL (an unrecognized SHOW carries data; RESET MASTER/REPLICA is a privileged admin op).
+func (e *mysqlEngine) CommandPassthrough(string) bool { return false }
+
+// MySQL rejects a derived-table/CTE body with duplicated output labels: ER_DUP_FIELDNAME.
+func (e *mysqlEngine) RejectsDuplicateDerivedLabels() bool { return true }
+
 type postgresEngine struct {
 	dialect *dialects.Dialect
 }
@@ -235,7 +275,6 @@ func newPostgresEngine(*pb.EngineConfig) (*postgresEngine, error) {
 	return &postgresEngine{dialect: dialects.Postgres()}, nil
 }
 
-func (e *postgresEngine) Type() pb.Engine            { return pb.Engine_POSTGRES }
 func (e *postgresEngine) WireName() string           { return "postgres" }
 func (e *postgresEngine) Dialect() *dialects.Dialect { return e.dialect }
 
@@ -272,6 +311,39 @@ func (e *postgresEngine) IsTrustedSystemQualifier(qualifier exp.Expression) bool
 // PostgreSQL has no relay rewrite: client_encoding is handled on the wire, not by an analyzer rewrite,
 // so there is nothing to rewrite here.
 func (e *postgresEngine) RewriteStatement(exp.Expression) string { return "" }
+
+// PostgreSQL resolves object identities live (search_path, type/function visibility), so a fresh
+// statement needs no pinning yet — later work pins trusted resolutions here.
+func (e *postgresEngine) FinalizeStatementIdentity(_ exp.Expression, _ string, facts *pb.StatementFacts, _ NamespaceConfig) *pb.StatementFacts {
+	return facts
+}
+
+func (e *postgresEngine) IsSafeNoFromFunction(name string) bool { return safeNoFromFunctions[name] }
+
+// postgresInformationSchemaFunctions are PostgreSQL's information_schema helper builtins — stable,
+// read-only transforms of their arguments (pgJDBC metadata queries call them). Safe ONLY under an
+// explicit `information_schema.` qualifier; the unqualified spelling stays gated so a same-named
+// user function cannot inherit the pass.
+var postgresInformationSchemaFunctions = stringSet(
+	"_pg_char_max_length", "_pg_char_octet_length", "_pg_datetime_precision", "_pg_expandarray",
+	"_pg_index_position", "_pg_interval_type", "_pg_numeric_precision", "_pg_numeric_precision_radix",
+	"_pg_numeric_scale", "_pg_truetypid", "_pg_truetypmod",
+)
+
+func (e *postgresEngine) IsTrustedInformationSchemaCall(qualifier exp.Expression, leaf string) bool {
+	return qualifier != nil && qualifier.Kind() == exp.KindIdentifier &&
+		qualifier.Name() == "information_schema" && postgresInformationSchemaFunctions[leaf]
+}
+
+// A statement that degrades to an unstructured Command on PostgreSQL can only be a benign
+// session/config form: RESET restores defaults (de-escalation), an unmodeled SHOW is a read-only
+// GUC read (no table data). Everything else stays fail-closed at the caller.
+func (e *postgresEngine) CommandPassthrough(command string) bool {
+	return command == "RESET" || command == "SHOW"
+}
+
+// PostgreSQL allows duplicate OUTPUT labels; only a reference to one is ambiguous.
+func (e *postgresEngine) RejectsDuplicateDerivedLabels() bool { return false }
 
 // PostgreSQL names an unaliased projection per parse_target.c FigureColname; a call is labeled by
 // its WRITTEN function name, read from the projection's parse-time SpanText.

--- a/analyzer/probe/engine.go
+++ b/analyzer/probe/engine.go
@@ -26,6 +26,7 @@ type engine interface {
 	// no separate parse-only string form to keep in sync with this one).
 	Dialect() *dialects.Dialect
 	NormalizeCatalogOnBuild() bool
+	ImplicitNonVisibleColumns() []string
 	FoldColumn(column string) string
 	// IsTempSchema reports whether a DDL target's schema identifier denotes session-local (temporary)
 	// storage for this engine, so the DDL is not catalog-changing. The schema is passed as its parsed
@@ -158,6 +159,8 @@ func (e *mysqlEngine) Dialect() *dialects.Dialect { return e.dialect }
 // spelling follows lower_case_table_names and the information_schema exception.
 func (e *mysqlEngine) NormalizeCatalogOnBuild() bool { return true }
 
+func (e *mysqlEngine) ImplicitNonVisibleColumns() []string { return nil }
+
 func (e *mysqlEngine) FoldColumn(column string) string {
 	return e.dialect.FoldIdentifierName(column, false)
 }
@@ -281,6 +284,8 @@ func (e *postgresEngine) Dialect() *dialects.Dialect { return e.dialect }
 // PostgreSQL does not fold the introspected catalog: quoted and unquoted names can identify distinct
 // real columns, while query-side qualification already preserves quoted names and folds unquoted ones.
 func (e *postgresEngine) NormalizeCatalogOnBuild() bool { return false }
+
+func (e *postgresEngine) ImplicitNonVisibleColumns() []string { return []string{"ctid"} }
 
 func (e *postgresEngine) FoldColumn(column string) string { return column }
 

--- a/analyzer/probe/engine.go
+++ b/analyzer/probe/engine.go
@@ -285,7 +285,9 @@ func (e *postgresEngine) Dialect() *dialects.Dialect { return e.dialect }
 // real columns, while query-side qualification already preserves quoted names and folds unquoted ones.
 func (e *postgresEngine) NormalizeCatalogOnBuild() bool { return false }
 
-func (e *postgresEngine) ImplicitNonVisibleColumns() []string { return []string{"ctid"} }
+func (e *postgresEngine) ImplicitNonVisibleColumns() []string {
+	return []string{"tableoid", "xmin", "cmin", "xmax", "cmax", "ctid"}
+}
 
 func (e *postgresEngine) FoldColumn(column string) string { return column }
 
@@ -377,7 +379,16 @@ func (e *postgresEngine) DiagnosticLeakKeys(report ProbeResult, qualifySchema sc
 		keys[id.String()+".*"] = true
 		return keys
 	}
+	// The qualify schema also lists the implicit system columns (ctid, xmin, …); a `Failing row
+	// contains (…)` DETAIL echoes only the real row.
+	implicit := map[string]bool{}
+	for _, col := range e.ImplicitNonVisibleColumns() {
+		implicit[col] = true
+	}
 	for _, col := range cols {
+		if implicit[col] {
+			continue
+		}
 		keys[id.String()+"."+col] = true
 	}
 	return keys

--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -87,7 +87,7 @@ func EmitFacts(sql string, engineConfig *pb.EngineConfig, sch *schema.Mapping, n
 	if err := detectRenderCollisions(sch); err != nil {
 		return unanalyzableFacts("VALIDATE", err.Error())
 	}
-	qualifySchema, err := schema.NewMappingSchema(sch, eng.Dialect(), eng.NormalizeCatalogOnBuild())
+	qualifySchema, err := newQualifySchema(sch, eng)
 	if err != nil {
 		return unanalyzableFacts("VALIDATE", err.Error())
 	}

--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -40,34 +40,6 @@ var safeNoFromFunctions = stringSet(
 	"iif", "if", "typeof", "pg_typeof",
 )
 
-// postgresInformationSchemaFunctions are PostgreSQL's information_schema helper builtins — stable,
-// read-only transforms of their arguments (pgJDBC metadata queries call them). Safe ONLY under an
-// explicit `information_schema.` qualifier; the unqualified spelling stays gated so a same-named
-// user function cannot inherit the pass.
-var postgresInformationSchemaFunctions = stringSet(
-	"_pg_char_max_length", "_pg_char_octet_length", "_pg_datetime_precision", "_pg_expandarray",
-	"_pg_index_position", "_pg_interval_type", "_pg_numeric_precision", "_pg_numeric_precision_radix",
-	"_pg_numeric_scale", "_pg_truetypid", "_pg_truetypmod",
-)
-
-func isTrustedInformationSchemaCall(qualifier exp.Expression, leaf string, eng engine) bool {
-	return eng.Type() == pb.Engine_POSTGRES && qualifier != nil &&
-		qualifier.Kind() == exp.KindIdentifier && qualifier.Name() == "information_schema" &&
-		postgresInformationSchemaFunctions[leaf]
-}
-
-// mysqlOnlySafeFunctions are safe no-FROM function names that exist ONLY on MySQL. `values` is MySQL's
-// INSERT … ON DUPLICATE KEY UPDATE pseudo-function — it names the value that would have been inserted, not a
-// callable function, and its lineage is traced in probe.go. PostgreSQL has no `values` builtin, so keeping
-// it out of the cross-engine set leaves a quoted PostgreSQL `"values"()` (a user function) gated.
-var mysqlOnlySafeFunctions = stringSet("values")
-
-// isSafeNoFromFunction reports whether a bare (unqualified) anonymous function name is a known-safe builtin
-// that needs no no-FROM Function grant — the cross-engine set plus any engine-specific pseudo-functions.
-func isSafeNoFromFunction(name string, eng engine) bool {
-	return safeNoFromFunctions[name] || (eng.Type() == pb.Engine_MYSQL && mysqlOnlySafeFunctions[name])
-}
-
 // userTypeCast returns the name of the first reference to a non-built-in (user) type anywhere in root, or
 // "" if every type reference is a safe built-in. sqlglot resolves a built-in type to a concrete DType and
 // a user type to DTypeUserDefined, so this is a single AST pass over DataType nodes. It covers every way a
@@ -214,6 +186,7 @@ func EmitFacts(sql string, engineConfig *pb.EngineConfig, sch *schema.Mapping, n
 			facts.RewrittenSql = &rewrite
 		}
 	}
+	facts = eng.FinalizeStatementIdentity(root, sql, facts, validatedNamespace)
 	facts.StatementExec = executeGrant(statementKind(root, eng))
 	facts.SchemaQualifierCandidates = candidates
 	return facts
@@ -680,20 +653,17 @@ func emitCommandFacts(root exp.Expression, eng engine) *pb.StatementFacts {
 		// engine-specific passthrough.
 		return inadmissibleFacts("VALIDATE", "SET statement is not structurally analyzable")
 	case "RESET":
-		if eng.Type() == pb.Engine_POSTGRES {
-			// A PostgreSQL RESET that degrades to Command (rather than the structured Reset node) is an
-			// unusual/laundering spelling; RESET only ever restores defaults (de-escalation), so it stays a
-			// benign session passthrough.
+		// The structured Reset node never reaches here; a RESET degraded to Command is an unusual
+		// spelling the engine may still vouch for as pure de-escalation.
+		if eng.CommandPassthrough(command) {
 			return passthroughFacts()
 		}
 		return inadmissibleFacts("VALIDATE", "RESET is not allowed on MySQL")
 	case "SHOW":
-		// The data-bearing MySQL SHOWs (WARNINGS/PROCESSLIST/BINLOG/… and SHOW CREATE USER) and PostgreSQL
-		// SHOW <guc> all parse as structured Show/Reset nodes and are handled in emitShowFacts, so they
-		// never reach here. A SHOW that still degrades to Command is a form sqlglot-go did not model: on
-		// PostgreSQL it can only be a read-only GUC/config read (no table data) → metadata passthrough; on
-		// MySQL an unrecognized SHOW is one the proxy cannot vouch for → fail closed.
-		if eng.Type() == pb.Engine_POSTGRES {
+		// The data-bearing SHOWs parse as structured Show/Reset nodes and are handled in
+		// emitShowFacts; a SHOW that still degrades to Command is a form sqlglot-go did not model,
+		// relayable only where the engine vouches it carries no table data.
+		if eng.CommandPassthrough(command) {
 			return passthroughFacts()
 		}
 		return unanalyzableFacts("PARSE", "unsupported SHOW command")
@@ -752,7 +722,7 @@ func noFromFunctionGrants(root exp.Expression, eng engine) []*pb.RequireResultRe
 			}
 			continue
 		}
-		if isTrustedInformationSchemaCall(dot.Left(), leaf, eng) {
+		if eng.IsTrustedInformationSchemaCall(dot.Left(), leaf) {
 			continue
 		}
 		emit(qualifiedCallName(dot.Left(), leaf, eng))
@@ -767,7 +737,7 @@ func noFromFunctionGrants(root exp.Expression, eng engine) []*pb.RequireResultRe
 		if schema == nil {
 			continue
 		}
-		if isTrustedInformationSchemaCall(schema, strings.ToLower(fn.Name()), eng) {
+		if eng.IsTrustedInformationSchemaCall(schema, strings.ToLower(fn.Name())) {
 			qualified[fn] = true
 		}
 	}
@@ -776,7 +746,7 @@ func noFromFunctionGrants(root exp.Expression, eng engine) []*pb.RequireResultRe
 			continue
 		}
 		name := strings.ToLower(fn.Name())
-		if isSafeNoFromFunction(name, eng) {
+		if eng.IsSafeNoFromFunction(name) {
 			continue
 		}
 		emit(name)
@@ -843,7 +813,7 @@ func hasUnsafeCall(root exp.Expression, eng engine) bool {
 			}
 			continue
 		}
-		if isTrustedInformationSchemaCall(dot.Left(), normalizedFunctionName(fn, eng), eng) {
+		if eng.IsTrustedInformationSchemaCall(dot.Left(), normalizedFunctionName(fn, eng)) {
 			continue
 		}
 		return true
@@ -857,7 +827,7 @@ func hasUnsafeCall(root exp.Expression, eng engine) bool {
 			continue
 		}
 		name := strings.ToLower(fn.Name())
-		if name != "" && name != "*" && !isSafeNoFromFunction(name, eng) {
+		if name != "" && name != "*" && !eng.IsSafeNoFromFunction(name) {
 			return true
 		}
 	}

--- a/analyzer/probe/output_labels.go
+++ b/analyzer/probe/output_labels.go
@@ -5,8 +5,6 @@ import (
 	"regexp"
 
 	exp "github.com/ridi-oss/sqlglot-go/expressions"
-
-	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
 )
 
 var syntheticLabelPattern = regexp.MustCompile(`^_col_\d+$`)
@@ -81,8 +79,7 @@ func stampNativeOutputLabels(root exp.Expression, eng engine) error {
 				if len(names) < 2 {
 					continue
 				}
-				if eng.Type() == pb.Engine_MYSQL {
-					// Real MySQL rejects the derived table itself: ER_DUP_FIELDNAME.
+				if eng.RejectsDuplicateDerivedLabels() {
 					return fmt.Errorf("duplicate column name '%s' in derived table", names[0])
 				}
 				// Real PostgreSQL rejects only a reference to the duplicated label.

--- a/analyzer/probe/pb/analyzer.pb.go
+++ b/analyzer/probe/pb/analyzer.pb.go
@@ -991,8 +991,8 @@ func (x *AnalyzeRequest) GetEngineConfig() *EngineConfig {
 }
 
 // One physical target-DB relation the statement scans (docs/facts-emission.md). catalog/schema/table
-// is the resolved identity; covered is true once at least one traced column fact names this table
-// (see probe.go's SourceInfo doc comment for the full per-table coverage rationale).
+// is the resolved identity; covered is true when emitted Column grants fully gate the scan. A read of an
+// implicit non-visible column without a catalog identity leaves the table uncovered.
 type SourceInfo struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/analyzer/probe/postgres_system_column_test.go
+++ b/analyzer/probe/postgres_system_column_test.go
@@ -116,6 +116,107 @@ func TestPostgresCTIDSupportsDataGripTableQuery(t *testing.T) {
 	}
 }
 
+func TestPostgresSystemColumnsResolveExplicitly(t *testing.T) {
+	catalog := []*pb.ColumnSpec{
+		columnSpec("acme", "public", "users", "id", "BIGINT"),
+		columnSpec("acme", "public", "users", "email", "VARCHAR"),
+	}
+
+	t.Run("all system columns", func(t *testing.T) {
+		facts := analyzeProto(t, &pb.AnalyzeRequest{
+			Sql:          "SELECT tableoid, xmin, cmin, xmax, cmax, ctid FROM public.users",
+			EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+			Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+			Catalog:      catalog,
+		})
+		if !facts.GetResolved() {
+			t.Fatalf("PostgreSQL system columns must resolve: stage=%s detail=%q", stageString(facts.FailedStage), facts.GetDetail())
+		}
+		if len(facts.GetResultReads()) != 1 {
+			t.Fatalf("system columns emitted unexpected grants: %+v", facts.GetResultReads())
+		}
+		table := facts.GetResultReads()[0].GetTable()
+		if table == nil || table.GetCatalog() != "acme" || table.GetSchema() != "public" || table.GetTable() != "users" {
+			t.Fatalf("system columns must emit the physical table grant: %+v", facts.GetResultReads())
+		}
+	})
+}
+
+func TestPostgresSystemColumnsSupportDataGripIntrospection(t *testing.T) {
+	cases := []struct {
+		name    string
+		sql     string
+		catalog []*pb.ColumnSpec
+		table   string
+	}{
+		{
+			name: "namespaces",
+			sql: `select N.oid::bigint as id,
+       N.xmin as state_number,
+       nspname as name,
+       D.description,
+       pg_catalog.pg_get_userbyid(N.nspowner) as "owner"
+from pg_catalog.pg_namespace N
+  left join pg_catalog.pg_description D on N.oid = D.objoid
+order by case when nspname = pg_catalog.current_schema() then -1::bigint else N.oid::bigint end`,
+			catalog: []*pb.ColumnSpec{
+				columnSpec("acme", "pg_catalog", "pg_namespace", "oid", "OID"),
+				columnSpec("acme", "pg_catalog", "pg_namespace", "nspname", "NAME"),
+				columnSpec("acme", "pg_catalog", "pg_namespace", "nspowner", "OID"),
+				columnSpec("acme", "pg_catalog", "pg_description", "objoid", "OID"),
+				columnSpec("acme", "pg_catalog", "pg_description", "description", "TEXT"),
+			},
+			table: "pg_namespace",
+		},
+		{
+			name: "tablespaces",
+			sql: `select T.oid::bigint as id, T.spcname as name,
+       T.xmin as state_number, pg_catalog.pg_get_userbyid(T.spcowner) as owner,
+       pg_catalog.pg_tablespace_location(T.oid) /* null */ as location,
+       T.spcoptions /* null */ as options,
+       D.description as comment
+from pg_catalog.pg_tablespace T
+  left join pg_catalog.pg_shdescription D on D.objoid = T.oid
+--  where pg_catalog.age(T.xmin) <= #TXAGE`,
+			catalog: []*pb.ColumnSpec{
+				columnSpec("acme", "pg_catalog", "pg_tablespace", "oid", "OID"),
+				columnSpec("acme", "pg_catalog", "pg_tablespace", "spcname", "NAME"),
+				columnSpec("acme", "pg_catalog", "pg_tablespace", "spcowner", "OID"),
+				columnSpec("acme", "pg_catalog", "pg_tablespace", "spcoptions", "TEXT[]"),
+				columnSpec("acme", "pg_catalog", "pg_shdescription", "objoid", "OID"),
+				columnSpec("acme", "pg_catalog", "pg_shdescription", "description", "TEXT"),
+			},
+			table: "pg_tablespace",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			facts := analyzeProto(t, &pb.AnalyzeRequest{
+				Sql:          tc.sql,
+				EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+				Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+				Catalog:      tc.catalog,
+			})
+			if !facts.GetResolved() {
+				t.Fatalf("DataGrip introspection must resolve: stage=%s detail=%q", stageString(facts.FailedStage), facts.GetDetail())
+			}
+			tableGrant := false
+			for _, grant := range facts.GetResultReads() {
+				if column := grant.GetColumn(); column != nil && strings.EqualFold(column.GetIdentity().GetColumn(), "xmin") {
+					t.Fatalf("virtual xmin emitted a catalog-column grant: %+v", grant)
+				}
+				if table := grant.GetTable(); table != nil && table.GetCatalog() == "acme" && table.GetSchema() == "pg_catalog" && table.GetTable() == tc.table {
+					tableGrant = true
+				}
+			}
+			if !tableGrant {
+				t.Fatalf("virtual xmin emitted no %s table grant: %+v", tc.table, facts.GetResultReads())
+			}
+		})
+	}
+}
+
 func TestPostgresCTIDResolutionBoundaries(t *testing.T) {
 	baseCatalog := []*pb.ColumnSpec{
 		columnSpec("acme", "public", "users", "id", "BIGINT"),

--- a/analyzer/probe/postgres_system_column_test.go
+++ b/analyzer/probe/postgres_system_column_test.go
@@ -1,0 +1,624 @@
+package probe
+
+import (
+	"strings"
+	"testing"
+
+	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
+	sqlglot "github.com/ridi-oss/sqlglot-go"
+	exp "github.com/ridi-oss/sqlglot-go/expressions"
+)
+
+func TestPostgresCTIDSupportsDataGripTableQuery(t *testing.T) {
+	catalog := []*pb.ColumnSpec{
+		columnSpec("acme", "public", "users", "id", "BIGINT"),
+		columnSpec("acme", "public", "users", "email", "VARCHAR"),
+		columnSpec("acme", "public", "users", "phone", "VARCHAR"),
+		columnSpec("acme", "public", "users", "name", "VARCHAR"),
+		columnSpec("acme", "public", "users", "ssn", "VARCHAR"),
+		columnSpec("acme", "public", "users", "region", "VARCHAR"),
+		columnSpec("acme", "public", "users", "created_at", "TIMESTAMP"),
+	}
+	req := &pb.AnalyzeRequest{
+		Sql:          "SELECT t.*, CTID FROM public.users t LIMIT 501",
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+		Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+		Catalog:      catalog,
+	}
+	result := analyzeProbe(t, req)
+	if !result.Resolved {
+		t.Fatalf("DataGrip query must resolve: stage=%v detail=%q", result.FailedStage, result.Detail)
+	}
+	if result.OutputColumns != 8 {
+		t.Fatalf("output columns = %d, want 8: %+v", result.OutputColumns, result.Origins)
+	}
+	if result.RewrittenSQL == nil {
+		t.Fatal("DataGrip query with t.* must carry a rewritten SQL statement")
+	}
+
+	rewritten, err := sqlglot.ParseOne(*result.RewrittenSQL, "postgres")
+	if err != nil {
+		t.Fatalf("parse rewritten SQL: %v; sql=%q", err, *result.RewrittenSQL)
+	}
+	ctidCount := 0
+	for _, projection := range rewritten.Selects() {
+		if projection.Kind() == exp.KindStar || (projection.Kind() == exp.KindColumn && projection.This().Kind() == exp.KindStar) {
+			t.Fatalf("rewritten SQL still contains a star: %q", *result.RewrittenSQL)
+		}
+		if strings.EqualFold(projection.AliasOrName(), "ctid") {
+			ctidCount++
+		}
+	}
+	if ctidCount != 1 {
+		t.Fatalf("rewritten SQL contains %d CTID outputs, want 1: %q", ctidCount, *result.RewrittenSQL)
+	}
+
+	expectedOrigins := []string{
+		"acme.public.users.id",
+		"acme.public.users.email",
+		"acme.public.users.phone",
+		"acme.public.users.name",
+		"acme.public.users.ssn",
+		"acme.public.users.region",
+		"acme.public.users.created_at",
+	}
+	for i, expected := range expectedOrigins {
+		origin := result.Origins[i]
+		if len(origin.Origins) != 1 || origin.Origins[0] != expected {
+			t.Fatalf("output %d origin = %+v, want %q", i, origin, expected)
+		}
+	}
+	ctidOrigin := result.Origins[len(result.Origins)-1]
+	if !strings.EqualFold(ctidOrigin.Column, "ctid") || len(ctidOrigin.Origins) != 0 {
+		t.Fatalf("CTID origin = %+v, want an unclassified system-column output", ctidOrigin)
+	}
+
+	facts := analyzeProto(t, req)
+	if !facts.GetResolved() {
+		t.Fatalf("FFM statement facts must resolve: stage=%s detail=%q", stageString(facts.FailedStage), facts.GetDetail())
+	}
+	if got := facts.GetOutputColumns(); len(got) != 8 || !strings.EqualFold(got[7], "ctid") {
+		t.Fatalf("statement-facts outputs = %v, want seven visible columns followed by CTID", got)
+	}
+	ordinals := map[string]int32{}
+	tableGrant := false
+	for _, grant := range facts.GetResultReads() {
+		if table := grant.GetTable(); table != nil {
+			if table.GetCatalog() == "acme" && table.GetSchema() == "public" && table.GetTable() == "users" {
+				tableGrant = true
+			}
+			continue
+		}
+		column := grant.GetColumn()
+		if column == nil {
+			continue
+		}
+		positions := grant.GetOutputOrdinals()
+		if len(positions) != 1 {
+			t.Fatalf("column %s has output ordinals %v, want one", column.GetIdentity().GetColumn(), positions)
+		}
+		ordinals[column.GetIdentity().GetColumn()] = positions[0]
+	}
+	if !tableGrant {
+		t.Fatalf("virtual CTID must emit a table grant even when visible columns cover the same source: %+v", result.Sources)
+	}
+	if len(ordinals) != len(expectedOrigins) {
+		t.Fatalf("statement facts emitted %d column grants, want %d: %v", len(ordinals), len(expectedOrigins), ordinals)
+	}
+	for i, spec := range catalog {
+		column := spec.GetIdentity().GetColumn()
+		if ordinal, ok := ordinals[column]; !ok || ordinal != int32(i) {
+			t.Fatalf("column %s output ordinal = %d, %t; want %d", column, ordinal, ok, i)
+		}
+	}
+	if _, ok := ordinals["ctid"]; ok {
+		t.Fatalf("virtual CTID must not emit a catalog-column grant: %v", ordinals)
+	}
+}
+
+func TestPostgresCTIDResolutionBoundaries(t *testing.T) {
+	baseCatalog := []*pb.ColumnSpec{
+		columnSpec("acme", "public", "users", "id", "BIGINT"),
+		columnSpec("acme", "public", "orders", "id", "BIGINT"),
+	}
+	analyze := func(t *testing.T, sql string, catalog []*pb.ColumnSpec) ProbeResult {
+		t.Helper()
+		return *analyzeProbe(t, &pb.AnalyzeRequest{
+			Sql:          sql,
+			EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+			Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+			Catalog:      catalog,
+		})
+	}
+
+	t.Run("qualified physical table", func(t *testing.T) {
+		result := analyze(t, "SELECT u.ctid FROM users u", baseCatalog)
+		if !result.Resolved || len(result.Origins) != 1 || len(result.Origins[0].Origins) != 0 {
+			t.Fatalf("qualified CTID must resolve without a catalog-column origin: %+v", result)
+		}
+		if len(result.Sources) != 1 || result.Sources[0].Catalog != "acme" || result.Sources[0].Schema != "public" || result.Sources[0].Table != "users" || result.Sources[0].Covered {
+			t.Fatalf("CTID-only read must require the physical table grant: %+v", result.Sources)
+		}
+	})
+
+	t.Run("composite virtual CTID emits only a table grant", func(t *testing.T) {
+		catalog := append([]*pb.ColumnSpec{}, baseCatalog...)
+		catalog = append(catalog, columnSpec("acme", "public", "users", "email", "VARCHAR"))
+		cases := []string{
+			"SELECT (u).ctid FROM users u",
+			"SELECT 1 FROM users u WHERE (u).ctid = '(0,1)'",
+			"UPDATE users u SET email = 'x' WHERE (u).ctid = '(0,1)'",
+			"UPDATE users u SET email = 'x' RETURNING (u).ctid",
+		}
+		for _, sql := range cases {
+			t.Run(sql, func(t *testing.T) {
+				facts := analyzeProto(t, &pb.AnalyzeRequest{
+					Sql:          sql,
+					EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+					Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+					Catalog:      catalog,
+				})
+				if !facts.GetResolved() {
+					t.Fatalf("composite virtual CTID must resolve: stage=%s detail=%q", stageString(facts.FailedStage), facts.GetDetail())
+				}
+				reads := facts.GetResultReads()
+				if len(reads) != 1 {
+					result := analyze(t, sql, catalog)
+					t.Fatalf("composite virtual CTID emitted unexpected result reads: %+v; references=%v", reads, result.References)
+				}
+				table := reads[0].GetTable()
+				if table == nil || table.GetCatalog() != "acme" || table.GetSchema() != "public" || table.GetTable() != "users" {
+					t.Fatalf("composite virtual CTID grant = %+v, want acme.public.users table", reads[0])
+				}
+			})
+		}
+	})
+
+	t.Run("mixed virtual CTID use requires table grant", func(t *testing.T) {
+		cases := []string{
+			"SELECT id, ctid FROM users",
+			"SELECT id FROM users WHERE ctid = '(0,1)'",
+			"SELECT id FROM users ORDER BY ctid",
+			"SELECT (u).ctid FROM users u",
+			"SELECT ((u)).ctid, u.id FROM users u",
+		}
+		for _, sql := range cases {
+			t.Run(sql, func(t *testing.T) {
+				result := analyze(t, sql, baseCatalog)
+				if !result.Resolved || len(result.Sources) != 1 || result.Sources[0].Covered {
+					t.Fatalf("virtual CTID must leave its physical source table-gated: %+v", result)
+				}
+				facts := analyzeProto(t, &pb.AnalyzeRequest{
+					Sql:          sql,
+					EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+					Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+					Catalog:      baseCatalog,
+				})
+				tableGrant := false
+				for _, grant := range facts.GetResultReads() {
+					if table := grant.GetTable(); table != nil && table.GetCatalog() == "acme" && table.GetSchema() == "public" && table.GetTable() == "users" {
+						tableGrant = true
+					}
+				}
+				if !tableGrant {
+					t.Fatalf("virtual CTID use emitted no users table grant: %+v", facts.GetResultReads())
+				}
+			})
+		}
+	})
+
+	t.Run("write CTID reads require table grant", func(t *testing.T) {
+		catalog := append([]*pb.ColumnSpec{}, baseCatalog...)
+		catalog = append(catalog, columnSpec("acme", "public", "users", "email", "VARCHAR"))
+		cases := []string{
+			"UPDATE users SET email = 'x' WHERE ctid = '(0,1)'",
+			"UPDATE users u SET email = 'x' WHERE u.ctid = '(0,1)' RETURNING u.ctid",
+			"UPDATE users SET email = 'x' WHERE id = 1 RETURNING ctid",
+			"DELETE FROM users WHERE ctid = '(0,1)'",
+			"DELETE FROM users WHERE ctid = '(0,1)' RETURNING ctid",
+			"INSERT INTO users (id, email) VALUES (3, 'x') RETURNING ctid",
+		}
+		for _, sql := range cases {
+			t.Run(sql, func(t *testing.T) {
+				result := analyze(t, sql, catalog)
+				if !result.Resolved || len(result.Sources) != 1 || result.Sources[0].Catalog != "acme" || result.Sources[0].Schema != "public" || result.Sources[0].Table != "users" || result.Sources[0].Covered {
+					t.Fatalf("virtual CTID write read must leave its target table-gated: %+v", result)
+				}
+				facts := analyzeProto(t, &pb.AnalyzeRequest{
+					Sql:          sql,
+					EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+					Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+					Catalog:      catalog,
+				})
+				if !facts.GetResolved() {
+					t.Fatalf("virtual CTID write facts must resolve: stage=%s detail=%q", stageString(facts.FailedStage), facts.GetDetail())
+				}
+				tableGrant := false
+				for _, grant := range facts.GetResultReads() {
+					if table := grant.GetTable(); table != nil && table.GetCatalog() == "acme" && table.GetSchema() == "public" && table.GetTable() == "users" {
+						tableGrant = true
+						if grant.GetMaskedDisposition() != pb.MaskedDisposition_MASKED_DISPOSITION_DENY_STATEMENT {
+							t.Fatalf("virtual CTID write table grant disposition = %s, want DENY_STATEMENT", grant.GetMaskedDisposition())
+						}
+					}
+					if column := grant.GetColumn(); column != nil && strings.EqualFold(column.GetIdentity().GetColumn(), "ctid") {
+						t.Fatalf("virtual CTID write emitted a catalog-column grant: %+v", grant)
+					}
+				}
+				if !tableGrant {
+					t.Fatalf("virtual CTID write emitted no users table grant: %+v", facts.GetResultReads())
+				}
+			})
+		}
+	})
+
+	t.Run("qualified multi-source write CTID resolves exact source", func(t *testing.T) {
+		catalog := append([]*pb.ColumnSpec{}, baseCatalog...)
+		catalog = append(catalog, columnSpec("acme", "public", "users", "email", "VARCHAR"))
+		cases := []struct {
+			sql     string
+			covered map[string]bool
+		}{
+			{
+				sql:     "UPDATE users u SET email = 'x' FROM orders o WHERE u.ctid = '(0,1)' AND o.id = 1",
+				covered: map[string]bool{"users": false, "orders": true},
+			},
+			{
+				sql:     "UPDATE users u SET email = 'x' FROM orders o WHERE o.ctid = '(0,1)'",
+				covered: map[string]bool{"orders": false},
+			},
+			{
+				sql:     "UPDATE users AS u SET email = 'x' FROM orders AS users WHERE users.ctid = '(0,1)'",
+				covered: map[string]bool{"orders": false},
+			},
+			{
+				sql:     "MERGE INTO users AS u USING orders AS o ON u.id = o.id WHEN MATCHED AND u.ctid = '(0,1)' THEN UPDATE SET email = 'x'",
+				covered: map[string]bool{"users": false, "orders": true},
+			},
+			{
+				sql:     "MERGE INTO users AS u USING orders AS o ON u.id = o.id WHEN NOT MATCHED AND o.ctid = '(0,1)' THEN INSERT (id, email) VALUES (o.id, 'x')",
+				covered: map[string]bool{"orders": false},
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.sql, func(t *testing.T) {
+				result := analyze(t, tc.sql, catalog)
+				if !result.Resolved || len(result.Sources) != len(tc.covered) {
+					t.Fatalf("qualified virtual CTID write must resolve exact sources: %+v", result)
+				}
+				for _, source := range result.Sources {
+					covered, ok := tc.covered[source.Table]
+					if !ok || source.Covered != covered {
+						t.Fatalf("qualified virtual CTID write source = %+v, want %v", source, tc.covered)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("nested write CTID resolves from its own scope", func(t *testing.T) {
+		catalog := append([]*pb.ColumnSpec{}, baseCatalog...)
+		catalog = append(
+			catalog,
+			columnSpec("acme", "public", "users", "email", "VARCHAR"),
+			columnSpec("acme", "public", "orders", "email", "VARCHAR"),
+		)
+		cases := []string{
+			"UPDATE users u SET email = (SELECT o.email FROM orders o WHERE ctid = '(0,1)') WHERE u.id = 1",
+			"INSERT INTO users (id, email) SELECT o.id, o.email FROM orders o WHERE ctid = '(0,1)'",
+		}
+		for _, sql := range cases {
+			t.Run(sql, func(t *testing.T) {
+				result := analyze(t, sql, catalog)
+				if !result.Resolved || len(result.Sources) != 1 || result.Sources[0].Table != "orders" || result.Sources[0].Covered {
+					t.Fatalf("nested virtual CTID must gate its inner physical source: %+v", result)
+				}
+				facts := analyzeProto(t, &pb.AnalyzeRequest{
+					Sql:          sql,
+					EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+					Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+					Catalog:      catalog,
+				})
+				ordersTableGrant := false
+				for _, grant := range facts.GetResultReads() {
+					if table := grant.GetTable(); table != nil {
+						if table.GetTable() == "users" {
+							t.Fatalf("nested virtual CTID gated the outer write target: %+v", grant)
+						}
+						if table.GetTable() == "orders" {
+							ordersTableGrant = true
+							if grant.GetMaskedDisposition() != pb.MaskedDisposition_MASKED_DISPOSITION_DENY_STATEMENT {
+								t.Fatalf("nested virtual CTID table disposition = %s, want DENY_STATEMENT", grant.GetMaskedDisposition())
+							}
+						}
+					}
+					if column := grant.GetColumn(); column != nil && strings.EqualFold(column.GetIdentity().GetColumn(), "ctid") {
+						t.Fatalf("nested virtual CTID emitted a catalog-column grant: %+v", grant)
+					}
+				}
+				if !ordersTableGrant {
+					t.Fatalf("nested virtual CTID emitted no orders table grant: %+v", facts.GetResultReads())
+				}
+			})
+		}
+	})
+
+	t.Run("derived CTID output remains ordinary in write", func(t *testing.T) {
+		catalog := append([]*pb.ColumnSpec{}, baseCatalog...)
+		catalog = append(catalog, columnSpec("acme", "public", "users", "email", "VARCHAR"))
+		cases := []string{
+			"UPDATE users u SET email = (SELECT d.ctid::text FROM (SELECT '(9,9)'::tid AS ctid) d) WHERE u.id = 1",
+			"UPDATE users u SET email = (SELECT ctid::text FROM (SELECT '(9,9)'::tid AS ctid) d) WHERE u.id = 1",
+			"UPDATE users u SET email = (SELECT u.ctid::text FROM (SELECT '(9,9)'::tid AS ctid) u) WHERE u.id = 1",
+		}
+		for _, sql := range cases {
+			t.Run(sql, func(t *testing.T) {
+				result := analyze(t, sql, catalog)
+				if !result.Resolved {
+					t.Fatalf("derived CTID output must remain an ordinary scalar: %+v", result)
+				}
+				facts := analyzeProto(t, &pb.AnalyzeRequest{
+					Sql:          sql,
+					EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+					Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+					Catalog:      catalog,
+				})
+				for _, grant := range facts.GetResultReads() {
+					if table := grant.GetTable(); table != nil {
+						t.Fatalf("derived CTID output emitted a physical table grant: %+v", table)
+					}
+					if column := grant.GetColumn(); column != nil && strings.EqualFold(column.GetIdentity().GetColumn(), "ctid") {
+						t.Fatalf("derived CTID output emitted a CTID column grant: %+v", column)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("derived physical CTID keeps its table provenance", func(t *testing.T) {
+		catalog := append([]*pb.ColumnSpec{}, baseCatalog...)
+		catalog = append(catalog, columnSpec("acme", "public", "users", "email", "VARCHAR"))
+		cases := []string{
+			"SELECT d.ctid FROM (SELECT ctid, id FROM orders) d",
+			"SELECT d.row_id FROM (SELECT ctid AS row_id, id FROM orders) d",
+			"SELECT (d).ctid FROM (SELECT ctid, id FROM orders) d",
+			"SELECT (d).row_id FROM (SELECT ctid AS row_id, id FROM orders) d",
+			"WITH d AS (SELECT ctid, id FROM orders) UPDATE users u SET email = d.ctid::text FROM d WHERE d.id = u.id",
+			"UPDATE users u SET email = d.row_id::text FROM (SELECT ctid AS row_id, id FROM orders) d WHERE d.id = u.id",
+		}
+		for _, sql := range cases {
+			t.Run(sql, func(t *testing.T) {
+				result := analyze(t, sql, catalog)
+				if !result.Resolved {
+					t.Fatalf("derived physical CTID must resolve: %+v", result)
+				}
+				ordersTableGrant := false
+				for _, source := range result.Sources {
+					if source.Table == "orders" && !source.Covered {
+						ordersTableGrant = true
+					}
+				}
+				if !ordersTableGrant {
+					t.Fatalf("derived physical CTID lost its orders table grant: %+v", result.Sources)
+				}
+				facts := analyzeProto(t, &pb.AnalyzeRequest{
+					Sql:          sql,
+					EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+					Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+					Catalog:      catalog,
+				})
+				for _, grant := range facts.GetResultReads() {
+					if column := grant.GetColumn(); column != nil {
+						if strings.EqualFold(column.GetIdentity().GetColumn(), "ctid") {
+							t.Fatalf("derived virtual CTID emitted a catalog-column grant: %+v", grant)
+						}
+						if strings.HasPrefix(sql, "SELECT ") {
+							t.Fatalf("derived virtual CTID SELECT emitted an unrelated column grant: %+v", grant)
+						}
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("composite derived CTID expression keeps ordinary column provenance", func(t *testing.T) {
+		sql := "SELECT (d).mixed FROM (SELECT ctid::text || id::text AS mixed FROM orders) d"
+		facts := analyzeProto(t, &pb.AnalyzeRequest{
+			Sql:          sql,
+			EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+			Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+			Catalog:      baseCatalog,
+		})
+		if !facts.GetResolved() {
+			t.Fatalf("composite mixed CTID expression must resolve: stage=%s detail=%q", stageString(facts.FailedStage), facts.GetDetail())
+		}
+		ordersTableGrant := false
+		ordersIDGrant := false
+		for _, grant := range facts.GetResultReads() {
+			if table := grant.GetTable(); table != nil {
+				if table.GetCatalog() != "acme" || table.GetSchema() != "public" || table.GetTable() != "orders" {
+					t.Fatalf("composite mixed CTID expression emitted an unexpected table grant: %+v", grant)
+				}
+				ordersTableGrant = true
+			}
+			if column := grant.GetColumn(); column != nil {
+				identity := column.GetIdentity()
+				if identity.GetSchema() != "public" || identity.GetTable() != "orders" || identity.GetColumn() != "id" {
+					t.Fatalf("composite mixed CTID expression emitted an unexpected column grant: %+v", grant)
+				}
+				ordersIDGrant = true
+			}
+		}
+		if !ordersTableGrant || !ordersIDGrant {
+			t.Fatalf("composite mixed CTID grants = %+v, want orders table and orders.id column", facts.GetResultReads())
+		}
+	})
+
+	t.Run("dead derived CTID output emits no table grant", func(t *testing.T) {
+		cases := []string{
+			"SELECT d.id FROM (SELECT ctid, id FROM orders) d",
+			"SELECT d.id FROM (SELECT ctid AS row_id, id FROM orders) d",
+			"WITH d AS (SELECT ctid, id FROM orders) SELECT d.id FROM d",
+		}
+		for _, sql := range cases {
+			t.Run(sql, func(t *testing.T) {
+				facts := analyzeProto(t, &pb.AnalyzeRequest{
+					Sql:          sql,
+					EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+					Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+					Catalog:      baseCatalog,
+				})
+				if !facts.GetResolved() {
+					t.Fatalf("dead derived CTID output must not affect resolution: stage=%s detail=%q", stageString(facts.FailedStage), facts.GetDetail())
+				}
+				for _, grant := range facts.GetResultReads() {
+					if table := grant.GetTable(); table != nil && table.GetTable() == "orders" {
+						t.Fatalf("dead derived CTID output emitted an orders table grant: %+v", grant)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("unqualified write CTID ignores nonmatching derived sources", func(t *testing.T) {
+		catalog := append([]*pb.ColumnSpec{}, baseCatalog...)
+		catalog = append(catalog, columnSpec("acme", "public", "users", "email", "VARCHAR"))
+		cases := []string{
+			"UPDATE users u SET email = 'x' FROM (SELECT 1) d WHERE ctid = '(0,1)'",
+			"WITH d AS (SELECT id FROM orders) UPDATE users u SET email = 'x' WHERE ctid = '(0,1)' AND EXISTS (SELECT 1 FROM d WHERE d.id = u.id)",
+		}
+		for _, sql := range cases {
+			t.Run(sql, func(t *testing.T) {
+				result := analyze(t, sql, catalog)
+				if !result.Resolved {
+					t.Fatalf("unique target CTID must ignore nonmatching derived sources: %+v", result)
+				}
+				usersTableGrant := false
+				for _, source := range result.Sources {
+					if source.Table == "users" && !source.Covered {
+						usersTableGrant = true
+					}
+				}
+				if !usersTableGrant {
+					t.Fatalf("unique target CTID emitted no users table grant: %+v", result.Sources)
+				}
+			})
+		}
+	})
+
+	t.Run("write payload cannot read target CTID", func(t *testing.T) {
+		catalog := append([]*pb.ColumnSpec{}, baseCatalog...)
+		catalog = append(catalog, columnSpec("acme", "public", "users", "email", "VARCHAR"))
+		cases := []string{
+			"INSERT INTO users (id, email) SELECT 4, ctid::text FROM (SELECT 1) d",
+			"MERGE INTO users AS u USING orders AS o ON u.id = o.id WHEN NOT MATCHED THEN INSERT (id, email) VALUES (o.id, u.ctid::text)",
+		}
+		for _, sql := range cases {
+			t.Run(sql, func(t *testing.T) {
+				result := analyze(t, sql, catalog)
+				if result.Resolved {
+					t.Fatalf("write payload must not resolve CTID against its target: %+v", result)
+				}
+			})
+		}
+	})
+
+	t.Run("write target alias hides base name", func(t *testing.T) {
+		catalog := append([]*pb.ColumnSpec{}, baseCatalog...)
+		catalog = append(catalog, columnSpec("acme", "public", "users", "email", "VARCHAR"))
+		result := analyze(t, "UPDATE users AS u SET email = 'x' WHERE users.ctid = '(0,1)'", catalog)
+		if result.Resolved {
+			t.Fatalf("aliased write target must reject its hidden base name: %+v", result)
+		}
+	})
+
+	t.Run("ambiguous write CTID remains unresolved", func(t *testing.T) {
+		catalog := append([]*pb.ColumnSpec{}, baseCatalog...)
+		catalog = append(
+			catalog,
+			columnSpec("acme", "public", "users", "email", "VARCHAR"),
+			columnSpec("acme", "public", "orders", "email", "VARCHAR"),
+		)
+		cases := []string{
+			"UPDATE users u SET email = 'x' FROM orders o WHERE ctid = '(0,1)'",
+			"UPDATE users u SET email = 'x' FROM (SELECT id AS ctid FROM orders) o WHERE ctid = 1",
+			"UPDATE users u SET email = (SELECT o.email FROM orders o, orders p WHERE ctid = '(0,1)') WHERE u.id = 1",
+			"INSERT INTO users (id, email) SELECT o.id, o.email FROM orders o, orders p WHERE ctid = '(0,1)'",
+		}
+		for _, sql := range cases {
+			t.Run(sql, func(t *testing.T) {
+				result := analyze(t, sql, catalog)
+				if result.Resolved {
+					t.Fatalf("ambiguous write CTID must fail closed: %+v", result)
+				}
+			})
+		}
+	})
+
+	t.Run("output alias named CTID remains ordinary", func(t *testing.T) {
+		cases := []string{
+			"SELECT id AS ctid FROM users ORDER BY ctid",
+			"SELECT DISTINCT ON (ctid) id AS ctid FROM users",
+			"SELECT id AS ctid FROM users ORDER BY 1",
+			"SELECT u.id AS ctid, o.id FROM users u JOIN orders o ON u.id = o.id ORDER BY 1",
+			"SELECT id AS ctid FROM users UNION ALL SELECT id FROM users ORDER BY ctid",
+		}
+		for _, sql := range cases {
+			t.Run(sql, func(t *testing.T) {
+				result := analyze(t, sql, baseCatalog)
+				if !result.Resolved {
+					t.Fatalf("ordinary CTID output alias must resolve: %+v", result)
+				}
+				for _, source := range result.Sources {
+					if !source.Covered {
+						t.Fatalf("ordinary CTID output alias left a source table-gated: %+v", result.Sources)
+					}
+				}
+				facts := analyzeProto(t, &pb.AnalyzeRequest{
+					Sql:          sql,
+					EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+					Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+					Catalog:      baseCatalog,
+				})
+				for _, grant := range facts.GetResultReads() {
+					if table := grant.GetTable(); table != nil {
+						t.Fatalf("ordinary CTID output alias emitted a table grant: %+v", table)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("unqualified join is ambiguous", func(t *testing.T) {
+		result := analyze(t, "SELECT ctid FROM users u CROSS JOIN orders o", baseCatalog)
+		if result.Resolved {
+			t.Fatalf("ambiguous CTID must fail closed: %+v", result)
+		}
+	})
+
+	t.Run("derived table has no implicit CTID", func(t *testing.T) {
+		result := analyze(t, "SELECT ctid FROM (SELECT id FROM users) u", baseCatalog)
+		if result.Resolved {
+			t.Fatalf("derived-table CTID must fail closed: %+v", result)
+		}
+	})
+
+	t.Run("unknown column remains unresolved", func(t *testing.T) {
+		result := analyze(t, "SELECT bogus FROM users", baseCatalog)
+		if result.Resolved {
+			t.Fatalf("unknown column must fail closed: %+v", result)
+		}
+	})
+
+	t.Run("real CTID column remains catalog-backed", func(t *testing.T) {
+		catalog := append([]*pb.ColumnSpec{}, baseCatalog...)
+		catalog = append(catalog, columnSpec("acme", "public", "users", "ctid", "TEXT"))
+		result := analyze(t, "SELECT ctid FROM users", catalog)
+		if !result.Resolved || len(result.Origins) != 1 || len(result.Origins[0].Origins) != 1 || result.Origins[0].Origins[0] != "acme.public.users.ctid" {
+			t.Fatalf("real CTID column must retain ordinary lineage: %+v", result)
+		}
+		if len(result.Sources) != 1 || !result.Sources[0].Covered {
+			t.Fatalf("real CTID column must cover its source through the column grant: %+v", result.Sources)
+		}
+	})
+}

--- a/analyzer/probe/probe.go
+++ b/analyzer/probe/probe.go
@@ -38,16 +38,11 @@ type OriginInfo struct {
 }
 
 // SourceInfo is one physical target-DB relation the statement scans (docs/facts-emission.md).
-// `Table` is the fully-qualified `catalog.schema.table` identity. `Covered` is true when at least one
-// traced column fact (an origin base or a reference) names this table — meaning the existing column
-// authorization already gates the scan. An UNCOVERED table (Covered=false) is a scan that reads the
-// relation while tracing zero of its columns (`count(*)`, `SELECT 1`, `EXISTS`, a cross-join side that
-// only multiplies cardinality); its existence/row-count leaks unless a `result.read` grant covers the
-// Table resource, so the control-plane must gate it. Coverage is per-TABLE (not per scan occurrence):
-// once any column of a table is a granted fact, the principal can already observe that table's
-// cardinality, so no additional Table grant is required for another uncovered occurrence of the SAME
-// table. Computed from the FINAL emitted facts (not speculative resolution), so an ambiguous unqualified
-// column that resolves to nothing leaves its table uncovered → gated, fail-closed.
+// `Table` is the fully-qualified `catalog.schema.table` identity. `Covered` is true when an emitted
+// column fact gates the scan. It stays false when no column is traced, or when the statement reads an
+// implicit non-visible column with no catalog identity and therefore no Column grant of its own. An
+// uncovered table requires a `result.read` grant for the Table resource. Coverage is per table, not per
+// scan occurrence, and is computed from the final emitted facts.
 type SourceInfo struct {
 	Catalog string `json:"catalog"`
 	Schema  string `json:"schema"`
@@ -108,6 +103,7 @@ type prober struct {
 	analyzeQuery exp.Expression
 	payloadQuery exp.Expression
 	isWrite      bool
+	relAmbiguous bool
 	relOverflow  bool // set when the relation resolver hits its depth guard → fail closed (resolved=false)
 
 	scopes        []*optimizer.Scope
@@ -125,6 +121,8 @@ type prober struct {
 	physicalTables    map[exp.Expression]tableID
 	nonPhysicalTables map[exp.Expression]bool
 	newTargets        map[exp.Expression]bool
+
+	implicitNonVisibleSources map[tableID]bool
 }
 
 type resolveKey struct {
@@ -151,7 +149,7 @@ func Probe(sql string, engineConfig *pb.EngineConfig, sch *schema.Mapping, names
 	if err := detectRenderCollisions(sch); err != nil {
 		return failResult("VALIDATE", err.Error())
 	}
-	qualifySchema, err := schema.NewMappingSchema(sch, eng.Dialect(), eng.NormalizeCatalogOnBuild())
+	qualifySchema, err := newQualifySchema(sch, eng)
 	if err != nil {
 		return failResult("VALIDATE", err.Error())
 	}
@@ -190,6 +188,8 @@ func probeParsed(root exp.Expression, eng engine, qualifySchema schema.Schema, n
 		physicalTables:    map[exp.Expression]tableID{},
 		nonPhysicalTables: map[exp.Expression]bool{},
 		newTargets:        map[exp.Expression]bool{},
+
+		implicitNonVisibleSources: map[tableID]bool{},
 	}
 	// Emit the called-function facts even when analysis FAILS after parsing — an unsupported/
 	// unresolved statement (`SELECT * FROM dblink(...)`, a data-modifying CTE, PIVOT, …) that resolves=false.
@@ -569,7 +569,7 @@ func (p *prober) writeTargetTable() exp.Expression {
 }
 
 // writeTargetNodes is the set of table NODES that are the write target of an INSERT/UPDATE/DELETE/
-// MERGE/CREATE (or SELECT ... INTO) — the mutated relation, gated by sql.<kind>. Excludes the
+// MERGE/CREATE (or SELECT ... INTO) — the mutated relation, gated by stmt.kind.<kind>. Excludes the
 // target occurrence from scanned-source facts; a distinct read occurrence of the same table is
 // unaffected. Node-keyed (not tableID) so the target and an aliased self-read stay distinguishable.
 func (p *prober) writeTargetNodes() map[exp.Expression]bool {
@@ -790,10 +790,9 @@ func generateExecutableSQL(root exp.Expression, dialect *dialects.Dialect) (stri
 
 func (p *prober) buildScopes() {
 	p.scopes = optimizer.TraverseScope(p.qroot)
-	// INSERT has no native root query, and the root traversal can omit SELECTs nested under VALUES/SET,
-	// so retain those query scopes as independent analysis graphs for the INSERT conservation
-	// paths. UPDATE/DELETE/MERGE stay on the single native traversal graph validated below.
-	if p.qroot.Kind() == exp.KindInsert {
+	// Native DML traversal can omit SELECTs nested under payload expressions. Retain their scopes as
+	// independent analysis graphs; scopeChainFor links them back to the write root for correlation.
+	if p.isWrite {
 		seenExpressions := map[exp.Expression]bool{}
 		for _, sc := range p.scopes {
 			seenExpressions[sc.Expression] = true
@@ -841,6 +840,20 @@ func (p *prober) buildScopes() {
 
 func (p *prober) lineage() ProbeResult {
 	p.references = map[string]map[string]bool{}
+	p.implicitNonVisibleSources = map[tableID]bool{}
+
+	if p.isWrite {
+		for _, column := range p.qroot.FindAll(exp.KindColumn) {
+			if column.This() == nil ||
+				column.This().Kind() == exp.KindStar ||
+				isOutputAliasReference(column) {
+				continue
+			}
+			if source, virtual := p.implicitNonVisibleWriteSource(column); virtual && source == nil {
+				return failResult("VALIDATE", fmt.Sprintf("unresolved column '%s' in write", column.Name()))
+			}
+		}
+	}
 
 	p.opaqueSelects = map[exp.Expression]bool{}
 	for _, node := range append(p.qroot.FindAll(exp.KindSelect), p.findAllSetOperations(p.qroot)...) {
@@ -1092,9 +1105,26 @@ func (p *prober) lineage() ProbeResult {
 		if dot.Expr() != nil {
 			fld = dot.Expr().Name() // AS-IS; relationField lowercases only for the schema lookup
 		}
+		if table, physical := rel.(exp.Expression); physical && table != nil && table.Kind() == exp.KindTable &&
+			p.isImplicitNonVisibleColumn(fld) {
+			if _, catalogBacked := p.canonicalColumn(table, fld); !catalogBacked {
+				p.markImplicitNonVisibleTable(table, fld)
+				continue
+			}
+		}
+		virtual := false
+		if derived, ok := rel.(*optimizer.Scope); ok {
+			virtualSources := p.implicitNonVisibleScopeOutputSources(derived, fld, map[resolveKey]bool{})
+			virtual = len(virtualSources) > 0
+			for source := range virtualSources {
+				if id, resolved := p.resolvedTableID(source); resolved {
+					p.implicitNonVisibleSources[id] = true
+				}
+			}
+		}
 		if bases, found := p.relationField(rel, fld); found {
 			p.addRef(OTHER, bases) // (x).f → the specific base column(s)
-		} else {
+		} else if !virtual {
 			p.addRef(OTHER, p.relationColumns(rel)) // unresolved field → whole relation (fail closed)
 		}
 	}
@@ -1432,6 +1462,22 @@ func (p *prober) lineage() ProbeResult {
 			}
 			bases, ok := wbase(c.Name(), c.TableName(), c)
 			if !ok {
+				virtualSources := p.implicitNonVisibleColumnSources(c, map[resolveKey]bool{})
+				if len(virtualSources) > 0 {
+					for source := range virtualSources {
+						if id, resolved := p.resolvedTableID(source); resolved {
+							p.implicitNonVisibleSources[id] = true
+						}
+					}
+					continue
+				}
+				if source, virtual := p.implicitNonVisibleWriteSource(c); virtual {
+					if source == nil {
+						return failResult("VALIDATE", fmt.Sprintf("unresolved column '%s' in write", c.Name()))
+					}
+					p.markImplicitNonVisibleTable(source, c.Name())
+					continue
+				}
 				return failResult("VALIDATE", fmt.Sprintf("unresolved column '%s' in write", c.Name()))
 			}
 			p.addRef(OTHER, subtractSet(bases, accounted))
@@ -1463,6 +1509,9 @@ func (p *prober) lineage() ProbeResult {
 				continue
 			}
 			if c.This() != nil && c.This().Kind() == exp.KindStar {
+				continue
+			}
+			if c.FindAncestor(exp.KindDot) != nil {
 				continue
 			}
 			if within(c, payloadBody) || c.FindAncestor(exp.KindCTE) != nil {
@@ -1521,6 +1570,13 @@ func (p *prober) lineage() ProbeResult {
 				}
 			}
 		}
+	}
+
+	if p.relAmbiguous {
+		return failResult("VALIDATE", "ambiguous relation column")
+	}
+	if p.relOverflow {
+		return failResult("LINEAGE", "relation-resolution depth exceeded (possible composite cycle)")
 	}
 
 	refsOut := map[string][]string{}
@@ -1612,15 +1668,373 @@ func (p *prober) calledFunctions() []string {
 // (docs/facts-emission.md). p.physicalTables holds only relations the resolution report proved
 // Physical — a shadowed CTE reference resolves to CTE/Derived and is absent, so `WITH t AS (...)
 // SELECT count(*) FROM t` emits no physical `t` (ALLOW), while a CTE BODY that reads the real table
-// does (a scanned source, gated). Write TARGETS are excluded upstream (p.newTargets is skipped in
-// consumeResolutionReport), so an INSERT/UPDATE/DELETE target is never a scanned source.
+// does (a scanned source, gated). A write target is excluded unless an implicit non-visible column
+// reads it and therefore requires a Table grant.
 //
-// Coverage is per-TABLE and computed from the FINAL emitted facts: a table is covered iff some origin
-// base or reference key begins with `<catalog.schema.table>.` — i.e. a column of it is a traced fact
-// the column gate already authorizes. The trailing dot makes the prefix injective (a `users.` prefix
-// never matches `users_archive.col`). An unqualified column that stays ambiguous resolves to no base
-// key, so its table is left uncovered → gated, never silently covered. Over-attribution can only make
-// a table appear UNCOVERED (a dotted pathological name failing the prefix) → over-deny, fail-closed.
+// Coverage is per table and computed from the final emitted facts. A traced origin/reference normally
+// covers its table, but an implicit non-visible column has no catalog-backed Column resource and forces
+// the Table grant. The trailing dot keeps the base-key prefix injective (`users.` never matches
+// `users_archive.col`). Anything unresolved leaves the table uncovered and gated.
+func isOutputAliasReference(column exp.Expression) bool {
+	if column.TableName() != "" || column.Parent() == nil {
+		return false
+	}
+	if column.Parent().Kind() != exp.KindOrdered && column.FindAncestor(exp.KindDistinct) == nil {
+		return false
+	}
+	for query := column.Parent(); query != nil; query = query.Parent() {
+		if !query.Is(exp.TraitQuery) {
+			continue
+		}
+		for _, projection := range query.Selects() {
+			if projection.AliasOrName() == column.Name() {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+func (p *prober) isImplicitNonVisibleColumn(name string) bool {
+	name = p.engine.FoldColumn(name)
+	for _, candidate := range p.engine.ImplicitNonVisibleColumns() {
+		if p.engine.FoldColumn(candidate) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// PostgreSQL excludes the target row from INSERT payloads and MERGE NOT MATCHED BY TARGET clauses.
+func (p *prober) writeTargetVisibleAt(node exp.Expression) bool {
+	switch p.qroot.Kind() {
+	case exp.KindInsert:
+		return node.FindAncestor(exp.KindReturning, exp.KindOnConflict) != nil
+	case exp.KindMerge:
+		when := node.FindAncestor(exp.KindWhen)
+		if when == nil {
+			return true
+		}
+		matched, _ := when.Arg("matched").(bool)
+		bySource, _ := when.Arg("source").(bool)
+		return matched || bySource
+	default:
+		return true
+	}
+}
+
+func (p *prober) implicitNonVisibleWriteSource(column exp.Expression) (exp.Expression, bool) {
+	if column == nil || column.This() == nil || column.This().Kind() == exp.KindStar {
+		return nil, false
+	}
+	name := p.engine.FoldColumn(column.Name())
+	if !p.isImplicitNonVisibleColumn(name) {
+		return nil, false
+	}
+
+	physical := func(source any) exp.Expression {
+		table, ok := source.(exp.Expression)
+		if !ok || table == nil || table.Kind() != exp.KindTable {
+			return nil
+		}
+		if _, ok := p.resolvedTableID(table); !ok {
+			return nil
+		}
+		return table
+	}
+
+	target := p.writeTargetTable()
+	if target != nil && p.newTargets[target] {
+		target = nil
+	}
+	target = physical(target)
+	targetVisible := p.writeTargetVisibleAt(column)
+
+	classify := func(scope *optimizer.Scope, alias string, source any) (exp.Expression, bool, bool) {
+		var table exp.Expression
+		var derived *optimizer.Scope
+		switch source := source.(type) {
+		case exp.Expression:
+			if source == nil {
+				return nil, false, false
+			}
+			if source.Kind() == exp.KindTable {
+				table = physical(source)
+				if table == nil {
+					return nil, false, false
+				}
+				if table == target && (!targetVisible || (target.Alias() != "" && alias != target.Alias())) {
+					return nil, false, true
+				}
+			}
+		case *optimizer.Scope:
+			if source == nil || source.Expression == nil {
+				return nil, false, false
+			}
+			derived = source
+		default:
+			return nil, false, false
+		}
+
+		if derived != nil {
+			sources := p.implicitNonVisibleScopeOutputSources(derived, name, map[resolveKey]bool{})
+			if len(sources) > 1 {
+				return nil, false, false
+			}
+			for source := range sources {
+				return source, true, true
+			}
+		}
+
+		columns := optimizer.NewResolver(scope, p.qualifySchema, false).GetSourceColumns(alias)
+		for _, candidate := range columns {
+			if candidate != name {
+				continue
+			}
+			if table != nil {
+				if _, catalogBacked := p.canonicalColumn(table, name); catalogBacked {
+					return nil, true, true
+				}
+				return table, true, true
+			}
+			return nil, true, true
+		}
+		return nil, false, true
+	}
+
+	if alias := column.TableName(); alias != "" {
+		for _, scope := range p.queryScopeChainFor(column) {
+			selected, ok := scope.SelectedSources()[alias]
+			if !ok {
+				continue
+			}
+			table, matches, certain := classify(scope, alias, selected.Source)
+			if !certain || !matches {
+				return nil, true
+			}
+			if table == nil {
+				return nil, false
+			}
+			return table, true
+		}
+		if target == nil || !targetVisible || alias != target.AliasOrName() {
+			return nil, true
+		}
+		if _, catalogBacked := p.canonicalColumn(target, name); catalogBacked {
+			return nil, false
+		}
+		return target, true
+	}
+
+	for _, scope := range p.queryScopeChainFor(column) {
+		candidates := []exp.Expression{}
+		uncertain := false
+		for alias, selected := range scope.SelectedSources() {
+			table, matches, certain := classify(scope, alias, selected.Source)
+			if !certain {
+				uncertain = true
+				continue
+			}
+			if matches {
+				candidates = append(candidates, table)
+			}
+		}
+		if uncertain || len(candidates) > 1 {
+			return nil, true
+		}
+		if len(candidates) == 1 {
+			if candidates[0] == nil {
+				return nil, false
+			}
+			return candidates[0], true
+		}
+	}
+	if target == nil || !targetVisible {
+		return nil, true
+	}
+	if _, catalogBacked := p.canonicalColumn(target, name); catalogBacked {
+		return nil, false
+	}
+	return target, true
+}
+
+func (p *prober) implicitNonVisibleSourceIDs() map[tableID]bool {
+	out := make(map[tableID]bool, len(p.implicitNonVisibleSources))
+	for id := range p.implicitNonVisibleSources {
+		out[id] = true
+	}
+	return out
+}
+
+func (p *prober) markImplicitNonVisibleColumn(column exp.Expression) {
+	for table := range p.implicitNonVisibleColumnSources(column, map[resolveKey]bool{}) {
+		if id, ok := p.resolvedTableID(table); ok {
+			p.implicitNonVisibleSources[id] = true
+		}
+	}
+}
+
+func (p *prober) markImplicitNonVisibleTable(table exp.Expression, column string) {
+	if table == nil || table.Kind() != exp.KindTable || !p.isImplicitNonVisibleColumn(column) {
+		return
+	}
+	if _, catalogBacked := p.canonicalColumn(table, column); catalogBacked {
+		return
+	}
+	if id, ok := p.resolvedTableID(table); ok {
+		p.implicitNonVisibleSources[id] = true
+	}
+}
+
+func (p *prober) implicitNonVisibleColumnSources(
+	column exp.Expression,
+	seen map[resolveKey]bool,
+) map[exp.Expression]bool {
+	out := map[exp.Expression]bool{}
+	if column == nil || column.This() == nil || column.This().Kind() == exp.KindStar ||
+		isOutputAliasReference(column) {
+		return out
+	}
+	name := column.Name()
+	alias := column.TableName()
+	for _, scope := range p.scopeChainFor(column) {
+		if alias != "" {
+			selected, ok := scope.SelectedSources()[alias]
+			if !ok {
+				continue
+			}
+			return p.implicitNonVisibleSourceColumnSources(selected.Source, name, seen)
+		}
+		resolver := optimizer.NewResolver(scope, p.qualifySchema, false)
+		var source any
+		matches := 0
+		for sourceAlias, selected := range scope.SelectedSources() {
+			for _, candidate := range resolver.GetSourceColumns(sourceAlias) {
+				if candidate == name {
+					source = selected.Source
+					matches++
+					break
+				}
+			}
+		}
+		if matches == 1 {
+			return p.implicitNonVisibleSourceColumnSources(source, name, seen)
+		}
+		if matches > 1 {
+			return out
+		}
+	}
+	return out
+}
+
+func (p *prober) implicitNonVisibleSourceColumnSources(
+	source any,
+	name string,
+	seen map[resolveKey]bool,
+) map[exp.Expression]bool {
+	out := map[exp.Expression]bool{}
+	switch source := source.(type) {
+	case exp.Expression:
+		if source == nil || source.Kind() != exp.KindTable || !p.isImplicitNonVisibleColumn(name) {
+			return out
+		}
+		if _, catalogBacked := p.canonicalColumn(source, name); !catalogBacked {
+			out[source] = true
+		}
+	case *optimizer.Scope:
+		return p.implicitNonVisibleScopeOutputSources(source, name, seen)
+	}
+	return out
+}
+
+func (p *prober) implicitNonVisibleScopeOutputSources(
+	scope *optimizer.Scope,
+	name string,
+	seen map[resolveKey]bool,
+) map[exp.Expression]bool {
+	out := map[exp.Expression]bool{}
+	if scope == nil || scope.Expression == nil {
+		return out
+	}
+	key := resolveKey{scope: scope, name: name}
+	if seen[key] {
+		return out
+	}
+	seen[key] = true
+	expr := scope.Expression
+	if expr.Is(exp.TraitSetOperation) {
+		branches := p.leafSelects(expr)
+		names := []string{}
+		if cte := expr.Parent(); cte != nil && cte.Kind() == exp.KindCTE {
+			names = p.cteColNames(cte)
+		}
+		if len(names) == 0 && len(branches) > 0 {
+			for _, projection := range branches[0].Selects() {
+				names = append(names, projection.AliasOrName())
+			}
+		}
+		for index, candidate := range names {
+			if candidate != name {
+				continue
+			}
+			for _, branch := range branches {
+				selects := branch.Selects()
+				if index < len(selects) {
+					p.collectImplicitNonVisibleSources(selects[index], out, seen)
+				}
+			}
+		}
+		return out
+	}
+	if scope.IsUnion() {
+		for _, branch := range scope.UnionScopes {
+			for table := range p.implicitNonVisibleScopeOutputSources(branch, name, seen) {
+				out[table] = true
+			}
+		}
+		return out
+	}
+	if value := p.scopeProjectionValue(scope, name); value != nil {
+		p.collectImplicitNonVisibleSources(value, out, seen)
+	}
+	return out
+}
+
+func (p *prober) collectImplicitNonVisibleSources(
+	node exp.Expression,
+	out map[exp.Expression]bool,
+	seen map[resolveKey]bool,
+) {
+	if node == nil {
+		return
+	}
+	columns := []exp.Expression{}
+	if node.Kind() == exp.KindColumn {
+		columns = append(columns, node)
+	} else {
+		columns = node.FindAll(exp.KindColumn)
+	}
+	for _, column := range columns {
+		for table := range p.implicitNonVisibleColumnSources(column, seen) {
+			out[table] = true
+		}
+	}
+	for _, dot := range node.FindAll(exp.KindDot) {
+		if dot.FindAncestor(exp.KindDot) != nil || dot.Expr() == nil ||
+			!p.isImplicitNonVisibleColumn(dot.Expr().Name()) {
+			continue
+		}
+		if table, ok := p.relationOfNode(dot.This(), 0); ok {
+			if physical, ok := table.(exp.Expression); ok && physical != nil && physical.Kind() == exp.KindTable {
+				if _, catalogBacked := p.canonicalColumn(physical, dot.Expr().Name()); !catalogBacked {
+					out[physical] = true
+				}
+			}
+		}
+	}
+}
+
 func (p *prober) scannedSources(origins []OriginInfo, refs map[string][]string) []SourceInfo {
 	baseKeys := map[string]bool{}
 	for _, origin := range origins {
@@ -1633,15 +2047,16 @@ func (p *prober) scannedSources(origins []OriginInfo, refs map[string][]string) 
 			baseKeys[base] = true
 		}
 	}
-	// The write TARGET occurrence is gated by sql.<kind>, not result.read (docs/facts-emission.md:
+	// The write TARGET occurrence is gated by stmt.kind.<kind>, not result.read (docs/facts-emission.md:
 	// "A write target is not a scanned Table solely because it is the target"). Exclude the target
 	// NODE(s), not the tableID — a DIFFERENT occurrence of the same table (a subquery reading old
 	// values) is a genuine scanned source and its column reads still emit facts / conservation applies.
 	targets := p.writeTargetNodes()
+	tableGrantRequired := p.implicitNonVisibleSourceIDs()
 	seen := map[tableID]bool{}
 	out := []SourceInfo{}
 	for node, id := range p.physicalTables {
-		if targets[node] {
+		if targets[node] && !tableGrantRequired[id] {
 			continue
 		}
 		if seen[id] {
@@ -1650,16 +2065,18 @@ func (p *prober) scannedSources(origins []OriginInfo, refs map[string][]string) 
 		seen[id] = true
 		prefix := id.String() + "."
 		covered := false
-		for base := range baseKeys {
-			// A base key is `<catalog>.<schema>.<table>.<column>`. Coverage requires the prefix AND that
-			// the remainder (the column) carries no further '.', so a table literally named "x.foo" (a
-			// dot in the name) cannot make a clean sibling `x` look covered — its base key `…x.foo.col`
-			// has a dotted remainder past the `x.` prefix. A delimiter-bearing identity therefore reads
-			// as UNCOVERED → gated → DENIED downstream (authorizeTables/authorizeColumns reject it),
-			// fail-closed, instead of relying on that Kotlin guard for correctness.
-			if strings.HasPrefix(base, prefix) && !strings.Contains(base[len(prefix):], ".") {
-				covered = true
-				break
+		if !tableGrantRequired[id] {
+			for base := range baseKeys {
+				// A base key is `<catalog>.<schema>.<table>.<column>`. Coverage requires the prefix AND that
+				// the remainder (the column) carries no further '.', so a table literally named "x.foo" (a
+				// dot in the name) cannot make a clean sibling `x` look covered — its base key `…x.foo.col`
+				// has a dotted remainder past the `x.` prefix. A delimiter-bearing identity therefore reads
+				// as UNCOVERED → gated → DENIED downstream (authorizeTables/authorizeColumns reject it),
+				// fail-closed, instead of relying on that Kotlin guard for correctness.
+				if strings.HasPrefix(base, prefix) && !strings.Contains(base[len(prefix):], ".") {
+					covered = true
+					break
+				}
 			}
 		}
 		out = append(out, SourceInfo{Catalog: id.catalog, Schema: id.schema, Table: id.table, Covered: covered})
@@ -1793,6 +2210,7 @@ func (p *prober) resolve(col exp.Expression, seen map[resolveKey]bool) map[strin
 	if col == nil {
 		return map[string]bool{}
 	}
+	p.markImplicitNonVisibleColumn(col)
 	scope := p.col2scope[col]
 	if scope == nil {
 		return map[string]bool{}
@@ -1913,6 +2331,7 @@ func (p *prober) resolveIdent(col exp.Expression, seen map[identKey]bool) (map[s
 	if col == nil {
 		return map[string]bool{}, true
 	}
+	p.markImplicitNonVisibleColumn(col)
 	scope := p.col2scope[col]
 	if scope == nil {
 		return map[string]bool{}, true

--- a/analyzer/probe/qualify_schema.go
+++ b/analyzer/probe/qualify_schema.go
@@ -1,0 +1,42 @@
+package probe
+
+import (
+	"slices"
+
+	"github.com/ridi-oss/sqlglot-go/dialects"
+	"github.com/ridi-oss/sqlglot-go/schema"
+)
+
+type implicitNonVisibleSchema struct {
+	schema.Schema
+	columns []string
+}
+
+func newQualifySchema(mapping *schema.Mapping, eng engine) (schema.Schema, error) {
+	base, err := schema.NewMappingSchema(mapping, eng.Dialect(), eng.NormalizeCatalogOnBuild())
+	if err != nil {
+		return nil, err
+	}
+	columns := eng.ImplicitNonVisibleColumns()
+	if len(columns) == 0 {
+		return base, nil
+	}
+	return &implicitNonVisibleSchema{Schema: base, columns: columns}, nil
+}
+
+// sqlglot resolves explicit columns with onlyVisible=false and expands stars with onlyVisible=true.
+func (s *implicitNonVisibleSchema) ColumnNames(table any, onlyVisible bool, dialect dialects.DialectType, normalize *bool) ([]string, error) {
+	columns, err := s.Schema.ColumnNames(table, onlyVisible, dialect, normalize)
+	if err != nil || onlyVisible {
+		return columns, err
+	}
+	out := append([]string(nil), columns...)
+	for _, implicit := range s.columns {
+		if !slices.Contains(columns, implicit) {
+			out = append(out, implicit)
+		}
+	}
+	return out, nil
+}
+
+var _ schema.Schema = (*implicitNonVisibleSchema)(nil)

--- a/analyzer/probe/relation.go
+++ b/analyzer/probe/relation.go
@@ -67,9 +67,7 @@ func unwrapParen(e exp.Expression) exp.Expression {
 	return e
 }
 
-// scopeChainFor is the chain a bare identifier at `node` resolves against, PG-style: prefer the
-// node's own scope, otherwise its enclosing SELECT, then chain-walk parents (correlation) and finally
-// the native DML-root scope. One walk covers reads and write clauses such as SET and RETURNING.
+// scopeChainFor walks the optimizer-assigned scope through correlations and the DML root.
 func (p *prober) scopeChainFor(node exp.Expression) []*optimizer.Scope {
 	start := p.col2scope[node]
 	if start == nil {
@@ -77,6 +75,21 @@ func (p *prober) scopeChainFor(node exp.Expression) []*optimizer.Scope {
 			start = p.scopeOfSelect[sel]
 		}
 	}
+	return p.scopeChain(start)
+}
+
+// queryScopeChainFor starts from the exact SELECT that owns a nested write payload.
+func (p *prober) queryScopeChainFor(node exp.Expression) []*optimizer.Scope {
+	start := p.col2scope[node]
+	if sel := node.FindAncestor(exp.KindSelect); sel != nil {
+		if queryScope := p.scopeOfSelect[sel]; queryScope != nil {
+			start = queryScope
+		}
+	}
+	return p.scopeChain(start)
+}
+
+func (p *prober) scopeChain(start *optimizer.Scope) []*optimizer.Scope {
 	var chain []*optimizer.Scope
 	seen := map[*optimizer.Scope]bool{}
 	hasDMLRoot := false
@@ -158,21 +171,41 @@ func (p *prober) relationBaseOf(name string, chain []*optimizer.Scope, depth int
 // that value, NOT a static node-shape check, so it works even where a write's disabled qualify left a
 // relation reference as a bare exp.Column), or not a column here.
 func (p *prober) scopeColumn(sc *optimizer.Scope, name string, depth int) relResult {
-	for _, src := range sc.Sources {
+	var found relResult
+	matched := false
+	for _, selected := range sc.SelectedSources() {
+		src := selected.Source
+		var candidate relResult
+		candidateMatched := false
 		if tbl, ok := src.(exp.Expression); ok && tbl != nil && tbl.Kind() == exp.KindTable {
-			if key, found := p.columnKey(tbl, name); found {
-				return relResult{scalar: map[string]bool{key: true}}
+			if key, ok := p.columnKey(tbl, name); ok {
+				candidate = relResult{scalar: map[string]bool{key: true}}
+				candidateMatched = true
 			}
 		} else if scope, ok := src.(*optimizer.Scope); ok && scope != nil {
 			if val := p.scopeProjectionValue(scope, name); val != nil {
+				candidateMatched = true
 				if rel, ok := p.relationOfNode(val, depth+1); ok {
-					return relResult{rel: rel} // a relation-valued column
+					candidate = relResult{rel: rel}
+				} else {
+					candidate = relResult{scalar: p.resolveScopeOutput(scope, name, map[resolveKey]bool{})}
+					if candidate.scalar == nil {
+						candidate.scalar = map[string]bool{}
+					}
 				}
-				return relResult{scalar: p.resolveScopeOutput(scope, name, map[resolveKey]bool{})} // scalar derived output
 			}
 		}
+		if !candidateMatched {
+			continue
+		}
+		if matched {
+			p.relAmbiguous = true
+			return relResult{}
+		}
+		found = candidate
+		matched = true
 	}
-	return relResult{}
+	return found
 }
 
 // scopeProjectionValue returns the value expression of a derived scope's output column `name`

--- a/docs/facts-emission.md
+++ b/docs/facts-emission.md
@@ -161,13 +161,15 @@ and read-side sources synthesized for write analysis. A write target is not a
 scanned Table solely because it is the target — `INSERT INTO t VALUES (...)` is
 gated by its kind (`stmt.kind.insert` ∈ `stmt.cat.write.insert`), not a new
 result-read grant. Any target data actually read (`RETURNING`, `ON CONFLICT`,
-expressions reading old values, write-payload lineage) already emits Column or
-physical-read facts.
+expressions reading old values, write-payload lineage) emits Column facts, or a
+Table fact when an implicit non-visible column has no catalog identity.
 
-`covered` is computed from the final emitted facts: a table with any traced
-column is already exposed through it and needs no separate Table grant; a scan
-with no covering column fact requires `result.read.unmasked` or
-`result.read.masked` on the Table.
+`covered` is computed from the final emitted facts. A traced column normally
+covers its table. A scan with no covering column fact requires
+`result.read.unmasked` or `result.read.masked` on the Table. An implicit
+non-visible column without a catalog identity, such as PostgreSQL `ctid`, cannot
+emit a Column grant and therefore requires the Table grant even when the query
+also traces ordinary columns.
 
 <!-- prettier-ignore -->
 | statement | facts | result |
@@ -175,6 +177,8 @@ with no covering column fact requires `result.read.unmasked` or
 | `SELECT ssn FROM users` | `users.ssn`; `users` covered by the column | column verdict |
 | `SELECT count(*) FROM users` | uncovered `users` scan | require read on `Table::.../users` |
 | `SELECT u.id FROM users u, orders o` | `users` covered; `orders` uncovered | require `users.id` and `orders` |
+| `SELECT id, ctid FROM users` | `users.id`; `users` uncovered by virtual `ctid` | require `users.id` and `users` |
+| `UPDATE users SET email = 'x' WHERE ctid = '(0,1)'` | `users` uncovered by virtual `ctid` | require `stmt.kind.update` and `users` |
 | `WITH orders AS (SELECT 1) SELECT count(*) FROM orders` | no physical Table | no table-read gate |
 
 Verified by `KnownGapsTest` and `ScannedTableMySqlTest` (control-plane) and

--- a/proto/src/main/proto/analyzer.proto
+++ b/proto/src/main/proto/analyzer.proto
@@ -85,8 +85,8 @@ message AnalyzeRequest {
 // ---- response side ----
 
 // One physical target-DB relation the statement scans (docs/facts-emission.md). catalog/schema/table
-// is the resolved identity; covered is true once at least one traced column fact names this table
-// (see probe.go's SourceInfo doc comment for the full per-table coverage rationale).
+// is the resolved identity; covered is true when emitted Column grants fully gate the scan. A read of an
+// implicit non-visible column without a catalog identity leaves the table uncovered.
 message SourceInfo {
   string catalog = 1;
   string schema = 2;


### PR DESCRIPTION
## Summary
- resolve CTID and the other PostgreSQL system columns when referenced explicitly
- keep hidden columns out of `SELECT *` expansion
- require physical table access for virtual hidden-column reads

## Risk
Column lineage and DataGrip table browsing with column-only grants.

## Verification
- `mise run verify`