### PR TITLE
refactor(analyzer): fold identifiers once, up front, instead of per consumer

### DIFF
--- a/analyzer/probe/analyze_statement_test.go
+++ b/analyzer/probe/analyze_statement_test.go
@@ -1,0 +1,110 @@
+package probe
+
+import (
+	"testing"
+
+	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
+	"google.golang.org/protobuf/proto"
+)
+
+// AnalyzeStatement is the FFM entry point the JVM calls, and it owns the proto→internal decode that
+// EmitFacts itself never sees: a malformed catalog or namespace must surface as an ERROR here rather
+// than reaching the analyzer as an empty one, which would analyze against a catalog that isn't there
+// and resolve nothing — the fail-OPEN direction. The tests named for it elsewhere drive Probe through
+// a helper that reimplements this plumbing, so the decode boundary itself was never exercised.
+func TestAnalyzeStatementDecodesCatalogAndNamespace(t *testing.T) {
+	base := func() *pb.AnalyzeRequest {
+		return &pb.AnalyzeRequest{
+			Sql: "SELECT id FROM users",
+			EngineConfig: &pb.EngineConfig{
+				Engine: pb.Engine_MYSQL, EngineVersion: "8.0.44",
+				MysqlLowerCaseTableNames: proto.Int32(0),
+			},
+			Namespace: &pb.Namespace{Catalog: "def", SearchPath: []string{"acme"}},
+			Catalog: []*pb.ColumnSpec{
+				columnSpec("def", "acme", "users", "id", "BIGINT"),
+			},
+		}
+	}
+
+	facts, err := AnalyzeStatement(base())
+	if err != nil {
+		t.Fatalf("a well-formed request must analyze: %v", err)
+	}
+	if !facts.GetResolved() {
+		t.Fatalf("expected resolved, got %s: %s", stageString(facts.FailedStage), facts.GetDetail())
+	}
+
+	// A namespace with no search path cannot resolve an unqualified name; it must be refused at the
+	// boundary, not silently analyzed under an empty one.
+	noSearchPath := base()
+	noSearchPath.Namespace = &pb.Namespace{Catalog: "def"}
+	if _, err := AnalyzeStatement(noSearchPath); err == nil {
+		t.Error("an empty search path must be refused at the decode boundary, got no error")
+	}
+
+	// A duplicate catalog column makes the mapping ambiguous — a lineage key could bind either row.
+	dup := base()
+	dup.Catalog = append(dup.Catalog, columnSpec("def", "acme", "users", "id", "BIGINT"))
+	if _, err := AnalyzeStatement(dup); err == nil {
+		t.Error("a duplicate catalog column must be refused at the decode boundary, got no error")
+	}
+}
+
+// The FFM boundary is a cgo boundary: a panic crossing it crashes the host JVM. AnalyzeStatementSafe
+// must therefore be TOTAL — every input yields a decodable StatementFacts, and a failure is expressed
+// as resolved=false rather than an error or a panic.
+func TestAnalyzeStatementSafeIsTotal(t *testing.T) {
+	catalog := []*pb.ColumnSpec{columnSpec("def", "acme", "users", "id", "BIGINT")}
+	engine := &pb.EngineConfig{
+		Engine: pb.Engine_MYSQL, EngineVersion: "8.0.44",
+		MysqlLowerCaseTableNames: proto.Int32(0),
+	}
+	namespace := &pb.Namespace{Catalog: "def", SearchPath: []string{"acme"}}
+
+	encode := func(t *testing.T, req *pb.AnalyzeRequest) []byte {
+		t.Helper()
+		b, err := proto.Marshal(req)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return b
+	}
+
+	for _, tc := range []struct {
+		name         string
+		in           []byte
+		wantResolved bool
+	}{
+		{"well-formed", encode(t, &pb.AnalyzeRequest{
+			Sql: "SELECT id FROM users", EngineConfig: engine, Namespace: namespace, Catalog: catalog,
+		}), true},
+		// Not a valid proto at all — the decode itself fails.
+		{"garbage bytes", []byte{0xff, 0xfe, 0xfd, 0x01, 0x02}, false},
+		{"empty bytes", []byte{}, false},
+		{"nil bytes", nil, false},
+		// Decodes, but the request is unusable: no engine, no namespace, no catalog.
+		{"empty request", encode(t, &pb.AnalyzeRequest{}), false},
+		// Decodes and is well-formed, but the statement cannot be parsed.
+		{"unparseable sql", encode(t, &pb.AnalyzeRequest{
+			Sql: "SELECT FROM WHERE ((", EngineConfig: engine, Namespace: namespace, Catalog: catalog,
+		}), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := AnalyzeStatementSafe(tc.in)
+			if len(out) == 0 && tc.wantResolved {
+				t.Fatal("a resolvable request must return a non-empty encoding")
+			}
+			var facts pb.StatementFacts
+			if err := proto.Unmarshal(out, &facts); err != nil {
+				t.Fatalf("output must always be a decodable StatementFacts, got %v", err)
+			}
+			if got := facts.GetResolved(); got != tc.wantResolved {
+				t.Errorf("resolved = %v, want %v (detail %q)", got, tc.wantResolved, facts.GetDetail())
+			}
+			if !tc.wantResolved && facts.GetDetail() == "" {
+				t.Error("a fail-closed result must carry a detail explaining why")
+			}
+		})
+	}
+}

