### PR TITLE
fix(analyzer): keep output labels native across rewrites and references

### DIFF
--- a/analyzer/go.mod
+++ b/analyzer/go.mod
@@ -8,6 +8,6 @@ module github.com/ridi-oss/proxy-monster/analyzer
 
 go 1.26.0
 
-require github.com/ridi-oss/sqlglot-go v0.25.0
+require github.com/ridi-oss/sqlglot-go v0.27.0
 
 require google.golang.org/protobuf v1.36.11

--- a/analyzer/go.sum
+++ b/analyzer/go.sum
@@ -1,8 +1,6 @@
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/ridi-oss/sqlglot-go v0.24.0 h1:dq25mbuMyRk2xMZqrw77WUARppsEMhckbuTGQf6uwMY=
-github.com/ridi-oss/sqlglot-go v0.24.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
-github.com/ridi-oss/sqlglot-go v0.25.0 h1:t+lKLkvzhDYJnN/UQlb9ZT1aXrs4Bjl7cGZxBWcaGR0=
-github.com/ridi-oss/sqlglot-go v0.25.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
+github.com/ridi-oss/sqlglot-go v0.27.0 h1:bJXqEfVwKbfp4SSw9d2PGkOaasLFXM5+6zTgJN3z9go=
+github.com/ridi-oss/sqlglot-go v0.27.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/analyzer/probe/engine.go
+++ b/analyzer/probe/engine.go
@@ -43,6 +43,13 @@ type engine interface {
 	// RewriteStatement optionally rewrites a parsed statement into the SQL the proxy should relay to the
 	// target DB, returning "" to leave it unchanged.
 	RewriteStatement(root exp.Expression) string
+	// NativeOutputLabel computes the output label THIS engine's target DB natively assigns to an
+	// unaliased projection: PostgreSQL derives it from the resolved expression (parse_target.c
+	// FigureColname, written function names from the parse-time SpanText); MySQL uses the
+	// projection's verbatim source spelling (SpanText). query is the SELECT the projection belongs
+	// to, for resolving references to its derived sources. ok=false means the label is unknowable —
+	// the caller leaves Qualify's synthetic name.
+	NativeOutputLabel(projection, query exp.Expression) (string, bool)
 	// DiagnosticLeakKeys is the column keys this statement's target-DB error/warning diagnostic could echo
 	// — engine-specific, since what a diagnostic contains is (MySQL echoes the operated value; PostgreSQL
 	// also dumps a failed write's whole row via `DETAIL: Failing row contains (…)`). Start from
@@ -144,6 +151,20 @@ func (e *mysqlEngine) IsTempSchema(exp.Expression) bool { return false }
 // performance_schema, sys) are access-controlled resources the system-classification manifest covers,
 // not a blanket pass for calls made under them.
 func (e *mysqlEngine) IsTrustedSystemQualifier(exp.Expression) bool { return false }
+
+// MySQL labels an unaliased computed projection with its verbatim source text (`1 +    1` keeps
+// its exact spacing; verified against MySQL 8.0), truncated to 255 runes as the server does for
+// implicit labels. Fails closed on an unstamped node (only parse-time projections carry text).
+func (e *mysqlEngine) NativeOutputLabel(projection, _ exp.Expression) (string, bool) {
+	text, ok := projection.SpanText()
+	if !ok {
+		return "", false
+	}
+	if runes := []rune(text); len(runes) > 255 {
+		text = string(runes[:255])
+	}
+	return text, true
+}
 
 // RewriteStatement pins a single, session-scoped `SET character_set_results = NULL` — the default MySQL
 // Connector/J (and so DBeaver) session-init, which asks the target DB to return each column in its own charset
@@ -251,6 +272,12 @@ func (e *postgresEngine) IsTrustedSystemQualifier(qualifier exp.Expression) bool
 // PostgreSQL has no relay rewrite: client_encoding is handled on the wire, not by an analyzer rewrite,
 // so there is nothing to rewrite here.
 func (e *postgresEngine) RewriteStatement(exp.Expression) string { return "" }
+
+// PostgreSQL names an unaliased projection per parse_target.c FigureColname; a call is labeled by
+// its WRITTEN function name, read from the projection's parse-time SpanText.
+func (e *postgresEngine) NativeOutputLabel(projection, query exp.Expression) (string, bool) {
+	return nativeOutputLabel(projection, query, e, 0)
+}
 
 // PostgreSQL adds a failed write's WHOLE target row to the template: `INSERT INTO users (id) …` can fail
 // with `DETAIL: Failing row contains (1, 010-1234-5678, …)` — columns the statement never named. If the

--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -125,6 +125,15 @@ func EmitFacts(sql string, engineConfig *pb.EngineConfig, sch *schema.Mapping, n
 	// left to fold by hand. Quote-aware, so a quoted identifier keeps its case: `"PG_CATALOG"` stays a
 	// distinct user schema from `pg_catalog`, and `"MySchema".fn` from `myschema.fn`.
 	root := optimizer.NormalizeIdentifiers(unwrapSubquery(stmts[0]), eng.Dialect())
+	if !hasSyntheticAlias(root) {
+		// A duplicate-label error is the target DB's own rejection (MySQL ER_DUP_FIELDNAME, a
+		// referenced PostgreSQL ambiguity) — the statement would never run there.
+		if err := stampNativeOutputLabels(root, eng); err != nil {
+			facts := inadmissibleFacts("VALIDATE", err.Error())
+			facts.StatementExec = executeGrant(statementKind(root, eng))
+			return facts
+		}
+	}
 	candidates := schemaQualifierCandidates(root)
 
 	var facts *pb.StatementFacts

--- a/analyzer/probe/output_labels.go
+++ b/analyzer/probe/output_labels.go
@@ -1,0 +1,195 @@
+package probe
+
+import (
+	"fmt"
+	"regexp"
+
+	exp "github.com/ridi-oss/sqlglot-go/expressions"
+
+	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
+)
+
+var syntheticLabelPattern = regexp.MustCompile(`^_col_\d+$`)
+
+var functionLabelPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// hasSyntheticAlias reports whether root aliases anything as `_col_N`. On a qualified tree it
+// means Qualify synthesized labels; on the client's ORIGINAL tree it means client labels are
+// indistinguishable from synthetic ones, so native-label stamping must be skipped.
+func hasSyntheticAlias(root exp.Expression) bool {
+	if root == nil {
+		return false
+	}
+	for _, alias := range root.FindAll(exp.KindAlias) {
+		if syntheticLabelPattern.MatchString(alias.Alias()) {
+			return true
+		}
+	}
+	return false
+}
+
+// stampNativeOutputLabels aliases every unaliased computed projection of every SELECT in root
+// with the label the engine's target DB would natively assign, BEFORE Qualify runs — so Qualify
+// never synthesizes `_col_N` for them, the star expansion references real names, and a client
+// reference to a native label (`SELECT c."current_database" FROM (SELECT current_database()) c`,
+// valid on the real DB) resolves instead of failing closed.
+//
+// Duplicate labels follow the target DB's own error direction, verified against PG 16 and MySQL
+// 8.0: MySQL rejects a derived-table/CTE body with duplicated labels outright (ER_DUP_FIELDNAME,
+// case-insensitive), so that returns an error → the statement fails VALIDATE. PostgreSQL accepts
+// duplicated OUTPUT labels and rejects only a REFERENCE to one ("column reference is ambiguous"),
+// so a PG duplicate is not stamped (references stay unresolvable) and errors only when the query
+// references it through the source alias. A SELECT whose list contains a star is never stamped —
+// the star hides labels this pass cannot count. A label the engine cannot compute is left to
+// Qualify (its synthetic name may then surface; restoreRelayOutputLabels repairs display labels).
+func stampNativeOutputLabels(root exp.Expression, eng engine) error {
+	derived := derivedBodySelects(root)
+	for _, sel := range root.FindAll(exp.KindSelect) {
+		projections := sel.Selects()
+		hasStar := false
+		for _, projection := range projections {
+			if projectionIsStar(projection) {
+				hasStar = true
+			}
+		}
+
+		// A projection is unaliased when it is not an Alias node and not itself a named column —
+		// a bare column's own name IS its label and needs no stamp.
+		type stamp struct {
+			projection exp.Expression
+			label      string
+		}
+		inUse := map[string][]string{} // folded label → display labels seen
+		stamps := []stamp{}
+		for _, projection := range projections {
+			if projection.Kind() == exp.KindAlias || projection.Kind() == exp.KindColumn || projectionIsStar(projection) {
+				if name := projection.AliasOrName(); name != "" {
+					inUse[eng.FoldColumn(name)] = append(inUse[eng.FoldColumn(name)], name)
+				}
+				continue
+			}
+			label, ok := eng.NativeOutputLabel(projection, sel)
+			if !ok || label == "" {
+				continue
+			}
+			inUse[eng.FoldColumn(label)] = append(inUse[eng.FoldColumn(label)], label)
+			stamps = append(stamps, stamp{projection, label})
+		}
+
+		if alias, isDerived := derived[sel]; isDerived && !hasStar {
+			for folded, names := range inUse {
+				if len(names) < 2 {
+					continue
+				}
+				if eng.Type() == pb.Engine_MYSQL {
+					// Real MySQL rejects the derived table itself: ER_DUP_FIELDNAME.
+					return fmt.Errorf("duplicate column name '%s' in derived table", names[0])
+				}
+				// Real PostgreSQL rejects only a reference to the duplicated label.
+				if alias != "" && referencesLabel(root, sel, alias, folded, eng) {
+					return fmt.Errorf("column reference %q is ambiguous", names[0])
+				}
+			}
+		}
+		if hasStar {
+			continue // a star hides labels; stamping here could collide with a hidden name
+		}
+
+		stamped := map[exp.Expression]string{}
+		for _, s := range stamps {
+			if len(inUse[eng.FoldColumn(s.label)]) > 1 {
+				continue
+			}
+			stamped[s.projection] = s.label
+		}
+		if len(stamped) == 0 {
+			continue
+		}
+		// Rebuild the select list with explicit Alias wrappers — AliasExpr would set an `alias`
+		// ARG on kinds that accept one (a Window renders it inside OVER(...)), not a wrapper.
+		newSelections := make([]exp.Expression, 0, len(projections))
+		for _, projection := range projections {
+			if label, ok := stamped[projection]; ok {
+				projection = exp.AliasNode(exp.Args{"this": projection, "alias": exp.ToIdentifier(label, true)})
+			}
+			newSelections = append(newSelections, projection)
+		}
+		sel.Set("expressions", newSelections)
+	}
+	return nil
+}
+
+// derivedBodySelects maps each SELECT that is a derived-table or CTE body to its source alias
+// ("" when unaliased). Set-operation bodies map their leftmost branch, the label-bearing one.
+func derivedBodySelects(root exp.Expression) map[exp.Expression]string {
+	out := map[exp.Expression]string{}
+	for _, subquery := range root.FindAll(exp.KindSubquery) {
+		if sel := leftmostSelect(subquery.This()); sel != nil {
+			out[sel] = subquery.Alias()
+		}
+	}
+	for _, cte := range root.FindAll(exp.KindCTE) {
+		if sel := leftmostSelect(cte.This()); sel != nil {
+			out[sel] = cte.Alias()
+		}
+	}
+	return out
+}
+
+// referencesLabel reports whether any column outside body references alias.label (folded per the
+// engine). Alias shadowing in unrelated scopes can over-match — that only fails closed.
+func referencesLabel(root, body exp.Expression, alias, foldedLabel string, eng engine) bool {
+	inBody := map[exp.Expression]bool{}
+	for _, node := range body.Walk(true) {
+		inBody[node] = true
+	}
+	for _, column := range root.FindAll(exp.KindColumn) {
+		if inBody[column] {
+			continue
+		}
+		if eng.FoldColumn(column.TableName()) == eng.FoldColumn(alias) && eng.FoldColumn(column.Name()) == foldedLabel {
+			return true
+		}
+	}
+	return false
+}
+
+// restoreRelayOutputLabels renames the outermost select list's remaining `_col_N` aliases on a
+// relay-only tree to their native labels — the display repair for projections
+// stampNativeOutputLabels had to skip (a PG duplicate is legal as OUTPUT: two `?column?`s). A
+// set-operation root restores its leftmost branch, the label-bearing one. Only the top-level
+// alias is touched; a label something still references is left alone.
+func restoreRelayOutputLabels(root exp.Expression, eng engine) bool {
+	sel := leftmostSelect(root)
+	if sel == nil {
+		return false
+	}
+	referenced := map[string]bool{}
+	for _, column := range root.FindAll(exp.KindColumn) {
+		if column.TableName() == "" && syntheticLabelPattern.MatchString(column.Name()) {
+			referenced[column.Name()] = true
+		}
+	}
+	renamed := false
+	for _, projection := range sel.Selects() {
+		if !syntheticLabelPattern.MatchString(projection.Alias()) || referenced[projection.Alias()] {
+			continue
+		}
+		expression := projection
+		if projection.Kind() == exp.KindAlias {
+			expression = projection.This()
+		}
+		native, ok := eng.NativeOutputLabel(expression, sel)
+		if !ok || native == "" {
+			continue
+		}
+		projection.Set("alias", exp.ToIdentifier(native, true))
+		renamed = true
+	}
+	return renamed
+}
+
+func projectionIsStar(projection exp.Expression) bool {
+	return projection != nil && (projection.Kind() == exp.KindStar ||
+		(projection.Kind() == exp.KindColumn && projection.This() != nil && projection.This().Kind() == exp.KindStar))
+}

--- a/analyzer/probe/output_labels_test.go
+++ b/analyzer/probe/output_labels_test.go
@@ -1,0 +1,191 @@
+package probe
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
+)
+
+// A client may reference a derived table's implicit native label — valid on the real DB:
+// PostgreSQL names unaliased projections per FigureColname, MySQL by verbatim source text.
+// Pre-Qualify stamping makes those references resolve; a DUPLICATED label stays unresolvable,
+// matching the target DB's own ambiguity/duplicate error.
+func TestNativeLabelReferencesResolve(t *testing.T) {
+	pg := func(sql string) *pb.StatementFacts {
+		return analyzeProto(t, &pb.AnalyzeRequest{
+			Sql:          sql,
+			EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+			Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"pg_catalog", "public"}},
+			Catalog:      []*pb.ColumnSpec{columnSpec("acme", "public", "users", "id", "BIGINT")},
+		})
+	}
+	my := func(sql string) *pb.StatementFacts {
+		return analyzeProto(t, &pb.AnalyzeRequest{
+			Sql:          sql,
+			EngineConfig: &pb.EngineConfig{Engine: pb.Engine_MYSQL, EngineVersion: "8.0.42", MysqlLowerCaseTableNames: proto.Int32(0)},
+			Namespace:    &pb.Namespace{Catalog: "def", SearchPath: []string{"acme"}},
+			Catalog:      []*pb.ColumnSpec{columnSpec("def", "acme", "users", "id", "BIGINT")},
+		})
+	}
+
+	if f := pg(`SELECT c."current_database" FROM (SELECT current_database()) c`); !f.GetResolved() {
+		t.Fatalf("PG native-label reference must resolve: %q", f.GetDetail())
+	}
+	if f := pg(`SELECT c."?column?" FROM (SELECT 1+1) c`); !f.GetResolved() {
+		t.Fatalf("PG ?column? reference must resolve when unique: %q", f.GetDetail())
+	}
+	// Real PG: `column reference "?column?" is ambiguous`.
+	if f := pg(`SELECT c."?column?" FROM (SELECT 1+1, 2+2) c`); f.GetResolved() {
+		t.Fatal("PG duplicated ?column? reference must stay unresolvable")
+	}
+	if f := my("SELECT c.`1+1` FROM (SELECT 1+1) c"); !f.GetResolved() {
+		t.Fatalf("MySQL verbatim-label reference must resolve: %q", f.GetDetail())
+	}
+	// Real MySQL: ER_DUP_FIELDNAME on the derived table.
+	if f := my("SELECT c.`1+1` FROM (SELECT 1+1, 1+1) c"); f.GetResolved() {
+		t.Fatal("MySQL duplicated label reference must stay unresolvable")
+	}
+}
+
+// MySQL's label is the projection's verbatim source spelling — the relayed rewrite must carry it.
+func TestMySQLRewriteKeepsVerbatimLabels(t *testing.T) {
+	f := analyzeProto(t, &pb.AnalyzeRequest{
+		Sql:          "SELECT * FROM (SELECT database( ), u.id FROM users u) c",
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_MYSQL, EngineVersion: "8.0.42", MysqlLowerCaseTableNames: proto.Int32(0)},
+		Namespace:    &pb.Namespace{Catalog: "def", SearchPath: []string{"acme"}},
+		Catalog:      []*pb.ColumnSpec{columnSpec("def", "acme", "users", "id", "BIGINT")},
+	})
+	if !f.GetResolved() {
+		t.Fatalf("must resolve: %q", f.GetDetail())
+	}
+	if rewrite := f.GetRewrittenSql(); !strings.Contains(rewrite, "`database( )`") {
+		t.Fatalf("rewrite lost MySQL's verbatim label: %s", rewrite)
+	}
+}
+
+// A client alias spelled `_col_N` disables stamping entirely — synthetic and client labels are
+// then indistinguishable.
+func TestClientSyntheticAliasDisablesStamping(t *testing.T) {
+	f := analyzeProto(t, &pb.AnalyzeRequest{
+		Sql:          `SELECT * FROM (SELECT current_database() AS _col_99, oid FROM pg_catalog.pg_namespace) c`,
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+		Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"pg_catalog", "public"}},
+		Catalog:      []*pb.ColumnSpec{columnSpec("acme", "pg_catalog", "pg_namespace", "oid", "OID")},
+	})
+	if !f.GetResolved() {
+		t.Fatalf("must resolve: %q", f.GetDetail())
+	}
+	if !strings.Contains(f.GetRewrittenSql(), "_col_99") {
+		t.Fatalf("client _col_99 alias destroyed: %s", f.GetRewrittenSql())
+	}
+}
+
+// PostgreSQL labels a call by its WRITTEN name — canonicalized AST names are the wrong label and
+// would rebind a client's ORDER-BY-label to a different column than the target DB uses.
+func TestPostgresWrittenFunctionLabels(t *testing.T) {
+	// char_length/position/CEILING regenerate under different spellings; such rewrites are
+	// already denied fail-closed (postgresFunctionChangedByRegeneration), so no wrong label can
+	// relay for them. These cases regenerate faithfully and must carry the written name.
+	cases := []struct{ sql, label string }{
+		{`SELECT * FROM (SELECT md5(nspname), oid FROM pg_catalog.pg_namespace) c`, "md5"},
+		{`SELECT * FROM (SELECT ROUND(oid + 0.5), nspname FROM pg_catalog.pg_namespace) c`, "round"},
+		{`SELECT * FROM (SELECT now() at time zone 'UTC', nspname FROM pg_catalog.pg_namespace) c`, "timezone"},
+		{`SELECT * FROM (SELECT (array[1,2])[1], nspname FROM pg_catalog.pg_namespace) c`, "array"},
+	}
+	for _, tc := range cases {
+		f := analyzeProto(t, &pb.AnalyzeRequest{
+			Sql:          tc.sql,
+			EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+			Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"pg_catalog", "public"}},
+			Catalog: []*pb.ColumnSpec{
+				columnSpec("acme", "pg_catalog", "pg_namespace", "oid", "OID"),
+				columnSpec("acme", "pg_catalog", "pg_namespace", "nspname", "NAME"),
+			},
+		})
+		if !f.GetResolved() {
+			t.Fatalf("%s: did not resolve: %q", tc.sql, f.GetDetail())
+		}
+		if rewrite := f.GetRewrittenSql(); !strings.Contains(rewrite, `"`+tc.label+`"`) {
+			t.Fatalf("%s: rewrite lost written label %q: %s", tc.sql, tc.label, rewrite)
+		}
+	}
+}
+
+// Real MySQL rejects a derived table with duplicated labels (ER_DUP_FIELDNAME, case-insensitive);
+// the analyzer must fail the statement, never sanitize it into unique synthetic names.
+func TestMySQLDuplicateDerivedLabelsFailClosed(t *testing.T) {
+	my := func(sql string) *pb.StatementFacts {
+		return analyzeProto(t, &pb.AnalyzeRequest{
+			Sql:          sql,
+			EngineConfig: &pb.EngineConfig{Engine: pb.Engine_MYSQL, EngineVersion: "8.0.42", MysqlLowerCaseTableNames: proto.Int32(0)},
+			Namespace:    &pb.Namespace{Catalog: "def", SearchPath: []string{"acme"}},
+			Catalog:      []*pb.ColumnSpec{columnSpec("def", "acme", "users", "id", "BIGINT")},
+		})
+	}
+	for _, sql := range []string{
+		"SELECT * FROM (SELECT 1+1, 1+1) c",
+		"WITH c AS (SELECT 1+1, 1+1) SELECT * FROM c",
+		"SELECT * FROM (SELECT 1 AS `A`, 2 AS `a`) c", // case-insensitive duplicate
+	} {
+		if f := my(sql); f.GetResolved() {
+			t.Fatalf("%s: must fail like MySQL ER_DUP_FIELDNAME, got resolved", sql)
+		}
+	}
+	// Top-level duplicates are legal output on MySQL — only derived/CTE bodies reject.
+	if f := my("SELECT 1+1, 1+1"); !f.GetResolved() {
+		t.Fatalf("top-level duplicate labels are valid MySQL: %q", f.GetDetail())
+	}
+}
+
+// A referenced duplicated PostgreSQL label is ambiguous on the real DB — including a duplicate
+// the client made with explicit aliases.
+func TestPostgresReferencedDuplicateStaysAmbiguous(t *testing.T) {
+	pg := func(sql string) *pb.StatementFacts {
+		return analyzeProto(t, &pb.AnalyzeRequest{
+			Sql:          sql,
+			EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+			Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"pg_catalog", "public"}},
+			Catalog:      []*pb.ColumnSpec{columnSpec("acme", "public", "users", "id", "BIGINT")},
+		})
+	}
+	for _, sql := range []string{
+		`SELECT c."?column?" FROM (SELECT 1+1, 2+2) c`,
+		`SELECT c."?column?" FROM (SELECT 1 AS "?column?", 2+2) c`,
+	} {
+		if f := pg(sql); f.GetResolved() {
+			t.Fatalf("%s: reference to duplicated label must stay unresolvable", sql)
+		}
+	}
+	// Unreferenced duplicates are legal output on PG.
+	if f := pg(`SELECT * FROM (SELECT 1+1, 2+2) c`); !f.GetResolved() {
+		t.Fatalf("unreferenced PG duplicates are valid: %q", f.GetDetail())
+	}
+}
+
+// The window and aggregate-filter parity cases are deferred (native labels vs the oracle's
+// _col_0), which also removed their lineage coverage from the golden harness — keep it here.
+func TestDeferredParityCasesKeepLineage(t *testing.T) {
+	window := Probe("SELECT row_number() OVER (PARTITION BY region ORDER BY ssn) FROM users",
+		parityEngineConfig(t, "postgres"), qualifyParitySchema(defaultProbeSchema(), "postgres"), parityNamespace("postgres"))
+	if !window.Resolved {
+		t.Fatalf("window: %q", window.Detail)
+	}
+	if got := window.References["ORDER_BY"]; len(got) != 1 || got[0] != "acme.public.users.ssn" {
+		t.Fatalf("window ORDER_BY refs = %v, want [acme.public.users.ssn]", got)
+	}
+	if got := window.References["PREDICATE"]; len(got) != 1 || got[0] != "acme.public.users.region" {
+		t.Fatalf("window PREDICATE refs = %v, want [acme.public.users.region]", got)
+	}
+
+	filter := Probe("SELECT count(*) FILTER (WHERE ssn IS NOT NULL) FROM users",
+		parityEngineConfig(t, "postgres"), qualifyParitySchema(defaultProbeSchema(), "postgres"), parityNamespace("postgres"))
+	if !filter.Resolved {
+		t.Fatalf("filter: %q", filter.Detail)
+	}
+	if got := filter.References["AGGREGATE"]; len(got) != 1 || got[0] != "acme.public.users.ssn" {
+		t.Fatalf("filter AGGREGATE refs = %v, want [acme.public.users.ssn]", got)
+	}
+}

