### PR TITLE
fix(postgres): secure catalog browsing

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -759,6 +759,11 @@ fun decideQuery(
             )?.let { ref.key to it }
         }.toMap()
     } ?: emptyMap()
+    val systemRedactedColumns = systemClassification?.let { sc ->
+        columnRefs.filterTo(LinkedHashSet()) { ref ->
+            sc.redactsColumn(ds.engine, ds.engineVersion, ref.catalog, ref.schema, ref.table, ref.column)
+        }.mapTo(HashSet()) { it.key }
+    } ?: emptySet()
 
     val functionGrants = facts.resultReadsList.filter { it.hasFunction() }
     if (functionGrants.isNotEmpty() || facts.functionsList.isNotEmpty()) {
@@ -782,11 +787,22 @@ fun decideQuery(
     val columnVerdicts = if (columnRefs.isEmpty()) emptyMap() else
         authz.authorizeColumns(principal, roles, ds.name, columnRefs, context, columnSystemTags, ds.tags)
     val masks = ArrayList<ColumnMask>()
+    var hasMandatoryRedaction = false
     for (grant in columnGrants) {
         val column = grant.column
         val key = listOf(column.catalog, column.identity.schema, column.identity.table, column.identity.column).joinToString(".")
         val row = catalogIndex.rowsByKey.getValue(key)
-        val verdict = if (row.isTemp) ColumnVerdict.UNMASKED else columnVerdicts[key] ?: ColumnVerdict.DENIED
+        val systemRedacted = key in systemRedactedColumns
+        val authorizedVerdict = if (row.isTemp) {
+            ColumnVerdict.UNMASKED
+        } else {
+            columnVerdicts[key] ?: ColumnVerdict.DENIED
+        }
+        val verdict = if (systemRedacted && authorizedVerdict != ColumnVerdict.DENIED) {
+            ColumnVerdict.MASKED
+        } else {
+            authorizedVerdict
+        }
         when (verdict) {
             ColumnVerdict.UNMASKED -> Unit
             ColumnVerdict.DENIED -> return deny("policy denies column $key")
@@ -799,25 +815,32 @@ fun decideQuery(
                 MaskedDisposition.MASKED_DISPOSITION_MASK_OUTPUT,
                 MaskedDisposition.MASKED_DISPOSITION_REDACT_OUTPUT_NULL -> {
                     // Ordinals were bounds-checked up front (fail-closed contract validation), so each is a
-                    // valid index here; apply the first grant per ordinal (first-wins).
+                    // valid index here. NULL redaction dominates any ordinary mask on that ordinal.
                     for (ordinal in grant.outputOrdinalsList) {
-                        if (masks.none { it.ordinal == ordinal }) {
-                            masks += if (grant.maskedDisposition == MaskedDisposition.MASKED_DISPOSITION_REDACT_OUTPUT_NULL) {
-                                columnMask {
-                                    this.column = facts.outputColumnsList[ordinal]
-                                    maskFn = "redact"
-                                    kind = "NULL"
-                                    this.ordinal = ordinal
-                                }
-                            } else {
-                                val fn = row.classification?.maskFnName
-                                columnMask {
-                                    this.column = facts.outputColumnsList[ordinal]
-                                    maskFn = fn ?: "mask"
-                                    kind = fn?.let { maskKinds[it] } ?: "FIXED"
-                                    this.ordinal = ordinal
-                                }
+                        val redactOutput = systemRedacted ||
+                            grant.maskedDisposition == MaskedDisposition.MASKED_DISPOSITION_REDACT_OUTPUT_NULL
+                        hasMandatoryRedaction = hasMandatoryRedaction || systemRedacted
+                        val candidate = if (redactOutput) {
+                            columnMask {
+                                this.column = facts.outputColumnsList[ordinal]
+                                maskFn = "redact"
+                                kind = "NULL"
+                                this.ordinal = ordinal
                             }
+                        } else {
+                            val fn = row.classification?.maskFnName
+                            columnMask {
+                                this.column = facts.outputColumnsList[ordinal]
+                                maskFn = fn ?: "mask"
+                                kind = fn?.let { maskKinds[it] } ?: "FIXED"
+                                this.ordinal = ordinal
+                            }
+                        }
+                        val existing = masks.indexOfFirst { it.ordinal == ordinal }
+                        if (existing == -1) {
+                            masks += candidate
+                        } else if (redactOutput && masks[existing].kind != "NULL") {
+                            masks[existing] = candidate
                         }
                     }
                 }
@@ -851,7 +874,7 @@ fun decideQuery(
         facts.sourcesList.mapTo(this) { it.schema }
         columnGrants.mapTo(this) { it.column.identity.schema }
     }.filterNotTo(LinkedHashSet()) { it.startsWith("pg_temp", ignoreCase = true) }
-    val unmaskablePermitted = action == EnfAction.MASK && authz.authorizeDatasourceAction(
+    val unmaskablePermitted = action == EnfAction.MASK && !hasMandatoryRedaction && authz.authorizeDatasourceAction(
         principal, roles, AuthzAction.EXCEPTION_UNMASKABLE, ds.name, context, ds.tags,
     ) is AuthzDecision.Allow
     // MASK/DENY always redacts; an ALLOW redacts iff the analyzer's leak set holds a column the viewer

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -232,8 +232,9 @@ internal fun readsAllUnmasked(
     // Same system-tag attachment as the main column authz — a leak column of pg_authid must keep
     // system:critical, or a datasource-wide unmasked grant would release its failing-row dump raw.
     val systemTags = systemClassification?.let { sc ->
-        refs.map { Triple(it.catalog, it.schema, it.table) }.distinct().mapNotNull { (cat, schema, table) ->
-            sc.tagForTable(ds.engine, ds.engineVersion, cat, schema, table)?.let { Triple(cat, schema, table) to it }
+        refs.mapNotNull { ref ->
+            sc.tagForColumn(ds.engine, ds.engineVersion, ref.catalog, ref.schema, ref.table, ref.column)
+                ?.let { ref.key to it }
         }.toMap()
     } ?: emptyMap()
     return authz.authorizeColumns(principal, roles, ds.name, refs, context.copy(stmtKind = null), systemTags, ds.tags)
@@ -741,9 +742,21 @@ fun decideQuery(
         facts.sourcesList.mapTo(this) { Triple(it.catalog, it.schema, it.table) }
         facts.resultReadsList.filter { it.hasTable() }.mapTo(this) { Triple(it.table.catalog, it.table.schema, it.table.table) }
     }
-    val systemTags = systemClassification?.let { sc ->
+    val tableSystemTags = systemClassification?.let { sc ->
         touchedTableIds.mapNotNull { (cat, schema, table) ->
             sc.tagForTable(ds.engine, ds.engineVersion, cat, schema, table)?.let { Triple(cat, schema, table) to it }
+        }.toMap()
+    } ?: emptyMap()
+    val columnSystemTags = systemClassification?.let { sc ->
+        columnRefs.mapNotNull { ref ->
+            sc.tagForColumn(
+                ds.engine,
+                ds.engineVersion,
+                ref.catalog,
+                ref.schema,
+                ref.table,
+                ref.column,
+            )?.let { ref.key to it }
         }.toMap()
     } ?: emptyMap()
 
@@ -767,7 +780,7 @@ fun decideQuery(
     }
 
     val columnVerdicts = if (columnRefs.isEmpty()) emptyMap() else
-        authz.authorizeColumns(principal, roles, ds.name, columnRefs, context, systemTags, ds.tags)
+        authz.authorizeColumns(principal, roles, ds.name, columnRefs, context, columnSystemTags, ds.tags)
     val masks = ArrayList<ColumnMask>()
     for (grant in columnGrants) {
         val column = grant.column
@@ -819,7 +832,7 @@ fun decideQuery(
             val table = grant.table
             TableRef("${table.catalog}.${table.schema}.${table.table}", table.catalog, table.schema, table.table)
         }.distinctBy { it.key }
-        val verdicts = authz.authorizeTables(principal, roles, ds.name, refs, context, systemTags, ds.tags)
+        val verdicts = authz.authorizeTables(principal, roles, ds.name, refs, context, tableSystemTags, ds.tags)
         refs.firstOrNull { verdicts[it.key] != TableVerdict.READ }?.let {
             return deny("no read grant for scanned table '${it.schema}.${it.table}'")
         }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationService.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationService.kt
@@ -75,6 +75,15 @@ class SystemClassificationService(
         return tagForTable(engine, engineVersion, catalog, schema, table)
     }
 
+    fun redactsColumn(
+        engine: Engine,
+        engineVersion: String?,
+        catalog: String,
+        schema: String,
+        table: String,
+        column: String,
+    ): Boolean = classifierFor(engine, engineVersion)?.redactsColumn(catalog, schema, table, column) == true
+
     /**
      * The strongest EXPLICIT dangerous tag (stronger than [SystemTag.CATALOG]) any shipped manifest of [engine]
      * assigns the relation, or null when no manifest classifies it beyond the catalog default. Used only for a

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationService.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationService.kt
@@ -61,6 +61,20 @@ class SystemClassificationService(
         return (noManifestDangerousFloor(engine, catalog, schema, table) ?: SystemTag.CRITICAL).id
     }
 
+    fun tagForColumn(
+        engine: Engine,
+        engineVersion: String?,
+        catalog: String,
+        schema: String,
+        table: String,
+        column: String,
+    ): String? {
+        classifierFor(engine, engineVersion)?.let {
+            return it.classifyColumn(catalog, schema, table, column)?.id
+        }
+        return tagForTable(engine, engineVersion, catalog, schema, table)
+    }
+
     /**
      * The strongest EXPLICIT dangerous tag (stronger than [SystemTag.CATALOG]) any shipped manifest of [engine]
      * assigns the relation, or null when no manifest classifies it beyond the catalog default. Used only for a

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
@@ -528,10 +528,10 @@ fun Authz.authorizeColumns(
     datasource: String,
     columns: List<ColumnRef>,
     context: AuthzContext = AuthzContext(),
-    // System tag per touched table identity `(catalog, schema, table)` (system-classification.md):
-    // attached to the Table entity so its Columns inherit it transitively — a column of `pg_authid`
-    // is `in Tag::"system:critical"` through its Table parent. Empty = no system object touched.
-    systemTags: Map<Triple<String, String, String>, String> = emptyMap(),
+    // System tag per touched column key (system-classification.md). Attached directly to the Column so an
+    // exact column override can differ from its relation while ordinary Table grants still apply through the
+    // Column's Table parent. Empty = no system column touched.
+    systemTags: Map<String, String> = emptyMap(),
     // The datasource's own tags. Attached to the Datasource entity so a policy matches transitively (a
     // Column is `in Tag::"…"` through its Datasource parent), which is how the shipped conditional forbids
     // and preset permits reach a column.
@@ -552,15 +552,11 @@ fun Authz.authorizeColumns(
                 tableEuid(datasource, col.catalog, col.schema, col.table)
             }
             val colEuid = columnEuid(datasource, col.catalog, col.schema, col.table, col.column)
-            columnEntities[col.key] = Entity(colEuid, emptyMap(), (setOf(tblEuid, dsEuid) + col.tags.map(tag)).toSet())
+            val parents = (setOf(tblEuid, dsEuid) + col.tags.map(tag)).toMutableSet()
+            systemTags[col.key]?.let { parents += tag(it) }
+            columnEntities[col.key] = Entity(colEuid, emptyMap(), parents)
         }
-        // Each Table entity carries its datasource parent + its system tag, so a Column inherits the system
-        // classification through its Table parent (no second direct system tag on the column).
-        val tableEntities = tableEuids.map { (identity, euid) ->
-            val parents = mutableSetOf(dsEuid)
-            systemTags[identity]?.let { parents += tag(it) }
-            Entity(euid, emptyMap(), parents)
-        }
+        val tableEntities = tableEuids.values.map { euid -> Entity(euid, emptyMap(), setOf(dsEuid)) }
         columnEntities to tableEntities
     },
     verdict = { unmasked, masked ->

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationEnforcementDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationEnforcementDbTest.kt
@@ -4,6 +4,7 @@ import com.ridi.oss.proxymonster.grpc.EnfAction
 import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
 import com.ridi.oss.proxymonster.controlplane.management.ManagementException
 import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
+import com.ridi.oss.proxymonster.controlplane.support.pushTestCatalog
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -124,6 +125,141 @@ class SystemClassificationEnforcementDbTest {
     }
 
     @Test
+    fun `foreign catalog metadata stays browsable while credential options are always null`() {
+        setEngineVersion("PostgreSQL 17.4 on x86_64-pc-linux-gnu, compiled by gcc")
+        assertEquals(EnfAction.ALLOW, decide("select oid, srvname from pg_catalog.pg_foreign_server"))
+        val star = decideContext("select * from pg_catalog.pg_foreign_server")
+        assertEquals(EnfAction.MASK, star.action)
+        assertTrue(star.rewrittenSql != null)
+        assertEquals("srvoptions", star.masks.single().column)
+        assertEquals(7, star.masks.single().ordinal)
+        assertEquals("NULL", star.masks.single().kind)
+
+        for ((table, key, option) in listOf(
+            Triple("pg_foreign_data_wrapper", "oid", "fdwoptions"),
+            Triple("pg_foreign_server", "oid", "srvoptions"),
+            Triple("pg_user_mapping", "oid", "umoptions"),
+            Triple("pg_foreign_table", "ftrelid", "ftoptions"),
+        )) {
+            val output = decideContext("select $key, $option from pg_catalog.$table")
+            assertEquals(EnfAction.MASK, output.action, "$table.$option output must be redacted")
+            val mask = output.masks.single()
+            assertEquals(option, mask.column)
+            assertEquals("redact", mask.maskFn)
+            assertEquals("NULL", mask.kind)
+
+            assertEquals(
+                EnfAction.DENY,
+                decide("select $key from pg_catalog.$table where $option is not null"),
+                "$table.$option must not affect row selection",
+            )
+            assertEquals(
+                EnfAction.DENY,
+                decide("select $key from pg_catalog.$table order by $option"),
+                "$table.$option must not affect row order",
+            )
+        }
+
+        val derived = decideContext(
+            "select coalesce(srvoptions, '{}') as options from pg_catalog.pg_foreign_server",
+        )
+        assertEquals(EnfAction.MASK, derived.action, derived.detail)
+        assertEquals("options", derived.masks.single().column)
+        assertEquals("redact", derived.masks.single().maskFn)
+        assertEquals("NULL", derived.masks.single().kind)
+    }
+
+    @Test
+    fun `forced redaction dominates an ordinary mask on the same set-operation output`() {
+        fx.execOnTarget("create schema app")
+        fx.execOnTarget("create table app.secrets (secret_options text[])")
+        fx.datasourceStore.pushTestCatalog(
+            fx.datasource,
+            fx.targetJdbcUrl,
+            fx.targetUser,
+            fx.targetPassword,
+        )
+        setEngineVersion("PostgreSQL 17.4 on x86_64-pc-linux-gnu, compiled by gcc")
+        val last4 = fx.policyStore.getMaskFnByName("last4")!!
+        fx.datasourceStore.upsertClassification(
+            fx.datasource.id,
+            ClassificationInput(
+                schema = "app",
+                table = "secrets",
+                column = "secret_options",
+                tags = listOf("pii"),
+                maskFnId = last4.id,
+            ),
+        )
+        val secret = fx.datasourceStore.catalog(fx.datasource.id).single {
+            it.schema == "app" && it.table == "secrets" && it.column == "secret_options"
+        }
+        val tableEuid = listOf(
+            fx.datasource.name,
+            secret.catalog,
+            secret.schema,
+            secret.table,
+        ).joinToString("/")
+        fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "test-union-secret-mask",
+                cedarSrc =
+                    """permit(principal in Role::"${fx.role}", action == Action::"result.read.masked", resource in Table::"$tableEuid") when { resource in Tag::"pii" };""",
+            ),
+            updatedBy = "test",
+        )
+
+        val sql =
+            """select secret_options as value from app.secrets
+                |union all
+                |select srvoptions from pg_catalog.pg_foreign_server
+            """.trimMargin()
+        fx.execOnTarget(sql)
+        val output = decideContext(sql)
+        assertEquals(EnfAction.MASK, output.action, output.detail)
+        val mask = output.masks.single()
+        assertEquals(0, mask.ordinal)
+        assertEquals("value", mask.column)
+        assertEquals("redact", mask.maskFn)
+        assertEquals("NULL", mask.kind)
+    }
+
+    @Test
+    fun `forced redaction does not override a Cedar denial`() {
+        setEngineVersion("PostgreSQL 17.4 on x86_64-pc-linux-gnu, compiled by gcc")
+        val who = "redaction-denied@example.com"
+        val srvoptions = fx.datasourceStore.catalog(fx.datasource.id).single {
+            it.schema == "pg_catalog" && it.table == "pg_foreign_server" && it.column == "srvoptions"
+        }
+        val columnEuid = listOf(
+            fx.datasource.name,
+            srvoptions.catalog,
+            srvoptions.schema,
+            srvoptions.table,
+            srvoptions.column,
+        ).joinToString("/")
+        fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "test-redaction-reader",
+                cedarSrc = """permit(principal == User::"$who", action, resource in Datasource::"${fx.datasource.name}");""",
+            ),
+            updatedBy = "test",
+        )
+        fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "test-redaction-column-forbid",
+                cedarSrc = """forbid(principal == User::"$who", action, resource == Column::"$columnEuid");""",
+            ),
+            updatedBy = "test",
+        )
+
+        assertEquals(EnfAction.ALLOW, decideContext("select oid from pg_catalog.pg_foreign_server", who).action)
+        val denied = decideContext("select srvoptions from pg_catalog.pg_foreign_server", who)
+        assertEquals(EnfAction.DENY, denied.action)
+        assertTrue(denied.detail?.contains("policy denies column") == true)
+    }
+
+    @Test
     fun `the dangerous forbids override even a broad datasource read grant`() {
         // The DENY cases above are deny-by-default for the ungranted analyst. This case makes the forbids
         // LOAD-BEARING: a principal with a broad any-action grant on the whole datasource. Without the shipped
@@ -139,9 +275,18 @@ class SystemClassificationEnforcementDbTest {
             ),
             updatedBy = "test",
         )
-        fun decideAs(who: String, sql: String) = decideContext(sql, who).action
+        fun decideAsContext(who: String, sql: String) = decideContext(sql, who)
+        fun decideAs(who: String, sql: String) = decideAsContext(who, sql).action
         // The broad grant genuinely permits: system:catalog browses.
         assertEquals(EnfAction.ALLOW, decideAs(broad, "select count(*) from pg_catalog.pg_class"), "broad grant permits system:catalog")
+        val redacted = decideAsContext(broad, "select oid, srvoptions from pg_catalog.pg_foreign_server")
+        assertEquals(EnfAction.MASK, redacted.action, "a broad unmasked grant cannot expose srvoptions")
+        assertEquals("NULL", redacted.masks.single().kind)
+        assertFalse(redacted.unmaskablePermitted, "mandatory redaction cannot be bypassed on a binary wire path")
+        val redactedForeignTable = decideAsContext(broad, "select ftrelid, ftoptions from pg_catalog.pg_foreign_table")
+        assertEquals(EnfAction.MASK, redactedForeignTable.action, "a broad unmasked grant cannot expose ftoptions")
+        assertEquals("NULL", redactedForeignTable.masks.single().kind)
+        assertFalse(redactedForeignTable.unmaskablePermitted, "mandatory redaction cannot be bypassed on a binary wire path")
         assertEquals(EnfAction.ALLOW, decideAs(broad, "select transactionid from pg_catalog.pg_locks"))
         assertEquals(EnfAction.DENY, decideAs(broad, "select pid from pg_catalog.pg_locks"))
         assertEquals(EnfAction.DENY, decideAs(broad, "select count(*) from pg_catalog.pg_locks"))
@@ -160,6 +305,7 @@ class SystemClassificationEnforcementDbTest {
         // unrecognized fixed-system table cannot be assumed benign catalog metadata.
         assertEquals(EnfAction.DENY, decide("select count(*) from pg_catalog.pg_class"), "no version → pg_class treated as critical → denied")
         assertEquals(EnfAction.DENY, decide("select count(*) from pg_catalog.pg_authid"), "no version → pg_authid denied")
+        assertEquals(EnfAction.DENY, decide("select oid from pg_catalog.pg_foreign_server"), "no version → foreign metadata stays closed")
     }
 
     @Test

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationEnforcementDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationEnforcementDbTest.kt
@@ -47,15 +47,21 @@ class SystemClassificationEnforcementDbTest {
         }
     }
 
-    private fun decide(sql: String): EnfAction {
-        val ds = fx.datasourceStore.get(fx.datasource.id)!! // re-fetch so ds.engineVersion reflects setEngineVersion
-        return decideQuery(
-            principal = principal, ds = ds, sql = sql, channel = Channel.WIRE,
-            catalog = fx.datasourceStore.catalog(fx.datasource.id), policyStore = fx.policyStore, accessStore = fx.accessStore,
-            userGroupStore = fx.userGroupStore, roleResolver = fx.roleResolver, authz = fx.authz,
-            systemClassification = classifier,
-        ).action
-    }
+    private fun decideContext(sql: String, who: String = principal) = decideQuery(
+        principal = who,
+        ds = fx.datasourceStore.get(fx.datasource.id)!!,
+        sql = sql,
+        channel = Channel.WIRE,
+        catalog = fx.datasourceStore.catalog(fx.datasource.id),
+        policyStore = fx.policyStore,
+        accessStore = fx.accessStore,
+        userGroupStore = fx.userGroupStore,
+        roleResolver = fx.roleResolver,
+        authz = fx.authz,
+        systemClassification = classifier,
+    )
+
+    private fun decide(sql: String): EnfAction = decideContext(sql).action
 
     @Test
     fun `a column classification may name a product system tag but not invent one`() {
@@ -100,6 +106,24 @@ class SystemClassificationEnforcementDbTest {
     }
 
     @Test
+    fun `only the transaction id column of pg_locks is catalog-readable`() {
+        setEngineVersion("PostgreSQL 17.4 on x86_64-pc-linux-gnu, compiled by gcc")
+        val decision = decideContext(
+            """select L.transactionid::varchar::bigint as transaction_id
+                |from pg_catalog.pg_locks L
+                |where L.transactionid is not null
+                |order by pg_catalog.age(L.transactionid) desc
+                |limit 1
+            """.trimMargin(),
+        )
+        assertEquals(EnfAction.ALLOW, decision.action)
+        assertEquals(null, decision.rewrittenSql, "the target DB must execute the original query")
+        assertEquals(EnfAction.DENY, decide("select pid from pg_catalog.pg_locks"))
+        assertEquals(EnfAction.DENY, decide("select transactionid, pid from pg_catalog.pg_locks"))
+        assertEquals(EnfAction.DENY, decide("select count(*) from pg_catalog.pg_locks"))
+    }
+
+    @Test
     fun `the dangerous forbids override even a broad datasource read grant`() {
         // The DENY cases above are deny-by-default for the ungranted analyst. This case makes the forbids
         // LOAD-BEARING: a principal with a broad any-action grant on the whole datasource. Without the shipped
@@ -115,14 +139,12 @@ class SystemClassificationEnforcementDbTest {
             ),
             updatedBy = "test",
         )
-        fun decideAs(who: String, sql: String) = decideQuery(
-            principal = who, ds = fx.datasourceStore.get(fx.datasource.id)!!, sql = sql, channel = Channel.WIRE,
-            catalog = fx.datasourceStore.catalog(fx.datasource.id), policyStore = fx.policyStore, accessStore = fx.accessStore,
-            userGroupStore = fx.userGroupStore, roleResolver = fx.roleResolver, authz = fx.authz,
-            systemClassification = classifier,
-        ).action
+        fun decideAs(who: String, sql: String) = decideContext(sql, who).action
         // The broad grant genuinely permits: system:catalog browses.
         assertEquals(EnfAction.ALLOW, decideAs(broad, "select count(*) from pg_catalog.pg_class"), "broad grant permits system:catalog")
+        assertEquals(EnfAction.ALLOW, decideAs(broad, "select transactionid from pg_catalog.pg_locks"))
+        assertEquals(EnfAction.DENY, decideAs(broad, "select pid from pg_catalog.pg_locks"))
+        assertEquals(EnfAction.DENY, decideAs(broad, "select count(*) from pg_catalog.pg_locks"))
         // ...but the shipped forbids OVERRIDE that broad grant on every dangerous tag (production floor).
         assertEquals(EnfAction.DENY, decideAs(broad, "select count(*) from pg_catalog.pg_authid"), "critical forbid overrides the broad grant")
         assertEquals(EnfAction.DENY, decideAs(broad, "select count(*) from pg_catalog.pg_stats"), "data-leak forbid overrides the broad grant")

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationServiceTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationServiceTest.kt
@@ -88,6 +88,9 @@ class SystemClassificationServiceTest {
             assertEquals("system:activity", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_statio_user_tables"), v)
             assertEquals("system:activity", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_replication_slots"), v)
             assertEquals("system:activity", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_replication_origin_status"), v)
+            assertEquals("system:activity", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_locks"), v)
+            assertEquals("system:catalog", svc.tagForColumn(Engine.POSTGRES, v, "app", "pg_catalog", "pg_locks", "transactionid"), v)
+            assertEquals("system:activity", svc.tagForColumn(Engine.POSTGRES, v, "app", "pg_catalog", "pg_locks", "pid"), v)
             // FDW option views expose raw srvoptions/fdwoptions — critical, mirroring the already-critical
             // public foreign_server_options / pg_foreign_server twins; _pg_user_mappings exposes umoptions.
             assertEquals("system:critical", svc.tagForTable(Engine.POSTGRES, v, "app", "information_schema", "_pg_user_mappings"), v)
@@ -126,6 +129,11 @@ class SystemClassificationServiceTest {
         assertEquals("system:data-leak", svc.tagForTable(Engine.MYSQL, null, "def", "information_schema", "COLUMN_STATISTICS"))
         // A catalog-default table (structural, no explicit dangerous rule) is closed as critical, not catalog.
         assertEquals("system:critical", svc.tagForTable(Engine.POSTGRES, null, "acme", "pg_catalog", "pg_class"))
+        assertEquals(
+            "system:activity",
+            svc.tagForColumn(Engine.POSTGRES, null, "acme", "pg_catalog", "pg_locks", "transactionid"),
+            "without a governing manifest the column keeps the relation's dangerous floor",
+        )
         // An unrecognized table in a fixed system schema (in no shipped manifest) is likewise closed as critical.
         assertEquals("system:critical", svc.tagForTable(Engine.MYSQL, null, "def", "performance_schema", "not_a_real_pfs_table_xyz"))
         // A table the manifest DOES classify dangerous keeps that explicit tag even with no governing version

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationServiceTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationServiceTest.kt
@@ -3,6 +3,7 @@ package com.ridi.oss.proxymonster.controlplane
 import com.ridi.oss.proxymonster.grpc.Engine
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -91,11 +92,17 @@ class SystemClassificationServiceTest {
             assertEquals("system:activity", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_locks"), v)
             assertEquals("system:catalog", svc.tagForColumn(Engine.POSTGRES, v, "app", "pg_catalog", "pg_locks", "transactionid"), v)
             assertEquals("system:activity", svc.tagForColumn(Engine.POSTGRES, v, "app", "pg_catalog", "pg_locks", "pid"), v)
-            // FDW option views expose raw srvoptions/fdwoptions — critical, mirroring the already-critical
-            // public foreign_server_options / pg_foreign_server twins; _pg_user_mappings exposes umoptions.
             assertEquals("system:critical", svc.tagForTable(Engine.POSTGRES, v, "app", "information_schema", "_pg_user_mappings"), v)
             assertEquals("system:critical", svc.tagForTable(Engine.POSTGRES, v, "app", "information_schema", "_pg_foreign_servers"), v)
             assertEquals("system:critical", svc.tagForTable(Engine.POSTGRES, v, "app", "information_schema", "_pg_foreign_data_wrappers"), v)
+            assertEquals("system:catalog", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_foreign_data_wrapper"), v)
+            assertEquals("system:catalog", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_foreign_server"), v)
+            assertEquals("system:catalog", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_user_mapping"), v)
+            assertEquals("system:catalog", svc.tagForTable(Engine.POSTGRES, v, "app", "pg_catalog", "pg_foreign_table"), v)
+            assertTrue(svc.redactsColumn(Engine.POSTGRES, v, "app", "pg_catalog", "pg_foreign_data_wrapper", "fdwoptions"), v)
+            assertTrue(svc.redactsColumn(Engine.POSTGRES, v, "app", "pg_catalog", "pg_foreign_server", "srvoptions"), v)
+            assertTrue(svc.redactsColumn(Engine.POSTGRES, v, "app", "pg_catalog", "pg_user_mapping", "umoptions"), v)
+            assertTrue(svc.redactsColumn(Engine.POSTGRES, v, "app", "pg_catalog", "pg_foreign_table", "ftoptions"), v)
             // Grant/privilege views expose the access model — data-leak, parity with the MySQL role_*_grants.
             assertEquals("system:data-leak", svc.tagForTable(Engine.POSTGRES, v, "app", "information_schema", "role_table_grants"), v)
             assertEquals("system:data-leak", svc.tagForTable(Engine.POSTGRES, v, "app", "information_schema", "table_privileges"), v)
@@ -146,6 +153,7 @@ class SystemClassificationServiceTest {
         assertNull(svc.tagForTable(Engine.POSTGRES, null, "acme", "public", "orders"))
         // Ephemeral pg_temp_/pg_toast are not fixed system schemas — their connection-local path owns them.
         assertNull(svc.tagForTable(Engine.POSTGRES, null, "acme", "pg_temp_3", "scratch"))
+        assertFalse(svc.redactsColumn(Engine.POSTGRES, null, "acme", "pg_catalog", "pg_foreign_server", "srvoptions"))
     }
 
     // tagForFunction resolves a BARE function name (the only form the analyzer can emit, since

--- a/docs/system-classification.md
+++ b/docs/system-classification.md
@@ -177,6 +177,14 @@ analyzer. A manifest is declarative:
       "tag": "system:activity"
     }
   ],
+  "columnOverrides": [
+    {
+      "schema": "pg_catalog",
+      "table": "pg_locks",
+      "column": "transactionid",
+      "tag": "system:catalog"
+    }
+  ],
   "functions": [{ "schema": "*", "name": "dblink", "tag": "system:data-leak" }],
   "functionFamilies": [
     { "schema": "pg_catalog", "prefix": "pg_read_", "tag": "system:data-leak" }
@@ -197,9 +205,9 @@ Boot validation rejects a manifest whose declared engine/series disagrees with
 its file path; a duplicate manifest for one engine/series; any tag outside the
 four `system:` tags; a wildcard schema on a relation rule (only a function rule
 may be cross-schema); duplicate exact identities with different tags;
-overlapping prefix families with different tags; and an exact rule weaker than a
-family prefix it matches — a category downgrade that would depend on match
-ordering. Anything rejected throws `SystemManifestException`, which aborts
+overlapping prefix families with different tags; an exact relation rule weaker
+than a family prefix it matches; and a column override outside an exposed system
+schema. Anything rejected throws `SystemManifestException`, which aborts
 startup.
 
 Validation does not check command ids against the analyzer: nothing verifies
@@ -246,15 +254,12 @@ object. Manifests may therefore store the canonical server spelling
   then over-classified — safe (a deny), and the reason `schema: "*"` is refused
   on a relation rule.
 
-Relations are classified whole. A Column receives the owning Table's system
-class through its Cedar Table parent; it is not independently default-tagged
-`system:catalog`. Otherwise a column of `pg_authid` would inherit
-`system:critical` and carry a direct catalog permit at once, and disabling or
-exempting the stronger guard would accidentally create access without an
-ordinary grant. Several security surfaces (`pg_settings`, grant tables) mix
-benign and sensitive rows/columns; with no row-conditional system tags, the
-whole relation takes the strongest necessary class. Over-denying beats exposing
-a credential-bearing row.
+A relation tag governs uncovered Table scans such as `count(*)`. A traced Column
+uses that same tag unless the manifest carries an exact `columnOverrides` entry;
+that entry replaces the relation tag only for the named Column. The Column keeps
+its ordinary Table parent for direct table grants, while its system tag is
+attached directly for Cedar policy. This permits a reviewed structural field of
+a dangerous relation without opening another column or a column-free scan.
 
 ## Exposed system surface and catalog boundary
 
@@ -395,7 +400,9 @@ Relations/views:
   `pg_stat_subscription`, `pg_stat_subscription_stats`;
 - `pg_catalog.pg_stat_ssl`, `pg_stat_gssapi`;
 - the `pg_catalog.pg_stat_progress_*` family;
-- `pg_catalog.pg_prepared_statements`, `pg_cursors`, `pg_locks`;
+- `pg_catalog.pg_prepared_statements`, `pg_cursors`, `pg_locks`; the exact
+  `pg_locks.transactionid` column is `system:catalog`, while every other column
+  and uncovered scan remains `system:activity`;
 - extension relations `pg_stat_statements`, `pg_stat_statements_info`; and
 - Aurora `pg_catalog.aurora_replica_status`, `aurora_stat_activity`,
   `aurora_global_db_status`, `aurora_global_db_instance_status`, and the
@@ -665,13 +672,14 @@ function inventory ([facts-emission.md](./facts-emission.md)).
 
 ### Decision time
 
-For each Table/Function/Utility fact the control-plane asks
-`SystemClassificationService.tagForTable` / `tagForFunction` / `tagForCommand`,
-which returns exactly one system tag or none. A Table in an exposed system
-schema gets at least `system:catalog`; a recognized cross-schema dangerous
-function can get a shipped tag outside a system schema. A Column inherits its
-owning Table's system tag through the Cedar entity graph and receives no
-separate shipped system parent; user column tags stay direct Column parents.
+For each Table/Column/Function/Utility fact the control-plane asks
+`SystemClassificationService.tagForTable` / `tagForColumn` / `tagForFunction` /
+`tagForCommand`, which returns exactly one system tag or none. A Table in an
+exposed system schema gets at least `system:catalog`; a Column gets its exact
+override or its Table's tag; and a recognized cross-schema dangerous function
+can get a shipped tag outside a system schema. The Column's resolved system tag
+is a direct Cedar parent, while ordinary Table membership and user column tags
+remain unchanged.
 
 Admin write APIs reject `system:*`: a classification write carrying any tag with
 that prefix fails with `datasource.reserved_tag`
@@ -787,6 +795,7 @@ means rather than which statements pass.
 - `datasource.engine_version`, the raw target DB version string the proxy
   pushed, which is what manifest resolution keys off;
 - canonical Utility grants and manifest command/tag mappings;
+- exact manifest column overrides;
 - `catalog_column` as the physical column inventory, including the system
   schemas; and
 - `column_classification.tags` as user/admin tags only.
@@ -828,9 +837,10 @@ surfaces:
 
 - `SystemClassificationTest` (`engine/`) — manifest validation (bad tag,
   duplicate identity, overlapping family, downgrade-by-ordering, wildcard
-  relation), the strongest-wins combinator, version resolution and fallback, and
-  that all four bundled manifests load and classify a spot-checked set of real
-  PostgreSQL and MySQL objects including the Aurora ones.
+  relation, column override scope), the strongest-wins combinator, version
+  resolution and fallback, and that all four bundled manifests load and
+  classify a spot-checked set of real PostgreSQL and MySQL objects including the
+  Aurora ones.
 - `ManifestCommandCoverageDbTest` (`control-plane/`) — the fail-closed
   completeness guard in the direction that can be automated: every dangerous
   command id in every shipped manifest must either DENY through the real

--- a/docs/system-classification.md
+++ b/docs/system-classification.md
@@ -185,6 +185,13 @@ analyzer. A manifest is declarative:
       "tag": "system:catalog"
     }
   ],
+  "redactedColumns": [
+    {
+      "schema": "pg_catalog",
+      "table": "pg_foreign_server",
+      "column": "srvoptions"
+    }
+  ],
   "functions": [{ "schema": "*", "name": "dblink", "tag": "system:data-leak" }],
   "functionFamilies": [
     { "schema": "pg_catalog", "prefix": "pg_read_", "tag": "system:data-leak" }
@@ -206,9 +213,9 @@ its file path; a duplicate manifest for one engine/series; any tag outside the
 four `system:` tags; a wildcard schema on a relation rule (only a function rule
 may be cross-schema); duplicate exact identities with different tags;
 overlapping prefix families with different tags; an exact relation rule weaker
-than a family prefix it matches; and a column override outside an exposed system
-schema. Anything rejected throws `SystemManifestException`, which aborts
-startup.
+than a family prefix it matches; a column override outside an exposed system
+schema; and a redacted column outside a catalog-class relation. Anything
+rejected throws `SystemManifestException`, which aborts startup.
 
 Validation does not check command ids against the analyzer: nothing verifies
 that a manifest command id is one `analyzer/probe/facts.go` can actually emit,
@@ -260,6 +267,11 @@ that entry replaces the relation tag only for the named Column. The Column keeps
 its ordinary Table parent for direct table grants, while its system tag is
 attached directly for Cedar policy. This permits a reviewed structural field of
 a dangerous relation without opening another column or a column-free scan.
+
+`redactedColumns` is separate from classification. A named catalog column may
+appear only as an output, is always masked to SQL `NULL`, and cannot affect a
+predicate, join, ordering, or write. The forced redaction applies even under a
+broad datasource grant.
 
 ## Exposed system surface and catalog boundary
 
@@ -321,13 +333,18 @@ Relations/views:
 | object | why |
 | --- | --- |
 | `pg_catalog.pg_authid`, `pg_catalog.pg_shadow` | password verifiers and privileged role attributes |
-| `pg_catalog.pg_user_mapping`, `pg_catalog.pg_user_mappings` | user-mapping options can include remote credentials |
-| `pg_catalog.pg_foreign_server`, `pg_catalog.pg_foreign_data_wrapper` | server/wrapper options can include connection and handler configuration |
+| `pg_catalog.pg_user_mappings` | public user-mapping view can expose remote credentials |
 | `information_schema.user_mapping_options` | user-mapping option view |
 | `information_schema.foreign_server_options`, `information_schema.foreign_data_wrapper_options` | FDW option views |
 | `pg_catalog.pg_subscription` | logical-subscription connection string (`subconninfo`) |
 | `pg_catalog.pg_hba_file_rules`, `pg_catalog.pg_ident_file_mappings` | authentication/identity-map configuration |
 | `pg_catalog.pg_config`, `pg_catalog.pg_file_settings`, `pg_catalog.pg_settings`, `pg_catalog.pg_db_role_setting` | build/config paths, source files, pending values, per-role/database settings, and potentially sensitive connection/config values |
+
+The structural columns of `pg_catalog.pg_foreign_data_wrapper`,
+`pg_foreign_server`, `pg_user_mapping`, and `pg_foreign_table` are
+`system:catalog`. Their exact option columns (`fdwoptions`, `srvoptions`,
+`umoptions`, and `ftoptions`) always return SQL `NULL` and cannot be used
+outside output.
 
 Privileged functions:
 
@@ -795,7 +812,7 @@ means rather than which statements pass.
 - `datasource.engine_version`, the raw target DB version string the proxy
   pushed, which is what manifest resolution keys off;
 - canonical Utility grants and manifest command/tag mappings;
-- exact manifest column overrides;
+- exact manifest column overrides and forced-NULL redaction rules;
 - `catalog_column` as the physical column inventory, including the system
   schemas; and
 - `column_classification.tags` as user/admin tags only.
@@ -837,8 +854,8 @@ surfaces:
 
 - `SystemClassificationTest` (`engine/`) — manifest validation (bad tag,
   duplicate identity, overlapping family, downgrade-by-ordering, wildcard
-  relation, column override scope), the strongest-wins combinator, version
-  resolution and fallback, and that all four bundled manifests load and
+  relation, column override and redaction scope), the strongest-wins combinator,
+  version resolution and fallback, and that all four bundled manifests load and
   classify a spot-checked set of real PostgreSQL and MySQL objects including the
   Aurora ones.
 - `ManifestCommandCoverageDbTest` (`control-plane/`) — the fail-closed

--- a/engine/src/main/kotlin/com/ridi/oss/proxymonster/classification/SystemClassifier.kt
+++ b/engine/src/main/kotlin/com/ridi/oss/proxymonster/classification/SystemClassifier.kt
@@ -32,6 +32,9 @@ class SystemClassifier(val manifest: SystemManifest) {
     // schema -> [(prefix, tag)]; a "*" schema (cross-schema function) is keyed under "*".
     private val relationFamilies: Map<String, List<Pair<String, SystemTag>>> = familyMap(manifest.relationFamilies)
     private val functionFamilies: Map<String, List<Pair<String, SystemTag>>> = familyMap(manifest.functionFamilies)
+    private val redactedColumns: Set<Triple<String, String, String>> = manifest.redactedColumns
+        .map { Triple(fold(it.schema), fold(it.table), fold(it.column)) }
+        .toSet()
     private val commandTags: Map<String, SystemTag> = manifest.commands.associate { it.id to requireTag(it.tag, "command ${it.id}") }
     // Cross-schema (schema "*") function rules apply in ANY schema.
     private val functionAnySchema: Map<String, SystemTag> =
@@ -57,6 +60,10 @@ class SystemClassifier(val manifest: SystemManifest) {
         return columnOverrides[Triple(fold(schema), fold(table), fold(column))]
             ?: classifySystemRelation(schema, table)
     }
+
+    /** True when the shipped manifest requires the catalog column to be output only as NULL. */
+    fun redactsColumn(catalog: String, schema: String, table: String, column: String): Boolean =
+        isSystemSchema(catalog, schema) && Triple(fold(schema), fold(table), fold(column)) in redactedColumns
 
     private fun classifySystemRelation(schema: String, name: String): SystemTag {
         val s = fold(schema)
@@ -177,6 +184,18 @@ class SystemClassifier(val manifest: SystemManifest) {
                 throw SystemManifestException(
                     "${manifestId()}: column override ${rule.schema}.${rule.table}.${rule.column} is outside a system schema",
                 )
+            }
+        }
+        val redactionKeys = manifest.redactedColumns.map { Triple(fold(it.schema), fold(it.table), fold(it.column)) }
+        if (redactionKeys.size != redactionKeys.toSet().size) {
+            throw SystemManifestException("${manifestId()}: duplicate redacted column")
+        }
+        for (rule in manifest.redactedColumns) {
+            if (fold(rule.schema) !in systemSchemas) {
+                throw SystemManifestException("${manifestId()}: redacted column ${rule.schema}.${rule.table}.${rule.column} is outside a system schema")
+            }
+            if (classifySystemRelation(rule.schema, rule.table) != SystemTag.CATALOG) {
+                throw SystemManifestException("${manifestId()}: redacted column ${rule.schema}.${rule.table}.${rule.column} belongs to a non-catalog relation")
             }
         }
         for ((schema, families) in relationFamilies + functionFamilies) {

--- a/engine/src/main/kotlin/com/ridi/oss/proxymonster/classification/SystemClassifier.kt
+++ b/engine/src/main/kotlin/com/ridi/oss/proxymonster/classification/SystemClassifier.kt
@@ -14,8 +14,9 @@ class SystemManifestException(message: String) : Exception(message)
  * classifier owns only the manifest lookup, never namespace resolution.
  *
  * The constructor VALIDATES and throws [SystemManifestException] on any manifest violation (bad tag, duplicate
- * exact identity with a different tag, overlapping families with different tags, or an exact rule that would
- * downgrade a stronger family by match ordering). A malformed manifest must abort startup like a bad
+ * exact identity with a different tag, overlapping families with different tags, an invalid column scope, or
+ * an exact relation rule that would downgrade a stronger family by match ordering). A malformed manifest must
+ * abort startup like a bad
  * migration.
  */
 class SystemClassifier(val manifest: SystemManifest) {
@@ -27,6 +28,7 @@ class SystemClassifier(val manifest: SystemManifest) {
     // (schema, name) -> tag, deduped strongest-first so the exact-map value is already the winning tag.
     private val relationExact: Map<Pair<String, String>, SystemTag> = exactMap(manifest.relations, "relation")
     private val functionExact: Map<Pair<String, String>, SystemTag> = exactMap(manifest.functions, "function")
+    private val columnOverrides: Map<Triple<String, String, String>, SystemTag> = columnMap(manifest.columnOverrides)
     // schema -> [(prefix, tag)]; a "*" schema (cross-schema function) is keyed under "*".
     private val relationFamilies: Map<String, List<Pair<String, SystemTag>>> = familyMap(manifest.relationFamilies)
     private val functionFamilies: Map<String, List<Pair<String, SystemTag>>> = familyMap(manifest.functionFamilies)
@@ -46,6 +48,17 @@ class SystemClassifier(val manifest: SystemManifest) {
      */
     fun classifyRelation(catalog: String, schema: String, name: String): SystemTag? {
         if (!isSystemSchema(catalog, schema)) return null
+        return classifySystemRelation(schema, name)
+    }
+
+    /** The exact column override, or the owning relation's tag when no override exists. */
+    fun classifyColumn(catalog: String, schema: String, table: String, column: String): SystemTag? {
+        if (!isSystemSchema(catalog, schema)) return null
+        return columnOverrides[Triple(fold(schema), fold(table), fold(column))]
+            ?: classifySystemRelation(schema, table)
+    }
+
+    private fun classifySystemRelation(schema: String, name: String): SystemTag {
         val s = fold(schema)
         val n = fold(name)
         var tag = SystemTag.CATALOG
@@ -129,6 +142,21 @@ class SystemClassifier(val manifest: SystemManifest) {
         return out
     }
 
+    private fun columnMap(rules: List<ColumnRule>): Map<Triple<String, String, String>, SystemTag> {
+        val out = HashMap<Triple<String, String, String>, SystemTag>()
+        for (r in rules) {
+            val key = Triple(fold(r.schema), fold(r.table), fold(r.column))
+            val tag = requireTag(r.tag, "column ${r.schema}.${r.table}.${r.column}")
+            val previous = out.putIfAbsent(key, tag)
+            if (previous != null && previous != tag) {
+                throw SystemManifestException(
+                    "${manifestId()}: duplicate column ${r.schema}.${r.table}.${r.column} with conflicting tags $previous/$tag",
+                )
+            }
+        }
+        return out
+    }
+
     private fun familyMap(rules: List<FamilyRule>): Map<String, List<Pair<String, SystemTag>>> {
         val out = HashMap<String, MutableList<Pair<String, SystemTag>>>()
         for (r in rules) {
@@ -144,6 +172,13 @@ class SystemClassifier(val manifest: SystemManifest) {
         (manifest.relations.map { it.schema } + manifest.relationFamilies.map { it.schema })
             .firstOrNull { it == "*" }
             ?.let { throw SystemManifestException("${manifestId()}: wildcard schema \"*\" is only valid on a function rule, not a relation") }
+        for (rule in manifest.columnOverrides) {
+            if (fold(rule.schema) !in systemSchemas) {
+                throw SystemManifestException(
+                    "${manifestId()}: column override ${rule.schema}.${rule.table}.${rule.column} is outside a system schema",
+                )
+            }
+        }
         for ((schema, families) in relationFamilies + functionFamilies) {
             // Overlapping families with different tags are ambiguous (which wins?). Reject.
             for (i in families.indices) for (j in families.indices) if (i != j) {

--- a/engine/src/main/kotlin/com/ridi/oss/proxymonster/classification/SystemManifest.kt
+++ b/engine/src/main/kotlin/com/ridi/oss/proxymonster/classification/SystemManifest.kt
@@ -6,8 +6,8 @@ import kotlinx.serialization.Serializable
  * The shipped system classification (docs/system-classification.md). Every object in an exposed system
  * schema is one of four `system:` tags; only the dangerous overrides are enumerated — everything else
  * defaults to `system:catalog` (open browsing). These tags are a product fact, immutable and bundled per
- * engine MAJOR version; exact column overrides are bundled with those facts, while policy over them lives
- * in Cedar (`access-model.md`).
+ * engine MAJOR version; exact column overrides and forced redactions are bundled with those facts, while
+ * policy over them lives in Cedar (`access-model.md`).
  *
  * Strength order (strongest first) drives the classifier: when several rules match one object it takes the
  * STRONGEST tag, so a weaker exact rule can never downgrade a stronger family rule. Over-classifying is
@@ -47,6 +47,10 @@ data class FamilyRule(val schema: String, val prefix: String, val tag: String)
 @Serializable
 data class ColumnRule(val schema: String, val table: String, val column: String, val tag: String)
 
+/** A system-catalog column whose output is always NULL and whose non-output use is denied. */
+@Serializable
+data class RedactedColumnRule(val schema: String, val table: String, val column: String)
+
 /** A utility command → the resource it exposes + that resource's tag (SHOW/DESCRIBE/…). */
 @Serializable
 data class CommandRule(val id: String, val resource: String, val tag: String)
@@ -54,8 +58,8 @@ data class CommandRule(val id: String, val resource: String, val tag: String)
 /**
  * One bundled manifest, deserialized from `resources/system-classification/<engine>/<series>.json`
  * (docs/system-classification.md). Declarative: schemas + exact/family relation & function rules + exact
- * column overrides + the utility-command map. `series` is the engine major (PostgreSQL `17`, MySQL
- * `8.0`/`8.4`).
+ * column overrides/redactions + the utility-command map. `series` is the engine major (PostgreSQL `17`,
+ * MySQL `8.0`/`8.4`).
  */
 @Serializable
 data class SystemManifest(
@@ -69,6 +73,7 @@ data class SystemManifest(
     val relations: List<ObjectRule> = emptyList(),
     val relationFamilies: List<FamilyRule> = emptyList(),
     val columnOverrides: List<ColumnRule> = emptyList(),
+    val redactedColumns: List<RedactedColumnRule> = emptyList(),
     val functions: List<ObjectRule> = emptyList(),
     val functionFamilies: List<FamilyRule> = emptyList(),
     val commands: List<CommandRule> = emptyList(),

--- a/engine/src/main/kotlin/com/ridi/oss/proxymonster/classification/SystemManifest.kt
+++ b/engine/src/main/kotlin/com/ridi/oss/proxymonster/classification/SystemManifest.kt
@@ -6,7 +6,8 @@ import kotlinx.serialization.Serializable
  * The shipped system classification (docs/system-classification.md). Every object in an exposed system
  * schema is one of four `system:` tags; only the dangerous overrides are enumerated — everything else
  * defaults to `system:catalog` (open browsing). These tags are a product fact, immutable and bundled per
- * engine MAJOR version; policy over them lives in Cedar (`access-model.md`).
+ * engine MAJOR version; exact column overrides are bundled with those facts, while policy over them lives
+ * in Cedar (`access-model.md`).
  *
  * Strength order (strongest first) drives the classifier: when several rules match one object it takes the
  * STRONGEST tag, so a weaker exact rule can never downgrade a stronger family rule. Over-classifying is
@@ -42,14 +43,19 @@ data class ObjectRule(val schema: String, val name: String, val tag: String)
 @Serializable
 data class FamilyRule(val schema: String, val prefix: String, val tag: String)
 
+/** An exact system column classification that replaces its relation's tag for traced column reads. */
+@Serializable
+data class ColumnRule(val schema: String, val table: String, val column: String, val tag: String)
+
 /** A utility command → the resource it exposes + that resource's tag (SHOW/DESCRIBE/…). */
 @Serializable
 data class CommandRule(val id: String, val resource: String, val tag: String)
 
 /**
  * One bundled manifest, deserialized from `resources/system-classification/<engine>/<series>.json`
- * (docs/system-classification.md). Declarative: schemas + exact/family relation & function rules +
- * the utility-command map. `series` is the engine major (PostgreSQL `17`, MySQL `8.0`/`8.4`).
+ * (docs/system-classification.md). Declarative: schemas + exact/family relation & function rules + exact
+ * column overrides + the utility-command map. `series` is the engine major (PostgreSQL `17`, MySQL
+ * `8.0`/`8.4`).
  */
 @Serializable
 data class SystemManifest(
@@ -62,6 +68,7 @@ data class SystemManifest(
     val logicalFunctionSchemas: List<SystemSchema> = emptyList(),
     val relations: List<ObjectRule> = emptyList(),
     val relationFamilies: List<FamilyRule> = emptyList(),
+    val columnOverrides: List<ColumnRule> = emptyList(),
     val functions: List<ObjectRule> = emptyList(),
     val functionFamilies: List<FamilyRule> = emptyList(),
     val commands: List<CommandRule> = emptyList(),

--- a/engine/src/main/resources/system-classification/postgres/16.json
+++ b/engine/src/main/resources/system-classification/postgres/16.json
@@ -27,22 +27,7 @@
     },
     {
       "schema": "pg_catalog",
-      "name": "pg_user_mapping",
-      "tag": "system:critical"
-    },
-    {
-      "schema": "pg_catalog",
       "name": "pg_user_mappings",
-      "tag": "system:critical"
-    },
-    {
-      "schema": "pg_catalog",
-      "name": "pg_foreign_server",
-      "tag": "system:critical"
-    },
-    {
-      "schema": "pg_catalog",
-      "name": "pg_foreign_data_wrapper",
       "tag": "system:critical"
     },
     {
@@ -317,11 +302,6 @@
     },
     {
       "schema": "pg_catalog",
-      "name": "pg_foreign_table",
-      "tag": "system:data-leak"
-    },
-    {
-      "schema": "pg_catalog",
       "name": "pg_sequences",
       "tag": "system:data-leak"
     },
@@ -352,6 +332,28 @@
       "table": "pg_locks",
       "column": "transactionid",
       "tag": "system:catalog"
+    }
+  ],
+  "redactedColumns": [
+    {
+      "schema": "pg_catalog",
+      "table": "pg_foreign_data_wrapper",
+      "column": "fdwoptions"
+    },
+    {
+      "schema": "pg_catalog",
+      "table": "pg_foreign_server",
+      "column": "srvoptions"
+    },
+    {
+      "schema": "pg_catalog",
+      "table": "pg_user_mapping",
+      "column": "umoptions"
+    },
+    {
+      "schema": "pg_catalog",
+      "table": "pg_foreign_table",
+      "column": "ftoptions"
     }
   ],
   "relationFamilies": [

--- a/engine/src/main/resources/system-classification/postgres/16.json
+++ b/engine/src/main/resources/system-classification/postgres/16.json
@@ -346,6 +346,14 @@
       "tag": "system:activity"
     }
   ],
+  "columnOverrides": [
+    {
+      "schema": "pg_catalog",
+      "table": "pg_locks",
+      "column": "transactionid",
+      "tag": "system:catalog"
+    }
+  ],
   "relationFamilies": [
     {
       "schema": "pg_catalog",

--- a/engine/src/main/resources/system-classification/postgres/17.json
+++ b/engine/src/main/resources/system-classification/postgres/17.json
@@ -27,22 +27,7 @@
     },
     {
       "schema": "pg_catalog",
-      "name": "pg_user_mapping",
-      "tag": "system:critical"
-    },
-    {
-      "schema": "pg_catalog",
       "name": "pg_user_mappings",
-      "tag": "system:critical"
-    },
-    {
-      "schema": "pg_catalog",
-      "name": "pg_foreign_server",
-      "tag": "system:critical"
-    },
-    {
-      "schema": "pg_catalog",
-      "name": "pg_foreign_data_wrapper",
       "tag": "system:critical"
     },
     {
@@ -317,11 +302,6 @@
     },
     {
       "schema": "pg_catalog",
-      "name": "pg_foreign_table",
-      "tag": "system:data-leak"
-    },
-    {
-      "schema": "pg_catalog",
       "name": "pg_sequences",
       "tag": "system:data-leak"
     },
@@ -352,6 +332,28 @@
       "table": "pg_locks",
       "column": "transactionid",
       "tag": "system:catalog"
+    }
+  ],
+  "redactedColumns": [
+    {
+      "schema": "pg_catalog",
+      "table": "pg_foreign_data_wrapper",
+      "column": "fdwoptions"
+    },
+    {
+      "schema": "pg_catalog",
+      "table": "pg_foreign_server",
+      "column": "srvoptions"
+    },
+    {
+      "schema": "pg_catalog",
+      "table": "pg_user_mapping",
+      "column": "umoptions"
+    },
+    {
+      "schema": "pg_catalog",
+      "table": "pg_foreign_table",
+      "column": "ftoptions"
     }
   ],
   "relationFamilies": [

--- a/engine/src/main/resources/system-classification/postgres/17.json
+++ b/engine/src/main/resources/system-classification/postgres/17.json
@@ -346,6 +346,14 @@
       "tag": "system:activity"
     }
   ],
+  "columnOverrides": [
+    {
+      "schema": "pg_catalog",
+      "table": "pg_locks",
+      "column": "transactionid",
+      "tag": "system:catalog"
+    }
+  ],
   "relationFamilies": [
     {
       "schema": "pg_catalog",

--- a/engine/src/test/kotlin/com/ridi/oss/proxymonster/classification/SystemClassificationTest.kt
+++ b/engine/src/test/kotlin/com/ridi/oss/proxymonster/classification/SystemClassificationTest.kt
@@ -92,6 +92,44 @@ class SystemClassificationTest {
     }
 
     @Test
+    fun `a redacted catalog column is exact and stays inside an open system relation`() {
+        val c = SystemClassifier(
+            SystemManifest(
+                engine = "postgres", series = "17", manifestVersion = 1, curatedThrough = "17.6",
+                systemSchemas = listOf(SystemSchema("*", "pg_catalog")),
+                redactedColumns = listOf(RedactedColumnRule("pg_catalog", "pg_foreign_server", "srvoptions")),
+            ),
+        )
+        assertTrue(c.redactsColumn("acme", "PG_CATALOG", "PG_FOREIGN_SERVER", "SRVOPTIONS"))
+        assertFalse(c.redactsColumn("acme", "pg_catalog", "pg_foreign_server", "srvname"))
+        assertFalse(c.redactsColumn("acme", "public", "pg_foreign_server", "srvoptions"))
+        assertEquals(SystemTag.CATALOG, c.classifyRelation("acme", "pg_catalog", "pg_foreign_server"))
+    }
+
+    @Test
+    fun `a redacted column outside an open system relation aborts`() {
+        assertFailsWith<SystemManifestException> {
+            SystemClassifier(
+                SystemManifest(
+                    engine = "postgres", series = "17", manifestVersion = 1, curatedThrough = "17.6",
+                    systemSchemas = listOf(SystemSchema("*", "pg_catalog")),
+                    relations = listOf(ObjectRule("pg_catalog", "pg_foreign_server", "system:critical")),
+                    redactedColumns = listOf(RedactedColumnRule("pg_catalog", "pg_foreign_server", "srvoptions")),
+                ),
+            )
+        }
+        assertFailsWith<SystemManifestException> {
+            SystemClassifier(
+                SystemManifest(
+                    engine = "postgres", series = "17", manifestVersion = 1, curatedThrough = "17.6",
+                    systemSchemas = listOf(SystemSchema("*", "pg_catalog")),
+                    redactedColumns = listOf(RedactedColumnRule("public", "pg_foreign_server", "srvoptions")),
+                ),
+            )
+        }
+    }
+
+    @Test
     fun `a utility command maps to its resource tag`() {
         val c = SystemClassifier(
             SystemManifest(
@@ -233,9 +271,17 @@ class SystemClassificationTest {
         assertEquals(SystemTag.ACTIVITY, c.classifyRelation("acme", "pg_catalog", "pg_stat_activity"))
         assertEquals(SystemTag.ACTIVITY, c.classifyRelation("acme", "pg_catalog", "pg_stat_progress_vacuum"), "family")
         assertEquals(SystemTag.CATALOG, c.classifyRelation("acme", "pg_catalog", "pg_class"), "ordinary catalog stays open")
+        assertEquals(SystemTag.CATALOG, c.classifyRelation("acme", "pg_catalog", "pg_foreign_server"))
+        assertEquals(SystemTag.CATALOG, c.classifyRelation("acme", "pg_catalog", "pg_foreign_table"))
         assertEquals(SystemTag.ACTIVITY, c.classifyRelation("acme", "pg_catalog", "pg_locks"))
         assertEquals(SystemTag.CATALOG, c.classifyColumn("acme", "pg_catalog", "pg_locks", "transactionid"))
         assertEquals(SystemTag.ACTIVITY, c.classifyColumn("acme", "pg_catalog", "pg_locks", "pid"))
+        assertTrue(c.redactsColumn("acme", "pg_catalog", "pg_foreign_server", "srvoptions"))
+        assertTrue(c.redactsColumn("acme", "pg_catalog", "pg_foreign_data_wrapper", "fdwoptions"))
+        assertTrue(c.redactsColumn("acme", "pg_catalog", "pg_user_mapping", "umoptions"))
+        assertTrue(c.redactsColumn("acme", "pg_catalog", "pg_foreign_table", "ftoptions"))
+        assertFalse(c.redactsColumn("acme", "pg_catalog", "pg_foreign_server", "srvname"))
+        assertFalse(c.redactsColumn("acme", "pg_catalog", "pg_foreign_table", "ftrelid"))
         assertEquals(SystemTag.CRITICAL, c.classifyFunction("acme", "pg_catalog", "set_config"))
         assertEquals(SystemTag.DATA_LEAK, c.classifyFunction("acme", "pg_catalog", "pg_read_file"), "pg_read_ family")
         assertEquals(SystemTag.DATA_LEAK, c.classifyFunction("acme", "public", "dblink"), "cross-schema extension fn")

--- a/engine/src/test/kotlin/com/ridi/oss/proxymonster/classification/SystemClassificationTest.kt
+++ b/engine/src/test/kotlin/com/ridi/oss/proxymonster/classification/SystemClassificationTest.kt
@@ -63,6 +63,35 @@ class SystemClassificationTest {
     }
 
     @Test
+    fun `an exact column override replaces the relation tag only for that column`() {
+        val c = SystemClassifier(
+            SystemManifest(
+                engine = "postgres", series = "17", manifestVersion = 1, curatedThrough = "17.6",
+                systemSchemas = listOf(SystemSchema("*", "pg_catalog")),
+                relations = listOf(ObjectRule("pg_catalog", "pg_locks", "system:activity")),
+                columnOverrides = listOf(ColumnRule("pg_catalog", "pg_locks", "transactionid", "system:catalog")),
+            ),
+        )
+        assertEquals(SystemTag.ACTIVITY, c.classifyRelation("acme", "pg_catalog", "pg_locks"))
+        assertEquals(SystemTag.CATALOG, c.classifyColumn("acme", "PG_CATALOG", "PG_LOCKS", "TRANSACTIONID"))
+        assertEquals(SystemTag.ACTIVITY, c.classifyColumn("acme", "pg_catalog", "pg_locks", "pid"))
+        assertNull(c.classifyColumn("acme", "public", "pg_locks", "transactionid"))
+    }
+
+    @Test
+    fun `a column override outside a system schema aborts`() {
+        assertFailsWith<SystemManifestException> {
+            SystemClassifier(
+                SystemManifest(
+                    engine = "postgres", series = "17", manifestVersion = 1, curatedThrough = "17.6",
+                    systemSchemas = listOf(SystemSchema("*", "pg_catalog")),
+                    columnOverrides = listOf(ColumnRule("public", "users", "id", "system:catalog")),
+                ),
+            )
+        }
+    }
+
+    @Test
     fun `a utility command maps to its resource tag`() {
         val c = SystemClassifier(
             SystemManifest(
@@ -204,6 +233,9 @@ class SystemClassificationTest {
         assertEquals(SystemTag.ACTIVITY, c.classifyRelation("acme", "pg_catalog", "pg_stat_activity"))
         assertEquals(SystemTag.ACTIVITY, c.classifyRelation("acme", "pg_catalog", "pg_stat_progress_vacuum"), "family")
         assertEquals(SystemTag.CATALOG, c.classifyRelation("acme", "pg_catalog", "pg_class"), "ordinary catalog stays open")
+        assertEquals(SystemTag.ACTIVITY, c.classifyRelation("acme", "pg_catalog", "pg_locks"))
+        assertEquals(SystemTag.CATALOG, c.classifyColumn("acme", "pg_catalog", "pg_locks", "transactionid"))
+        assertEquals(SystemTag.ACTIVITY, c.classifyColumn("acme", "pg_catalog", "pg_locks", "pid"))
         assertEquals(SystemTag.CRITICAL, c.classifyFunction("acme", "pg_catalog", "set_config"))
         assertEquals(SystemTag.DATA_LEAK, c.classifyFunction("acme", "pg_catalog", "pg_read_file"), "pg_read_ family")
         assertEquals(SystemTag.DATA_LEAK, c.classifyFunction("acme", "public", "dblink"), "cross-schema extension fn")

--- a/goproxy/pgproxy/extended.go
+++ b/goproxy/pgproxy/extended.go
@@ -409,9 +409,12 @@ func (s *Server) handleExecute(sess *session, message *pgproto3.Execute) error {
 	masks := proceed.Masks
 	if portal.binary {
 		if proceed.Decision.Action == "MASK" && !proceed.Decision.UnmaskablePermitted {
-			return refuseExtended(sess, "0A000", "binary result format is not supported for a masked statement")
+			if !nullOnlyMasks(masks) {
+				return refuseExtended(sess, "0A000", "binary result format is not supported for a masked statement")
+			}
+		} else {
+			masks = nil
 		}
-		masks = nil
 	}
 	// The fresh verdict authorizes the SQL already parsed on the target DB. A fresh rewrite cannot replace
 	// that prepared statement, so RewrittenSQL is deliberately ignored at Execute.
@@ -436,6 +439,18 @@ func (s *Server) handleExecute(sess *session, message *pgproto3.Execute) error {
 		}
 	}
 	return nil
+}
+
+func nullOnlyMasks(masks []*pb.ColumnMask) bool {
+	if len(masks) == 0 {
+		return false
+	}
+	for _, mask := range masks {
+		if mask.GetKind() != "NULL" {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *Server) relayExecuteStream(sess *session, masks []*pb.ColumnMask, stats *engine.RelayStats) (pgproto3.BackendMessage, error) {

--- a/goproxy/pgproxy/extended_test.go
+++ b/goproxy/pgproxy/extended_test.go
@@ -682,6 +682,37 @@ func TestExtendedBinaryMaskWithoutPermitFailsClosed(t *testing.T) {
 	}
 }
 
+func TestExtendedBinaryNullMaskWithoutPermitRedacts(t *testing.T) {
+	h := startBroker(t)
+	h.fake.decideFn = func(*pb.DecisionRequest) (*pb.WireDecision, error) {
+		return wireVerdict(&pb.Verdict{
+			Decision: pb.EnfAction_MASK,
+			Masks:    []*pb.ColumnMask{{Column: "ssn", Kind: "NULL", Ordinal: proto.Int32(2)}},
+		}), nil
+	}
+	conn, err := h.connect(t, validToken, false)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	ctx := context.Background()
+	const query = "SELECT id, name, ssn FROM it_pgproxy.people WHERE id = $1"
+	if _, err := conn.Prepare(ctx, "stmt_bin_null", query); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	var id int
+	var name string
+	var ssn *string
+	if err := conn.QueryRow(ctx, "stmt_bin_null", pgx.QueryResultFormats{1, 1, 1}, 1).Scan(&id, &name, &ssn); err != nil {
+		t.Fatalf("binary QueryRow: %v", err)
+	}
+	if id != 1 || name != "Alice" || ssn != nil {
+		t.Fatalf("row = (%d, %q, %v), want redacted Alice row", id, name, ssn)
+	}
+	if got := len(h.fake.requests()); got != 2 {
+		t.Fatalf("Decide requests = %d, want 2", got)
+	}
+}
+
 func TestExtendedBinaryMaskWithPermitRelaysVerbatim(t *testing.T) {
 	h := startBroker(t)
 	h.fake.decideFn = func(*pb.DecisionRequest) (*pb.WireDecision, error) {


### PR DESCRIPTION
## Summary
- classify exact PostgreSQL system columns without widening uncovered table scans
- expose structural catalog metadata needed by database browsers
- force FDW, server, user-mapping, and foreign-table options to SQL NULL, including binary rows

## Risk
System-catalog policy scope and mandatory result redaction.

## Verification
- `mise run verify`
- pgx binary-result NULL redaction regression