### PR TITLE
fix(pmon): stabilize daemon control sockets

### DIFF
--- a/pmon/README.md
+++ b/pmon/README.md
@@ -77,7 +77,7 @@ pmon CLI ──┐                        ┌── menu-bar app
            │  connect → else spawn detached → wait for socket
            ▼                        ▼
       pmon daemon  (detached; survives whichever peer started it)
-        ├─ daemon.sock  /status /login /logout /reload /shutdown /events
+        ├─ /tmp/pmon-<uid>/pmon-<hash>.sock  control API
         ├─ daemon.pid   flock: single-instance + liveness
         ├─ 127.0.0.1:6100+  one listener per datasource
         └─ config.json  the daemon is the sole writer

--- a/pmon/control/api.go
+++ b/pmon/control/api.go
@@ -2,9 +2,7 @@
 // the tray are SYMMETRIC peers over this API: neither is privileged, both can start and stop the daemon, and
 // both work when it is down. All state and logic live in the daemon; a peer holds none.
 //
-// Transport is a unix socket in the state directory. Not a loopback TCP port: this API can start a login
-// flow, and a localhost port is reachable from any web page in the user's browser. The socket's directory is
-// created 0700, so filesystem permissions ARE the authentication — only the same OS user can connect.
+// Transport is a Unix socket under a per-user 0700 directory, so only the same OS user can connect.
 package control
 
 // Status is the daemon's whole observable state, and the only thing a peer renders. Live listener facts come

--- a/pmon/control/client.go
+++ b/pmon/control/client.go
@@ -31,15 +31,27 @@ type Client struct {
 // NewClient dials the socket lazily per request — so a Client constructed while the daemon is down starts
 // working the moment one comes up, with no reconstruction.
 func NewClient() (*Client, error) {
-	sock, err := state.SocketPath()
+	sockets, err := state.SocketPaths()
 	if err != nil {
 		return nil, err
 	}
 	return &Client{http: &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				var d net.Dialer
-				return d.DialContext(ctx, "unix", sock)
+				var dialErr error
+				for _, socket := range sockets {
+					var d net.Dialer
+					conn, err := d.DialContext(ctx, "unix", socket)
+					if err != nil {
+						dialErr = err
+						if ctx.Err() != nil || !isDialFailure(err) {
+							return nil, err
+						}
+						continue
+					}
+					return conn, nil
+				}
+				return nil, dialErr
 			},
 		},
 	}}, nil

--- a/pmon/control/control_test.go
+++ b/pmon/control/control_test.go
@@ -151,8 +151,123 @@ func TestStatusRoundTrips(t *testing.T) {
 	}
 }
 