--- a/analyzer/probe/parity_test.go
+++ b/analyzer/probe/parity_test.go
@@ -63,8 +63,8 @@ func probeParityCases() []probeParityCase {
 		{name: "qualify", sql: "SELECT ssn, row_number() OVER (PARTITION BY region ORDER BY id) AS rn FROM users QUALIFY rn = 1", category: "clause refs"},
 		{name: "distinct", sql: "SELECT DISTINCT ssn FROM users", category: "clause refs"},
 		{name: "distinct on", dialect: "postgres", sql: "SELECT DISTINCT ON (region) ssn FROM users ORDER BY region", category: "clause refs"},
-		{name: "window", sql: "SELECT row_number() OVER (PARTITION BY region ORDER BY ssn) FROM users", category: "window"},
-		{name: "aggregate filter", dialect: "postgres", sql: "SELECT count(*) FILTER (WHERE ssn IS NOT NULL) FROM users", category: "aggregate"},
+		{name: "window", sql: "SELECT row_number() OVER (PARTITION BY region ORDER BY ssn) FROM users", category: "window", deferredReason: "Go stamps the engine-native output label (PG row_number, MySQL verbatim source) where the pinned Python oracle leaves Qualify's synthetic _col_0"},
+		{name: "aggregate filter", dialect: "postgres", sql: "SELECT count(*) FILTER (WHERE ssn IS NOT NULL) FROM users", category: "aggregate", deferredReason: "Go stamps the native label (count) where the pinned Python oracle leaves _col_0"},
 		{name: "insert values", sql: "INSERT INTO sink (id, data) VALUES (1, 'x')", category: "insert"},
 		{name: "insert values scalar subquery", sql: "INSERT INTO sink (id, data) VALUES ((SELECT id FROM users WHERE ssn = 'x'), 'x')", category: "insert"},
 		{name: "insert select", sql: "INSERT INTO sink (id, data) SELECT id, ssn FROM users", category: "insert"},
@@ -211,7 +211,7 @@ func TestProbeParity(t *testing.T) {
 		t.Logf("regenerated %s (%d entries)", goldenPath, len(golden))
 	}
 
-	const minParity = 94 // Ratchet: set to the achieved count and never lower to mask a regression.
+	const minParity = 91 // Ratchet: set to the achieved count and never lower to mask a regression.
 	if exactMatches < minParity {
 		t.Fatalf("probe parity regressed: got %d/%d exact matches, min %d", exactMatches, len(expanded), minParity)
 	}

--- a/analyzer/probe/postgres_output_labels.go
+++ b/analyzer/probe/postgres_output_labels.go
@@ -1,0 +1,301 @@
+// PostgreSQL's implicit output-label rules, ported from FigureColname/FigureColnameInternal in
+// the server's parser (src/backend/parser/parse_target.c) and verified against a live PostgreSQL
+// 16: a call is labeled by its written function name, a cast overrides only a weak inner name
+// (strength ≤ 1), CASE takes its ELSE's name, a scalar subquery its single output's resname, and
+// anything nameless falls back to "?column?".
+package probe
+
+import (
+	"strings"
+
+	exp "github.com/ridi-oss/sqlglot-go/expressions"
+)
+
+// normalizedFunctionName is a call's name folded through the dialect's quote-aware
+// NormalizeIdentifier — an unquoted spelling lowercases, a quoted one keeps its case.
+func normalizedFunctionName(function exp.Expression, eng engine) string {
+	if identifier, ok := function.Arg("this").(exp.Expression); ok && identifier.Kind() == exp.KindIdentifier {
+		identifier = identifier.Copy()
+		eng.Dialect().NormalizeIdentifier(identifier)
+		return identifier.Name()
+	}
+	return strings.ToLower(function.Name())
+}
+
+// nativeOutputLabel is FigureColname for one projection: the label PostgreSQL assigns to an
+// unaliased output, with the no-name fallback applied. query is the SELECT the projection belongs
+// to, for resolving references to its derived sources. ok=false means the label is unknowable —
+// the caller must not stamp.
+func nativeOutputLabel(node exp.Expression, query exp.Expression, eng engine, depth int) (string, bool) {
+	name, strength, ok := figureLabel(node, query, eng, depth)
+	if !ok {
+		return "", false
+	}
+	if strength == 0 || name == "" {
+		return "?column?", true
+	}
+	return name, true
+}
+
+// figureLabel mirrors PostgreSQL's FigureColnameInternal: (label, strength, resolvable) where
+// strength 0 = no name (caller falls back to ?column?), 1 = weak (a cast may override it),
+// 2 = strong.
+func figureLabel(node exp.Expression, query exp.Expression, eng engine, depth int) (string, int, bool) {
+	if node == nil || depth > 20 {
+		return "", 0, false
+	}
+	switch node.Kind() {
+	case exp.KindColumn:
+		// A reference to a derived table or CTE carries that source's projection label — in real
+		// PostgreSQL the reference's column NAME is the inner resname; here the inner name may be
+		// synthetic, so resolve through to the defining expression.
+		if table := node.TableName(); table != "" && syntheticLabelPattern.MatchString(node.Name()) {
+			if inner, innerSelect := derivedSourceProjection(query, table, node.Name()); inner != nil {
+				return figureProjectionLabel(inner, innerSelect, eng, depth+1)
+			}
+			return "", 0, false
+		}
+		if name := node.Name(); name != "" {
+			return name, 2, true
+		}
+		return "", 0, false
+	case exp.KindDot, exp.KindTableColumn, exp.KindIdentifier:
+		if name := node.Name(); name != "" {
+			return name, 2, true
+		}
+		return "", 0, false
+	case exp.KindParen, exp.KindCollate:
+		return figureLabel(node.This(), query, eng, depth+1)
+	case exp.KindBracket:
+		// Indirection keeps the base expression's label: `(array[1,2])[1]` is `array`.
+		return figureLabel(node.This(), query, eng, depth+1)
+	case exp.KindCast, exp.KindTryCast:
+		name, strength, ok := figureLabel(node.This(), query, eng, depth+1)
+		if ok && strength == 2 {
+			return name, 2, true
+		}
+		if label, mapped := postgresCastLabel(node); mapped {
+			return label, 1, true
+		}
+		return name, strength, ok
+	case exp.KindCase:
+		if defresult, ok := node.Arg("default").(exp.Expression); ok && defresult != nil {
+			if name, strength, ok := figureLabel(defresult, query, eng, depth+1); ok && strength == 2 {
+				return name, 2, true
+			}
+		}
+		return "case", 1, true
+	case exp.KindSubquery:
+		return subqueryLabel(node, eng, depth)
+	case exp.KindWindow, exp.KindFilter:
+		return figureLabel(node.This(), query, eng, depth+1)
+	case exp.KindAtTimeZone:
+		return "timezone", 2, true
+	case exp.KindTrim:
+		switch strings.ToUpper(node.Text("position")) {
+		case "LEADING":
+			return "ltrim", 2, true
+		case "TRAILING":
+			return "rtrim", 2, true
+		}
+		return "btrim", 2, true
+	}
+	if label, ok := postgresFixedKindLabels[node.Kind()]; ok {
+		return label, 2, true
+	}
+	if node.Kind() == exp.KindAnonymous {
+		// An Anonymous call keeps the client's spelling as its AST name — safe without a span.
+		if name := normalizedFunctionName(node, eng); name != "" {
+			return name, 2, true
+		}
+		return "", 0, false
+	}
+	if node.Is(exp.TraitFunc) {
+		// A DEDICATED function kind canonicalizes its AST name (`char_length` parses to Length,
+		// `position(...)` to StrPosition) but PostgreSQL labels the call by its WRITTEN name, so
+		// read that off the node's source span; no span (a sub-expression) → unknowable.
+		return writtenFunctionLabel(node)
+	}
+	// Operators, literals, boolean tests, … — PostgreSQL gives them no name (→ ?column?).
+	return "", 0, true
+}
+
+// writtenFunctionLabel is the function name as the client wrote it: the leading identifier of the
+// call's parse-time SpanText, folded per PostgreSQL's case rule (unquoted → lowercase, quoted →
+// verbatim).
+func writtenFunctionLabel(node exp.Expression) (string, int, bool) {
+	text, ok := node.SpanText()
+	if !ok {
+		return "", 0, false
+	}
+	open := strings.IndexByte(text, '(')
+	if open <= 0 {
+		return "", 0, false
+	}
+	written := strings.TrimSpace(text[:open])
+	if len(written) >= 2 && written[0] == '"' && written[len(written)-1] == '"' {
+		return strings.ReplaceAll(written[1:len(written)-1], `""`, `"`), 2, true
+	}
+	if !functionLabelPattern.MatchString(written) {
+		return "", 0, false
+	}
+	return strings.ToLower(written), 2, true
+}
+
+// figureProjectionLabel is the label of one projection inside a derived source: its resname (the
+// explicit alias when real) or FigureColname of its expression.
+func figureProjectionLabel(projection exp.Expression, query exp.Expression, eng engine, depth int) (string, int, bool) {
+	if projection == nil || depth > 20 {
+		return "", 0, false
+	}
+	if projection.Kind() == exp.KindAlias {
+		if alias := projection.Alias(); alias != "" && !syntheticLabelPattern.MatchString(alias) {
+			return alias, 2, true
+		}
+		return figureLabel(projection.This(), query, eng, depth+1)
+	}
+	return figureLabel(projection, query, eng, depth+1)
+}
+
+// subqueryLabel is a scalar subquery's label: its single output column's resname.
+func subqueryLabel(subquery exp.Expression, eng engine, depth int) (string, int, bool) {
+	sel := leftmostSelect(subquery.This())
+	if sel == nil {
+		return "", 0, false
+	}
+	projections := sel.Selects()
+	if len(projections) != 1 {
+		return "", 0, false
+	}
+	name, strength, ok := figureProjectionLabel(projections[0], sel, eng, depth+1)
+	if !ok || strength == 0 || name == "" {
+		return "", 0, ok
+	}
+	return name, 2, true
+}
+
+// derivedSourceProjection finds the derived table or CTE named alias among query's sources and
+// returns its projection labeled name (by alias or output name) plus the SELECT it projects from.
+func derivedSourceProjection(query exp.Expression, alias, name string) (exp.Expression, exp.Expression) {
+	sel := sourceSelect(query, alias)
+	if sel == nil {
+		return nil, nil
+	}
+	for _, projection := range sel.Selects() {
+		if projection.AliasOrName() == name {
+			return projection, sel
+		}
+	}
+	return nil, nil
+}
+
+func sourceSelect(query exp.Expression, alias string) exp.Expression {
+	check := func(node exp.Expression) exp.Expression {
+		if node != nil && node.Kind() == exp.KindSubquery && node.Alias() == alias {
+			return leftmostSelect(node.This())
+		}
+		return nil
+	}
+	if from := asExpression(query.Arg("from_")); from != nil {
+		if sel := check(from.This()); sel != nil {
+			return sel
+		}
+		for _, e := range expressionsFor(from, "expressions") {
+			if sel := check(e); sel != nil {
+				return sel
+			}
+		}
+	}
+	for _, join := range expressionsFor(query, "joins") {
+		if sel := check(join.This()); sel != nil {
+			return sel
+		}
+	}
+	if with := asExpression(query.Arg("with_")); with != nil {
+		for _, cte := range with.Expressions() {
+			if cte.Alias() == alias {
+				return leftmostSelect(cte.This())
+			}
+		}
+	}
+	return nil
+}
+
+// leftmostSelect unwraps parens/subqueries and takes a set operation's first branch — the branch
+// PostgreSQL takes output names from.
+func leftmostSelect(node exp.Expression) exp.Expression {
+	for node != nil {
+		switch {
+		case node.Kind() == exp.KindSelect:
+			return node
+		case node.Kind() == exp.KindSubquery || node.Kind() == exp.KindParen:
+			node = node.This()
+		case node.Is(exp.TraitSetOperation):
+			node = node.Left()
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+// postgresCastTypeLabels maps sqlglot's DType to the type name PostgreSQL uses as a cast's output
+// label when the cast argument itself has none (`1::int` labels `int4`).
+var postgresCastTypeLabels = map[exp.DType]string{
+	exp.DTypeInt:         "int4",
+	exp.DTypeSmallInt:    "int2",
+	exp.DTypeBigInt:      "int8",
+	exp.DTypeBoolean:     "bool",
+	exp.DTypeFloat:       "float4",
+	exp.DTypeDouble:      "float8",
+	exp.DTypeDecimal:     "numeric",
+	exp.DTypeText:        "text",
+	exp.DTypeVarchar:     "varchar",
+	exp.DTypeChar:        "bpchar",
+	exp.DTypeBpchar:      "bpchar",
+	exp.DTypeDate:        "date",
+	exp.DTypeTime:        "time",
+	exp.DTypeTimeTz:      "timetz",
+	exp.DTypeTimestamp:   "timestamp",
+	exp.DTypeTimestampTz: "timestamptz",
+	exp.DTypeUUID:        "uuid",
+	exp.DTypeJSON:        "json",
+	exp.DTypeJSONB:       "jsonb",
+	exp.DTypeInterval:    "interval",
+	exp.DTypeName:        "name",
+	exp.DTypeInet:        "inet",
+}
+
+var postgresFixedKindLabels = map[exp.Kind]string{
+	exp.KindExists:           "exists",
+	exp.KindArray:            "array",
+	exp.KindTuple:            "row",
+	exp.KindInterval:         "interval",
+	exp.KindCurrentDate:      "current_date",
+	exp.KindCurrentTime:      "current_time",
+	exp.KindCurrentTimestamp: "current_timestamp",
+	exp.KindLocaltime:        "localtime",
+	exp.KindLocaltimestamp:   "localtimestamp",
+	exp.KindCurrentSchema:    "current_schema",
+	exp.KindCurrentCatalog:   "current_catalog",
+	exp.KindCurrentUser:      "current_user",
+	exp.KindSessionUser:      "session_user",
+}
+
+func postgresCastLabel(cast exp.Expression) (string, bool) {
+	to, _ := cast.Arg("to").(exp.Expression)
+	if to == nil {
+		return "", false
+	}
+	if dtype, ok := to.Arg("this").(exp.DType); ok {
+		if label, mapped := postgresCastTypeLabels[dtype]; mapped {
+			return label, true
+		}
+		if dtype == exp.DTypeUserDefined {
+			if kind, ok := to.Arg("kind").(exp.Expression); ok && kind.Kind() == exp.KindIdentifier {
+				return kind.Name(), true
+			}
+		}
+	}
+	return "", false
+}

--- a/analyzer/probe/postgres_output_labels_test.go
+++ b/analyzer/probe/postgres_output_labels_test.go
@@ -1,0 +1,74 @@
+package probe
+
+import (
+	"strings"
+	"testing"
+
+	sqlglot "github.com/ridi-oss/sqlglot-go"
+	"github.com/ridi-oss/sqlglot-go/dialects"
+
+	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
+)
+
+func labelFacts(t *testing.T, sql string) *pb.StatementFacts {
+	t.Helper()
+	return analyzeProto(t, &pb.AnalyzeRequest{
+		Sql:          sql,
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+		Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"pg_catalog", "public"}},
+		Catalog: []*pb.ColumnSpec{
+			columnSpec("acme", "pg_catalog", "pg_namespace", "oid", "OID"),
+			columnSpec("acme", "pg_catalog", "pg_namespace", "nspname", "NAME"),
+		},
+	})
+}
+
+// pgJDBC's metadata queries read results by label, so a star-expansion rewrite must keep the
+// output names PostgreSQL itself would assign — never Qualify's synthetic `_col_N`.
+func TestPostgresRewriteKeepsNativeOutputLabels(t *testing.T) {
+	cases := []struct {
+		sql   string
+		label string
+	}{
+		{"SELECT * FROM (SELECT current_database(), n.nspname FROM pg_catalog.pg_namespace n) c", "current_database"},
+		{"SELECT * FROM (SELECT n.oid + 1, n.nspname FROM pg_catalog.pg_namespace n) c", "?column?"},
+		{"SELECT * FROM (SELECT n.oid::text, n.nspname FROM pg_catalog.pg_namespace n) c", "oid"},
+		{"SELECT * FROM (SELECT count(*), n.nspname FROM pg_catalog.pg_namespace n GROUP BY n.nspname) c", "count"},
+		{"WITH t AS (SELECT current_database(), n.nspname FROM pg_catalog.pg_namespace n) SELECT * FROM t", "current_database"},
+		// CASE takes its ELSE's strong name; a weak CASE name yields to a cast's type name.
+		{"SELECT * FROM (SELECT CASE WHEN true THEN 'x' ELSE current_database() END, n.nspname FROM pg_catalog.pg_namespace n) c", "current_database"},
+		{"SELECT * FROM (SELECT (CASE WHEN true THEN 1 END)::text, n.nspname FROM pg_catalog.pg_namespace n) c", "text"},
+		{"SELECT * FROM (SELECT CASE WHEN true THEN 1 END, n.nspname FROM pg_catalog.pg_namespace n) c", "case"},
+		// A scalar subquery inherits its single output's label.
+		{"SELECT * FROM (SELECT (SELECT n2.nspname FROM pg_catalog.pg_namespace n2 LIMIT 1), n.oid FROM pg_catalog.pg_namespace n) c", "nspname"},
+		// PostgreSQL permits duplicate output labels.
+		{"SELECT * FROM (SELECT n.oid + 1, n.oid + 2, n.nspname FROM pg_catalog.pg_namespace n) c", "?column?|?column?"},
+	}
+	for _, tc := range cases {
+		facts := labelFacts(t, tc.sql)
+		if !facts.GetResolved() {
+			t.Fatalf("%s: did not resolve: %q", tc.sql, facts.GetDetail())
+		}
+		rewrite := facts.GetRewrittenSql()
+		if rewrite == "" {
+			t.Fatalf("%s: expected a star-expansion rewrite", tc.sql)
+		}
+		// The client-visible labels are the outermost select list's aliases; inner synthetic
+		// aliases stay (valid internal references).
+		root, err := sqlglot.ParseOne(rewrite, dialects.Postgres())
+		if err != nil {
+			t.Fatalf("%s: reparse rewrite: %v", tc.sql, err)
+		}
+		labels := []string{}
+		for _, projection := range root.Selects() {
+			label := projection.AliasOrName()
+			if strings.HasPrefix(label, "_col_") {
+				t.Fatalf("%s: rewrite exposes a synthetic label: %s", tc.sql, rewrite)
+			}
+			labels = append(labels, label)
+		}
+		if !strings.Contains(strings.Join(labels, "|"), tc.label) {
+			t.Fatalf("%s: rewrite lost the native label %q (labels %v): %s", tc.sql, tc.label, labels, rewrite)
+		}
+	}
+}

--- a/analyzer/probe/probe.go
+++ b/analyzer/probe/probe.go
@@ -169,7 +169,13 @@ func Probe(sql string, engineConfig *pb.EngineConfig, sch *schema.Mapping, names
 	if len(stmts) != 1 {
 		return failResult("PARSE", fmt.Sprintf("expected 1 statement, got %d", len(stmts)))
 	}
-	return probeParsed(stmts[0], eng, qualifySchema, validatedNamespace)
+	root := stmts[0]
+	if !hasSyntheticAlias(root) {
+		if err := stampNativeOutputLabels(root, eng); err != nil {
+			return failResult("VALIDATE", err.Error())
+		}
+	}
+	return probeParsed(root, eng, qualifySchema, validatedNamespace)
 }
 
 func probeParsed(root exp.Expression, eng engine, qualifySchema schema.Schema, namespace NamespaceConfig) (out ProbeResult) {
@@ -1168,7 +1174,18 @@ func (p *prober) lineage() ProbeResult {
 			starExpanded = true
 		}
 		if starExpanded {
-			s, err := generateExecutableSQL(p.qroot, p.dialect)
+			relayRoot := p.qroot
+			// Repair the outermost display labels on a relay-only copy — lineage and mask ordinals
+			// keep reading p.qroot. Only projections the pre-Qualify stamping skipped (duplicate
+			// native labels, legal as OUTPUT) still carry `_col_N` here. Skipped when the client
+			// wrote a `_col_N` alias anywhere: client labels are then indistinguishable.
+			if hasSyntheticAlias(p.qroot) && !hasSyntheticAlias(p.root) {
+				restored := p.qroot.Copy()
+				if restoreRelayOutputLabels(restored, p.engine) {
+					relayRoot = restored
+				}
+			}
+			s, err := generateExecutableSQL(relayRoot, p.dialect)
 			if err != nil {
 				panic(err)
 			}

--- a/analyzer/probe/testdata/golden.json
+++ b/analyzer/probe/testdata/golden.json
@@ -867,56 +867,6 @@
     "isWrite": true,
     "rewrittenSql": null
   },
-  "mysql|window": {
-    "resolved": true,
-    "failedStage": null,
-    "detail": "ok",
-    "outputColumns": 1,
-    "tracedColumns": 0,
-    "origins": [
-      {
-        "column": "_col_0",
-        "origins": []
-      }
-    ],
-    "references": {
-      "PREDICATE": [
-        "users.region"
-      ],
-      "ORDER_BY": [
-        "users.ssn"
-      ],
-      "DERIVED": [
-        "users.region",
-        "users.ssn"
-      ]
-    },
-    "isWrite": false,
-    "rewrittenSql": null
-  },
-  "postgres|aggregate filter": {
-    "resolved": true,
-    "failedStage": null,
-    "detail": "ok",
-    "outputColumns": 1,
-    "tracedColumns": 0,
-    "origins": [
-      {
-        "column": "_col_0",
-        "origins": []
-      }
-    ],
-    "references": {
-      "AGGREGATE": [
-        "users.ssn"
-      ],
-      "DERIVED": [
-        "users.ssn"
-      ]
-    },
-    "isWrite": false,
-    "rewrittenSql": null
-  },
   "postgres|bare star": {
     "resolved": true,
     "failedStage": null,
@@ -1966,33 +1916,6 @@
       ]
     },
     "isWrite": true,
-    "rewrittenSql": null
-  },
-  "postgres|window": {
-    "resolved": true,
-    "failedStage": null,
-    "detail": "ok",
-    "outputColumns": 1,
-    "tracedColumns": 0,
-    "origins": [
-      {
-        "column": "_col_0",
-        "origins": []
-      }
-    ],
-    "references": {
-      "PREDICATE": [
-        "users.region"
-      ],
-      "ORDER_BY": [
-        "users.ssn"
-      ],
-      "DERIVED": [
-        "users.region",
-        "users.ssn"
-      ]
-    },
-    "isWrite": false,
     "rewrittenSql": null
   }
 }

