### PR TITLE
fix(control-plane): refetch an unheld schema before relaying it unanalyzed

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ConnectionDecide.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/ConnectionDecide.kt
@@ -120,7 +120,12 @@ suspend fun decideConnection(
         ctx
     }
     val afterStatement = if (effectiveCtx.action != EnfAction.DENY && effectiveCtx.catalogChanging) {
-        core.connectionCatalog.markAfterStatement(connection, required + effectiveCtx.referencedSchemas)
+        // schemaCandidates too: DDL reads no column, so its target schema appears in no source or read
+        // grant, and a cross-schema `ALTER` would leave the schema it just changed held and stale.
+        core.connectionCatalog.markAfterStatement(
+            connection,
+            required + effectiveCtx.referencedSchemas + effectiveCtx.schemaCandidates,
+        )
     } else {
         emptyList()
     }

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -647,6 +647,9 @@ fun decideQuery(
                 contextTags = derivedTags,
                 catalogChanging = facts.catalogChanging || facts.functionsList.isNotEmpty(),
                 schemaCandidates = facts.schemaQualifierCandidatesList.toSet(),
+                // A statement may be unresolvable only because this connection never fetched the schema it
+                // names, so refetch the qualifiers before relaying it unmasked.
+                catalogMiss = true,
             )
             is AuthzDecision.Deny -> deny(reason, catalogMiss = true)
         }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PerConnectionCatalogAdversarialDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PerConnectionCatalogAdversarialDbTest.kt
@@ -4,6 +4,7 @@ import com.ridi.oss.proxymonster.grpc.EnfAction
 import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
 import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
 import com.ridi.oss.proxymonster.controlplane.support.PerConnectionCatalogFixture
+import com.ridi.oss.proxymonster.controlplane.support.SharedMySql
 import com.ridi.oss.proxymonster.controlplane.support.requireDocker
 import com.ridi.oss.proxymonster.grpc.schemaFragmentPush
 import kotlinx.coroutines.runBlocking