--- a/analyzer/probe/engine.go
+++ b/analyzer/probe/engine.go
@@ -34,6 +34,11 @@ type engine interface {
 	// Engine-specific: PostgreSQL's pg_temp; MySQL has no temp-schema convention (its temporary tables
 	// are marked by the TEMPORARY keyword).
 	IsTempSchema(schema exp.Expression) bool
+	// IsTrustedSystemQualifier reports whether a call/type qualifier names THIS engine's trusted system
+	// schema, so a call under it is a system builtin rather than user code. Engine-specific, and the
+	// reason it cannot be a name comparison at the call site: `pg_catalog` is a PostgreSQL schema, so a
+	// MySQL database literally named `pg_catalog` is ordinary user code and never trusted.
+	IsTrustedSystemQualifier(qualifier exp.Expression) bool
 	// RewriteStatement optionally rewrites a parsed statement into the SQL the proxy should relay to the
 	// target DB, returning "" to leave it unchanged.
 	RewriteStatement(root exp.Expression) string
@@ -112,6 +117,11 @@ func (e *mysqlEngine) FoldColumn(column string) string {
 // temporary arg / TemporaryProperty on the DDL), which isTemporaryDDL detects directly off the tree.
 func (e *mysqlEngine) IsTempSchema(exp.Expression) bool { return false }
 
+// MySQL has no trusted system-schema qualifier: its system databases (mysql, information_schema,
+// performance_schema, sys) are access-controlled resources the system-classification manifest covers,
+// not a blanket pass for calls made under them.
+func (e *mysqlEngine) IsTrustedSystemQualifier(exp.Expression) bool { return false }
+
 // RewriteStatement pins a single, session-scoped `SET character_set_results = NULL` — the default MySQL
 // Connector/J (and so DBeaver) session-init, which asks the target DB to return each column in its own charset
 // for client-side decoding — to utf8mb4, so the wire masker keeps decoding results as UTF-8. Only that exact
@@ -186,20 +196,27 @@ func (e *postgresEngine) NormalizeCatalogOnBuild() bool { return false }
 func (e *postgresEngine) FoldColumn(column string) string { return column }
 
 // PostgreSQL places session-temporary objects in pg_temp (a per-backend alias for the numbered
-// pg_temp_<n> temp schema), so a DDL target there is session-local, not catalog-changing. The schema
-// identifier is folded through the dialect's NormalizeIdentifier — the same quote-aware normalization
-// the analyzer applies to every other identifier — so an unquoted pg_temp/PG_TEMP matches (PostgreSQL
-// lowercases unquoted identifiers) while a quoted "PG_TEMP", a distinct case-sensitive user schema,
-// does not. A raw strings.ToLower would wrongly conflate the two and also mis-fold non-ASCII. A
-// deep-copied node is folded so the shared parse tree is never mutated by this read-only check.
+// pg_temp_<n> temp schema), so a DDL target there is session-local, not catalog-changing. Read off the
+// already-folded spelling (EmitFacts normalizes the statement's identifiers up front, quote-aware), so
+// an unquoted pg_temp/PG_TEMP matches while a quoted "PG_TEMP" — a distinct case-sensitive user schema —
+// does not. A raw strings.ToLower here would wrongly conflate the two and mis-fold non-ASCII.
 func (e *postgresEngine) IsTempSchema(schema exp.Expression) bool {
 	if schema == nil {
 		return false
 	}
-	id := schema.Copy()
-	e.dialect.NormalizeIdentifier(id)
-	name := id.Name()
+	name := schema.Name()
 	return name == "pg_temp" || strings.HasPrefix(name, "pg_temp_")
+}
+
+// pg_catalog is PostgreSQL's system schema: a call qualified by it is a builtin, so it carries no
+// unclassified Function grant. Only a single bare identifier qualifies — a quoted "PG_CATALOG" keeps its
+// case and is a DISTINCT user schema PostgreSQL's case-sensitive `pg_` reservation allows to exist, so a
+// user function there must not inherit a builtin's pass.
+func (e *postgresEngine) IsTrustedSystemQualifier(qualifier exp.Expression) bool {
+	if qualifier == nil || qualifier.Kind() != exp.KindIdentifier {
+		return false
+	}
+	return qualifier.Name() == "pg_catalog"
 }
 
 // PostgreSQL has no relay rewrite: client_encoding is handled on the wire, not by an analyzer rewrite,

--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ridi-oss/sqlglot-go/dialects"
 	exp "github.com/ridi-oss/sqlglot-go/expressions"
 	"github.com/ridi-oss/sqlglot-go/generator"
+	"github.com/ridi-oss/sqlglot-go/optimizer"
 	"github.com/ridi-oss/sqlglot-go/schema"
 )
 
@@ -118,7 +119,12 @@ func EmitFacts(sql string, engineConfig *pb.EngineConfig, sch *schema.Mapping, n
 	// Peel a whole-statement parenthesized wrapper: `(SELECT 1)` parses to a Subquery whose `this` is the
 	// real statement. Classification/lineage must run on the inner statement, not fail closed on the
 	// wrapper (a wrapped SELECT is ordinary chatter, a wrapped write is still a write).
-	root := unwrapSubquery(stmts[0])
+	// Fold identifiers ONCE, here, so every consumer below reads canonical spellings. Qualify does this
+	// as its own first step (optimizer.Qualify → NormalizeIdentifiers), but Qualify needs the catalog and
+	// runs only in VALIDATE — so the paths that never reach it, or that reach it and fail, were each
+	// left to fold by hand. Quote-aware, so a quoted identifier keeps its case: `"PG_CATALOG"` stays a
+	// distinct user schema from `pg_catalog`, and `"MySchema".fn` from `myschema.fn`.
+	root := optimizer.NormalizeIdentifiers(unwrapSubquery(stmts[0]), eng.Dialect())
 	candidates := schemaQualifierCandidates(root)
 
 	var facts *pb.StatementFacts
@@ -681,7 +687,7 @@ func noFromFunctionGrants(root exp.Expression, eng engine) []*pb.RequireResultRe
 		}
 		qualified[fn] = true
 		leaf := strings.ToLower(fn.Name())
-		if isTrustedSystemQualifier(dot.Left(), eng) {
+		if eng.IsTrustedSystemQualifier(dot.Left()) {
 			if !safeNoFromFunctions[leaf] {
 				emit(leaf)
 			}
@@ -702,29 +708,9 @@ func noFromFunctionGrants(root exp.Expression, eng engine) []*pb.RequireResultRe
 	return out
 }
 
-// isTrustedSystemQualifier reports whether a call/type qualifier is the ONE trusted system-schema form:
-// a single bare identifier that resolves to PostgreSQL's `pg_catalog`. Trust is decided on the qualifier
-// folded through the dialect's quote-aware NormalizeIdentifier, NOT a raw EqualFold — an UNQUOTED
-// `PG_CATALOG` folds to `pg_catalog` (trusted), but a QUOTED `"PG_CATALOG"` stays case-sensitive and is a
-// DISTINCT user schema PostgreSQL's case-sensitive `pg_` reservation allows to exist, so it must NOT be
-// trusted (a user function there would otherwise inherit a system builtin's pass). It is also engine-gated:
-// `pg_catalog` is a PostgreSQL schema, so a MySQL database literally named `pg_catalog` is ordinary user
-// code and never trusted. A multi-part qualifier (its left side is itself a Dot, i.e. `db.pg_catalog` /
-// `current_database().public`) is never trusted either — its leaf spelling `pg_catalog` must not smuggle a
-// call into the safe branch — so it fails this test and its call/type is emitted with a full qualified
-// identity the control-plane cannot classify as safe.
-func isTrustedSystemQualifier(qualifier exp.Expression, eng engine) bool {
-	if qualifier == nil || eng.Type() != pb.Engine_POSTGRES || qualifier.Kind() != exp.KindIdentifier {
-		return false
-	}
-	folded := qualifier.Copy()
-	eng.Dialect().NormalizeIdentifier(folded)
-	return folded.Name() == "pg_catalog"
-}
-
 // qualifiedCallName renders a user-code call's fully-qualified identity so it is always an unclassified
-// Function grant. The single-identifier qualifier is folded through the dialect's quote-aware
-// NormalizeIdentifier — matching how the analyzer resolves every other relation, so the emitted name keys
+// Function grant. The single-identifier qualifier arrives already folded (EmitFacts normalizes up front,
+// quote-aware) — matching how the analyzer resolves every other relation, so the emitted name keys
 // identically to the control-plane's catalog (`"MySchema".fn` and `myschema.fn` stay DISTINCT rather than
 // both collapsing to one lowercased name a classification could ride). A multi-part qualifier is rendered
 // whole (`current_database().public.fn`) so the leaf never stands alone; that rendered form is always an
@@ -735,9 +721,7 @@ func qualifiedCallName(qualifier exp.Expression, leaf string, eng engine) string
 			return strings.ToLower(rendered) + "." + leaf
 		}
 	}