--- a/goproxy/go.mod
+++ b/goproxy/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/ridi-oss/sqlglot-go v0.25.0 // indirect
+	github.com/ridi-oss/sqlglot-go v0.27.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.6 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect

--- a/goproxy/go.sum
+++ b/goproxy/go.sum
@@ -105,8 +105,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/ridi-oss/sqlglot-go v0.25.0 h1:t+lKLkvzhDYJnN/UQlb9ZT1aXrs4Bjl7cGZxBWcaGR0=
-github.com/ridi-oss/sqlglot-go v0.25.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
+github.com/ridi-oss/sqlglot-go v0.27.0 h1:bJXqEfVwKbfp4SSw9d2PGkOaasLFXM5+6zTgJN3z9go=
+github.com/ridi-oss/sqlglot-go v0.27.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/shirou/gopsutil/v4 v4.26.6 h1:Mzr/npDtQC/xpeEuQKHZt8Zo9CmPvhTj8nkR8w5TLDs=


### PR DESCRIPTION
## Summary
- stamp each unaliased computed projection with its engine-native output label before Qualify: PostgreSQL per FigureColname (src/backend/parser/parse_target.c; provenance documented in the file header) using the written function name from sqlglot-go v0.27.0 source spans, MySQL by verbatim source spelling (255-rune truncation)
- star-expansion rewrites carry native labels — pgJDBC metadata queries read results by label and crashed on Qualify's `_col_N`
- a client reference to a native implicit label (`SELECT c."current_database" FROM (SELECT current_database()) c`, valid on real PostgreSQL) resolves instead of failing closed
- duplicate labels follow the target DB's error direction: MySQL derived/CTE duplicates fail VALIDATE (ER_DUP_FIELDNAME, case-insensitive); PG duplicates stay legal as output and any reference to one is ambiguous

## Risk
Stamping mutates the tree pre-analysis; mask ordinals stay positional and lineage/grants are unchanged apart from output names. An unknowable or colliding label is never stamped — the synthetic name may surface, only ever a display divergence. Window/aggregate-filter parity cases are deferred (Go emits native labels where the pinned oracle leaves `_col_0`); their lineage stays pinned by a Go-side test.

## Verification
- `mise run verify` (parity 91/91)
- three-reviewer round on the stacked ancestor; all verified findings fixed and regression-tested (duplicate/case/truncation rules confirmed against live MySQL 8.0 and PG 16)
- live E2E through pmon → goproxy → PostgreSQL 16: pgJDBC 42.7.5 metadata (getTables/getColumns/getPrimaryKeys), DataGrip's introspection corpus 84/95 byte-identical, native-label reference and dup-ambiguity behavior matches direct PG