-// TestSocketIsOwnerOnly locks the control API's whole authentication model: there is no token, so the socket's
-// mode (inside a 0700 dir) is what keeps another OS user out.
+func TestReleasedClientPathReachesNewDaemon(t *testing.T) {
+	backend := newFakeBackend()
+	serve(t, backend)
+	paths, err := state.SocketPaths()
+	if err != nil {
+		t.Fatalf("SocketPaths: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("SocketPaths = %v, want canonical and released paths", paths)
+	}
+	info, err := os.Lstat(paths[1])
+	if err != nil {
+		t.Fatalf("Lstat released path: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("released path mode = %v, want symlink", info.Mode())
+	}
+	if target, err := os.Readlink(paths[1]); err != nil || target != paths[0] {
+		t.Fatalf("released path target = %q, %v; want %q", target, err, paths[0])
+	}
+
+	resp, err := unixHTTPClient(paths[1]).Get("http://pmon" + PathStatus)
+	if err != nil {
+		t.Fatalf("GET status through released path: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET status through released path = HTTP %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestNewClientReachesReleasedDaemonPath(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	if _, err := state.EnsureDir(); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	held, err := state.AcquirePidLock()
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
+	}
+	t.Cleanup(state.ReleasePidLock)
+	paths, err := state.SocketPaths()
+	if err != nil {
+		t.Fatalf("SocketPaths: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("SocketPaths = %v, want canonical and released paths", paths)
+	}
+	ln, err := net.Listen("unix", paths[1])
+	if err != nil {
+		t.Fatalf("listen on released path: %v", err)
+	}
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, Status{Principal: "released-daemon"})
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	client, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	status, err := client.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status through released daemon path: %v", err)
+	}
+	if status.Principal != "released-daemon" {
+		t.Errorf("Status principal = %q, want released-daemon", status.Principal)
+	}
+}
+
+func TestBlockedReleasedPathDoesNotDisableCanonicalSocket(t *testing.T) {
+	t.Setenv("PMON_CONFIG_DIR", t.TempDir())
+	if _, err := state.EnsureDir(); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	paths, err := state.SocketPaths()
+	if err != nil {
+		t.Fatalf("SocketPaths: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("SocketPaths = %v, want canonical and released paths", paths)
+	}
+	if err := os.Mkdir(paths[1], 0o700); err != nil {
+		t.Fatalf("Mkdir released path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(paths[1], "blocked"), nil, 0o600); err != nil {
+		t.Fatalf("seed blocked released path: %v", err)
+	}
+	held, err := state.AcquirePidLock()
+	if err != nil || !held {
+		t.Fatalf("AcquirePidLock = %v, %v; want true, nil", held, err)
+	}
+	t.Cleanup(state.ReleasePidLock)
+
+	server, err := Listen(newFakeBackend())
+	if err != nil {
+		t.Fatalf("Listen with blocked released path: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = server.Serve(ctx); close(done) }()
+	t.Cleanup(func() {
+		cancel()
+		server.Close()
+		<-done
+	})
+	client, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if _, err := client.Status(context.Background()); err != nil {
+		t.Fatalf("Status through canonical socket: %v", err)
+	}
+}
+
+// The socket mode and its 0700 parent directory authenticate the control API.
 func TestSocketIsOwnerOnly(t *testing.T) {
 	serve(t, newFakeBackend())
 

--- a/pmon/control/server.go
+++ b/pmon/control/server.go
@@ -35,37 +35,44 @@ type Backend interface {
 type Server struct {
 	backend Backend
 	ln      net.Listener
+	sockets []string
 	srv     *http.Server
 }
 
-// Listen binds the control socket, recovering from a stale one left by a killed daemon.
-//
-// A crashed daemon leaves the socket file behind, so bind fails with EADDRINUSE. The disambiguation is the
-// pid lock, not a connect probe: this is called by a daemon that has ALREADY taken the lock, so any socket
-// file present now is necessarily stale and safe to unlink.
+// Listen binds the control socket, recovering from stale paths after the caller takes the daemon lock.
 func Listen(backend Backend) (*Server, error) {
 	if _, err := state.EnsureDir(); err != nil {
 		return nil, err
 	}
-	sock, err := state.SocketPath()
+	sockets, err := state.SocketPaths()
 	if err != nil {
 		return nil, err
 	}
-	if err := os.Remove(sock); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("could not clear the stale control socket %s: %w", sock, err)
+	canonical := sockets[0]
+	if err := os.Remove(canonical); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("could not clear the stale control socket %s: %w", canonical, err)
 	}
-	ln, err := net.Listen("unix", sock)
+	ln, err := net.Listen("unix", canonical)
 	if err != nil {
-		return nil, fmt.Errorf("listen %s: %w", sock, err)
+		return nil, fmt.Errorf("listen %s: %w", canonical, err)
 	}
-	// Belt to the directory's 0700: even if the directory mode were loosened, the socket itself stays
-	// owner-only. Together with the directory, this IS the control API's authentication.
-	if err := os.Chmod(sock, 0o600); err != nil {
+	if err := os.Chmod(canonical, 0o600); err != nil {
 		ln.Close()
-		return nil, fmt.Errorf("chmod %s: %w", sock, err)
+		os.Remove(canonical)
+		return nil, fmt.Errorf("chmod %s: %w", canonical, err)
+	}
+	activeSockets := []string{canonical}
+	for _, alias := range sockets[1:] {
+		if err := os.Remove(alias); err != nil && !errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err := os.Symlink(canonical, alias); err != nil {
+			continue
+		}
+		activeSockets = append(activeSockets, alias)
 	}
 
-	s := &Server{backend: backend, ln: ln}
+	s := &Server{backend: backend, ln: ln, sockets: activeSockets}
 	mux := http.NewServeMux()
 	mux.HandleFunc(PathStatus, s.handleStatus)
 	mux.HandleFunc(PathLogin, s.handleLogin)
@@ -92,11 +99,15 @@ func (s *Server) Serve(ctx context.Context) error {
 	return err
 }
 
-// Close stops serving and removes the socket file.
+// Close stops serving and removes the socket paths.
 func (s *Server) Close() {
 	s.srv.Close()
-	if sock, err := state.SocketPath(); err == nil {
-		os.Remove(sock)
+	removeSockets(s.sockets)
+}
+
+func removeSockets(sockets []string) {
+	for _, socket := range sockets {
+		os.Remove(socket)
 	}
 }
 

--- a/pmon/state/state.go
+++ b/pmon/state/state.go
@@ -73,9 +73,7 @@ const localPasswordBytes = 24
 // (parallel dev worktrees), or to keep a test off the real user config dir.
 const dirEnv = "PMON_CONFIG_DIR"
 
-// Dir is the directory holding every piece of pmon state: the config, the pid lock, the control socket, and
-// the daemon log. Created 0700, which is also what protects the control socket — a peer is authenticated by
-// its ability to open the socket at all, so the directory mode IS the access control.
+// Dir is the directory holding pmon's config, pid lock, and daemon log.
 func Dir() (string, error) {
 	if d := os.Getenv(dirEnv); d != "" {
 		return d, nil
@@ -87,9 +85,7 @@ func Dir() (string, error) {
 	return filepath.Join(base, "proxy-monster"), nil
 }
 
-// EnsureDir creates the state directory 0700 and returns it. It also TIGHTENS a pre-existing directory that
-// is looser than 0700: MkdirAll's mode applies only on create, and this directory's mode is what keeps another
-// OS user away from the control socket and the config's bearer secrets.
+// EnsureDir creates the state directory 0700 and tightens a pre-existing directory that is looser.
 func EnsureDir() (string, error) {
 	d, err := Dir()
 	if err != nil {
@@ -104,7 +100,7 @@ func EnsureDir() (string, error) {
 	}
 	if perm := info.Mode().Perm(); perm&0o077 != 0 {
 		if err := os.Chmod(d, 0o700); err != nil {
-			return "", fmt.Errorf("could not tighten %s to 0700 (it is %o and holds the control socket): %w", d, perm, err)
+			return "", fmt.Errorf("could not tighten %s to 0700 (it is %o): %w", d, perm, err)
 		}
 	}
 	return d, nil
@@ -130,14 +126,63 @@ const ConfigName = "config.json"
 // Linux), minus room for the NUL. A bind past it fails with EINVAL, so the path is checked, never assumed.
 const maxSocketPath = 100
 
-// SocketPath is the daemon's control socket, which the CLI and the tray both drive.
-//
-// A unix socket path is length-limited by the kernel, and the state directory can be deep (a nested worktree,
-// a long PMON_CONFIG_DIR). When the in-directory path would not fit, this falls back to a short path in the
-// temp dir, named from a hash of the state directory — deterministic, so every peer derives the SAME path
-// without coordination. The fallback is created 0700 and owner-scoped, keeping the "only the same OS user can
-// connect" property that is this API's entire authentication.
-func SocketPath() (string, error) {
+const socketRoot = "/tmp"
+
+func SocketPath() (string, error) { return socketPathAt(socketRoot) }
+
+// SocketPaths returns the canonical path followed by paths used by released peers.
+func SocketPaths() ([]string, error) {
+	canonical, err := SocketPath()
+	if err != nil {
+		return nil, err
+	}
+	legacy, err := legacySocketPath()
+	if err != nil {
+		return []string{canonical}, nil
+	}
+	if sameSocketPath(canonical, legacy) {
+		return []string{canonical}, nil
+	}
+	return []string{canonical, legacy}, nil
+}
+
+func sameSocketPath(a, b string) bool {
+	if a == b {
+		return true
+	}
+	if filepath.Base(a) != filepath.Base(b) {
+		return false
+	}
+	aDir, err := os.Stat(filepath.Dir(a))
+	if err != nil {
+		return false
+	}
+	bDir, err := os.Stat(filepath.Dir(b))
+	return err == nil && os.SameFile(aDir, bDir)
+}
+
+func socketPathAt(root string) (string, error) {
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+	dir, err = filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	short, err := socketDirAt(root, os.Getuid())
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(dir))
+	p := filepath.Join(short, fmt.Sprintf("pmon-%s.sock", hex.EncodeToString(sum[:8])))
+	if len(p) > maxSocketPath {
+		return "", fmt.Errorf("no control-socket path fits the %d-byte limit (tried %q)", maxSocketPath, p)
+	}
+	return p, nil
+}
+
+func legacySocketPath() (string, error) {
 	p, err := pathIn("daemon.sock")
 	if err != nil {
 		return "", err
@@ -149,35 +194,21 @@ func SocketPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	short, err := shortSocketDir()
+	short, err := socketDirAt(os.TempDir(), os.Getuid())
 	if err != nil {
 		return "", err
 	}
 	sum := sha256.Sum256([]byte(dir))
 	p = filepath.Join(short, fmt.Sprintf("pmon-%s.sock", hex.EncodeToString(sum[:8])))
 	if len(p) > maxSocketPath {
-		return "", fmt.Errorf("no control-socket path fits the %d-byte limit (tried %q)", maxSocketPath, p)
+		return "", fmt.Errorf("no compatible control-socket path fits the %d-byte limit (tried %q)", maxSocketPath, p)
 	}
 	return p, nil
 }
 
-// shortSocketDir is the owner-only directory holding fallback sockets, under the temp dir because that is the
-// only reliably-short writable path.
-//
-// The temp dir is usually world-writable + sticky (/tmp on Linux; macOS gives each user a private one), so a
-// pre-existing entry cannot be trusted: MkdirAll succeeds on ANY existing directory regardless of its owner or
-// mode, which would let another local user own the path where a login-capable socket lands. So the directory is
-// VERIFIED after creation — owned by us, and not group/other-accessible — and a failure is fatal rather than
-// silently accepted. A symlink is rejected too (Lstat, not Stat), so it cannot be redirected somewhere the
-// attacker controls.
-func shortSocketDir() (string, error) {
-	return shortSocketDirFor(os.Getuid())
-}
-
-// shortSocketDirFor is [shortSocketDir] with the expected owner injected, so the ownership refusal is testable
-// (a test cannot chown a directory to another user).
-func shortSocketDirFor(wantUID int) (string, error) {
-	d := filepath.Join(os.TempDir(), fmt.Sprintf("pmon-%d", os.Getuid()))
+// Socket directories must be owned by the current user, mode 0700, and not symlinks.
+func socketDirAt(root string, wantUID int) (string, error) {
+	d := filepath.Join(root, fmt.Sprintf("pmon-%d", os.Getuid()))
 	if err := os.MkdirAll(d, 0o700); err != nil {
 		return "", err
 	}
@@ -198,10 +229,9 @@ func shortSocketDirFor(wantUID int) (string, error) {
 	if int(st.Uid) != wantUID {
 		return "", fmt.Errorf("control-socket directory %s is owned by uid %d, not %d; refusing to use it", d, st.Uid, wantUID)
 	}
-	if perm := info.Mode().Perm(); perm&0o077 != 0 {
-		// Ours, but loose — tighten it. Safe now that ownership is proven.
+	if perm := info.Mode().Perm(); perm != 0o700 {
 		if err := os.Chmod(d, 0o700); err != nil {
-			return "", fmt.Errorf("could not tighten the control-socket directory %s (it is %o): %w", d, perm, err)
+			return "", fmt.Errorf("could not set the control-socket directory %s to 0700 (it is %o): %w", d, perm, err)
 		}
 	}
 	return d, nil

--- a/pmon/state/state_test.go
+++ b/pmon/state/state_test.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -145,8 +147,7 @@ func TestLoggedInRequiresTokenAndControlPlane(t *testing.T) {
 	}
 }
 
-// TestEnsureDirIsOwnerOnly locks the property the control socket's security rests on: the state directory is
-// 0700, so only the same OS user can reach the socket inside it.
+// The state directory holds bearer credentials and must stay owner-only.
 func TestEnsureDirIsOwnerOnly(t *testing.T) {
 	t.Setenv(dirEnv, filepath.Join(t.TempDir(), "nested", "proxy-monster"))
 	dir, err := EnsureDir()
@@ -186,99 +187,197 @@ func TestEnsureDirTightensALooseExistingDir(t *testing.T) {
 	}
 }
 
-// TestSocketPathFitsTheKernelLimit covers the case a deep worktree hits for real: a unix socket path longer
-// than sun_path fails to bind with EINVAL, so SocketPath must fall back to a short path rather than hand back
-// one the daemon cannot listen on.
-func TestSocketPathFitsTheKernelLimit(t *testing.T) {
-	// A state dir well past the limit on its own.
-	deep := filepath.Join(t.TempDir(), strings.Repeat("nested-directory-segment/", 8), "proxy-monster")
-	t.Setenv(dirEnv, deep)
+func TestSocketPathAlwaysUsesFixedOwnerDirectory(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "proxy-monster")
+	t.Setenv(dirEnv, stateDir)
+	root := t.TempDir()
 
-	sock, err := SocketPath()
+	sock, err := socketPathAt(root)
 	if err != nil {
-		t.Fatalf("SocketPath for a deep state dir: %v", err)
+		t.Fatalf("socketPathAt: %v", err)
+	}
+	wantDir := filepath.Join(root, fmt.Sprintf("pmon-%d", os.Getuid()))
+	if got := filepath.Dir(sock); got != wantDir {
+		t.Errorf("socket directory = %q, want %q", got, wantDir)
 	}
 	if len(sock) > maxSocketPath {
 		t.Errorf("socket path is %d bytes (%q), over the %d-byte limit", len(sock), sock, maxSocketPath)
 	}
-	// Deterministic: every peer must derive the same path from the same state dir, with no coordination.
-	again, err := SocketPath()
+
+	t.Setenv("TMPDIR", t.TempDir())
+	again, err := socketPathAt(root)
 	if err != nil {
-		t.Fatalf("SocketPath (second call): %v", err)
+		t.Fatalf("socketPathAt with a different TMPDIR: %v", err)
 	}
 	if again != sock {
-		t.Errorf("SocketPath is not deterministic: %q then %q", sock, again)
-	}
-	// A different state dir must NOT collide with it.
-	t.Setenv(dirEnv, filepath.Join(t.TempDir(), strings.Repeat("another-long-directory/", 8), "proxy-monster"))
-	other, err := SocketPath()
-	if err != nil {
-		t.Fatalf("SocketPath for a second deep dir: %v", err)
-	}
-	if other == sock {
-		t.Error("two different state dirs derived the same fallback socket path")
+		t.Errorf("socket path changed with TMPDIR: %q then %q", sock, again)
 	}
 
-	// The fallback's directory is owner-only, which is this API's whole authentication.
+	t.Setenv(dirEnv, filepath.Join(t.TempDir(), "proxy-monster"))
+	other, err := socketPathAt(root)
+	if err != nil {
+		t.Fatalf("socketPathAt for a second state directory: %v", err)
+	}
+	if other == sock {
+		t.Error("two state directories derived the same socket path")
+	}
+
 	info, err := os.Stat(filepath.Dir(sock))
 	if err != nil {
-		t.Fatalf("Stat fallback socket dir: %v", err)
+		t.Fatalf("Stat socket directory: %v", err)
 	}
 	if perm := info.Mode().Perm(); perm != 0o700 {
-		t.Errorf("fallback socket dir perm = %o, want 0700", perm)
+		t.Errorf("socket directory mode = %o, want 0700", perm)
 	}
 }
 
-// TestShortSocketDirRefusesADirectoryOwnedByAnotherUser is the multi-user half of the fallback's safety. The
-// temp dir is world-writable + sticky on Linux and the directory name is predictable, so another local user can
-// pre-create it; MkdirAll succeeds on ANY existing directory regardless of owner, which would put a
-// login-capable socket in a path someone else controls. Ownership must be verified, and a mismatch fatal.
-func TestShortSocketDirRefusesADirectoryOwnedByAnotherUser(t *testing.T) {
-	// root's uid (0) stands in for "not us" — a real attacker's dir is the same case. Skip when running AS root,
-	// where the check would legitimately pass.
+func TestSocketPathsIncludeReleasedLocation(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv(dirEnv, stateDir)
+
+	paths, err := SocketPaths()
+	if err != nil {
+		t.Fatalf("SocketPaths: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("SocketPaths = %v, want canonical and released paths", paths)
+	}
+	if paths[0] == paths[1] {
+		t.Fatalf("SocketPaths returned duplicate paths: %v", paths)
+	}
+	if want := filepath.Join(stateDir, "daemon.sock"); paths[1] != want {
+		t.Errorf("released socket path = %q, want %q", paths[1], want)
+	}
+}
+
+func TestSocketPathsPreserveReleasedLongLocation(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	stateDir := filepath.Join(strings.Repeat("long-state-dir/", 10), "proxy-monster")
+	t.Setenv(dirEnv, stateDir)
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+
+	paths, err := SocketPaths()
+	if err != nil {
+		t.Fatalf("SocketPaths: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("SocketPaths = %v, want canonical and released paths", paths)
+	}
+	sum := sha256.Sum256([]byte(stateDir))
+	want := filepath.Join(
+		tempRoot,
+		fmt.Sprintf("pmon-%d", os.Getuid()),
+		fmt.Sprintf("pmon-%s.sock", hex.EncodeToString(sum[:8])),
+	)
+	if paths[1] != want {
+		t.Errorf("released long socket path = %q, want %q", paths[1], want)
+	}
+}
+
+func TestSocketPathsDeduplicateEquivalentRoots(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), strings.Repeat("long-state-dir/", 10), "proxy-monster")
+	t.Setenv(dirEnv, stateDir)
+	aliasRoot := filepath.Join(t.TempDir(), "tmp-link")
+	if err := os.Symlink(socketRoot, aliasRoot); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	t.Setenv("TMPDIR", aliasRoot)
+
+	paths, err := SocketPaths()
+	if err != nil {
+		t.Fatalf("SocketPaths: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("SocketPaths = %v, want one path for equivalent roots", paths)
+	}
+}
+
+func TestSocketPathsIgnoreUnavailableReleasedLocation(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), strings.Repeat("long-state-dir/", 10), "proxy-monster")
+	t.Setenv(dirEnv, stateDir)
+	blockedTemp := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blockedTemp, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv("TMPDIR", blockedTemp)
+
+	paths, err := SocketPaths()
+	if err != nil {
+		t.Fatalf("SocketPaths: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("SocketPaths = %v, want canonical path only", paths)
+	}
+}
+
+func TestSocketPathDistinguishesRelativeStateDirsAcrossWorkingDirectories(t *testing.T) {
+	root := t.TempDir()
+	firstWD := filepath.Join(root, "first")
+	secondWD := filepath.Join(root, "second")
+	for _, dir := range []string{firstWD, secondWD} {
+		if err := os.Mkdir(dir, 0o700); err != nil {
+			t.Fatalf("Mkdir %s: %v", dir, err)
+		}
+	}
+	relativeStateDir := filepath.Join(strings.Repeat("long-state-dir/", 10), "proxy-monster")
+	t.Setenv(dirEnv, relativeStateDir)
+	shortRoot := "short"
+
+	t.Chdir(firstWD)
+	first, err := socketPathAt(shortRoot)
+	if err != nil {
+		t.Fatalf("SocketPath from first working directory: %v", err)
+	}
+	t.Chdir(secondWD)
+	second, err := socketPathAt(shortRoot)
+	if err != nil {
+		t.Fatalf("SocketPath from second working directory: %v", err)
+	}
+	if first == second {
+		t.Fatalf("relative state dirs in different working directories share %q", first)
+	}
+}
+
+func TestSocketDirEnforcesOwnerAndMode(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("running as root: uid 0 is not a foreign owner here")
 	}
 	tmp := t.TempDir()
-	t.Setenv("TMPDIR", tmp)
 	d := filepath.Join(tmp, fmt.Sprintf("pmon-%d", os.Getuid()))
 	if err := os.MkdirAll(d, 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	// A test cannot chown to another user, so drive the guard with a DIFFERENT expected owner — exactly the
-	// comparison it makes when an attacker pre-created the path. Without this the uid branch is never exercised
-	// and could be deleted with the suite still green.
-	if _, err := shortSocketDirFor(os.Getuid() + 1); err == nil {
+	if _, err := socketDirAt(tmp, os.Getuid()+1); err == nil {
 		t.Error("a directory owned by another uid was accepted; it must fail closed")
 	} else if !strings.Contains(err.Error(), "owned by uid") {
 		t.Errorf("refused with %q; want the ownership check to be what rejects it", err)
 	}
 
-	// Ours, so it is accepted — and tightened if loose.
-	if err := os.Chmod(d, 0o777); err != nil {
-		t.Fatalf("Chmod: %v", err)
-	}
-	got, err := shortSocketDir()
-	if err != nil {
-		t.Fatalf("shortSocketDir on our own dir: %v", err)
-	}
-	if got != d {
-		t.Errorf("shortSocketDir = %q, want %q", got, d)
-	}
-	after, err := os.Lstat(d)
-	if err != nil {
-		t.Fatalf("Lstat: %v", err)
-	}
-	if perm := after.Mode().Perm(); perm != 0o700 {
-		t.Errorf("perm = %o after shortSocketDir, want 0700 (a loose dir must be tightened)", perm)
+	for _, mode := range []os.FileMode{0o777, 0o500} {
+		if err := os.Chmod(d, mode); err != nil {
+			t.Fatalf("Chmod %o: %v", mode, err)
+		}
+		got, err := socketDirAt(tmp, os.Getuid())
+		if err != nil {
+			t.Fatalf("socketDirAt on mode %o: %v", mode, err)
+		}
+		if got != d {
+			t.Errorf("socketDir = %q, want %q", got, d)
+		}
+		after, err := os.Lstat(d)
+		if err != nil {
+			t.Fatalf("Lstat: %v", err)
+		}
+		if perm := after.Mode().Perm(); perm != 0o700 {
+			t.Errorf("mode = %o after socketDirAt, want 0700", perm)
+		}
 	}
 }
 
-// TestShortSocketDirRefusesASymlink: a symlink at the predictable path would redirect the socket somewhere the
-// attacker controls, so it must be rejected rather than followed.
-func TestShortSocketDirRefusesASymlink(t *testing.T) {
+func TestSocketDirRefusesASymlink(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("TMPDIR", tmp)
 	target := filepath.Join(tmp, "elsewhere")
 	if err := os.MkdirAll(target, 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
@@ -288,28 +387,24 @@ func TestShortSocketDirRefusesASymlink(t *testing.T) {
 		t.Fatalf("Symlink: %v", err)
 	}
 
-	_, err := shortSocketDir()
+	_, err := socketDirAt(tmp, os.Getuid())
 	if err == nil {
-		t.Fatal("shortSocketDir followed a symlink at the fallback path; it must refuse")
+		t.Fatal("socketDirAt followed a symlink")
 	}
-	// Pin the SYMLINK check specifically. A symlink-to-directory satisfies MkdirAll and IsDir, so without an
-	// Lstat-based check the refusal would come from somewhere else (or not at all) and this test would pass
-	// while an attacker-controlled redirect went unnoticed.
 	if !strings.Contains(err.Error(), "symlink") {
 		t.Errorf("refused with %q; want the symlink check to be what rejects it", err)
 	}
 }
 
-// TestSocketPathStaysInTheStateDirWhenItFits: the fallback is for long paths only — a normal install keeps its
-// socket beside the config, where it is discoverable.
-func TestSocketPathStaysInTheStateDirWhenItFits(t *testing.T) {
-	dir := isolate(t)
+func TestSocketPathUsesProductionRoot(t *testing.T) {
+	isolate(t)
 	sock, err := SocketPath()
 	if err != nil {
 		t.Fatalf("SocketPath: %v", err)
 	}
-	if filepath.Dir(sock) != dir {
-		t.Errorf("socket = %q, want it inside the state dir %q", sock, dir)
+	want := filepath.Join(socketRoot, fmt.Sprintf("pmon-%d", os.Getuid()))
+	if got := filepath.Dir(sock); got != want {
+		t.Errorf("socket directory = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- use a deterministic owner-only `/tmp` socket for new pmon processes
- keep released clients and daemons interoperable through temporary compatibility paths

## Risk
Daemon discovery during mixed-version upgrades.

## Verification
- `go test -count=1 ./pmon/... ./pmontray/...`