-	folded := qualifier.Copy()
-	eng.Dialect().NormalizeIdentifier(folded)
-	return folded.Name() + "." + leaf
+	return qualifier.Name() + "." + leaf
 }
 
 func unsafeExpression(value any, eng engine) bool {
@@ -777,7 +761,7 @@ func hasUnsafeCall(root exp.Expression, eng engine) bool {
 			continue
 		}
 		qualified[fn] = true
-		if isTrustedSystemQualifier(dot.Left(), eng) {
+		if eng.IsTrustedSystemQualifier(dot.Left()) {
 			if !safeNoFromFunctions[strings.ToLower(fn.Name())] {
 				return true
 			}
@@ -996,6 +980,11 @@ func isAccountObjectDDL(root exp.Expression) bool {
 	return false
 }
 
+// schemaQualifierCandidates collects every schema the statement names, so a caller holding a partial
+// catalog can fetch the ones it lacks. The names are the target DB's own spelling — EmitFacts folds the
+// statement's identifiers before this runs — because a candidate is used to look that schema up: MySQL
+// under lower_case_table_names=1 reports information_schema lowercase, so an unfolded `GOODS_STORE`
+// would match nothing.
 func schemaQualifierCandidates(root exp.Expression) []string {
 	set := map[string]bool{}
 	for _, table := range root.FindAll(exp.KindTable) {

--- a/analyzer/probe/normalize_upfront_test.go
+++ b/analyzer/probe/normalize_upfront_test.go
@@ -1,0 +1,202 @@
+package probe
+
+import (
+	"sort"
+	"testing"
+
+	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
+	sqlglot "github.com/ridi-oss/sqlglot-go"
+	exp "github.com/ridi-oss/sqlglot-go/expressions"
+	"github.com/ridi-oss/sqlglot-go/optimizer"
+	"google.golang.org/protobuf/proto"
+)
+
+// EmitFacts folds identifiers once, up front, so every consumer below reads one canonical spelling
+// rather than re-deriving the fold. The property that makes that safe is quote-awareness — an unquoted
+// identifier folds, a quoted one keeps its case — and two authorization decisions depend on exactly it:
+// `pg_catalog` trust ([engine.IsTrustedSystemQualifier]) and a call's emitted identity ([qualifiedCallName]).
+// A blanket fold that lost it would hand a user schema a system builtin's pass. Asserted against those
+// two helpers directly, on a root normalized the way EmitFacts normalizes it.
+func TestUpfrontFoldKeepsQualifierTrustQuoteAware(t *testing.T) {
+	eng, err := createEngine(&pb.EngineConfig{Engine: pb.Engine_POSTGRES, EngineVersion: "16.0"})
+	if err != nil {
+		t.Fatalf("build engine: %v", err)
+	}
+	for _, tc := range []struct {
+		sql         string
+		wantName    string
+		wantTrusted bool
+	}{
+		{`SELECT PG_CATALOG.f(1)`, "pg_catalog", true},
+		// A quoted "PG_CATALOG" is a DISTINCT user schema PostgreSQL's case-sensitive `pg_` reservation
+		// allows to exist; trusting it would give a user function a system builtin's pass.
+		{`SELECT "PG_CATALOG".f(1)`, "PG_CATALOG", false},
+		{`SELECT MySchema.f(1)`, "myschema", false},
+		{`SELECT "MySchema".f(1)`, "MySchema", false},
+	} {
+		parsed, err := sqlglot.Parse(tc.sql, eng.Dialect())
+		if err != nil {
+			t.Fatalf("parse %s: %v", tc.sql, err)
+		}
+		root := optimizer.NormalizeIdentifiers(parsed[0], eng.Dialect())
+		dots := root.FindAll(exp.KindDot)
+		if len(dots) == 0 {
+			t.Fatalf("%s: expected a qualified call", tc.sql)
+		}
+		qualifier := dots[0].Left()
+		if got := qualifier.Name(); got != tc.wantName {
+			t.Errorf("%s: qualifier spelling = %q, want %q", tc.sql, got, tc.wantName)
+		}
+		if got := eng.IsTrustedSystemQualifier(qualifier); got != tc.wantTrusted {
+			t.Errorf("%s: trusted = %v, want %v", tc.sql, got, tc.wantTrusted)
+		}
+		if got, want := qualifiedCallName(qualifier, "f", eng), tc.wantName+".f"; got != want {
+			t.Errorf("%s: call identity = %q, want %q", tc.sql, got, want)
+		}
+	}
+}
+
+// The fold must also reach the relation identities the control plane authorizes against: MySQL under
+// lower_case_table_names=1 folds relation names, so an uppercase statement resolves and its scanned-table
+// identity carries the folded spelling the catalog is keyed by.
+func TestUpfrontFoldReachesRelationIdentities(t *testing.T) {
+	mapping, err := schemaMappingFromProto([]*pb.ColumnSpec{
+		columnSpec("def", "bom", "tb_user", "id", "BIGINT"),
+	})
+	if err != nil {
+		t.Fatalf("build schema: %v", err)
+	}
+	facts := EmitFacts(
+		"SELECT id FROM BOM.TB_USER",
+		&pb.EngineConfig{Engine: pb.Engine_MYSQL, EngineVersion: "8.0.44", MysqlLowerCaseTableNames: proto.Int32(1)},
+		mapping,
+		NamespaceConfig{Catalog: "def", SearchPath: []string{"bom"}},
+	)
+	if !facts.GetResolved() {
+		t.Fatalf("lower_case_table_names=1 folds relation names, so this must resolve: %s", facts.GetDetail())
+	}
+	for _, src := range facts.GetSources() {
+		if src.GetSchema() != "bom" || src.GetTable() != "tb_user" {
+			t.Errorf("source carries %s.%s, want the folded bom.tb_user", src.GetSchema(), src.GetTable())
+		}
+	}
+}
+
+// The fold's whole point is an equivalence: two spellings the ENGINE calls the same must produce the
+// same facts, and two it calls distinct must not. Asserted on the emitted source identity, which is what
+// the control plane authorizes against.
+//
+// This guards OVER-reach specifically — a fold applied with the wrong dialect, or unconditionally, which
+// would merge relations the engine keeps distinct (lctn=0 relation names, PostgreSQL quoted identifiers)
+// and hand a query the wrong table's masks. It does NOT fail if the up-front fold is removed entirely:
+// on a RESOLVED statement Qualify folds again in VALIDATE, so these facts come out identical either way.
+// The under-reach direction is covered where it is actually observable — on the paths Qualify never
+// completes: [TestSchemaQualifierCandidatesFoldToTheStoredSpelling] (candidates from a statement whose
+// schema is absent) and [TestUpfrontFoldKeepsQualifierTrustQuoteAware] (a qualifier read before Qualify).
+func TestUpfrontFoldRespectsEngineEquivalence(t *testing.T) {
+	mysqlMapping, err := schemaMappingFromProto([]*pb.ColumnSpec{
+		columnSpec("def", "bom", "tb_user", "id", "BIGINT"),
+		columnSpec("def", "bom", "tb_user", "email", "VARCHAR"),
+	})
+	if err != nil {
+		t.Fatalf("build mysql schema: %v", err)
+	}
+	mysqlNs := NamespaceConfig{Catalog: "def", SearchPath: []string{"bom"}}
+	mysqlFacts := func(t *testing.T, sql string, lctn int32) *pb.StatementFacts {
+		t.Helper()
+		return EmitFacts(sql, &pb.EngineConfig{
+			Engine: pb.Engine_MYSQL, EngineVersion: "8.0.44",
+			MysqlLowerCaseTableNames: proto.Int32(lctn),
+		}, mysqlMapping, mysqlNs)
+	}
+
+	// lower_case_table_names=1: relation names are case-insensitive, so the uppercase spelling is the
+	// SAME relation and must resolve to the same source identity.
+	folded := mysqlFacts(t, "SELECT id FROM BOM.TB_USER", 1)
+	plain := mysqlFacts(t, "SELECT id FROM bom.tb_user", 1)
+	if !folded.GetResolved() || !plain.GetResolved() {
+		t.Fatalf("both spellings must resolve under lctn=1: %q / %q", folded.GetDetail(), plain.GetDetail())
+	}
+	if got, want := sourceKeys(folded), sourceKeys(plain); !equalStrings(got, want) {
+		t.Errorf("lctn=1 treats these as one relation, so sources must match: %v vs %v", got, want)
+	}
+
+	// lower_case_table_names=0: table/db names are case-SENSITIVE, so BOM.TB_USER is a relation that
+	// does not exist. Folding it would invent a resolution the target DB would reject.
+	if sensitive := mysqlFacts(t, "SELECT id FROM BOM.TB_USER", 0); sensitive.GetResolved() {
+		t.Errorf("lctn=0 is case-sensitive for relation names, so this must NOT resolve, got sources %v",
+			sourceKeys(sensitive))
+	}
+
+	// A MySQL COLUMN is case-insensitive even under lctn=0, so the fold must still reach column names —
+	// the case an lctn-gated relation fold would miss.
+	upperCol := mysqlFacts(t, "SELECT ID FROM bom.tb_user", 0)
+	lowerCol := mysqlFacts(t, "SELECT id FROM bom.tb_user", 0)
+	if !upperCol.GetResolved() {
+		t.Fatalf("a MySQL column is case-insensitive at every lctn mode: %s", upperCol.GetDetail())
+	}
+	if got, want := readKeys(upperCol), readKeys(lowerCol); !equalStrings(got, want) {
+		t.Errorf("column case must not change the traced column: %v vs %v", got, want)
+	}
+}
+
+// PostgreSQL folds unquoted identifiers at DDL time and keeps quoted ones verbatim, so a quoted and an
+// unquoted relation of the same letters are genuinely TWO tables. Folding them together would merge two
+// catalog rows into one key and mask (or expose) the wrong column.
+func TestUpfrontFoldKeepsPostgresQuotedRelationsDistinct(t *testing.T) {
+	mapping, err := schemaMappingFromProto([]*pb.ColumnSpec{
+		columnSpec("acme", "public", "mixedcase", "id", "BIGINT"),
+		columnSpec("acme", "public", "MixedCase", "id", "BIGINT"),
+	})
+	if err != nil {
+		t.Fatalf("build schema: %v", err)
+	}
+	pg := &pb.EngineConfig{Engine: pb.Engine_POSTGRES, EngineVersion: "16.0"}
+	ns := NamespaceConfig{Catalog: "acme", SearchPath: []string{"public"}}
+
+	// Unquoted folds to the lowercase table; quoted resolves to the case-preserved one.
+	unquoted := EmitFacts(`SELECT id FROM MixedCase`, pg, mapping, ns)
+	quoted := EmitFacts(`SELECT id FROM "MixedCase"`, pg, mapping, ns)
+	if !unquoted.GetResolved() || !quoted.GetResolved() {
+		t.Fatalf("both relations exist: %q / %q", unquoted.GetDetail(), quoted.GetDetail())
+	}
+	if got, want := sourceKeys(unquoted), []string{"acme.public.mixedcase"}; !equalStrings(got, want) {
+		t.Errorf("an unquoted PostgreSQL relation folds: got %v, want %v", got, want)
+	}
+	if got, want := sourceKeys(quoted), []string{"acme.public.MixedCase"}; !equalStrings(got, want) {
+		t.Errorf("a quoted PostgreSQL relation keeps its case: got %v, want %v", got, want)
+	}
+}
+
+func sourceKeys(facts *pb.StatementFacts) []string {
+	out := make([]string, 0, len(facts.GetSources()))
+	for _, src := range facts.GetSources() {
+		out = append(out, src.GetCatalog()+"."+src.GetSchema()+"."+src.GetTable())
+	}
+	sort.Strings(out)
+	return out
+}
+
+func readKeys(facts *pb.StatementFacts) []string {
+	out := []string{}
+	for _, grant := range facts.GetResultReads() {
+		if col := grant.GetColumn(); col != nil {
+			id := col.GetIdentity()
+			out = append(out, id.GetSchema()+"."+id.GetTable()+"."+id.GetColumn())
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/analyzer/probe/schema_candidate_case_test.go
+++ b/analyzer/probe/schema_candidate_case_test.go
@@ -1,0 +1,47 @@
+package probe
+
+import (
+	"slices"
+	"testing"
+
+	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
+	"google.golang.org/protobuf/proto"
+)
+
+// A schema qualifier is emitted so the control plane can FETCH that schema when the connection does not
+// hold it. MySQL under lower_case_table_names=1 stores information_schema lowercase, so a raw uppercase
+// candidate matches zero rows: the fetch records an empty fragment as held, and the retry relays the
+// statement unanalyzed — unmasked. The candidate must therefore carry the spelling the target DB stores.
+func TestSchemaQualifierCandidatesFoldToTheStoredSpelling(t *testing.T) {
+	mapping, err := schemaMappingFromProto([]*pb.ColumnSpec{
+		columnSpec("def", "bom", "tb_user", "id", "BIGINT"),
+	})
+	if err != nil {
+		t.Fatalf("build schema: %v", err)
+	}
+	for _, tc := range []struct {
+		lowerCaseTableNames int32
+		want                string
+	}{
+		// Mode 0 is case-sensitive: the stored spelling IS the raw one, so folding would break the fetch.
+		{0, "GOODS_STORE"},
+		{1, "goods_store"},
+		{2, "goods_store"},
+	} {
+		facts := EmitFacts(
+			"SELECT id FROM GOODS_STORE.orders",
+			&pb.EngineConfig{
+				Engine:                   pb.Engine_MYSQL,
+				EngineVersion:            "8.0.44",
+				MysqlLowerCaseTableNames: proto.Int32(tc.lowerCaseTableNames),
+			},
+			mapping,
+			NamespaceConfig{Catalog: "def", SearchPath: []string{"bom"}},
+		)
+		got := facts.GetSchemaQualifierCandidates()
+		if !slices.Contains(got, tc.want) {
+			t.Errorf("lower_case_table_names=%d: want candidate %q for the refetch, got %v",
+				tc.lowerCaseTableNames, tc.want, got)
+		}
+	}
+}


### PR DESCRIPTION
Qualify normalizes identifiers as its own first step (`optimizer.Qualify` → `NormalizeIdentifiers`), so everything downstream of VALIDATE already read canonical spellings. But Qualify needs the catalog and runs only on the analyzed path, so every consumer outside it re-derived the same fold by hand on its own defensive copy — `isTrustedSystemQualifier`, `qualifiedCallName`, and `IsTempSchema` each parsed and normalized their own identifier again.

Fold once in `EmitFacts`, right after the statement is unwrapped, and let all three read the spelling that is already canonical. The rule is unchanged: `NormalizeIdentifiers` walks the tree applying the same dialect `NormalizeIdentifier` those call sites called, so it stays quote-aware — unquoted `PG_CATALOG` folds to the trusted `pg_catalog` while quoted `"PG_CATALOG"` keeps its case as the distinct user schema PostgreSQL allows, and `"MySchema".fn` stays distinct from `myschema.fn`.

Trusted-qualifier knowledge moves onto the engine, beside `IsTempSchema` — the same shape it already had, a per-engine predicate over a schema identifier. That replaces an `eng.Type() != POSTGRES` branch at the call site with dispatch.

## Where this could bite

The fold now touches every identifier in every statement, on a fail-closed path. The property that makes it safe is quote-awareness, and two authorization decisions rest on it: `pg_catalog` trust (a quoted `"PG_CATALOG"` must NOT inherit a system builtin's pass) and a call's emitted identity (`"MySchema".fn` must not collapse onto `myschema.fn`). Both are asserted against the engine predicates directly.

Also lands direct coverage for `AnalyzeStatement` / `AnalyzeStatementSafe`, which had none — the tests named for them drove `Probe` through a helper that reimplemented their decode, so the decode boundary and the cgo-totality contract were never exercised.

## Verification

`mise run verify` equivalent: analyzer + goproxy Go suites, `:control-plane:test`, lint — all green. Mutation-checked: folding with the wrong (always case-insensitive) dialect fails five tests across both engines; a naive `strings.ToLower` in either engine predicate fails the quote-awareness tests.

Prerequisite for a cross-schema masking fix that follows; landing it separately keeps that diff to the security change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UQtbMqbC15KdiaSFfJnqK