### PR TITLE
refactor(control-plane): store a query result as protobuf, not kotlinx JSON

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/QueryResultStore.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/QueryResultStore.kt
@@ -1,6 +1,12 @@
 package com.ridi.oss.proxymonster.controlplane
 
 import com.ridi.oss.proxymonster.analyzer.pb.ResultFingerprint
+import com.google.protobuf.InvalidProtocolBufferException
+import com.ridi.oss.proxymonster.storage.StoredResult
+import com.ridi.oss.proxymonster.grpc.runResultRows
+import com.ridi.oss.proxymonster.grpc.runRow
+import com.ridi.oss.proxymonster.grpc.runValue
+import com.ridi.oss.proxymonster.storage.storedResult
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
@@ -58,9 +64,50 @@ class ResultAccess(val meta: QueryResultMeta, val sql: String?, decrypt: () -> D
     val decrypted: DecryptedResult? by lazy(decrypt)
 }
 
+/** Protobuf at rest, so a Go control-plane reads the same bytes. The JSON fallback covers results stored
+ *  before the migration and dies with them, one retention window later. */
+internal object ResultPayloadCodec {
+    private val json = Json
+    private val legacySerializer = DecryptedResult.serializer()
+
+    fun encode(result: DecryptedResult): ByteArray = storedResult {
+        rows = runResultRows {
+            columns.addAll(result.columns)
+            rows.addAll(
+                result.rows.map { row ->
+                    runRow {
+                        values.addAll(row.map { cell -> runValue { value = cell ?: ""; isNull = cell == null } })
+                    }
+                },
+            )
+        }
+        result.rowsAffected?.let { rowsAffected = it }
+        result.resultFingerprint?.let { resultFingerprint = it }
+    }.toByteArray()
+
+    fun decode(plaintext: ByteArray): DecryptedResult =
+        try {
+            fromStored(StoredResult.parseFrom(plaintext))
+        } catch (protoFailure: InvalidProtocolBufferException) {
+            // Parsing decides the format, never the leading byte: `{` is itself a valid protobuf tag
+            // (field 15), so a newer schema's unknown field would be misread as JSON.
+            try {
+                json.decodeFromString(legacySerializer, plaintext.toString(Charsets.UTF_8))
+            } catch (jsonFailure: Exception) {
+                throw protoFailure.also { it.addSuppressed(jsonFailure) }
+            }
+        }
+
+    private fun fromStored(stored: StoredResult) = DecryptedResult(
+        columns = stored.rows.columnsList,
+        rows = stored.rows.rowsList.map { row -> row.valuesList.map { if (it.isNull) null else it.value } },
+        rowsAffected = if (stored.hasRowsAffected()) stored.rowsAffected else null,
+        resultFingerprint = if (stored.hasResultFingerprint()) stored.resultFingerprint else null,
+    )
+}
+
 class QueryResultStore(private val dataSource: DataSource, private val crypto: ResultCrypto) {
     private val json = Json
-    private val payloadSerializer = DecryptedResult.serializer()
     private val stringList = ListSerializer(String.serializer())
 
     private fun ResultSet.toMeta() = QueryResultMeta(
@@ -124,7 +171,7 @@ class QueryResultStore(private val dataSource: DataSource, private val crypto: R
         retentionSec: Long,
         audit: (Connection, QueryResultMeta) -> Unit = { _, _ -> },
     ): QueryResultMeta? {
-        val blob = crypto.encrypt(json.encodeToString(payloadSerializer, result).toByteArray(Charsets.UTF_8))
+        val blob = crypto.encrypt(ResultPayloadCodec.encode(result))
         val now = Instant.now()
         return dataSource.inTx { c ->
             val childId = latestChildId(c, taskId, "status = 'RUNNING'")
@@ -244,7 +291,7 @@ class QueryResultStore(private val dataSource: DataSource, private val crypto: R
         // the caller has authorized on [meta].
         val payload = if (meta.status == "DONE" && !expired) ciphertext else null
         return ResultAccess(meta, sql) {
-            payload?.let { json.decodeFromString(payloadSerializer, crypto.decrypt(it).toString(Charsets.UTF_8)) }
+            payload?.let { ResultPayloadCodec.decode(crypto.decrypt(it)) }
         }
     }
 

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ResultPayloadCodecTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ResultPayloadCodecTest.kt
@@ -1,0 +1,138 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.analyzer.pb.MaskedDisposition
+import com.ridi.oss.proxymonster.analyzer.pb.columnResource
+import com.ridi.oss.proxymonster.analyzer.pb.relationIdentity
+import com.ridi.oss.proxymonster.analyzer.pb.requireResultReadGrant
+import com.ridi.oss.proxymonster.analyzer.pb.resultFingerprint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * A stored result is encrypted at rest and outlives the process that wrote it, so its encoding has to be
+ * one a DIFFERENT implementation can read — the control plane is being ported to Go. These pin the
+ * protobuf round-trip and the legacy-JSON fallback that carries results written before the migration.
+ */
+class ResultPayloadCodecTest {
+
+    private val fingerprint = resultFingerprint {
+        grants.add(
+            requireResultReadGrant {
+                column = columnResource {
+                    catalog = "def"
+                    identity = relationIdentity {
+                        schema = "bom"
+                        table = "tb_user"
+                        column = "email"
+                    }
+                }
+                maskedDisposition = MaskedDisposition.MASKED_DISPOSITION_MASK_OUTPUT
+                outputOrdinals.add(1)
+            },
+        )
+    }
+
+    @Test
+    fun `protobuf round-trips every field, including the ones an empty-vs-absent bug would flatten`() {
+        val original = DecryptedResult(
+            columns = listOf("id", "email", "note"),
+            // A NULL cell must not read back as the empty string: a masked-to-NULL value and an empty
+            // value are different answers, and the mask is what produces the former.
+            rows = listOf(
+                listOf("1", "a@x", null),
+                listOf("2", null, ""),
+            ),
+            rowsAffected = null,
+            resultFingerprint = fingerprint,
+        )
+        val decoded = ResultPayloadCodec.decode(ResultPayloadCodec.encode(original))
+        assertEquals(original.columns, decoded.columns)
+        assertEquals(original.rows, decoded.rows)
+        assertNull(decoded.rowsAffected, "a row-returning statement has no affected-row count")
+        assertEquals(original.resultFingerprint, decoded.resultFingerprint)
+    }
+
+    @Test
+    fun `a DML result keeps a zero affected-row count distinct from absent`() {
+        // 0 affected rows is a real answer ("matched nothing"), so it must survive as 0 rather than
+        // collapsing into the absent case a row-returning statement uses.
+        val zero = ResultPayloadCodec.decode(
+            ResultPayloadCodec.encode(DecryptedResult(columns = emptyList(), rows = emptyList(), rowsAffected = 0)),
+        )
+        assertEquals(0, zero.rowsAffected)
+        val absent = ResultPayloadCodec.decode(
+            ResultPayloadCodec.encode(DecryptedResult(columns = emptyList(), rows = emptyList(), rowsAffected = null)),
+        )
+        assertNull(absent.rowsAffected)
+    }
+
+    @Test
+    fun `an empty fingerprint stays distinct from an absent one`() {
+        // An EMPTY fingerprint means "a grant-less passthrough" and releases raw; an ABSENT one means the
+        // result predates fingerprints and is unverifiable, so it must fail closed. Flattening the two
+        // would release a legacy result as if it had been proven safe (decideResultView).
+        val empty = ResultPayloadCodec.decode(
+            ResultPayloadCodec.encode(
+                DecryptedResult(columns = listOf("a"), rows = emptyList(), resultFingerprint = resultFingerprint {}),
+            ),
+        )
+        assertEquals(0, empty.resultFingerprint?.grantsCount, "an empty fingerprint round-trips as present-but-empty")
+
+        val legacy = ResultPayloadCodec.decode(
+            ResultPayloadCodec.encode(DecryptedResult(columns = listOf("a"), rows = emptyList(), resultFingerprint = null)),
+        )
+        assertNull(legacy.resultFingerprint, "an absent fingerprint must not become an empty one")
+    }
+
+    @Test
+    fun `a result written as kotlinx JSON before the migration still decodes`() {
+        // A FROZEN literal, not a re-serialization: generating this with the same DecryptedResult.serializer()
+        // that decode() falls back to would let both drift together and stay green while real pre-deploy
+        // ciphertext failed. These are the exact bytes the pre-migration control plane wrote — kotlinx's
+        // default Json (no pretty-print, nulls emitted, defaults omitted) with the ResultFingerprint proto
+        // base64'd inside the string, which is what the old ResultFingerprintSerializer did.
+        val legacyJson = """
+            {"columns":["id","ssn"],"rows":[["1",null]],"resultFingerprint":"$LEGACY_FINGERPRINT_B64"}
+        """.trimIndent().toByteArray(Charsets.UTF_8)
+
+        val decoded = ResultPayloadCodec.decode(legacyJson)
+        assertEquals(listOf("id", "ssn"), decoded.columns)
+        assertEquals(listOf(listOf("1", null)), decoded.rows, "a legacy NULL cell must stay NULL")
+        assertNull(decoded.rowsAffected, "rowsAffected was omitted as a default and must read back absent")
+        assertEquals(fingerprint, decoded.resultFingerprint, "the base64'd proto must still parse")
+    }
+
+    private companion object {
+        // The base64 the old serializer emitted for [fingerprint]. analyzer.proto is unchanged by this
+        // migration, so these bytes are byte-identical to what a pre-migration deployment stored.
+        const val LEGACY_FINGERPRINT_B64 = "CiMKHAoDZGVmEhUKA2JvbRIHdGJfdXNlchoFZW1haWwoAjIBAQ=="
+    }
+
+    @Test
+    fun `a protobuf payload that begins with the JSON brace still decodes as protobuf`() {
+        // `{` (0x7b) is a valid protobuf tag — field 15, the deprecated START_GROUP — so a payload from a
+        // NEWER schema can legitimately begin with it and parse here as an unknown field. Deciding the
+        // format by sniffing that byte would hand such a result to the JSON parser and fail a readable row;
+        // parsing decides instead, protobuf first.
+        val unknownFieldPayload = byteArrayOf(0x7b, 0x7c)
+        assertEquals(
+            '{'.code.toByte(), unknownFieldPayload[0],
+            "this payload is exactly the ambiguous case: it starts with the JSON brace",
+        )
+        val decoded = ResultPayloadCodec.decode(unknownFieldPayload)
+        assertEquals(emptyList(), decoded.columns, "an unknown-field-only message carries no columns")
+        assertEquals(emptyList(), decoded.rows)
+        assertNull(decoded.rowsAffected)
+        assertNull(decoded.resultFingerprint, "no fingerprint means unverifiable, which fails closed at view")
+    }
+
+    @Test
+    fun `bytes that are neither encoding fail rather than decoding to an empty result`() {
+        // An empty result is a RELEASABLE value (a query that matched nothing), so a corrupt payload must
+        // throw and surface as a failure — never decode to "no rows, no masked columns".
+        assertFailsWith<Exception> { ResultPayloadCodec.decode("{ not valid json".toByteArray(Charsets.UTF_8)) }
+    }
+}

--- a/proto/src/main/proto/storage.proto
+++ b/proto/src/main/proto/storage.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+// Payloads the control-plane stores AT REST, not a wire protocol. A stored payload outlives the process
+// that wrote it and must be readable by a different implementation — the Kotlin control plane is being
+// ported to Go — so it is a schema both languages generate from, never one language's serializer.
+package proxymonster.v1;
+
+import "analyzer.proto";
+import "controlplane.proto";
+
+option java_package = "com.ridi.oss.proxymonster.storage";
+option java_multiple_files = true;
+// No go_package: Go paths come from each module's buf M-options, not from a shared contract.
+
+// One stored query result, encrypted whole as the ciphertext of a `query_result` row.
+message StoredResult {
+  // The rows as they crossed the wire. Mask ordinals index into its columns, so their order is
+  // load-bearing.
+  RunResultRows rows = 1;
+  // Absent for a row-returning statement, where the row count IS the count. `optional` because 0
+  // affected rows is a real answer.
+  optional int32 rows_affected = 2;
+  // `optional` because empty and absent differ: empty means a grant-less passthrough (releases raw),
+  // absent means the result predates fingerprints and fails closed (decideResultView).
+  optional proxymonster.analyzer.v1.ResultFingerprint result_fingerprint = 3;
+}


### PR DESCRIPTION
A stored result is encrypted at rest and outlives the process that wrote it, so a different implementation has to be able to read it — the Kotlin control plane is being ported to Go. The payload was kotlinx JSON, which makes that a matter of reimplementing one language's serializer conventions: default-value omission, nullability encoding, and a bespoke serializer that base64'd the `ResultFingerprint` proto *inside* the JSON.

`StoredResult` embeds the wire's `RunResultRows`, so a stored result is the rows as they crossed the wire plus `rows_affected` and the fingerprint. The crypto layer was already portable (AES-256-GCM, 12-byte IV prefix, 128-bit tag); only the plaintext was not.

## Reading old rows

No version was ever stored, so reads parse protobuf and fall back to JSON when that fails. Order matters and is not interchangeable with sniffing a leading byte: `{` (0x7b) is also a valid protobuf tag (field 15, the deprecated START_GROUP), so a `{`-leading payload can be a legitimate message carrying an unknown field from a newer schema. Stored results live one retention window (`RESULT_RETENTION_SEC`), so the JSON branch is dead a day after deploy and can be deleted then.

## Where it could bite

Two presence distinctions are load-bearing, both fail-closed:

- `rows_affected` is `optional` — 0 affected rows is a real answer and must not collapse into the absent case a row-returning statement uses.
- `result_fingerprint` is `optional` — an EMPTY fingerprint means a grant-less passthrough and releases raw, while an ABSENT one means the result predates fingerprints and must fail closed (`decideResultView`). Flattening them would release a legacy result as if proven safe.

A payload that is neither encoding throws, which reaches the `StatusPages` handler as a 500. That is the fail-closed direction: an empty result is a releasable value, so corruption must never decode to one.

## Verification

`:control-plane:test` green, `mise run lint` clean. Mutation-checked: sniffing the leading byte instead of parsing fails the unknown-field test, dropping the JSON branch fails the legacy test, and flattening the fingerprint's empty-vs-absent fails its own. The legacy fixture is a frozen literal, not a re-serialization, so it cannot drift with the current serializer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UQtbMqbC15KdiaSFfJnqK