### PR TITLE
build(web): commit the agent files next dev regenerates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,3 +18,9 @@ control-plane/src/test/resources/atrail/
 # repo's style would be undone on the next release, and the mismatch fails `verify` on every release PR.
 CHANGELOG.md
 **/CHANGELOG.md
+
+# Rewritten unwrapped by `next dev` on every start (next/dist/server/lib/generate-agent-files.js), so
+# wrapping them to proseWrap:always is undone the next time anyone runs the console — same bind as the
+# release-please files above.
+web/AGENTS.md
+web/CLAUDE.md

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
`next dev` writes `web/AGENTS.md` and `web/CLAUDE.md` on every start — `app-info-log.js` (the module behind the `▲ Next.js` startup banner) calls `generate-agent-files.js`, which `writeFileSync`s both unconditionally. So anyone who runs the console gets an untracked pair and a dirty tree.

Deleting them is futile; the next `next dev` puts them back. The generated block says so itself and recommends committing:

> This block is written and re-added by `next dev` … Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.

The content is Next.js 16's warning to coding agents that its APIs differ from their training data, pointing at `node_modules/next/dist/docs/`. It's marker-delimited (`BEGIN`/`END:nextjs-agent-rules`) and rewritten in place, so a Next upgrade updates the block rather than conflicting with it.

## Worth knowing

`web/CLAUDE.md` is one line — `@AGENTS.md` — so it now auto-loads for agent sessions working under `web/`, alongside the repo-root `CLAUDE.md`/`AGENTS.md`. That's a small addition to session context, and it's Vercel-authored rather than ours. The alternative was gitignoring both, which keeps them out of the repo but leaves them untracked forever; committing is what upstream intends.

10 lines, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UQtbMqbC15KdiaSFfJnqK