### PR TITLE
fix(analyzer): trust information_schema helpers and txid_current

### DIFF
--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -38,6 +38,22 @@ var safeNoFromFunctions = stringSet(
 	"iif", "if", "typeof", "pg_typeof",
 )
 
+// postgresInformationSchemaFunctions are PostgreSQL's information_schema helper builtins — stable,
+// read-only transforms of their arguments (pgJDBC metadata queries call them). Safe ONLY under an
+// explicit `information_schema.` qualifier; the unqualified spelling stays gated so a same-named
+// user function cannot inherit the pass.
+var postgresInformationSchemaFunctions = stringSet(
+	"_pg_char_max_length", "_pg_char_octet_length", "_pg_datetime_precision", "_pg_expandarray",
+	"_pg_index_position", "_pg_interval_type", "_pg_numeric_precision", "_pg_numeric_precision_radix",
+	"_pg_numeric_scale", "_pg_truetypid", "_pg_truetypmod",
+)
+
+func isTrustedInformationSchemaCall(qualifier exp.Expression, leaf string, eng engine) bool {
+	return eng.Type() == pb.Engine_POSTGRES && qualifier != nil &&
+		qualifier.Kind() == exp.KindIdentifier && qualifier.Name() == "information_schema" &&
+		postgresInformationSchemaFunctions[leaf]
+}
+
 // mysqlOnlySafeFunctions are safe no-FROM function names that exist ONLY on MySQL. `values` is MySQL's
 // INSERT … ON DUPLICATE KEY UPDATE pseudo-function — it names the value that would have been inserted, not a
 // callable function, and its lineage is traced in probe.go. PostgreSQL has no `values` builtin, so keeping
@@ -725,7 +741,24 @@ func noFromFunctionGrants(root exp.Expression, eng engine) []*pb.RequireResultRe
 			}
 			continue
 		}
+		if isTrustedInformationSchemaCall(dot.Left(), leaf, eng) {
+			continue
+		}
 		emit(qualifiedCallName(dot.Left(), leaf, eng))
+	}
+	// A FROM-form call carries its qualifier on the Table node, not a Dot wrapper.
+	for _, table := range root.FindAll(exp.KindTable) {
+		fn := table.This()
+		if fn == nil || !fn.Is(exp.TraitFunc) || table.Arg("catalog") != nil {
+			continue
+		}
+		schema, _ := table.Arg("schema").(exp.Expression)
+		if schema == nil {
+			continue
+		}
+		if isTrustedInformationSchemaCall(schema, strings.ToLower(fn.Name()), eng) {
+			qualified[fn] = true
+		}
 	}
 	for _, fn := range root.FindAll(exp.TraitFunc) {
 		if fn.Kind() != exp.KindAnonymous || qualified[fn] {
@@ -797,6 +830,9 @@ func hasUnsafeCall(root exp.Expression, eng engine) bool {
 			if !safeNoFromFunctions[strings.ToLower(fn.Name())] {
 				return true
 			}
+			continue
+		}
+		if isTrustedInformationSchemaCall(dot.Left(), normalizedFunctionName(fn, eng), eng) {
 			continue
 		}
 		return true

--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -18,6 +18,7 @@ var safeNoFromFunctions = stringSet(
 	"version", "current_schema", "current_schemas", "current_database", "current_catalog",
 	"current_user", "session_user", "current_role", "user", "database", "schema", "connection_id",
 	"pg_backend_pid", "pg_is_in_recovery", "pg_postmaster_start_time", "current_setting",
+	"txid_current", "pg_current_xact_id",
 	"inet_server_addr", "inet_server_port", "inet_client_addr", "inet_client_port",
 	"last_insert_id", "row_count", "found_rows", "charset", "collation", "coercibility",
 	"now", "current_timestamp", "current_date", "current_time", "localtime", "localtimestamp",

--- a/analyzer/probe/function_facts_test.go
+++ b/analyzer/probe/function_facts_test.go
@@ -206,3 +206,44 @@ func probeFunctions(t *testing.T, sql, dialect string, cols []*pb.ColumnSpec, ns
 	res := analyzeProbe(t, &pb.AnalyzeRequest{Sql: sql, EngineConfig: engineConfig, Namespace: ns, Catalog: cols})
 	return res.Functions, res.Resolved
 }
+
+func TestPostgresInformationSchemaHelpersTrusted(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT (information_schema._pg_expandarray(ARRAY[1,2])).n",
+		"SELECT x.n FROM information_schema._pg_expandarray(ARRAY[1,2]) AS x(x,n)",
+	} {
+		f := postgresFacts(t, sql)
+		if !f.GetResolved() {
+			t.Fatalf("%s did not resolve: detail=%q", sql, f.GetDetail())
+		}
+		for _, g := range f.GetResultReads() {
+			if fn := g.GetFunction(); fn != nil {
+				t.Fatalf("%s: qualified information_schema helper must not emit a Function grant, got %q", sql, fn.GetName())
+			}
+		}
+	}
+
+	// The unqualified spelling could be a same-named user function: it stays gated.
+	f := postgresFacts(t, "SELECT (_pg_expandarray(ARRAY[1,2])).n")
+	gated := false
+	for _, g := range f.GetResultReads() {
+		if fn := g.GetFunction(); fn != nil && fn.GetName() == "_pg_expandarray" {
+			gated = true
+		}
+	}
+	if f.GetResolved() && !gated {
+		t.Fatalf("unqualified _pg_expandarray must stay gated: reads=%v", f.GetResultReads())
+	}
+
+	// A helper outside the fixed set is user code even under the information_schema qualifier.
+	f = postgresFacts(t, "SELECT information_schema.leak(1)")
+	gated = false
+	for _, g := range f.GetResultReads() {
+		if fn := g.GetFunction(); fn != nil {
+			gated = true
+		}
+	}
+	if f.GetResolved() && !gated {
+		t.Fatal("information_schema.<non-helper> must stay gated")
+	}
+}


### PR DESCRIPTION
## Summary
- trust PostgreSQL's fixed `information_schema._pg_*` helper set (11 names) under an explicit qualifier only, in both call forms — scalar (`(information_schema._pg_expandarray(x)).n`) and FROM (`FROM information_schema._pg_expandarray(x)`). pgJDBC `getPrimaryKeys`/`getIndexInfo` call them and were hard-denied, breaking DataGrip key introspection
- the bare spelling, quoted/case variants, and any non-helper name under the qualifier stay gated
- treat `txid_current`/`pg_current_xact_id` as safe session metadata (DataGrip's CurrentXid probe) — same class as `pg_backend_pid`

## Risk
Function-gating trust expansion; name-exact and quote-aware, mirroring the existing `pg_catalog` trust model.

## Verification
- `mise run verify`
- three-reviewer round (on the stacked ancestor of this extraction); pgJDBC 42.7.5 and the DataGrip introspection replay verified live through pmon → goproxy → PostgreSQL 16