### PR TITLE
fix(analyzer): trace PostgreSQL NATURAL JOIN lineage

### DIFF
--- a/analyzer/probe/engine.go
+++ b/analyzer/probe/engine.go
@@ -64,6 +64,9 @@ type engine interface {
 	// or CTE body whose output labels collide (MySQL ER_DUP_FIELDNAME; PostgreSQL allows duplicate
 	// OUTPUT labels and rejects only a reference to one).
 	RejectsDuplicateDerivedLabels() bool
+	// ExpandsNaturalJoins reports whether the prober expands NATURAL JOIN through this engine's
+	// catalog-backed USING semantics; false fails closed (shared-column lineage stays ambiguous).
+	ExpandsNaturalJoins() bool
 	// NativeOutputLabel computes the output label THIS engine's target DB natively assigns to an
 	// unaliased projection: PostgreSQL derives it from the resolved expression (parse_target.c
 	// FigureColname, written function names from the parse-time SpanText); MySQL uses the
@@ -270,6 +273,8 @@ func (e *mysqlEngine) CommandPassthrough(string) bool { return false }
 // MySQL rejects a derived-table/CTE body with duplicated output labels: ER_DUP_FIELDNAME.
 func (e *mysqlEngine) RejectsDuplicateDerivedLabels() bool { return true }
 
+func (e *mysqlEngine) ExpandsNaturalJoins() bool { return false }
+
 type postgresEngine struct {
 	dialect *dialects.Dialect
 }
@@ -351,6 +356,8 @@ func (e *postgresEngine) CommandPassthrough(command string) bool {
 
 // PostgreSQL allows duplicate OUTPUT labels; only a reference to one is ambiguous.
 func (e *postgresEngine) RejectsDuplicateDerivedLabels() bool { return false }
+
+func (e *postgresEngine) ExpandsNaturalJoins() bool { return true }
 
 // PostgreSQL names an unaliased projection per parse_target.c FigureColname; a call is labeled by
 // its WRITTEN function name, read from the projection's parse-time SpanText.

--- a/analyzer/probe/parity_test.go
+++ b/analyzer/probe/parity_test.go
@@ -82,7 +82,8 @@ func probeParityCases() []probeParityCase {
 		{name: "create view", sql: "CREATE VIEW sink AS SELECT id, ssn FROM users", category: "create"},
 		{name: "select into", sql: "SELECT id, ssn INTO sink FROM users", category: "select into"},
 		{name: "pivot", sql: "SELECT * FROM users PIVOT (SUM(id) FOR region IN ('x')) AS p", category: "fail closed"},
-		{name: "natural join", sql: "SELECT * FROM users NATURAL JOIN orders", category: "fail closed"},
+		{name: "natural join", dialect: "mysql", sql: "SELECT * FROM users NATURAL JOIN orders", category: "fail closed"},
+		{name: "natural join", dialect: "postgres", sql: "SELECT * FROM users NATURAL JOIN orders", category: "join", deferredReason: "Go expands PostgreSQL NATURAL JOIN through catalog-backed USING semantics; the pinned Python oracle intentionally denies it"},
 		{name: "unknown table", sql: "SELECT id FROM nope", category: "fail closed"},
 		{name: "unknown column", sql: "SELECT nope FROM users", category: "fail closed"},
 		{name: "multiple statements", sql: "SELECT 1; SELECT 2", category: "fail closed"},
@@ -211,7 +212,7 @@ func TestProbeParity(t *testing.T) {
 		t.Logf("regenerated %s (%d entries)", goldenPath, len(golden))
 	}
 
-	const minParity = 91 // Ratchet: set to the achieved count and never lower to mask a regression.
+	const minParity = 90 // Ratchet: set to the achieved count and never lower to mask a regression.
 	if exactMatches < minParity {
 		t.Fatalf("probe parity regressed: got %d/%d exact matches, min %d", exactMatches, len(expanded), minParity)
 	}

--- a/analyzer/probe/postgres_system_column_test.go
+++ b/analyzer/probe/postgres_system_column_test.go
@@ -217,6 +217,118 @@ from pg_catalog.pg_tablespace T
 	}
 }
 
+func TestPostgresDataGripRoutinesNaturalJoin(t *testing.T) {
+	query := `with languages as (
+    select oid as lang_oid, lanname as lang
+    from pg_catalog.pg_language
+),
+routines as (
+    select proname as r_name,
+           prolang as lang_oid,
+           oid as r_id,
+           xmin as r_state_number,
+           proargnames as arg_names,
+           proargmodes as arg_modes,
+           proargtypes::int[] as in_arg_types,
+           proallargtypes::int[] as all_arg_types,
+           pg_catalog.pg_get_expr(proargdefaults, 0) as arg_defaults,
+           provariadic as arg_variadic_id,
+           prorettype as ret_type_id,
+           proretset as ret_set,
+           prokind as kind,
+           provolatile as volatile_kind,
+           proisstrict as is_strict,
+           prosecdef as is_security_definer,
+           proconfig as configuration_parameters,
+           procost as cost,
+           pg_catalog.pg_get_userbyid(proowner) as "owner",
+           prorows as rows,
+           proleakproof as is_leakproof,
+           proparallel as concurrency_kind
+    from pg_catalog.pg_proc
+    where pronamespace = $1::oid
+      and not (prokind = 'a')
+      and pg_catalog.age(xmin) <= coalesce(
+          nullif(greatest(pg_catalog.age($2::varchar::xid), -1), -1),
+          2147483647
+      )
+)
+select *
+from routines natural join languages`
+	catalog := []*pb.ColumnSpec{
+		columnSpec("acme", "pg_catalog", "pg_language", "oid", "OID"),
+		columnSpec("acme", "pg_catalog", "pg_language", "lanname", "NAME"),
+	}
+	for name, kind := range map[string]string{
+		"proname": "NAME", "prolang": "OID", "oid": "OID", "pronamespace": "OID",
+		"proargnames": "TEXT[]", "proargmodes": "CHAR[]", "proargtypes": "OIDVECTOR",
+		"proallargtypes": "OID[]", "proargdefaults": "PG_NODE_TREE", "provariadic": "OID",
+		"prorettype": "OID", "proretset": "BOOLEAN", "prokind": "CHAR", "provolatile": "CHAR",
+		"proisstrict": "BOOLEAN", "prosecdef": "BOOLEAN", "proconfig": "TEXT[]", "procost": "REAL",
+		"proowner": "OID", "prorows": "REAL", "proleakproof": "BOOLEAN", "proparallel": "CHAR",
+	} {
+		catalog = append(catalog, columnSpec("acme", "pg_catalog", "pg_proc", name, kind))
+	}
+	req := &pb.AnalyzeRequest{
+		Sql:          query,
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+		Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"pg_catalog", "public"}},
+		Catalog:      catalog,
+	}
+	result := analyzeProbe(t, req)
+	if !result.Resolved {
+		t.Fatalf("DataGrip routines query must resolve: stage=%v detail=%q", result.FailedStage, result.Detail)
+	}
+	if result.OutputColumns != 23 {
+		t.Fatalf("output columns = %d, want 23: %+v", result.OutputColumns, result.Origins)
+	}
+	langOIDCount := 0
+	for _, origin := range result.Origins {
+		if origin.Column != "lang_oid" {
+			continue
+		}
+		langOIDCount++
+		want := []string{"acme.pg_catalog.pg_language.oid", "acme.pg_catalog.pg_proc.prolang"}
+		if len(origin.Origins) != len(want) || origin.Origins[0] != want[0] || origin.Origins[1] != want[1] {
+			t.Fatalf("lang_oid origins = %v, want %v", origin.Origins, want)
+		}
+	}
+	if langOIDCount != 1 {
+		t.Fatalf("lang_oid outputs = %d, want 1: %+v", langOIDCount, result.Origins)
+	}
+	for _, column := range []string{"acme.pg_catalog.pg_language.oid", "acme.pg_catalog.pg_proc.prolang"} {
+		found := false
+		for _, reference := range result.References[JOIN] {
+			if reference == column {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("JOIN references = %v, missing %s", result.References[JOIN], column)
+		}
+	}
+	if result.RewrittenSQL == nil {
+		t.Fatal("DataGrip routines star must carry an executable rewrite")
+	}
+	rewritten, err := sqlglot.ParseOne(*result.RewrittenSQL, "postgres")
+	if err != nil {
+		t.Fatalf("parse rewritten SQL: %v; sql=%q", err, *result.RewrittenSQL)
+	}
+	selects := rewritten.Selects()
+	if len(selects) != 23 {
+		t.Fatalf("rewritten outputs = %d, want 23: %q", len(selects), *result.RewrittenSQL)
+	}
+	if selects[0].AliasOrName() != "lang_oid" || selects[1].AliasOrName() != "r_name" || selects[22].AliasOrName() != "lang" {
+		t.Fatalf("rewritten output order is not PostgreSQL NATURAL JOIN order: %q", *result.RewrittenSQL)
+	}
+	for _, projection := range selects {
+		if projection.Kind() == exp.KindStar || projection.IsStar() {
+			t.Fatalf("rewritten SQL still contains a star: %q", *result.RewrittenSQL)
+		}
+	}
+}
+
 func TestPostgresCTIDResolutionBoundaries(t *testing.T) {
 	baseCatalog := []*pb.ColumnSpec{
 		columnSpec("acme", "public", "users", "id", "BIGINT"),

--- a/analyzer/probe/probe.go
+++ b/analyzer/probe/probe.go
@@ -123,6 +123,7 @@ type prober struct {
 	newTargets        map[exp.Expression]bool
 
 	implicitNonVisibleSources map[tableID]bool
+	naturalStarOrders         map[exp.Expression][]naturalStarColumn
 }
 
 type resolveKey struct {
@@ -135,6 +136,11 @@ type identKey struct {
 	scope *optimizer.Scope
 	alias string
 	name  string
+}
+
+type naturalStarColumn struct {
+	name   string
+	tables []string
 }
 
 func Probe(sql string, engineConfig *pb.EngineConfig, sch *schema.Mapping, namespace NamespaceConfig) ProbeResult {
@@ -190,6 +196,7 @@ func probeParsed(root exp.Expression, eng engine, qualifySchema schema.Schema, n
 		newTargets:        map[exp.Expression]bool{},
 
 		implicitNonVisibleSources: map[tableID]bool{},
+		naturalStarOrders:         map[exp.Expression][]naturalStarColumn{},
 	}
 	// Emit the called-function facts even when analysis FAILS after parsing — an unsupported/
 	// unresolved statement (`SELECT * FROM dblink(...)`, a data-modifying CTE, PIVOT, …) that resolves=false.
@@ -220,11 +227,6 @@ func probeParsed(root exp.Expression, eng engine, qualifySchema schema.Schema, n
 	if len(p.root.FindAll(exp.KindPivot)) > 0 {
 		return failResult("VALIDATE", "PIVOT/UNPIVOT not supported")
 	}
-	for _, join := range p.root.FindAll(exp.KindJoin) {
-		if strings.ToUpper(fmt.Sprint(firstNonNil(join.Arg("method"), ""))) == "NATURAL" || fmt.Sprint(join.Arg("kind")) == "NATURAL" {
-			return failResult("VALIDATE", "NATURAL JOIN not supported (shared-column lineage is ambiguous)")
-		}
-	}
 	for _, oc := range p.root.FindAll(exp.KindOnConflict) {
 		if truthy(oc.Arg("constraint")) {
 			return failResult("VALIDATE", "ON CONFLICT ON CONSTRAINT — cannot map a named constraint to columns")
@@ -232,6 +234,7 @@ func probeParsed(root exp.Expression, eng engine, qualifySchema schema.Schema, n
 	}
 	if fail := runStage("VALIDATE", func() {
 		p.qroot = p.root.Copy()
+		p.expandNaturalJoins(p.qroot)
 		p.markNewTargets(p.qroot)
 		// MySQL's DELETE target-alias list names sources already present under FROM. Keeping the
 		// selector nodes during qualification makes the native DML scope reject the duplicate alias;
@@ -292,6 +295,212 @@ func probeParsed(root exp.Expression, eng engine, qualifySchema schema.Schema, n
 		return *fail
 	}
 	return result
+}
+
+func (p *prober) expandNaturalJoins(root exp.Expression) {
+	if !p.engine.ExpandsNaturalJoins() {
+		for _, join := range root.FindAll(exp.KindJoin) {
+			if isNaturalJoin(join) {
+				panic(fmt.Errorf("NATURAL JOIN not supported (shared-column lineage is ambiguous)"))
+			}
+		}
+		return
+	}
+	for _, scope := range optimizer.TraverseScope(root) {
+		if scope == nil || scope.Expression == nil {
+			continue
+		}
+		joins := expressionsFor(scope.Expression, "joins")
+		hasNatural := false
+		for _, join := range joins {
+			if isNaturalJoin(join) {
+				hasNatural = true
+				break
+			}
+		}
+		if !hasNatural {
+			continue
+		}
+		if scope.Expression.Kind() != exp.KindSelect {
+			panic(fmt.Errorf("NATURAL JOIN is unsupported in %s", exp.ClassName(scope.Expression.Kind())))
+		}
+
+		sourceOrder := p.fromSourceOrder(scope.Expression)
+		if len(sourceOrder) != len(joins)+1 {
+			panic(fmt.Errorf("NATURAL JOIN source order is incomplete"))
+		}
+		resolver := optimizer.NewResolver(scope, p.qualifySchema, false)
+		sourceColumns := func(alias string) []naturalStarColumn {
+			names := resolver.GetSourceColumns(alias, true)
+			if len(names) == 0 {
+				panic(fmt.Errorf("NATURAL JOIN source %q has no known columns", alias))
+			}
+			columns := make([]naturalStarColumn, 0, len(names))
+			for _, name := range names {
+				if name == "*" {
+					panic(fmt.Errorf("NATURAL JOIN source %q has an unknown column set", alias))
+				}
+				columns = append(columns, naturalStarColumn{name: name, tables: []string{alias}})
+			}
+			return columns
+		}
+
+		prefix := []naturalStarColumn{}
+		group := sourceColumns(sourceOrder[0])
+		for i, join := range joins {
+			right := sourceColumns(sourceOrder[i+1])
+			if isCommaJoin(join) {
+				prefix = append(prefix, group...)
+				group = right
+				continue
+			}
+			kind := strings.ToUpper(fmt.Sprint(join.Arg("kind")))
+			side := strings.ToUpper(fmt.Sprint(join.Arg("side")))
+			if kind == "SEMI" || kind == "ANTI" || side == "SEMI" || side == "ANTI" {
+				panic(fmt.Errorf("NATURAL JOIN with %s%s join is unsupported", side, kind))
+			}
+
+			using := p.joinUsingColumns(join)
+			if isNaturalJoin(join) {
+				var err error
+				using, err = naturalCommonColumns(group, right)
+				if err != nil {
+					panic(err)
+				}
+				join.Set("method", nil)
+				if strings.EqualFold(fmt.Sprint(join.Arg("kind")), "NATURAL") {
+					join.Set("kind", nil)
+				}
+				if len(using) == 0 {
+					if side == "" {
+						join.Set("kind", "CROSS")
+						join.Set("side", nil)
+					} else {
+						join.Set("on", exp.Boolean(exp.Args{"this": true}))
+					}
+				} else {
+					identifiers := make([]exp.Expression, 0, len(using))
+					for _, name := range using {
+						identifiers = append(identifiers, exp.ToIdentifier(name, true))
+					}
+					join.Set("using", identifiers)
+				}
+			}
+
+			if len(using) == 0 {
+				group = append(group, right...)
+				continue
+			}
+			merged, err := mergeUsingColumns(group, right, using)
+			if err != nil {
+				panic(err)
+			}
+			group = merged
+		}
+		p.naturalStarOrders[scope.Expression] = append(prefix, group...)
+	}
+
+	for _, join := range root.FindAll(exp.KindJoin) {
+		if isNaturalJoin(join) {
+			panic(fmt.Errorf("NATURAL JOIN source shape is unsupported"))
+		}
+	}
+}
+
+func isNaturalJoin(join exp.Expression) bool {
+	return join != nil && (strings.EqualFold(fmt.Sprint(join.Arg("method")), "NATURAL") ||
+		strings.EqualFold(fmt.Sprint(join.Arg("kind")), "NATURAL"))
+}
+
+func isCommaJoin(join exp.Expression) bool {
+	return join != nil && join.Arg("method") == nil && join.Arg("kind") == nil &&
+		join.Arg("side") == nil && join.Arg("on") == nil && len(expressionsFor(join, "using")) == 0
+}
+
+func (p *prober) joinUsingColumns(join exp.Expression) []string {
+	using := expressionsFor(join, "using")
+	out := make([]string, 0, len(using))
+	for _, identifier := range using {
+		identifier = identifier.Copy()
+		p.dialect.NormalizeIdentifier(identifier)
+		out = append(out, identifier.Name())
+	}
+	return out
+}
+
+func naturalCommonColumns(left, right []naturalStarColumn) ([]string, error) {
+	leftCounts := map[string]int{}
+	rightCounts := map[string]int{}
+	for _, column := range left {
+		leftCounts[column.name]++
+	}
+	for _, column := range right {
+		rightCounts[column.name]++
+	}
+	common := []string{}
+	seen := map[string]bool{}
+	for _, column := range left {
+		name := column.name
+		if seen[name] || rightCounts[name] == 0 {
+			continue
+		}
+		seen[name] = true
+		if leftCounts[name] != 1 || rightCounts[name] != 1 {
+			return nil, fmt.Errorf("NATURAL JOIN common column %q is ambiguous", name)
+		}
+		common = append(common, name)
+	}
+	return common, nil
+}
+
+func mergeUsingColumns(left, right []naturalStarColumn, using []string) ([]naturalStarColumn, error) {
+	leftByName := map[string][]naturalStarColumn{}
+	rightByName := map[string][]naturalStarColumn{}
+	for _, column := range left {
+		leftByName[column.name] = append(leftByName[column.name], column)
+	}
+	for _, column := range right {
+		rightByName[column.name] = append(rightByName[column.name], column)
+	}
+
+	merged := make([]naturalStarColumn, 0, len(left)+len(right))
+	usingSet := map[string]bool{}
+	for _, name := range using {
+		if usingSet[name] {
+			return nil, fmt.Errorf("JOIN USING column %q appears more than once", name)
+		}
+		usingSet[name] = true
+		leftMatches := leftByName[name]
+		rightMatches := rightByName[name]
+		if len(leftMatches) != 1 || len(rightMatches) != 1 {
+			return nil, fmt.Errorf("JOIN USING column %q is missing or ambiguous", name)
+		}
+		tables := append([]string(nil), leftMatches[0].tables...)
+		for _, table := range rightMatches[0].tables {
+			found := false
+			for _, existing := range tables {
+				if existing == table {
+					found = true
+					break
+				}
+			}
+			if !found {
+				tables = append(tables, table)
+			}
+		}
+		merged = append(merged, naturalStarColumn{name: name, tables: tables})
+	}
+	for _, column := range left {
+		if !usingSet[column.name] {
+			merged = append(merged, column)
+		}
+	}
+	for _, column := range right {
+		if !usingSet[column.name] {
+			merged = append(merged, column)
+		}
+	}
+	return merged, nil
 }
 
 func tableNodes(node exp.Expression) []exp.Expression {
@@ -1642,11 +1851,9 @@ func (p *prober) predicateLiteralRefs() []PredicateLiteralRef {
 // IO/exec/admin function (pg_read_file, dblink, lo_*, load_file, rds_*, keyring_*, get_raw_page, …) parses
 // Anonymous, whereas standard-SQL builtins with dedicated node kinds (Count, Cast, Substring, …) are safe,
 // out of the shipped dangerous set, and carry unreliable Name()s (`count(*)` → "*"). Names are lowercased
-// so the resolver's fold-insensitive match is stable. This fact is the SOLE enforcement path for a FROM'd
-// dangerous builtin: the call resolves + emits here + is forbidden by the control-plane function gate
-// (via the per-version manifest or the version-independent BaselineDangerousFunctions floor). A no-FROM
-// dangerous call is gated separately by noFromFunctionGrants (facts.go), which emits a Function grant the
-// control-plane denies.
+// so the resolver's fold-insensitive match is stable. The control plane classifies these names against the
+// per-version manifest and the version-independent BaselineDangerousFunctions floor; functionCallGrants
+// separately preserves qualifiers and provides the fail-closed Function grant.
 func (p *prober) calledFunctions() []string {
 	seen := map[string]bool{}
 	out := []string{}
@@ -2682,9 +2889,6 @@ func (p *prober) expandableSources(sel exp.Expression) (bool, string) {
 		srcs = append(srcs, frm.This())
 	}
 	for _, j := range expressionsFor(sel, "joins") {
-		if strings.ToUpper(fmt.Sprint(firstNonNil(j.Arg("method"), ""))) == "NATURAL" || j.Arg("kind") == "NATURAL" {
-			return false, "a NATURAL join"
-		}
 		srcs = append(srcs, j.This())
 	}
 	for _, s := range srcs {
@@ -2706,6 +2910,28 @@ func (p *prober) expandableSources(sel exp.Expression) (bool, string) {
 	return true, ""
 }
 
+func naturalStarProjectionMatches(projection exp.Expression, expected naturalStarColumn) bool {
+	if projection == nil || projection.AliasOrName() != expected.name {
+		return false
+	}
+	actualTables := map[string]bool{}
+	for _, column := range projection.FindAll(exp.KindColumn) {
+		if column.Name() != expected.name || column.TableName() == "" {
+			return false
+		}
+		actualTables[column.TableName()] = true
+	}
+	if len(actualTables) != len(expected.tables) {
+		return false
+	}
+	for _, table := range expected.tables {
+		if !actualTables[table] {
+			return false
+		}
+	}
+	return true
+}
+
 func (p *prober) resortBareStarInplace(osel, qsel exp.Expression) {
 	starIdx := -1
 	for i, proj := range osel.Selects() {
@@ -2725,6 +2951,32 @@ func (p *prober) resortBareStarInplace(osel, qsel exp.Expression) {
 		pos[alias] = i
 	}
 	block := append([]exp.Expression(nil), qs[nb:len(qs)-na]...)
+	if order, ok := p.naturalStarOrders[qsel]; ok {
+		if len(order) != len(block) {
+			panic(fmt.Errorf("NATURAL JOIN star expansion produced %d columns, want %d", len(block), len(order)))
+		}
+		ordered := make([]exp.Expression, 0, len(block))
+		used := make([]bool, len(block))
+		for _, column := range order {
+			matched := -1
+			for i, projection := range block {
+				if !used[i] && naturalStarProjectionMatches(projection, column) {
+					matched = i
+					break
+				}
+			}
+			if matched < 0 {
+				panic(fmt.Errorf("NATURAL JOIN star output %q could not be ordered faithfully", column.name))
+			}
+			used[matched] = true
+			ordered = append(ordered, block[matched])
+		}
+		newSelects := append([]exp.Expression(nil), qs[:nb]...)
+		newSelects = append(newSelects, ordered...)
+		newSelects = append(newSelects, qs[len(qs)-na:]...)
+		qsel.Set("expressions", newSelects)
+		return
+	}
 	position := func(proj exp.Expression) int {
 		if col := proj.Find(exp.KindColumn); col != nil {
 			if value, ok := pos[col.TableName()]; ok {

--- a/analyzer/probe/probe_test.go
+++ b/analyzer/probe/probe_test.go
@@ -2,6 +2,7 @@ package probe
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
@@ -94,6 +95,163 @@ func TestFromSourceOrder(t *testing.T) {
 	want := []string{"u", "o"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("fromSourceOrder = %v, want %v", got, want)
+	}
+}
+
+func TestPostgresNaturalJoinExpandsWithPhysicalLineage(t *testing.T) {
+	result := analyzeProbe(t, &pb.AnalyzeRequest{
+		Sql:          "SELECT * FROM public.left_table l NATURAL JOIN public.right_table r",
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+		Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+		Catalog: []*pb.ColumnSpec{
+			columnSpec("acme", "public", "left_table", "left_value", "TEXT"),
+			columnSpec("acme", "public", "left_table", "id", "BIGINT"),
+			columnSpec("acme", "public", "right_table", "id", "BIGINT"),
+			columnSpec("acme", "public", "right_table", "right_value", "TEXT"),
+		},
+	})
+	if !result.Resolved {
+		t.Fatalf("NATURAL JOIN must resolve: stage=%v detail=%q", result.FailedStage, result.Detail)
+	}
+	wantNames := []string{"id", "left_value", "right_value"}
+	if result.OutputColumns != len(wantNames) {
+		t.Fatalf("output columns = %d, want %d: %+v", result.OutputColumns, len(wantNames), result.Origins)
+	}
+	for i, want := range wantNames {
+		if result.Origins[i].Column != want {
+			t.Fatalf("output %d = %q, want %q: %+v", i, result.Origins[i].Column, want, result.Origins)
+		}
+	}
+	wantIDOrigins := []string{"acme.public.left_table.id", "acme.public.right_table.id"}
+	if !reflect.DeepEqual(result.Origins[0].Origins, wantIDOrigins) {
+		t.Fatalf("id origins = %v, want %v", result.Origins[0].Origins, wantIDOrigins)
+	}
+	for _, column := range wantIDOrigins {
+		found := false
+		for _, reference := range result.References[JOIN] {
+			if reference == column {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("JOIN references = %v, missing %s", result.References[JOIN], column)
+		}
+	}
+	if result.RewrittenSQL == nil {
+		t.Fatal("NATURAL JOIN star must carry an executable rewrite")
+	}
+	rewritten, err := sqlglot.ParseOne(*result.RewrittenSQL, "postgres")
+	if err != nil {
+		t.Fatalf("parse rewritten SQL: %v", err)
+	}
+	for i, want := range wantNames {
+		if got := rewritten.Selects()[i].AliasOrName(); got != want {
+			t.Fatalf("rewritten output %d = %q, want %q: %q", i, got, want, *result.RewrittenSQL)
+		}
+	}
+}
+
+func TestPostgresNaturalJoinChainsAfterUsing(t *testing.T) {
+	result := analyzeProbe(t, &pb.AnalyzeRequest{
+		Sql:          "SELECT * FROM public.a JOIN public.b USING (id) NATURAL JOIN public.c",
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+		Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+		Catalog: []*pb.ColumnSpec{
+			columnSpec("acme", "public", "a", "id", "BIGINT"),
+			columnSpec("acme", "public", "a", "a_value", "TEXT"),
+			columnSpec("acme", "public", "b", "id", "BIGINT"),
+			columnSpec("acme", "public", "b", "shared", "TEXT"),
+			columnSpec("acme", "public", "b", "b_value", "TEXT"),
+			columnSpec("acme", "public", "c", "shared", "TEXT"),
+			columnSpec("acme", "public", "c", "c_value", "TEXT"),
+		},
+	})
+	if !result.Resolved {
+		t.Fatalf("chained NATURAL JOIN must resolve: stage=%v detail=%q", result.FailedStage, result.Detail)
+	}
+	want := []string{"shared", "id", "a_value", "b_value", "c_value"}
+	if len(result.Origins) != len(want) {
+		t.Fatalf("origins = %+v, want %d outputs", result.Origins, len(want))
+	}
+	for i, name := range want {
+		if result.Origins[i].Column != name {
+			t.Fatalf("output %d = %q, want %q: %+v", i, result.Origins[i].Column, name, result.Origins)
+		}
+	}
+}
+
+func TestPostgresNaturalJoinRespectsCommaPrecedence(t *testing.T) {
+	result := analyzeProbe(t, &pb.AnalyzeRequest{
+		Sql:          "SELECT * FROM public.a, public.b NATURAL JOIN public.c",
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+		Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+		Catalog: []*pb.ColumnSpec{
+			columnSpec("acme", "public", "a", "id", "BIGINT"),
+			columnSpec("acme", "public", "a", "a_value", "TEXT"),
+			columnSpec("acme", "public", "b", "shared", "TEXT"),
+			columnSpec("acme", "public", "b", "b_value", "TEXT"),
+			columnSpec("acme", "public", "c", "id", "BIGINT"),
+			columnSpec("acme", "public", "c", "shared", "TEXT"),
+			columnSpec("acme", "public", "c", "c_value", "TEXT"),
+		},
+	})
+	if !result.Resolved {
+		t.Fatalf("comma-bound NATURAL JOIN must resolve: stage=%v detail=%q", result.FailedStage, result.Detail)
+	}
+	want := []string{"id", "a_value", "shared", "b_value", "id", "c_value"}
+	if len(result.Origins) != len(want) {
+		t.Fatalf("origins = %+v, want %d outputs", result.Origins, len(want))
+	}
+	for i, name := range want {
+		if result.Origins[i].Column != name {
+			t.Fatalf("output %d = %q, want %q: %+v", i, result.Origins[i].Column, name, result.Origins)
+		}
+	}
+}
+
+func TestPostgresNaturalJoinWithoutCommonColumns(t *testing.T) {
+	catalog := []*pb.ColumnSpec{
+		columnSpec("acme", "public", "a", "a_id", "BIGINT"),
+		columnSpec("acme", "public", "b", "b_id", "BIGINT"),
+	}
+	for _, tc := range []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{name: "inner", sql: "SELECT * FROM public.a NATURAL JOIN public.b", want: "TRUE"},
+		{name: "left", sql: "SELECT * FROM public.a NATURAL LEFT JOIN public.b", want: "TRUE"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := analyzeProbe(t, &pb.AnalyzeRequest{
+				Sql:          tc.sql,
+				EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+				Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+				Catalog:      catalog,
+			})
+			if !result.Resolved || result.RewrittenSQL == nil {
+				t.Fatalf("empty-intersection NATURAL JOIN must resolve with a rewrite: %+v", result)
+			}
+			if !strings.Contains(strings.ToUpper(*result.RewrittenSQL), tc.want) {
+				t.Fatalf("rewrite %q does not contain %q", *result.RewrittenSQL, tc.want)
+			}
+		})
+	}
+}
+
+func TestPostgresNaturalJoinRejectsAmbiguousCommonColumn(t *testing.T) {
+	result := analyzeProbe(t, &pb.AnalyzeRequest{
+		Sql:          "SELECT * FROM (SELECT id, id AS id FROM public.a) l NATURAL JOIN public.b",
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+		Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+		Catalog: []*pb.ColumnSpec{
+			columnSpec("acme", "public", "a", "id", "BIGINT"),
+			columnSpec("acme", "public", "b", "id", "BIGINT"),
+		},
+	})
+	if result.Resolved || result.FailedStage == nil || *result.FailedStage != "VALIDATE" || !strings.Contains(result.Detail, "ambiguous") {
+		t.Fatalf("ambiguous NATURAL JOIN must fail closed in validation: %+v", result)
 	}
 }
 

--- a/analyzer/probe/testdata/golden.json
+++ b/analyzer/probe/testdata/golden.json
@@ -1477,17 +1477,6 @@
     "isWrite": false,
     "rewrittenSql": null
   },
-  "postgres|natural join": {
-    "resolved": false,
-    "failedStage": "VALIDATE",
-    "detail": "NATURAL JOIN not supported (shared-column lineage is ambiguous)",
-    "outputColumns": 0,
-    "tracedColumns": 0,
-    "origins": [],
-    "references": {},
-    "isWrite": false,
-    "rewrittenSql": null
-  },
   "postgres|nested derived": {
     "resolved": true,
     "failedStage": null,

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/BaselineDangerousFunctionEnforcementDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/BaselineDangerousFunctionEnforcementDbTest.kt
@@ -171,10 +171,8 @@ class BaselineDangerousFunctionEnforcementDbTest {
         // the call resolves + emits a function fact + is forbidden by the function gate. A `system:critical`
         // function (lo_export) is forbidden UNCONDITIONALLY (V25 -130), even under system:development.
         configure(pg, pg17, listOf("system:development"))
-        // Control: the exception.unanalyzable relay path IS live on this dev datasource — an actually-unanalyzable
-        // statement (NATURAL JOIN) is relayed verbatim (ALLOW, passthrough). This is the path the dangerous
-        // call would take without the function gate.
-        val relay = decide(pg, "select count(*) from orders natural join users")
+        // The exception.unanalyzable relay remains active for an unresolved catalog column.
+        val relay = decide(pg, "select missing_column from orders")
         assertEquals(EnfAction.ALLOW, relay.action, "dev datasource relays an unanalyzable statement via exception.unanalyzable")
         assertTrue(relay.passthrough, "the unanalyzable relay is a verbatim passthrough")
         // Improvement (RESOLVED forms only): a projected/scalar dangerous call RESOLVES + emits a function
@@ -195,13 +193,13 @@ class BaselineDangerousFunctionEnforcementDbTest {
         // - but a system:critical function (dblink_exec) hiding in a resolved=false statement DENIES even on a
         //   system:development datasource — the function gate runs ahead of the exception.unanalyzable relay, so a
         //   critical builtin is NEVER relayed verbatim (V25 -130 is unconditional). This is the residue CLOSED.
-        val critical = decide(pg, "select dblink_exec('c','s') from users natural join users")
+        val critical = decide(pg, "select dblink_exec('c','s'), missing_column from users")
         assertEquals(EnfAction.DENY, critical.action, "a resolved=false critical function is denied even on a system:development datasource (not relayed via exception.unanalyzable)")
         assertTrue(critical.detail?.contains("dangerous system function") == true, "the DENY is the function gate, not the relay: ${critical.detail}")
         // Both resolved=false forms DENY on the production floor (no exception.unanalyzable permit).
         configure(pg, pg17, listOf("system:production"))
         assertEquals(EnfAction.DENY, decide(pg, "select * from dblink('h','SELECT 1') as t(c text)").action, "resolved=false data-leak denies on the floor")
-        assertEquals(EnfAction.DENY, decide(pg, "select dblink_exec('c','s') from users natural join users").action, "resolved=false critical denies on the floor")
+        assertEquals(EnfAction.DENY, decide(pg, "select dblink_exec('c','s'), missing_column from users").action, "resolved=false critical denies on the floor")
         // BOUNDARY (explicit, not a gap this closes): the backfill only fires on a POST-PARSE failure — a
         // statement that sqlglot cannot PARSE (p.root == nil) emits no function facts, so a critical builtin in
         // a parse-failing statement the target DB still accepts takes the exception.unanalyzable verbatim relay on a

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/UnanalyzableGateDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/UnanalyzableGateDbTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertTrue
 
 /**
  * Unanalyzable-statement gate (docs/facts-emission.md) end-to-end on real PostgreSQL + real Cedar. The
- * analyzer cannot prove lineage for a NATURAL JOIN (shared-column lineage is ambiguous) → `resolved=false`.
+ * analyzer cannot resolve an unknown output column → `resolved=false`.
  * decideQuery asks the datasource for the `exception.unanalyzable` exception:
  *  - production floor (no exception policy) → DENY; and
  *  - a datasource that shipped a `exception.unanalyzable` permit → ALLOW, relaying the ORIGINAL statement verbatim
@@ -25,9 +25,8 @@ class UnanalyzableGateDbTest {
     private lateinit var fx: EnforcementFixture
     private val principal = "analyst@example.com"
 
-    // Admitted (single SELECT statement, passes the sql.select kind gate) but unanalyzable: the probe rejects
-    // NATURAL JOIN early, before catalog resolution, so this is `resolved=false` regardless of the schema.
-    private val unanalyzable = "select count(*) from orders natural join users"
+    // Admitted as SELECT but unresolved against the catalog.
+    private val unanalyzable = "select missing_column from orders"
 
     @BeforeAll
     fun setup() {


### PR DESCRIPTION
## Summary
- expand PostgreSQL NATURAL JOIN predicates from the resolved common columns
- preserve PostgreSQL output order and merged-column lineage across join variants
- fail closed when source shapes are ambiguous

## Risk
Nested join ordering and star expansion across LEFT, RIGHT, and FULL joins.

## Verification
- `mise run verify`