@@ -67,6 +68,10 @@ abstract class PerConnectionCatalogAdversarialDbContract {
     protected fun qualified(schema: String, table: String): String =
         if (fixture.datasource.engine.isMySql) "`$schema`.`$table`" else "\"$schema\".\"$table\""
 
+    /** A second schema on the target, holding its own `accounts` table; null when the engine fixture has
+     *  only one (the test that needs it then skips rather than asserting on a shape that does not exist). */
+    protected open fun secondSchema(): String? = null
+
     protected fun userSchema(): String = if (fixture.datasource.engine.isMySql) {
         fixture.datasource.dbName
     } else {
@@ -99,6 +104,40 @@ abstract class PerConnectionCatalogAdversarialDbContract {
             val blocked = decide(opened, "writer@example.com", "SELECT id FROM users", listOf(schema))
             assertIs<EnforcementOutcome.BeforeDecide>(blocked)
             assertEquals(afterDdl, auditCount(), "before_decide must not create an audit verdict")
+        }
+    }
+
+    // The cross-schema leak in its real shape: the connection holds only its search-path schema, and the
+    // statement names a SECOND schema that exists on the target. That statement cannot resolve against a
+    // catalog missing the schema, so it reaches the exception.unanalyzable gate — which relays VERBATIM AND
+    // UNMASKED. Nothing about it is unanalyzable except the absent catalog, so the decision must first ask
+    // for that schema and only then stand. Driven through decideConnection (not decideQuery) because the
+    // partial per-connection catalog IS the bug; a decideQuery test sees the whole stored catalog and can
+    // never observe it.
+    @Test
+    fun `a statement naming an unheld schema refetches it instead of relaying unmasked`() = runBlocking {
+        val second = secondSchema() ?: return@runBlocking
+        target().use { connectionTarget ->
+            val schema = userSchema()
+            val opened = openAndPush(connectionTarget, "analyst@example.com", listOf(schema))
+
+            val first = decide(opened, "analyst@example.com", "SELECT id FROM ${qualified(second, "accounts")}", listOf(schema))
+            val refetch = assertIs<EnforcementOutcome.BeforeDecide>(
+                first,
+                "an unheld schema must be requested, not relayed on a catalog that never held it",
+            )
+            assertContains(refetch.commands.map { it.schema }, second, "the unheld schema must be the one requested")
+
+            // Satisfy the refetch exactly as the proxy would, then re-decide: the statement now resolves, so
+            // the verdict is the column policy's — never the unmasked relay.
+            fixture.pushFromTarget(connectionTarget, opened.connectionId, second)
+            val retried = assertIs<EnforcementOutcome.Verdict>(
+                decide(opened, "analyst@example.com", "SELECT id FROM ${qualified(second, "accounts")}", listOf(schema)),
+            )
+            assertFalse(
+                retried.ctx.passthrough,
+                "after the refetch the statement resolves, so it must not relay as an unanalyzable passthrough",
+            )
         }
     }
 
@@ -195,6 +234,13 @@ abstract class PerConnectionCatalogAdversarialDbContract {
 class PerConnectionCatalogMysqlAdversarialDbTest : PerConnectionCatalogAdversarialDbContract() {
     override fun createEnforcement() = EnforcementFixture.mysql()
 
+    // A MySQL "database" IS a schema, so a second one is what makes a cross-schema statement — the shape a
+    // single-schema fixture cannot express — reachable on the priority engine. SharedMySql creates it and
+    // grants the test user, which the datasource's own non-root credentials cannot do.
+    private val second: String by lazy { SharedMySql.freshDatabase("pccat_second") }
+
+    override fun secondSchema() = second
+
     override fun configureFlagship() {
         val schema = enforcement.datasource.dbName
         target().use { c ->
@@ -202,6 +248,8 @@ class PerConnectionCatalogMysqlAdversarialDbTest : PerConnectionCatalogAdversari
                 st.execute("DROP TABLE IF EXISTS `$schema`.accounts")
                 st.execute("CREATE TABLE `$schema`.accounts (id BIGINT PRIMARY KEY)")
                 st.execute("INSERT INTO `$schema`.accounts VALUES (1)")
+                st.execute("CREATE TABLE `$second`.accounts (id BIGINT PRIMARY KEY)")
+                st.execute("INSERT INTO `$second`.accounts VALUES (2)")
                 st.execute("DROP PROCEDURE IF EXISTS pccat_refresh")
                 st.execute("CREATE PROCEDURE pccat_refresh() SELECT 1")
             }
@@ -332,6 +380,8 @@ class PerConnectionCatalogMysqlAdversarialDbTest : PerConnectionCatalogAdversari
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PerConnectionCatalogPostgresAdversarialDbTest : PerConnectionCatalogAdversarialDbContract() {
     override fun createEnforcement() = EnforcementFixture.postgres()
+
+    override fun secondSchema() = "restricted"
 
     override fun configureFlagship() {
         target().use { c ->

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/UnanalyzableGateDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/UnanalyzableGateDbTest.kt
@@ -63,5 +63,31 @@ class UnanalyzableGateDbTest {
         assertTrue(permitted.passthrough, "an unanalyzable relay is a verbatim passthrough (no rewrite, no masks)")
         assertTrue(permitted.masks.isEmpty(), "no masks are applied to an unanalyzable relay")
         assertTrue(permitted.detail?.contains("exception.unanalyzable") == true, "the ALLOW is attributed to the exception: ${permitted.detail}")
+        // Both verdicts must ask for a refetch first. A cross-schema statement whose qualifier this connection
+        // never fetched is unresolvable for that reason alone, and reaches this gate indistinguishable from a
+        // genuinely unanalyzable one — so without catalogMiss the relay stands on a catalog that never held
+        // the schema, and every column the analyzer would have masked is relayed in the clear.
+        assertTrue(floor.catalogMiss, "the deny carries catalogMiss so decideConnection refetches + retries first")
+        assertTrue(permitted.catalogMiss, "the relay carries catalogMiss so refetch-first runs before it stands")
+    }
+
+    // The cross-schema case the flag exists for, driven through the REAL analyzer rather than a synthetic
+    // failure: a statement qualifying a schema absent from the decision's catalog resolves nowhere, so it
+    // lands on the unanalyzable gate carrying that schema as a refetch candidate.
+    @Test
+    fun `a statement naming an unheld schema asks for that schema before relaying`() {
+        val candidate = "goods_store"
+        // Assert the premise rather than assume it: were this schema ever added to the fixture, the statement
+        // would resolve and the test would pass without exercising the gate at all.
+        assertTrue(
+            fx.datasourceStore.catalog(fx.datasource.id).none { it.schema == candidate },
+            "the probe schema must be absent from the catalog for this test to mean anything",
+        )
+        val ctx = decide("select id from $candidate.orders")
+        assertTrue(ctx.catalogMiss, "an unheld-schema statement must request a refetch, not stand on the partial catalog")
+        assertTrue(
+            candidate in ctx.schemaCandidates,
+            "the unheld schema must be named for the refetch, got ${ctx.schemaCandidates}",
+        )
     }
 }


### PR DESCRIPTION
Stacked on #257 — targets that branch so the diff is just these two commits. Will be retargeted to `main` before #257 merges.

## The leak

A wire/editor decision analyzes against the **connection's held schemas** (`decideConnection`), not the datasource's whole stored catalog, and the pre-gate derives what to hold from the session's search path alone — for MySQL just `DATABASE()`. So a statement qualifying any other schema resolves nowhere: `select id from goods_store.orders` on a `bom` session fails VALIDATE with "unknown table def.goods_store.orders", lands on the `exception.unanalyzable` gate, and **relays verbatim and unmasked**. The analyzer never saw the columns it would have masked, so the audit records it with no PII touched and no masked columns.

Confirmed live on dev before the fix: a real customer name, phone, and address returned in the clear with `PII TOUCHED: —`.

## The fix

One line. The refetch machinery already existed and was already wired — `decideConnection` reads `ctx.catalogMiss` and re-fetches every `schemaCandidate` not already held-and-fresh, then re-decides. This branch carried the candidates but never raised the flag, leaving that path dead. The sibling uncovered-column relay 40 lines below already sets `catalogMiss` on its ALLOW, and `CatalogCoverageGateDbTest` asserts it: two verdicts through the same escape hatch disagreed on whether to refetch first.

Termination: a fetched schema becomes held-and-fresh — including a nonexistent one, whose empty fragment is recorded like any other — and held-and-fresh candidates are excluded, so each schema is asked for at most once and the relay then stands. A failed probe fails closed; the proxy caps `before_decide` at 3 rounds as a backstop.

The second commit fixes a pre-existing bug in the same class, found in review: DDL reads no column, so a cross-schema `ALTER` re-measured only the session's own schema and left the one it just changed held and stale.

## Where this could bite

A statement that parses and names an unheld schema now costs one extra round trip before its verdict stands. Parse failures carry no candidates, so they are unaffected.

## Verification

Regression drives `decideConnection`, not `decideQuery` — the partial per-connection catalog *is* the bug, and a `decideQuery` test sees the whole stored catalog and can never observe it. Hold one schema, select from another, assert the refetch is requested, satisfy it as the proxy would, assert the retried verdict is no longer a passthrough. Both engines. **Verified by mutation: reverting the flag fails these tests on both.**

Also verified end-to-end on a live stack: after the fix the same query records `detail=ok` with all three cross-schema PII columns listed, instead of the unanalyzable relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UQtbMqbC15KdiaSFfJnqK