### PR TITLE
refactor(analyzer): engine behavior goes through the SPI, never a type check

### DIFF
--- a/analyzer/probe/engine.go
+++ b/analyzer/probe/engine.go
@@ -18,7 +18,6 @@ import (
 // sqlglot-go Dialect built from them) is captured at construction, so nothing downstream re-derives
 // it from a namespace or re-parses it from a bare wire-name string.
 type engine interface {
-	Type() pb.Engine
 	// WireName is the canonical lowercase sqlglot-go dialect name ("mysql" | "postgres").
 	WireName() string
 	// Dialect is the single *dialects.Dialect built once from this engine's config — reused for
@@ -43,6 +42,21 @@ type engine interface {
 	// RewriteStatement optionally rewrites a parsed statement into the SQL the proxy should relay to the
 	// target DB, returning "" to leave it unchanged.
 	RewriteStatement(root exp.Expression) string
+	// IsSafeNoFromFunction reports whether the function name is a safe builtin that may appear
+	// without a FROM clause (version(), now()) — the cross-engine set plus this engine's own
+	// pseudo-functions. Anything else emits an unclassified Function grant, which denies.
+	IsSafeNoFromFunction(name string) bool
+	// IsTrustedInformationSchemaCall reports whether a schema-qualified call is one of this engine's
+	// trusted information_schema helper builtins, needing no Function grant.
+	IsTrustedInformationSchemaCall(qualifier exp.Expression, leaf string) bool
+	// CommandPassthrough reports whether a statement that DEGRADED to an unstructured Command (the
+	// structured node forms never reach it) may relay as a benign session/metadata passthrough for
+	// this engine. False = fail closed.
+	CommandPassthrough(command string) bool
+	// RejectsDuplicateDerivedOutputLabels reports whether this engine's target DB rejects a derived-table
+	// or CTE body whose output labels collide (MySQL ER_DUP_FIELDNAME; PostgreSQL allows duplicate
+	// OUTPUT labels and rejects only a reference to one).
+	RejectsDuplicateDerivedOutputLabels() bool
 	// NativeOutputLabel computes the output label THIS engine's target DB natively assigns to an
 	// unaliased projection: PostgreSQL derives it from the resolved expression (parse_target.c
 	// FigureColname, written function names from the parse-time SpanText); MySQL uses the
@@ -131,7 +145,6 @@ func newMySQLEngine(config *pb.EngineConfig) (*mysqlEngine, error) {
 	return &mysqlEngine{dialect: dialect}, nil
 }
 
-func (e *mysqlEngine) Type() pb.Engine            { return pb.Engine_MYSQL }
 func (e *mysqlEngine) WireName() string           { return "mysql" }
 func (e *mysqlEngine) Dialect() *dialects.Dialect { return e.dialect }
 
@@ -227,6 +240,22 @@ func (e *mysqlEngine) DiagnosticLeakKeys(report ProbeResult, _ schema.Schema) ma
 	return referencedColumnKeys(report)
 }
 
+// `values` is MySQL's INSERT … ON DUPLICATE KEY UPDATE pseudo-function — it names the value that
+// would have been inserted, not a callable function; its lineage is traced in probe.go.
+func (e *mysqlEngine) IsSafeNoFromFunction(name string) bool {
+	return safeNoFromFunctions[name] || name == "values"
+}
+
+// MySQL's information_schema holds tables only — a function call qualified by it is user code.
+func (e *mysqlEngine) IsTrustedInformationSchemaCall(exp.Expression, string) bool { return false }
+
+// A statement that degrades to an unstructured Command is one the analyzer cannot vouch for on
+// MySQL (an unrecognized SHOW carries data; RESET MASTER/REPLICA is a privileged admin op).
+func (e *mysqlEngine) CommandPassthrough(string) bool { return false }
+
+// MySQL rejects a derived-table/CTE body with duplicated output labels: ER_DUP_FIELDNAME.
+func (e *mysqlEngine) RejectsDuplicateDerivedOutputLabels() bool { return true }
+
 type postgresEngine struct {
 	dialect *dialects.Dialect
 }
@@ -235,7 +264,6 @@ func newPostgresEngine(*pb.EngineConfig) (*postgresEngine, error) {
 	return &postgresEngine{dialect: dialects.Postgres()}, nil
 }
 
-func (e *postgresEngine) Type() pb.Engine            { return pb.Engine_POSTGRES }
 func (e *postgresEngine) WireName() string           { return "postgres" }
 func (e *postgresEngine) Dialect() *dialects.Dialect { return e.dialect }
 
@@ -272,6 +300,33 @@ func (e *postgresEngine) IsTrustedSystemQualifier(qualifier exp.Expression) bool
 // PostgreSQL has no relay rewrite: client_encoding is handled on the wire, not by an analyzer rewrite,
 // so there is nothing to rewrite here.
 func (e *postgresEngine) RewriteStatement(exp.Expression) string { return "" }
+
+func (e *postgresEngine) IsSafeNoFromFunction(name string) bool { return safeNoFromFunctions[name] }
+
+// postgresInformationSchemaFunctions are PostgreSQL's information_schema helper builtins — stable,
+// read-only transforms of their arguments (pgJDBC metadata queries call them). Safe ONLY under an
+// explicit `information_schema.` qualifier; the unqualified spelling stays gated so a same-named
+// user function cannot inherit the pass.
+var postgresInformationSchemaFunctions = stringSet(
+	"_pg_char_max_length", "_pg_char_octet_length", "_pg_datetime_precision", "_pg_expandarray",
+	"_pg_index_position", "_pg_interval_type", "_pg_numeric_precision", "_pg_numeric_precision_radix",
+	"_pg_numeric_scale", "_pg_truetypid", "_pg_truetypmod",
+)
+
+func (e *postgresEngine) IsTrustedInformationSchemaCall(qualifier exp.Expression, leaf string) bool {
+	return qualifier != nil && qualifier.Kind() == exp.KindIdentifier &&
+		qualifier.Name() == "information_schema" && postgresInformationSchemaFunctions[leaf]
+}
+
+// A statement that degrades to an unstructured Command on PostgreSQL can only be a benign
+// session/config form: RESET restores defaults (de-escalation), an unmodeled SHOW is a read-only
+// GUC read (no table data). Everything else stays fail-closed at the caller.
+func (e *postgresEngine) CommandPassthrough(command string) bool {
+	return command == "RESET" || command == "SHOW"
+}
+
+// PostgreSQL allows duplicate OUTPUT labels; only a reference to one is ambiguous.
+func (e *postgresEngine) RejectsDuplicateDerivedOutputLabels() bool { return false }
 
 // PostgreSQL names an unaliased projection per parse_target.c FigureColname; a call is labeled by
 // its WRITTEN function name, read from the projection's parse-time SpanText.

--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -40,34 +40,6 @@ var safeNoFromFunctions = stringSet(
 	"iif", "if", "typeof", "pg_typeof",
 )
 
-// postgresInformationSchemaFunctions are PostgreSQL's information_schema helper builtins — stable,
-// read-only transforms of their arguments (pgJDBC metadata queries call them). Safe ONLY under an
-// explicit `information_schema.` qualifier; the unqualified spelling stays gated so a same-named
-// user function cannot inherit the pass.
-var postgresInformationSchemaFunctions = stringSet(
-	"_pg_char_max_length", "_pg_char_octet_length", "_pg_datetime_precision", "_pg_expandarray",
-	"_pg_index_position", "_pg_interval_type", "_pg_numeric_precision", "_pg_numeric_precision_radix",
-	"_pg_numeric_scale", "_pg_truetypid", "_pg_truetypmod",
-)
-
-func isTrustedInformationSchemaCall(qualifier exp.Expression, leaf string, eng engine) bool {
-	return eng.Type() == pb.Engine_POSTGRES && qualifier != nil &&
-		qualifier.Kind() == exp.KindIdentifier && qualifier.Name() == "information_schema" &&
-		postgresInformationSchemaFunctions[leaf]
-}
-
-// mysqlOnlySafeFunctions are safe no-FROM function names that exist ONLY on MySQL. `values` is MySQL's
-// INSERT … ON DUPLICATE KEY UPDATE pseudo-function — it names the value that would have been inserted, not a
-// callable function, and its lineage is traced in probe.go. PostgreSQL has no `values` builtin, so keeping
-// it out of the cross-engine set leaves a quoted PostgreSQL `"values"()` (a user function) gated.
-var mysqlOnlySafeFunctions = stringSet("values")
-
-// isSafeNoFromFunction reports whether a bare (unqualified) anonymous function name is a known-safe builtin
-// that needs no no-FROM Function grant — the cross-engine set plus any engine-specific pseudo-functions.
-func isSafeNoFromFunction(name string, eng engine) bool {
-	return safeNoFromFunctions[name] || (eng.Type() == pb.Engine_MYSQL && mysqlOnlySafeFunctions[name])
-}
-
 // userTypeCast returns the name of the first reference to a non-built-in (user) type anywhere in root, or
 // "" if every type reference is a safe built-in. sqlglot resolves a built-in type to a concrete DType and
 // a user type to DTypeUserDefined, so this is a single AST pass over DataType nodes. It covers every way a
@@ -680,20 +652,17 @@ func emitCommandFacts(root exp.Expression, eng engine) *pb.StatementFacts {
 		// engine-specific passthrough.
 		return inadmissibleFacts("VALIDATE", "SET statement is not structurally analyzable")
 	case "RESET":
-		if eng.Type() == pb.Engine_POSTGRES {
-			// A PostgreSQL RESET that degrades to Command (rather than the structured Reset node) is an
-			// unusual/laundering spelling; RESET only ever restores defaults (de-escalation), so it stays a
-			// benign session passthrough.
+		// The structured Reset node never reaches here; a RESET degraded to Command is an unusual
+		// spelling the engine may still vouch for as pure de-escalation.
+		if eng.CommandPassthrough(command) {
 			return passthroughFacts()
 		}
 		return inadmissibleFacts("VALIDATE", "RESET is not allowed on MySQL")
 	case "SHOW":
-		// The data-bearing MySQL SHOWs (WARNINGS/PROCESSLIST/BINLOG/… and SHOW CREATE USER) and PostgreSQL
-		// SHOW <guc> all parse as structured Show/Reset nodes and are handled in emitShowFacts, so they
-		// never reach here. A SHOW that still degrades to Command is a form sqlglot-go did not model: on
-		// PostgreSQL it can only be a read-only GUC/config read (no table data) → metadata passthrough; on
-		// MySQL an unrecognized SHOW is one the proxy cannot vouch for → fail closed.
-		if eng.Type() == pb.Engine_POSTGRES {
+		// The data-bearing SHOWs parse as structured Show/Reset nodes and are handled in
+		// emitShowFacts; a SHOW that still degrades to Command is a form sqlglot-go did not model,
+		// relayable only where the engine vouches it carries no table data.
+		if eng.CommandPassthrough(command) {
 			return passthroughFacts()
 		}
 		return unanalyzableFacts("PARSE", "unsupported SHOW command")
@@ -752,7 +721,7 @@ func noFromFunctionGrants(root exp.Expression, eng engine) []*pb.RequireResultRe
 			}
 			continue
 		}
-		if isTrustedInformationSchemaCall(dot.Left(), leaf, eng) {
+		if eng.IsTrustedInformationSchemaCall(dot.Left(), leaf) {
 			continue
 		}
 		emit(qualifiedCallName(dot.Left(), leaf, eng))
@@ -767,7 +736,7 @@ func noFromFunctionGrants(root exp.Expression, eng engine) []*pb.RequireResultRe
 		if schema == nil {
 			continue
 		}
-		if isTrustedInformationSchemaCall(schema, strings.ToLower(fn.Name()), eng) {
+		if eng.IsTrustedInformationSchemaCall(schema, strings.ToLower(fn.Name())) {
 			qualified[fn] = true
 		}
 	}
@@ -776,7 +745,7 @@ func noFromFunctionGrants(root exp.Expression, eng engine) []*pb.RequireResultRe
 			continue
 		}
 		name := strings.ToLower(fn.Name())
-		if isSafeNoFromFunction(name, eng) {
+		if eng.IsSafeNoFromFunction(name) {
 			continue
 		}
 		emit(name)
@@ -843,7 +812,7 @@ func hasUnsafeCall(root exp.Expression, eng engine) bool {
 			}
 			continue
 		}
-		if isTrustedInformationSchemaCall(dot.Left(), normalizedFunctionName(fn, eng), eng) {
+		if eng.IsTrustedInformationSchemaCall(dot.Left(), normalizedFunctionName(fn, eng)) {
 			continue
 		}
 		return true
@@ -857,7 +826,7 @@ func hasUnsafeCall(root exp.Expression, eng engine) bool {
 			continue
 		}
 		name := strings.ToLower(fn.Name())
-		if name != "" && name != "*" && !isSafeNoFromFunction(name, eng) {
+		if name != "" && name != "*" && !eng.IsSafeNoFromFunction(name) {
 			return true
 		}
 	}

--- a/analyzer/probe/output_labels.go
+++ b/analyzer/probe/output_labels.go
@@ -5,8 +5,6 @@ import (
 	"regexp"
 
 	exp "github.com/ridi-oss/sqlglot-go/expressions"
-
-	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
 )
 
 var syntheticLabelPattern = regexp.MustCompile(`^_col_\d+$`)
@@ -81,8 +79,7 @@ func stampNativeOutputLabels(root exp.Expression, eng engine) error {
 				if len(names) < 2 {
 					continue
 				}
-				if eng.Type() == pb.Engine_MYSQL {
-					// Real MySQL rejects the derived table itself: ER_DUP_FIELDNAME.
+				if eng.RejectsDuplicateDerivedOutputLabels() {
 					return fmt.Errorf("duplicate column name '%s' in derived table", names[0])
 				}
 				// Real PostgreSQL rejects only a reference to the duplicated label.


### PR DESCRIPTION
## Summary
- delete `Type()` from the `engine` interface: every engine-specific decision in shared analysis code is an SPI method, so a new `eng.Type() == …` branch cannot be written
- new methods: `IsSafeNoFromFunction`, `IsTrustedInformationSchemaCall`, `CommandPassthrough` (RESET/SHOW degradation policy), `RejectsDuplicateDerivedOutputLabels`
- first commit of the PostgreSQL-support + opaque-functions line; the follow-up PRs implement their engine behavior as `postgresEngine` methods on this base

## Risk
No behavior change by construction — pure dispatch relocation. The only residual engine constant is `GetEngine()` on the raw config in the engine-construction-failure path, where no engine object exists.

## Verification
- `mise run verify` green at the stack tip; this commit builds and passes the analyzer suite standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3S55XrwTAptjTZi7GD2j9