### PR TITLE
fix(engine): gate SHOW GRANTS and SHOW PROCESSLIST by statement kind

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -373,6 +373,19 @@ The runtime classification core is shipped (bundled manifests → `system:` tag 
 the shipped forbids/permit). Two completeness/curation surfaces are deferred —
 they refine the "Open presets" caveat above:
 
+- 🟡 `SHOW GRANTS` and `SHOW [FULL] PROCESSLIST` gate on their statement kind
+  only (`stmt.cat.admin.account` / `.process`); they no longer emit a `Utility`,
+  so the `system:activity` / `system:critical` floors do not apply to them. On a
+  datasource carrying an action-unscoped
+  `permit(principal, action, resource in Datasource::"…")` both now relay, where
+  the tag forbid previously denied them — the same permit already reaches
+  `SELECT` and `DROP TABLE`, so scope the actions a role needs. Default
+  production still denies both (no admin preset ships). An existing policy
+  naming `Utility::"<ds>/SHOW_GRANTS"` or `…/SHOW_PROCESSLIST` is rejected on
+  write and listed by `/health`; rewrite it as a `stmt.kind.*` rule. Retiring
+  the remaining kind-duplicate utilities is tracked in
+  [#269](https://github.com/ridi-oss/proxy-monster/issues/269).
+
 - 🟡→🔴 No fail-closed manifest-completeness guard (defense-in-depth). A touched
   system table with no governing manifest gets _no_ `system:` tag — not a hard
   DENY. With only per-resource read grants it stays deny-by-default (🟡,

--- a/analyzer/go.mod
+++ b/analyzer/go.mod
@@ -8,6 +8,6 @@ module github.com/ridi-oss/proxy-monster/analyzer
 
 go 1.26.0
 
-require github.com/ridi-oss/sqlglot-go v0.24.0
+require github.com/ridi-oss/sqlglot-go v0.25.0
 
 require google.golang.org/protobuf v1.36.11

--- a/analyzer/go.sum
+++ b/analyzer/go.sum
@@ -2,5 +2,7 @@ github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/ridi-oss/sqlglot-go v0.24.0 h1:dq25mbuMyRk2xMZqrw77WUARppsEMhckbuTGQf6uwMY=
 github.com/ridi-oss/sqlglot-go v0.24.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
+github.com/ridi-oss/sqlglot-go v0.25.0 h1:t+lKLkvzhDYJnN/UQlb9ZT1aXrs4Bjl7cGZxBWcaGR0=
+github.com/ridi-oss/sqlglot-go v0.25.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/analyzer/probe/admission_parity_test.go
+++ b/analyzer/probe/admission_parity_test.go
@@ -339,6 +339,30 @@ func TestParityShowDescribe(t *testing.T) {
 	parityNoUtility(t, "SHOW PROCESSLIST", "mysql")
 	parityNoUtility(t, "SHOW FULL PROCESSLIST", "mysql")
 	parityNoUtility(t, "SHOW GRANTS", "mysql")
+	// The user@host / CURRENT_USER() / USING spellings resolve to the same kind, so they must not pick up a
+	// utility either. Asserting the KIND too is what makes this meaningful: without it, a spelling that
+	// silently degraded to SHOW_METADATA would also carry no utility and pass. A laundering spelling (a host
+	// detached from @, comma slop, a ? placeholder) stays an unmodeled Command → exception.unanalyzable,
+	// which is a DIFFERENT deny path than the kind gate.
+	for _, sql := range []string{
+		"SHOW GRANTS FOR 'store'@'172.27.0.0/255.255.0.0'",
+		"SHOW GRANTS FOR CURRENT_USER()",
+		"SHOW GRANTS FOR 'store'@'localhost' USING 'r1', 'r2'",
+	} {
+		parityNoUtility(t, sql, "mysql")
+		if got := factsKind(factsFor(t, sql, "mysql")); got != pb.StatementKind_STATEMENT_KIND_SHOW_GRANTS {
+			t.Errorf("[mysql] %q: kind %s, want STATEMENT_KIND_SHOW_GRANTS — a degraded kind would gate on the wrong category", sql, got)
+		}
+	}
+	for _, laundered := range []string{
+		"SHOW GRANTS FOR 'store'@ 'localhost'",
+		"SHOW GRANTS FOR 'u'@'h' USING 'r1',,'r2'",
+		"SHOW GRANTS FOR ?",
+	} {
+		if f := factsFor(t, laundered, "mysql"); f.GetResolved() {
+			t.Errorf("[mysql] %q: a laundering spelling must fail closed, got resolved", laundered)
+		}
+	}
 	parityUtility(t, "SHOW BINLOG EVENTS", "mysql", "SHOW_BINLOG_EVENTS")
 	parityUtility(t, "SHOW RELAYLOG EVENTS", "mysql", "SHOW_RELAYLOG_EVENTS")
 	parityUtility(t, "SHOW ENGINE INNODB STATUS", "mysql", "SHOW_ENGINE_STATUS")

--- a/analyzer/probe/admission_parity_test.go
+++ b/analyzer/probe/admission_parity_test.go
@@ -332,8 +332,13 @@ func TestParityShowDescribe(t *testing.T) {
 	// it parses to a Command and is metadata passthrough, tested in TestParityShowPgGuc.)
 	parityUtility(t, "SHOW WARNINGS", "mysql", "SHOW_WARNINGS")
 	parityUtility(t, "SHOW ERRORS", "mysql", "SHOW_ERRORS")
-	parityUtility(t, "SHOW PROCESSLIST", "mysql", "SHOW_PROCESSLIST")
-	parityUtility(t, "SHOW FULL PROCESSLIST", "mysql", "SHOW_PROCESSLIST")
+	// SHOW GRANTS / SHOW PROCESSLIST carry no utility: their kind (stmt.cat.admin.account / .process) is the
+	// gate. The Utility was a second gate over a synthetic resource, read off the same AST field as the kind.
+	// The TABLES they expose stay classified (mysql.global_grants, information_schema.PROCESSLIST), so the
+	// direct-SELECT path is unaffected.
+	parityNoUtility(t, "SHOW PROCESSLIST", "mysql")
+	parityNoUtility(t, "SHOW FULL PROCESSLIST", "mysql")
+	parityNoUtility(t, "SHOW GRANTS", "mysql")
 	parityUtility(t, "SHOW BINLOG EVENTS", "mysql", "SHOW_BINLOG_EVENTS")
 	parityUtility(t, "SHOW RELAYLOG EVENTS", "mysql", "SHOW_RELAYLOG_EVENTS")
 	parityUtility(t, "SHOW ENGINE INNODB STATUS", "mysql", "SHOW_ENGINE_STATUS")

--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -792,16 +792,12 @@ func showUtilityCommand(root exp.Expression) string {
 		return "SHOW_WARNINGS"
 	case "ERRORS":
 		return "SHOW_ERRORS"
-	case "PROCESSLIST":
-		return "SHOW_PROCESSLIST"
 	case "BINLOG EVENTS":
 		return "SHOW_BINLOG_EVENTS"
 	case "RELAYLOG EVENTS":
 		return "SHOW_RELAYLOG_EVENTS"
 	case "ENGINE":
 		return "SHOW_ENGINE_STATUS"
-	case "GRANTS":
-		return "SHOW_GRANTS"
 	case "REPLICA STATUS", "SLAVE STATUS":
 		return "SHOW_REPLICA_STATUS"
 	case "CREATE USER":

--- a/analyzer/probe/mysql_statement_coverage_test.go
+++ b/analyzer/probe/mysql_statement_coverage_test.go
@@ -350,6 +350,10 @@ var mysqlStatements = []mysqlStatement{
 	// utility for them, so they relay connect-only on wire. The statement-typing redesign closes them.
 	{"SHOW PROCESSLIST", "SHOW PROCESSLIST", "stmt.kind.show_processlist", pb.StatementKind_STATEMENT_KIND_SHOW_PROCESSLIST},
 	{"SHOW GRANTS", "SHOW GRANTS", "stmt.kind.show_grants", pb.StatementKind_STATEMENT_KIND_SHOW_GRANTS},
+	{"SHOW GRANTS FOR user@host", "SHOW GRANTS FOR 'store'@'172.27.0.0/255.255.0.0'", "stmt.kind.show_grants", pb.StatementKind_STATEMENT_KIND_SHOW_GRANTS},
+	{"SHOW GRANTS FOR CURRENT_USER()", "SHOW GRANTS FOR CURRENT_USER()", "stmt.kind.show_grants", pb.StatementKind_STATEMENT_KIND_SHOW_GRANTS},
+	{"SHOW GRANTS USING role", "SHOW GRANTS FOR 'store'@'localhost' USING 'r1', 'r2'", "stmt.kind.show_grants", pb.StatementKind_STATEMENT_KIND_SHOW_GRANTS},
+	{"SHOW GRANTS detached host", "SHOW GRANTS FOR 'store'@ 'localhost'", "unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_STMT_UNKNOWN},
 	{"SHOW CREATE USER", "SHOW CREATE USER CURRENT_USER", "stmt.kind.show_create_user + utility:SHOW_CREATE_USER", pb.StatementKind_STATEMENT_KIND_SHOW_CREATE_USER},
 	{"SHOW ENGINE INNODB STATUS", "SHOW ENGINE INNODB STATUS", "stmt.kind.show_engine_status + utility:SHOW_ENGINE_STATUS", pb.StatementKind_STATEMENT_KIND_SHOW_ENGINE_STATUS},
 	{"SHOW BINLOG EVENTS", "SHOW BINLOG EVENTS", "stmt.kind.show_binlog_events + utility:SHOW_BINLOG_EVENTS", pb.StatementKind_STATEMENT_KIND_SHOW_BINLOG_EVENTS},
@@ -440,6 +444,7 @@ var privilegedNeedingGate = map[string]bool{
 	"SET PASSWORD": true, "SET ROLE": true, "SET DEFAULT ROLE": true, "SET GLOBAL var": true,
 	"SET PERSIST var": true, "SET PERSIST_ONLY var": true, "SET sql_log_bin": true,
 	"SHOW PROCESSLIST": true, "SHOW GRANTS": true, "SHOW CREATE USER": true, "SHOW ENGINE INNODB STATUS": true,
+	"SHOW GRANTS FOR user@host": true, "SHOW GRANTS FOR CURRENT_USER()": true, "SHOW GRANTS USING role": true,
 	"SHOW BINLOG EVENTS": true, "SHOW RELAYLOG EVENTS": true, "SHOW REPLICA STATUS": true, "SHOW SLAVE STATUS": true,
 	"SHOW BINARY LOGS": true, "SHOW MASTER STATUS": true, "SHOW REPLICAS": true, "SHOW SLAVE HOSTS": true,
 }

--- a/analyzer/probe/mysql_statement_coverage_test.go
+++ b/analyzer/probe/mysql_statement_coverage_test.go
@@ -348,8 +348,8 @@ var mysqlStatements = []mysqlStatement{
 	// ---- SHOW: data/credential/topology-exposing — must be a utility or fail closed ----
 	// The `metadata`-only rows here are UNDER-GATED today (see knownConnectOnlyGaps): the analyzer emits no
 	// utility for them, so they relay connect-only on wire. The statement-typing redesign closes them.
-	{"SHOW PROCESSLIST", "SHOW PROCESSLIST", "stmt.kind.show_processlist + utility:SHOW_PROCESSLIST", pb.StatementKind_STATEMENT_KIND_SHOW_PROCESSLIST},
-	{"SHOW GRANTS", "SHOW GRANTS", "stmt.kind.show_grants + utility:SHOW_GRANTS", pb.StatementKind_STATEMENT_KIND_SHOW_GRANTS},
+	{"SHOW PROCESSLIST", "SHOW PROCESSLIST", "stmt.kind.show_processlist", pb.StatementKind_STATEMENT_KIND_SHOW_PROCESSLIST},
+	{"SHOW GRANTS", "SHOW GRANTS", "stmt.kind.show_grants", pb.StatementKind_STATEMENT_KIND_SHOW_GRANTS},
 	{"SHOW CREATE USER", "SHOW CREATE USER CURRENT_USER", "stmt.kind.show_create_user + utility:SHOW_CREATE_USER", pb.StatementKind_STATEMENT_KIND_SHOW_CREATE_USER},
 	{"SHOW ENGINE INNODB STATUS", "SHOW ENGINE INNODB STATUS", "stmt.kind.show_engine_status + utility:SHOW_ENGINE_STATUS", pb.StatementKind_STATEMENT_KIND_SHOW_ENGINE_STATUS},
 	{"SHOW BINLOG EVENTS", "SHOW BINLOG EVENTS", "stmt.kind.show_binlog_events + utility:SHOW_BINLOG_EVENTS", pb.StatementKind_STATEMENT_KIND_SHOW_BINLOG_EVENTS},
@@ -468,11 +468,13 @@ var knownConnectOnlyGaps = map[string]bool{
 // admin grant is present. This is the opposite of knownConnectOnlyGaps, which are genuinely under-gated
 // (a benign category). The map key is the resolve() output.
 var gatedBareKinds = map[string]bool{
-	"stmt.kind.create_user": true,
-	"stmt.kind.alter_user":  true,
-	"stmt.kind.drop_user":   true,
-	"stmt.kind.create_role": true,
-	"stmt.kind.drop_role":   true,
+	"stmt.kind.create_user":      true,
+	"stmt.kind.alter_user":       true,
+	"stmt.kind.drop_user":        true,
+	"stmt.kind.create_role":      true,
+	"stmt.kind.drop_role":        true,
+	"stmt.kind.show_grants":      true,
+	"stmt.kind.show_processlist": true,
 }
 
 // TestPrivilegedStatementsAreGated is the security invariant: every privileged or data-exposing MySQL

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/App.kt
@@ -6,6 +6,7 @@ import com.ridi.oss.proxymonster.controlplane.authz.AuthzAction
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzContext
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzDecision
 import com.ridi.oss.proxymonster.controlplane.authz.AuthzResource
+import com.ridi.oss.proxymonster.controlplane.authz.CedarSchema
 import com.ridi.oss.proxymonster.controlplane.authz.authorizeWithContext
 import com.ridi.oss.proxymonster.controlplane.authz.cedarPolicyRoutes
 import com.ridi.oss.proxymonster.controlplane.authz.contextTagLint
@@ -600,6 +601,9 @@ fun Application.module(config: Config, core: ControlPlaneCore) {
                 // Dangling-tag lint: warn on a context tag consumed with no producer (a grant that
                 // can never apply — likely a typo) or produced with no consumer (a dead tag rule).
                 addAll(contextTagLint(cedarPolicyStore.enabledSources()))
+                // An enabled policy naming a retired Utility command never matches. New writes are
+                // rejected, but an upgraded install already has them stored.
+                addAll(CedarSchema.retiredUtilityLint(cedarPolicyStore.enabledSources()))
             }
             call.respond(
                 kotlinx.serialization.json.JsonObject(

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationService.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/SystemClassificationService.kt
@@ -132,7 +132,7 @@ class SystemClassificationService(
     }
 
     /**
-     * The `system:` tag id for a utility command id — `SHOW_PROCESSLIST` → `system:activity`,
+     * The `system:` tag id for a utility command id — `SHOW_CREATE_USER` → `system:critical`,
      * `SHOW_BINLOG_EVENTS` → `system:data-leak`, … — or null when no manifest governs the datasource. Unlike a
      * function, a null result does NOT mean "safe": the caller marshals the utility anyway, so an unclassified
      * recognized utility denies-by-default (Authz.authorizeUtilities).

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/Authz.kt
@@ -140,7 +140,7 @@ enum class FunctionVerdict { ALLOWED, DENIED }
 
 /** A resource-bearing utility command a query performs (facts-emission.md), marshalled to a
  *  Cedar `Utility` entity by [authorizeUtilities]. [command] is the canonical per-engine command id
- *  (`SHOW_PROCESSLIST`, …); the caller resolves its shipped `system:` tag via the manifest. */
+ *  (`SHOW_BINLOG_EVENTS`, …); the caller resolves its shipped `system:` tag via the manifest. */
 data class UtilityRef(val command: String)
 
 /** Per-utility verdict — deny-by-default. [USE] iff a `result.read.unmasked`/`masked` permit covers the

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/CedarEngine.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/authz/CedarEngine.kt
@@ -241,8 +241,30 @@ object CedarSchema {
         val typeErrors = response.success
             .map { success -> success.validationErrors.map { it.error.message } }
             .orElseGet { emptyList() }
-        return parseErrors + typeErrors
+        return parseErrors + typeErrors + retiredUtilityErrors(cedarSrc)
     }
+
+    /**
+     * Reject a policy naming a Utility command the analyzer no longer emits. `Utility` is still a valid
+     * entity type, so `forbid(..., resource == Utility::"prod/SHOW_GRANTS")` passes schema validation and
+     * then never matches — an operator's carve-out silently stops working. Fail closed instead: name the
+     * replacement.
+     */
+    private fun retiredUtilityErrors(cedarSrc: String): List<String> =
+        RETIRED_UTILITY_COMMANDS.filter { (cmd, _) -> Regex("""Utility::"[^"]*/$cmd"""").containsMatchIn(cedarSrc) }
+            .map { (cmd, replacement) ->
+                "Utility::\"…/$cmd\" is no longer emitted — this policy would never match. Use $replacement instead."
+            }
+
+    /** Enabled-policy lint for retired Utility commands — see [retiredUtilityErrors]. */
+    fun retiredUtilityLint(sources: List<Pair<Long, String>>): List<String> =
+        sources.flatMap { (id, src) -> retiredUtilityErrors(src).map { "policy $id: $it" } }.distinct()
+
+    /** Retired utility command id -> the statement action that replaced it. */
+    private val RETIRED_UTILITY_COMMANDS = mapOf(
+        "SHOW_GRANTS" to "Action::\"stmt.kind.show_grants\" (or stmt.cat.admin.account)",
+        "SHOW_PROCESSLIST" to "Action::\"stmt.kind.show_processlist\" (or stmt.cat.admin.process)",
+    )
 }
 
 /**

--- a/control-plane/src/main/resources/authz/schema.cedarschema
+++ b/control-plane/src/main/resources/authz/schema.cedarschema
@@ -43,7 +43,7 @@ entity Function in [Datasource, Tag];
 
 // A resource-bearing UTILITY command a statement performs (facts-emission.md), keyed off the
 // datasource NAME + the canonical command id: `Utility::"<dsName>/<command>"`. Like Function it gains a
-// `Tag` parent for its shipped `system:` classification (SHOW PROCESSLIST → system:activity, SHOW BINLOG
+// `Tag` parent for its shipped `system:` classification (SHOW CREATE USER → system:critical, SHOW BINLOG
 // EVENTS → system:data-leak, …). Deny-by-default: unlike a Function (only dangerous ones are marshaled), a
 // RECOGNIZED utility with no classification is still marshaled and, carrying no permit, denies — so an
 // un-classifiable utility on an unsupported-version datasource fails closed (utilities are token-recognized,

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AccountManagementEnforcementDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/AccountManagementEnforcementDbTest.kt
@@ -151,4 +151,57 @@ class AccountManagementEnforcementDbTest {
         val ctx = decide("CREATE USER 'x'@'%'", connector)
         assertEquals(EnfAction.DENY, ctx.action, "CREATE USER must stay denied without stmt.cat.admin.account")
     }
+
+    @Test
+    fun `an admin-account holder reads SHOW GRANTS on production but never SHOW CREATE USER`() {
+        // The production surface this reopened: SHOW GRANTS is in stmt.cat.admin.account, so the holder that
+        // may CREATE USER may now audit privileges — previously impossible, because its system:critical
+        // Utility hit the unconditional -130 forbid no grant can override. SHOW CREATE USER keeps that
+        // Utility (it returns the stored password hash), so it stays denied for the SAME principal on the
+        // SAME datasource: the split is credential-vs-privilege-list, not admin-vs-non-admin.
+        setEngineVersion("8.0.44")
+        for (sql in listOf(
+            "SHOW GRANTS",
+            "SHOW GRANTS FOR 'books-frontend'@'10.23.0.0/255.255.0.0'",
+            "SHOW GRANTS FOR CURRENT_USER()",
+        )) {
+            val ctx = decideClassified(sql, admin)
+            assertEquals(EnfAction.ALLOW, ctx.action, "$sql must be readable by an admin.account holder: ${ctx.denyReason} (stage=${ctx.failedStage})")
+        }
+        assertEquals(
+            EnfAction.DENY,
+            decideClassified("SHOW CREATE USER CURRENT_USER()", admin).action,
+            "SHOW CREATE USER leaks the password hash — denied even for the admin.account holder",
+        )
+        assertEquals(
+            EnfAction.DENY,
+            decideClassified("SHOW GRANTS", connector).action,
+            "SHOW GRANTS still needs stmt.cat.admin.account — a connect-only role is denied at the kind gate",
+        )
+    }
+
+    private fun setEngineVersion(version: String) {
+        fx.dataSource.connection.use { c ->
+            c.prepareStatement("UPDATE datasource SET engine_version = ? WHERE id = ?").use { ps ->
+                ps.setString(1, version); ps.setLong(2, datasource.id); ps.executeUpdate()
+            }
+        }
+        datasource = checkNotNull(fx.datasourceStore.get(datasource.id))
+    }
+
+    // decide() with the shipped manifests loaded, so a system-classified Utility (SHOW CREATE USER) resolves
+    // its tag and the -130 forbid applies. The default helper passes null, which cannot tell the two apart.
+    private fun decideClassified(sql: String, who: String) = decideQuery(
+        principal = who,
+        ds = datasource,
+        sql = sql,
+        channel = Channel.WIRE,
+        catalog = fx.datasourceStore.catalog(datasource.id),
+        policyStore = fx.policyStore,
+        accessStore = fx.accessStore,
+        userGroupStore = fx.userGroupStore,
+        roleResolver = fx.roleResolver,
+        authz = fx.authz,
+        systemClassification = SystemClassificationService(),
+    )
 }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ManifestCommandCoverageDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ManifestCommandCoverageDbTest.kt
@@ -1,5 +1,6 @@
 package com.ridi.oss.proxymonster.controlplane
 
+import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
 import com.ridi.oss.proxymonster.grpc.EnfAction
 import com.ridi.oss.proxymonster.classification.SystemClassificationStore
 import com.ridi.oss.proxymonster.classification.SystemTag
@@ -110,13 +111,11 @@ class ManifestCommandCoverageDbTest {
         "LOAD_XML" to (Eng.MY to "LOAD XML INFILE '/tmp/x' INTO TABLE t"),
         // MySQL — data-bearing SHOW (the emission-leak class this guard protects).
         "SHOW_CREATE_USER" to (Eng.MY to "SHOW CREATE USER CURRENT_USER()"),
-        "SHOW_GRANTS" to (Eng.MY to "SHOW GRANTS"),
         "SHOW_BINLOG_EVENTS" to (Eng.MY to "SHOW BINLOG EVENTS"),
         "SHOW_RELAYLOG_EVENTS" to (Eng.MY to "SHOW RELAYLOG EVENTS"),
         "SHOW_ENGINE_STATUS" to (Eng.MY to "SHOW ENGINE INNODB STATUS"),
         "SHOW_WARNINGS" to (Eng.MY to "SHOW WARNINGS"),
         "SHOW_ERRORS" to (Eng.MY to "SHOW ERRORS"),
-        "SHOW_PROCESSLIST" to (Eng.MY to "SHOW PROCESSLIST"),
         "SHOW_REPLICA_STATUS" to (Eng.MY to "SHOW REPLICA STATUS"),
         // PostgreSQL.
         "PG_ALTER_SYSTEM" to (Eng.PG to "ALTER SYSTEM SET work_mem = '1MB'"),
@@ -188,15 +187,72 @@ class ManifestCommandCoverageDbTest {
             }
         }
         // The activity/critical distinction is real: on a CERTIFIED datasource with the system:development
-        // relaxation, SHOW REPLICA STATUS (system:activity) is relaxed to ALLOW, but SHOW CREATE USER /
-        // SHOW GRANTS (system:critical) are NEVER relaxed — proving the emitted commands carry the right tag,
-        // not just "some deny". (No-manifest can't distinguish these — both hard-deny unclassified.)
+        // relaxation, SHOW REPLICA STATUS (system:activity) is relaxed to ALLOW, but SHOW CREATE USER
+        // (system:critical — it returns the account's stored password hash) is NEVER relaxed — proving the
+        // emitted commands carry the right tag, not just "some deny". (No-manifest can't distinguish these —
+        // both hard-deny unclassified.)
         setEngineVersion(Eng.MY, "8.0.44")
         setDevPreset(Eng.MY, true)
         assertEquals(EnfAction.ALLOW, decide(Eng.MY, "SHOW REPLICA STATUS"), "SHOW REPLICA STATUS (activity) relaxes on a dev datasource")
         assertEquals(EnfAction.DENY, decide(Eng.MY, "SHOW CREATE USER CURRENT_USER()"), "SHOW CREATE USER (critical) is NEVER relaxed, even on dev")
-        assertEquals(EnfAction.DENY, decide(Eng.MY, "SHOW GRANTS"), "SHOW GRANTS (critical) is NEVER relaxed, even on dev")
         setDevPreset(Eng.MY, false)
+    }
+
+    @Test
+    fun `SHOW GRANTS and SHOW PROCESSLIST gate on their statement kind, not a Utility`() {
+        // Neither carries a utility grant — stmt.cat.admin.account / .process is the gate. SHOW CREATE USER
+        // still does (system:critical: it returns the stored password hash), so it stays denied on the very
+        // datasource that permits these two.
+        setEngineVersion(Eng.MY, "8.0.44")
+        try {
+            setDevPreset(Eng.MY, false)
+            // Production floor: the analyst holds no admin category, so the kind gate denies.
+            assertEquals(EnfAction.DENY, decide(Eng.MY, "SHOW GRANTS"), "SHOW GRANTS denies on the production floor (no admin.account)")
+            assertEquals(EnfAction.DENY, decide(Eng.MY, "SHOW PROCESSLIST"), "SHOW PROCESSLIST denies on the production floor (no admin.process)")
+            // A grantable capability now: the dev preset's stmt.cat.admin permit reaches it. Under the old
+            // system:critical Utility, SHOW GRANTS denied HERE too — the -130 forbid was unconditional.
+            setDevPreset(Eng.MY, true)
+            assertEquals(EnfAction.ALLOW, decide(Eng.MY, "SHOW GRANTS"), "SHOW GRANTS is grantable — the dev admin preset permits it")
+            assertEquals(EnfAction.ALLOW, decide(Eng.MY, "SHOW PROCESSLIST"), "SHOW PROCESSLIST is grantable — the dev admin preset permits it")
+            // SHOW CREATE USER returns the account's stored password hash, so it keeps its system:critical
+            // Utility and stays denied on the very datasource that now permits SHOW GRANTS.
+            assertEquals(EnfAction.DENY, decide(Eng.MY, "SHOW CREATE USER CURRENT_USER()"), "SHOW CREATE USER stays denied — it leaks the password hash")
+        } finally {
+            setDevPreset(Eng.MY, false)
+        }
+    }
+
+    @Test
+    fun `a datasource-wide permit reaches the kind-gated SHOWs, exactly as it reaches SELECT and DROP`() {
+        // The consequence of gating on the kind alone: a permit whose action is unscoped
+        // (`permit(principal, action, resource in Datasource::"…")`) authorizes stmt.cat.admin.* like any
+        // other kind, so SHOW GRANTS / SHOW FULL PROCESSLIST relay. That is the same over-broad permit
+        // already reaching SELECT and DROP TABLE on that datasource -- an operator scopes the actions they
+        // mean, and a policy written against Utility::"<ds>/SHOW_PROCESSLIST" no longer matches anything.
+        // Pinned here so the trade is explicit rather than discovered in production. The statements that
+        // still carry a utility are unaffected by the same permit (asserted below), and the default
+        // production floor still denies both (the sibling test above).
+        setEngineVersion(Eng.MY, "8.0.44")
+        val fx = fxOf(Eng.MY)
+        val wide = "wide-ds-permit@example.com"
+        val role = fx.policyStore.createRole(RoleInput("wide-ds-role"))
+        fx.policyStore.createAssignment(RoleAssignmentInput(wide, role.id))
+        val dsName = fx.datasource.name
+        val pols = listOf(
+            "test-wide-ds-self" to """permit(principal in Role::"wide-ds-role", action, resource == Datasource::"$dsName");""",
+            "test-wide-ds-under" to """permit(principal in Role::"wide-ds-role", action, resource in Datasource::"$dsName");""",
+        ).map { (n, src) -> fx.cedarPolicyStore.create(CedarPolicyInput(name = n, cedarSrc = src), updatedBy = "test") }
+        try {
+            assertEquals(EnfAction.ALLOW, decide(Eng.MY, "SHOW GRANTS", wide), "a datasource-wide permit reaches SHOW GRANTS")
+            assertEquals(EnfAction.ALLOW, decide(Eng.MY, "SHOW FULL PROCESSLIST", wide), "a datasource-wide permit reaches SHOW FULL PROCESSLIST")
+            // Not a hole this gate opened: the same permit already relays ordinary DML/DDL.
+            assertEquals(EnfAction.ALLOW, decide(Eng.MY, "DROP TABLE users", wide), "the same permit already reaches DROP TABLE")
+            // A statement that still emits a utility is NOT reachable by it — the utility floor holds.
+            assertEquals(EnfAction.DENY, decide(Eng.MY, "SHOW CREATE USER CURRENT_USER()", wide), "system:critical utility still overrides the wide permit")
+            assertEquals(EnfAction.DENY, decide(Eng.MY, "SHOW BINLOG EVENTS", wide), "system:data-leak utility still overrides the wide permit")
+        } finally {
+            pols.forEach { fx.cedarPolicyStore.delete(it.id) }
+        }
     }
 
     private fun setDevPreset(eng: Eng, on: Boolean) {

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/UtilityGateDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/UtilityGateDbTest.kt
@@ -2,12 +2,15 @@ package com.ridi.oss.proxymonster.controlplane
 
 import com.ridi.oss.proxymonster.grpc.EnfAction
 import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
+import com.ridi.oss.proxymonster.controlplane.authz.InvalidCedarPolicyException
 import com.ridi.oss.proxymonster.controlplane.support.EnforcementFixture
 import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
 
 /**
  * Utility gate, end-to-end on real MySQL + real Cedar: a data-bearing SHOW command (SHOW
@@ -52,8 +55,6 @@ class UtilityGateDbTest {
         setEngineVersion("8.0.44")
         setTags("""["system:production"]""")
         // Floor: forbidden by the shipped system:activity / system:data-leak guards.
-        assertEquals(EnfAction.DENY, decide("SHOW PROCESSLIST"), "SHOW PROCESSLIST (system:activity) denies on the floor")
-        assertEquals(EnfAction.DENY, decide("SHOW FULL PROCESSLIST"), "SHOW FULL PROCESSLIST denies on the floor")
         assertEquals(EnfAction.DENY, decide("SHOW BINLOG EVENTS"), "SHOW BINLOG EVENTS (system:data-leak) denies on the floor")
         assertEquals(EnfAction.DENY, decide("SHOW WARNINGS"), "SHOW WARNINGS (system:data-leak) denies on the floor")
         // GET DIAGNOSTICS launders a diagnostic string into a user var; it is denied on the floor
@@ -73,7 +74,6 @@ class UtilityGateDbTest {
         assertEquals(EnfAction.DENY, decide("SET PERSIST_ONLY max_connections=5000"), "SET PERSIST_ONLY (system:critical) denies on the floor")
         // Dev datasource: the -110/-120 activity/data-leak permits fire (V32, role-agnostic) → the SHOW is allowed.
         setTags("""["system:development"]""")
-        assertEquals(EnfAction.ALLOW, decide("SHOW PROCESSLIST"), "SHOW PROCESSLIST relaxed on a dev datasource")
         assertEquals(EnfAction.ALLOW, decide("SHOW BINLOG EVENTS"), "SHOW BINLOG EVENTS relaxed on a dev datasource")
         // SHOW WARNINGS relaxes on a dev datasource too (dev has no PII, so its diagnostics buffer
         // carries nothing to leak) — matching the production-posture diagnostic-redaction flag.
@@ -112,20 +112,97 @@ class UtilityGateDbTest {
         // The broad grant is genuinely load-bearing: an ordinary passthrough SHOW (no utility fact) allows.
         assertEquals(EnfAction.ALLOW, decideAs(broad, "SHOW TABLES"), "broad grant permits ordinary metadata (proves it's live)")
         // ...but the unclassified dangerous SHOW is HARD-denied ahead of Cedar — the grant cannot reach it.
-        val processlist = decideQuery(
-            principal = broad, ds = fx.datasourceStore.get(fx.datasource.id)!!, sql = "SHOW PROCESSLIST", channel = Channel.WIRE,
+        val warnings = decideQuery(
+            principal = broad, ds = fx.datasourceStore.get(fx.datasource.id)!!, sql = "SHOW WARNINGS", channel = Channel.WIRE,
             catalog = fx.datasourceStore.catalog(fx.datasource.id), policyStore = fx.policyStore, accessStore = fx.accessStore,
             userGroupStore = fx.userGroupStore, roleResolver = fx.roleResolver, authz = fx.authz,
             systemClassification = SystemClassificationService(),
         )
         assertEquals(
             EnfAction.DENY,
-            processlist.action,
-            "no manifest → unclassified utility hard-denied even WITH a Datasource read grant: ${processlist.detail}",
+            warnings.action,
+            "no manifest → unclassified utility hard-denied even WITH a Datasource read grant: ${warnings.detail}",
         )
         assertEquals(EnfAction.DENY, decideAs(broad, "SHOW BINLOG EVENTS"), "no manifest → hard-denied despite the broad grant")
         // And the analyst (no grant at all) is denied too — deny-by-default AND the hard-deny both hold.
-        assertEquals(EnfAction.DENY, decideAs(principal, "SHOW PROCESSLIST"), "no manifest → denied with no grant")
+        assertEquals(EnfAction.DENY, decideAs(principal, "SHOW WARNINGS"), "no manifest → denied with no grant")
         setEngineVersion("8.0.44")
+    }
+
+    @Test
+    fun `a broad production permit cannot reach a data-leak SHOW, and an operator forbid on it still bites`() {
+        // A statement that still carries a Utility must stay governed by it: a broad action-unscoped
+        // datasource permit must not reach SHOW BINLOG EVENTS, and an operator forbid written against the
+        // Utility EUID must still be evaluated. (SHOW GRANTS / SHOW PROCESSLIST no longer emit one — they
+        // gate on stmt.cat.admin.* alone.)
+        setEngineVersion("8.0.44")
+        setTags("""["system:production"]""")
+        val wide = "wide-prod@example.com"
+        val role = fx.policyStore.createRole(RoleInput("wide-prod-reader"))
+        fx.policyStore.createAssignment(RoleAssignmentInput(wide, role.id))
+        fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "test-wide-prod-grant",
+                cedarSrc = """permit(principal in Role::"wide-prod-reader", action, resource in Datasource::"${fx.datasource.name}");""",
+            ),
+            updatedBy = "test",
+        )
+        fun decideWide(sql: String) = decideQuery(
+            principal = wide, ds = fx.datasourceStore.get(fx.datasource.id)!!, sql = sql, channel = Channel.WIRE,
+            catalog = fx.datasourceStore.catalog(fx.datasource.id), policyStore = fx.policyStore, accessStore = fx.accessStore,
+            userGroupStore = fx.userGroupStore, roleResolver = fx.roleResolver, authz = fx.authz,
+            systemClassification = SystemClassificationService(),
+        ).action
+        assertEquals(EnfAction.DENY, decideWide("SHOW BINLOG EVENTS"), "the system:data-leak floor must survive a broad datasource permit")
+        assertEquals(EnfAction.DENY, decideWide("SHOW CREATE USER CURRENT_USER()"), "system:critical must survive a broad datasource permit")
+
+        val forbid = fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "test-operator-binlog-forbid",
+                cedarSrc = """forbid(principal, action in [Action::"result.read.unmasked", Action::"result.read.masked"], resource == Utility::"${fx.datasource.name}/SHOW_BINLOG_EVENTS");""",
+            ),
+            updatedBy = "test",
+        )
+        try {
+            setTags("""["system:development"]""")
+            assertEquals(
+                EnfAction.DENY,
+                decideWide("SHOW BINLOG EVENTS"),
+                "an operator forbid on the Utility EUID must override even the dev relaxation — a dead forbid is fail-open",
+            )
+        } finally {
+            fx.cedarPolicyStore.delete(forbid.id)
+            setTags("""["system:production"]""")
+        }
+    }
+
+    @Test
+    fun `a policy naming a retired Utility command is rejected, not silently inert`() {
+        // Utility is still a valid entity type, so forbid(... resource == Utility::"ds/SHOW_GRANTS") passes
+        // schema validation and then never matches — an operator's carve-out would stop working in silence.
+        // Reject it at write time and name the replacement.
+        val ds = fx.datasource.name
+        for (cmd in listOf("SHOW_GRANTS", "SHOW_PROCESSLIST")) {
+            val e = assertFailsWith<InvalidCedarPolicyException> {
+                fx.cedarPolicyStore.create(
+                    CedarPolicyInput(
+                        name = "retired-$cmd",
+                        cedarSrc = """forbid(principal, action in [Action::"result.read.unmasked"], resource == Utility::"$ds/$cmd");""",
+                    ),
+                    updatedBy = "test",
+                )
+            }
+            assertTrue(e.message.orEmpty().contains("no longer emitted"), "must say why: ${e.message}")
+            assertTrue(e.message.orEmpty().contains("stmt.kind."), "must name the replacement: ${e.message}")
+        }
+        // A utility that IS still emitted stays writable.
+        val ok = fx.cedarPolicyStore.create(
+            CedarPolicyInput(
+                name = "live-utility-policy",
+                cedarSrc = """forbid(principal, action in [Action::"result.read.unmasked"], resource == Utility::"$ds/SHOW_BINLOG_EVENTS");""",
+            ),
+            updatedBy = "test",
+        )
+        fx.cedarPolicyStore.delete(ok.id)
     }
 }

--- a/docs/access-model.md
+++ b/docs/access-model.md
@@ -47,7 +47,7 @@ construction in
 [mapping-schema-construction.md](./mapping-schema-construction.md)). Functions
 and utilities are name-keyed only — `Function::"<datasource>/<name>"`,
 `Utility::"<datasource>/<command>"` (e.g. `Function::"acme-pg/pg_read_file"`,
-`Utility::"acme-mysql/SHOW_PROCESSLIST"`). That is what makes system-catalog
+`Utility::"acme-mysql/SHOW_BINLOG_EVENTS"`). That is what makes system-catalog
 introspection safe: `public.tables` is a different resource from
 `information_schema.tables`. It holds on both engines (a MySQL database is a
 schema).
@@ -75,14 +75,15 @@ guard.
 
 Utility commands map to the resource they expose. `SHOW`/`DESCRIBE` read no
 table, so the analyzer maps each to a canonical command id and the shipped
-manifest tags it: `SHOW [FULL] PROCESSLIST` → `SHOW_PROCESSLIST` /
-`system:activity`, `SHOW CREATE TABLE` / `DESCRIBE` → `system:catalog`,
-`SHOW BINLOG EVENTS` → `system:data-leak`. A command uses the real
-Table/Function when one exists; a command with no mirrored SQL object uses a
-dedicated `Utility::"<datasource>/<command>"` resource. Either way the same tag
-policy decides it. This command→resource map is a small, declarative part of the
-classification — the one place a resource is named rather than derived from
-lineage.
+manifest tags it: `SHOW BINLOG EVENTS` → `SHOW_BINLOG_EVENTS` /
+`system:data-leak`, `SHOW CREATE USER` → `system:critical`, `SHOW CREATE TABLE`
+/ `DESCRIBE` → `system:catalog`. `SHOW GRANTS` and `SHOW [FULL] PROCESSLIST`
+emit no utility — they gate on `stmt.cat.admin.account` / `.process`. A command
+uses the real Table/Function when one exists; a command with no mirrored SQL
+object uses a dedicated `Utility::"<datasource>/<command>"` resource. Either way
+the same tag policy decides it. This command→resource map is a small,
+declarative part of the classification — the one place a resource is named
+rather than derived from lineage.
 
 Only dangerous-classified functions are marshalled as Function resources (safe
 builtins and ordinary UDFs are not gated on this path). General UDF-output

--- a/docs/policy-store.md
+++ b/docs/policy-store.md
@@ -401,9 +401,10 @@ Development datasource (`system:development`) — connect via any dev role;
 | user table, non-PII column (`users.id`) | cleartext (`-200`) |
 | user table, PII column (`users.ssn`) | cleartext — dev holds no PII, nothing is masked (`-200`) |
 | system table — catalog (`pg_class`, `information_schema`) | readable (`-100`) |
-| system table — activity (`pg_stat_activity`, `SHOW PROCESSLIST`) | readable (`-110` relaxed on dev, `-200` permits) |
+| system table — activity (`pg_stat_activity`, `information_schema.PROCESSLIST`) | readable (`-110` relaxed on dev, `-200` permits) |
 | system table — data-leak (`pg_stats`, `SHOW BINLOG EVENTS`) | readable (`-120` relaxed on dev) |
-| system — critical (`pg_authid`, `SET GLOBAL`, `SHOW GRANTS`, `SET PASSWORD`) | DENIED even on dev (`-130`) |
+| system — critical (`pg_authid`, `SET GLOBAL`, `SHOW CREATE USER`, `SET PASSWORD`) | DENIED even on dev (`-130`) |
+| admin statement kind (`SHOW GRANTS`, `SHOW PROCESSLIST`) | permitted by the dev admin preset (`-238`); prod ships none |
 | dangerous function — file/remote read (`pg_read_file`, `dblink`, `get_raw_page`) | allowed (data-leak, relaxed on dev) |
 | dangerous function — critical (`dblink_exec`, `pg_terminate_backend`, `lo_export`) | DENIED even on dev (`-130`) |
 | un-analyzable statement / binary-result relay | relayed (`-201`/`-202`); a hidden critical function is still denied first |

--- a/docs/statement-typing.md
+++ b/docs/statement-typing.md
@@ -16,7 +16,8 @@ And the "category" was smeared across three mechanisms of `StatementFacts`:
 
 - `GrantAction` — five `sql.*` verbs, on a datasource grant;
 - a separate relay class field (`session` / `metadata` / `analyzed`);
-- a `Utility` resource tag (`SET_ROLE`, `SHOW_PROCESSLIST`) — a third mechanism.
+- a `Utility` resource tag (`SET_ROLE`, `SHOW_BINLOG_EVENTS`) — a third
+  mechanism.
 
 So "what kind of statement is this?" had no single answer, and sensitivity was
 decided per statement, inline in `facts.go`: `SET ROLE` got a utility tag and

--- a/docs/system-classification.md
+++ b/docs/system-classification.md
@@ -183,9 +183,9 @@ analyzer. A manifest is declarative:
   ],
   "commands": [
     {
-      "id": "SHOW_PROCESSLIST",
-      "resource": "information_schema/PROCESSLIST",
-      "tag": "system:activity"
+      "id": "SHOW_BINLOG_EVENTS",
+      "resource": "show-binlog-events",
+      "tag": "system:data-leak"
     }
   ]
 }
@@ -458,7 +458,7 @@ Utility command ids:
 - account administration: `SET_PASSWORD`, `CREATE_USER`, `ALTER_USER`,
   `DROP_USER`, `RENAME_USER`, `GRANT`, `REVOKE`, `SET_DEFAULT_ROLE`, `SET_ROLE`;
 - credential-bearing reads: `SHOW_CREATE_USER` (an account's stored password
-  hash), `SHOW_GRANTS`;
+  hash);
 - server-state mutation: `SET_GLOBAL`, `SET_PERSIST`, `SET_PERSIST_ONLY`,
   `RESET_PERSIST`, `ALTER_INSTANCE`, `CLONE_INSTANCE`, `RESTART`, `SHUTDOWN`;
 - replication and binary log: `CHANGE_REPLICATION_SOURCE`, `RESET_REPLICA`,
@@ -531,10 +531,11 @@ Relations/views and prefix families:
 The `sys.io_*` and latest-file-I/O views are not classified, so they are
 `system:catalog`.
 
-Utility commands: `SHOW [FULL] PROCESSLIST` (`SHOW_PROCESSLIST`) and
-`SHOW REPLICA STATUS` / `SHOW SLAVE STATUS` (`SHOW_REPLICA_STATUS`).
-`SHOW_STATUS` carries this tag in the manifest but is a passthrough the analyzer
-never emits.
+Utility commands: `SHOW REPLICA STATUS` / `SHOW SLAVE STATUS`
+(`SHOW_REPLICA_STATUS`). `SHOW_STATUS` carries this tag in the manifest but is a
+passthrough the analyzer never emits. `SHOW [FULL] PROCESSLIST` emits no utility
+(it gates on `stmt.cat.admin.process`); `information_schema.PROCESSLIST` and the
+`sys`/`performance_schema` views keep this tag.
 
 ### Explicit catalog examples
 
@@ -563,7 +564,6 @@ EUID is always `Utility::"<datasource>/<command>"`:
 <!-- prettier-ignore -->
 | statement | emitted command id | tag |
 | --- | --- | --- |
-| MySQL `SHOW [FULL] PROCESSLIST` | `SHOW_PROCESSLIST` | `system:activity` |
 | MySQL `SHOW BINLOG EVENTS` | `SHOW_BINLOG_EVENTS` | `system:data-leak` |
 | MySQL `SHOW WARNINGS` / `SHOW ERRORS` | `SHOW_WARNINGS` / `SHOW_ERRORS` | `system:data-leak` |
 | MySQL `SHOW CREATE USER u` | `SHOW_CREATE_USER` | `system:critical` |
@@ -574,13 +574,24 @@ EUID is always `Utility::"<datasource>/<command>"`:
 | PostgreSQL `SET ROLE` / `SET SESSION AUTH…` | `SET_ROLE` / `SET_SESSION_AUTHORIZATION` | `system:critical` |
 | MySQL `SET sql_mode` / PostgreSQL lexer-mode GUC | `SET_SQL_MODE` / `SET_STANDARD_CONFORMING_STRINGS` | `system:critical` |
 | MySQL `SHOW CREATE TABLE users`, `DESCRIBE users` | metadata passthrough (no utility grant) | — |
+| MySQL `SHOW GRANTS`, `SHOW [FULL] PROCESSLIST` | no utility — gated by kind (`stmt.cat.admin.account` / `.process`) | — |
 | PostgreSQL `SHOW ALL` / `SHOW <guc>` | intentional passthrough (`PG_SHOW_GUC` never emitted) | — |
 
 ```text
 Utility::"acme-mysql/SET_GLOBAL"
 Utility::"acme-pg/PG_ALTER_SYSTEM"
-Utility::"acme-mysql/SHOW_PROCESSLIST"
+Utility::"acme-mysql/SHOW_BINLOG_EVENTS"
 ```
+
+A statement is authorized by its kind. `SHOW GRANTS` and
+`SHOW [FULL] PROCESSLIST` emit no utility and gate on `stmt.cat.admin.account` /
+`stmt.cat.admin.process`.
+
+One trap: `permit(principal, action, resource in Datasource::"prod")` now
+reaches both, as it already reaches `SELECT` and `DROP TABLE` — scope the
+actions. A policy naming `Utility::"prod/SHOW_GRANTS"` is rejected on write and
+listed by `/health`, so an old carve-out fails loudly rather than silently never
+matching.
 
 The key is datasource / canonical command id, outside the SQL catalog/schema
 namespace, so a quoted user schema or function cannot collide with it. The
@@ -738,16 +749,18 @@ policies are enabled:
 | `SELECT most_common_vals FROM pg_stats` | Table `system:data-leak` | DENY | dev policy may permit |
 | `SELECT rolpassword FROM pg_authid` | Table `system:critical` | DENY | DENY — critical is never relaxed by the dev preset |
 | `SELECT LOAD_FILE('/etc/passwd')` | Function `system:data-leak` | DENY | dev policy may permit |
-| `SHOW FULL PROCESSLIST` | Utility `SHOW_PROCESSLIST`, `system:activity` | DENY | dev policy may permit |
+| `SHOW FULL PROCESSLIST` | kind `stmt.cat.admin.process` (no utility) | DENY | dev policy may permit |
+| `SHOW GRANTS` | kind `stmt.cat.admin.account` (no utility) | DENY | dev policy may permit |
+| `SHOW CREATE USER u` | Utility `SHOW_CREATE_USER`, `system:critical` | DENY | DENY — it returns the stored password hash |
 | `SHOW CREATE TABLE users` | no grant at all (metadata passthrough) | ALLOW | ALLOW |
 | `SHOW BINLOG EVENTS` | Utility `SHOW_BINLOG_EVENTS`, `system:data-leak` | DENY | dev policy may permit |
 | `SET GLOBAL general_log = ON` | Utility `SET_GLOBAL`, `system:critical` | DENY | DENY — critical is never relaxed by the dev preset |
 
 The `system:critical` rows are unconditional: `ManifestCommandCoverageDbTest`
-asserts that `SHOW CREATE USER` and `SHOW GRANTS` deny even on a
-`system:development` datasource, while `SHOW REPLICA STATUS` (`system:activity`)
-relaxes to ALLOW there. Relaxing a critical tag takes an admin editing or
-disabling the shipped forbid, not a preset.
+asserts that `SHOW CREATE USER` denies even on a `system:development`
+datasource, while `SHOW REPLICA STATUS` (`system:activity`) relaxes to ALLOW
+there. Relaxing a critical tag takes an admin editing or disabling the shipped
+forbid, not a preset.
 
 Two things the table's shape can mislead about. First, catalog policy does not
 bypass the statement-kind gate: a principal still needs `stmt.kind.select` (or

--- a/engine/src/main/resources/system-classification/mysql/8.0.json
+++ b/engine/src/main/resources/system-classification/mysql/8.0.json
@@ -882,11 +882,6 @@
       "tag": "system:critical"
     },
     {
-      "id": "SHOW_GRANTS",
-      "resource": "show-grants",
-      "tag": "system:critical"
-    },
-    {
       "id": "SHOW_VARIABLES",
       "resource": "performance_schema/global_variables",
       "tag": "system:critical"
@@ -915,11 +910,6 @@
       "id": "SHOW_ERRORS",
       "resource": "session-diagnostics",
       "tag": "system:data-leak"
-    },
-    {
-      "id": "SHOW_PROCESSLIST",
-      "resource": "def/information_schema/PROCESSLIST",
-      "tag": "system:activity"
     },
     {
       "id": "SHOW_STATUS",

--- a/engine/src/main/resources/system-classification/mysql/8.4.json
+++ b/engine/src/main/resources/system-classification/mysql/8.4.json
@@ -882,11 +882,6 @@
       "tag": "system:critical"
     },
     {
-      "id": "SHOW_GRANTS",
-      "resource": "show-grants",
-      "tag": "system:critical"
-    },
-    {
       "id": "SHOW_VARIABLES",
       "resource": "performance_schema/global_variables",
       "tag": "system:critical"
@@ -915,11 +910,6 @@
       "id": "SHOW_ERRORS",
       "resource": "session-diagnostics",
       "tag": "system:data-leak"
-    },
-    {
-      "id": "SHOW_PROCESSLIST",
-      "resource": "def/information_schema/PROCESSLIST",
-      "tag": "system:activity"
     },
     {
       "id": "SHOW_STATUS",

--- a/engine/src/test/kotlin/com/ridi/oss/proxymonster/classification/SystemClassificationTest.kt
+++ b/engine/src/test/kotlin/com/ridi/oss/proxymonster/classification/SystemClassificationTest.kt
@@ -217,6 +217,7 @@ class SystemClassificationTest {
     fun `real MySQL classifications (incl Aurora rds_) are correct`() {
         val c = SystemClassificationStore.load().classifierFor("mysql", "8.0")!!
         assertEquals(SystemTag.CRITICAL, c.classifyRelation("def", "mysql", "user"))
+        assertEquals(SystemTag.ACTIVITY, c.classifyRelation("def", "information_schema", "PROCESSLIST"))
         assertEquals(SystemTag.CRITICAL, c.classifyRelation("def", "information_schema", "USER_PRIVILEGES"))
         assertEquals(SystemTag.DATA_LEAK, c.classifyRelation("def", "information_schema", "COLUMN_STATISTICS"))
         assertEquals(SystemTag.ACTIVITY, c.classifyRelation("def", "information_schema", "PROCESSLIST"))
@@ -227,7 +228,14 @@ class SystemClassificationTest {
         // Aurora proprietary management procedures (mysql.rds_* family → critical)
         assertEquals(SystemTag.CRITICAL, c.classifyFunction("def", "mysql", "rds_kill"))
         assertEquals(SystemTag.CRITICAL, c.classifyFunction("def", "mysql", "rds_set_configuration"))
-        assertEquals(SystemTag.ACTIVITY, c.classifyCommand("SHOW_PROCESSLIST"))
+        assertEquals(SystemTag.CRITICAL, c.classifyCommand("SET_GLOBAL"))
+        // SHOW GRANTS / SHOW PROCESSLIST gate on their statement kind, not a Utility, so the shipped manifest
+        // carries no command entry. The tables they expose stay classified below.
+        assertNull(c.classifyCommand("SHOW_GRANTS"))
+        assertNull(c.classifyCommand("SHOW_PROCESSLIST"))
+        assertEquals(SystemTag.CRITICAL, c.classifyRelation("def", "mysql", "global_grants"))
+        assertEquals(SystemTag.CRITICAL, c.classifyRelation("def", "mysql", "user"))
+        assertEquals(SystemTag.ACTIVITY, c.classifyRelation("def", "information_schema", "PROCESSLIST"))
     }
 
     @Test

--- a/goproxy/go.mod
+++ b/goproxy/go.mod
@@ -4,9 +4,9 @@ go 1.26.0
 
 require (
 	github.com/alecthomas/kong v1.16.0
-	github.com/docker/go-connections v0.8.1
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/jackc/pgx/v5 v5.10.0
+	github.com/moby/moby/api v1.55.0
 	github.com/ridi-oss/proxy-monster/analyzer v0.0.0-00010101000000-000000000000
 	github.com/ridi-oss/proxy-monster/mysqlwire v0.1.4
 	github.com/testcontainers/testcontainers-go v0.44.0
@@ -38,6 +38,7 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/go-connections v0.8.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.1 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
@@ -53,7 +54,6 @@ require (
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
-	github.com/moby/moby/api v1.55.0 // indirect
 	github.com/moby/moby/client v0.5.0 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/sys/sequential v0.7.0 // indirect
@@ -64,7 +64,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/ridi-oss/sqlglot-go v0.24.0 // indirect
+	github.com/ridi-oss/sqlglot-go v0.25.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.6 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect

--- a/goproxy/go.sum
+++ b/goproxy/go.sum
@@ -105,10 +105,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/ridi-oss/sqlglot-go v0.23.0 h1:yk4tCVNXOO/2amBKEAK800lvcEITh0ixQbiquvGIhsM=
-github.com/ridi-oss/sqlglot-go v0.23.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
-github.com/ridi-oss/sqlglot-go v0.24.0 h1:dq25mbuMyRk2xMZqrw77WUARppsEMhckbuTGQf6uwMY=
-github.com/ridi-oss/sqlglot-go v0.24.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
+github.com/ridi-oss/sqlglot-go v0.25.0 h1:t+lKLkvzhDYJnN/UQlb9ZT1aXrs4Bjl7cGZxBWcaGR0=
+github.com/ridi-oss/sqlglot-go v0.25.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/shirou/gopsutil/v4 v4.26.6 h1:Mzr/npDtQC/xpeEuQKHZt8Zo9CmPvhTj8nkR8w5TLDs=


### PR DESCRIPTION
`SHOW GRANTS` could not be authorized by any policy. It emitted a `Utility` grant
tagged `system:critical` alongside its statement kind, and `-130` is a
`forbid(result.read.*)` with no `unless` — so a privilege audit ("which grants
does this service account hold?") was unreachable, though `SHOW GRANTS` returns a
privilege list and no credential.

The `Utility` was also redundant. Its command id and the statement kind are both
read off the same AST field (`Show.this` — `showUtilityCommand` in
`analyzer/probe/facts.go`, `showKind` in `kinds.go`), so it stated no fact the
kind did not. A statement's authorization is its kind.

## What changed

Drop the `SHOW_GRANTS` and `SHOW_PROCESSLIST` command entries from the MySQL
manifests and stop emitting them. Both now gate on `stmt.cat.admin.account` /
`stmt.cat.admin.process`:

```
default production floor      DENY   statement kind 'show_grants' is not permitted
dev (preset -238)             ALLOW
per-role, exact kind          permit(principal in Role::"auditor",
                                     action == Action::"stmt.kind.show_grants",
                                     resource == Datasource::"prod-mysql");
```

A retired `Utility` EUID is now rejected rather than silently ignored.
`forbid(… resource == Utility::"prod/SHOW_GRANTS")` previously parsed, loaded, and
never matched — an operator's carve-out disappearing in silence. It now fails on
write naming the replacement action, and `/health` lists any already-stored one
for upgraded installs.

`SHOW CREATE USER` keeps its `system:critical` utility — it returns the stored
password hash (`IDENTIFIED WITH 'mysql_native_password' AS '*9024…'`).
`mysql.global_grants`, `mysql.user`, `information_schema.PROCESSLIST` and the
`sys`/`performance_schema` views keep their tags, so `SELECT` against them is
unaffected.

## Trap

`permit(principal, action, resource in Datasource::"prod")` now reaches both
statements — as it already reaches `SELECT` and `DROP TABLE`. Scope the actions
you mean. Pinned by a test.

## sqlglot-go v0.25.0

`SHOW GRANTS FOR 'u'@'h'` did not parse — the parser read one identifier after
`FOR` and choked on `@`. v0.25.0 routes the `FOR` target through the same
user-spec parser `SHOW CREATE USER` already used. Laundering spellings stay
unmodeled Commands (fail-closed): detached `@`, comma slop in `USING`, `?`
placeholders. goproxy's indirect pin moves too — the server image builds
`goproxy/go.mod` with `GOWORK=off`.

## Verification

`mise run verify` green. Reviewed by three independent reviewers; two findings
fixed (the inert-EUID hole above, and a doc paragraph that contradicted the code).

Follow-up: [#269](https://github.com/ridi-oss/proxy-monster/issues/269) — 13 more
utilities duplicate a statement kind, 32 manifest ids are never emitted.
