### PR TITLE
docs: describe pmon upstream TLS as chain verification, not pinning

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,7 +76,7 @@ only.
 | Web console | UI · Next.js | User-facing UI: query editor, policy/role/grant management, approvals, audit view. Thin, and holds no state. Rewrites `/api` and `/auth` to the CP so the browser talks same-origin — the browser's paths, not the CP's whole surface: `/mcp`, `/oauth`, and `/.well-known` are not rewritten, so a deployment using MCP routes those to the CP at the edge (see [How users reach it](#how-users-reach-it)). |
 | auditmon | watcher · Go | Independent audit monitor: reads the committed trail, re-verifies the tamper-evident hash chain, exports redacted batches to a WORM object store, signs off-box anchors, runs anomaly rules to alerts. Separate from the CP by design. Its access to the control-plane store is read-only. |
 | Control-plane store | store · PostgreSQL only | System of record: identity, policy, catalog, sessions, and the `audit_event` hash chain. The CP reads and writes it; auditmon only reads. PostgreSQL is the only supported store engine — `Db.kt` hardcodes the Postgres JDBC driver, and the migrations use `RETURNING`, `ON CONFLICT`, `jsonb`, and `::` casts. Independent of which engine a target database runs. |
-| pmon | client connector · Go | A single static binary each user runs locally. `pmon login` authenticates to the CP (OIDC device auth) and mints a short-lived wire token, and re-running it is how a login is extended — there is no silent renewal in the client; the daemon then opens one local broker per datasource, which any SQL client points at with the sticky local password, injecting the real token upstream and pinning the proxy to its advertised leaf-cert fingerprint. |
+| pmon | client connector · Go | A single static binary each user runs locally. `pmon login` authenticates to the CP (OIDC device auth) and mints a short-lived wire token; the daemon renews it while the server-side session window remains open. It opens one local broker per datasource, which any SQL client points at with the sticky local password, injecting the real token upstream and verifying the proxy against its advertised certificate chain. |
 
 Source layout, module by module, is in [AGENTS.md](./AGENTS.md#layout).
 
@@ -134,17 +134,14 @@ registers itself, and why the control plane holds no target credentials).
 - Apps and SQL clients connect through pmon: `pmon login` runs the CP
   device-auth flow and stores a short-lived wire token; the daemon then runs a
   local broker you point any SQL driver at with the sticky local password,
-  injecting the token to the proxy over the wire's clear-password auth-switch.
-  Upstream TLS is pinned, not CA-verified: the control plane hands the broker
-  the proxy's advertised leaf-cert SHA-256, and the broker accepts exactly that
-  leaf — no CA, no system trust store, no hostname check — so a self-signed wire
-  cert works and nothing has to be distributed to clients. A pinned datasource
-  whose proxy offers no TLS is refused rather than sent the token in the clear.
-  Without an advertised fingerprint, TLS (if the proxy offers it) falls back to
-  system-trust verification against the proxy's hostname, and a proxy offering
-  no TLS is brokered in plaintext — the token crosses in the clear, which only a
-  trusted network makes acceptable. Brokering, and so pinning, is MySQL-only
-  today.
+  injecting the token to the proxy over the wire's clear-password exchange. When
+  the control plane advertises a certificate chain, pmon uses it as the trust
+  pool and verifies the advertised hostname; a self-signed leaf works as its own
+  anchor. Without an advertised chain, TLS uses the system trust store. A
+  datasource marked as serving wire TLS is refused if the proxy declines the
+  upgrade, before the token is sent. A proxy configured without wire TLS is
+  brokered in plaintext, which is acceptable only over a trusted network.
+  Brokering is MySQL-only today.
 
 Only the CP's HTTP surface should be public, and only these paths; keep the gRPC
 port internal (nothing in the code enforces either):

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -199,11 +199,9 @@ mechanism). Authoritative: [docs/auth-model.md](docs/auth-model.md).
     a fixed `127.0.0.1:<port>` and a localhost password that never rotates,
     while the daemon injects the current token on the upstream hop. Only MySQL
     is brokered — a PostgreSQL datasource is discovered then skipped, so `psql`
-    connects to the proxy directly with a token as its password. Renewal is
-    server-side only: the control plane serves `POST /auth/session/renew`, but
-    `pmon` stores the renewal token from device login and never calls it, so a
-    login lasts one token lifetime (12h default) and then needs a fresh
-    `pmon login`.
+    connects to the proxy directly with a token as its password. The daemon
+    renews the wire token before expiry until the server-side session window
+    closes, then requires a fresh `pmon login`.
   - One-shot token: the console's Access page (`/access`) mints a short-lived
     password (`POST /api/tokens`) the user pastes into any client.
   - Expiring-only — every credential has a server-set expiry (TTL clamped
@@ -215,9 +213,9 @@ mechanism). Authoritative: [docs/auth-model.md](docs/auth-model.md).
     crosses the network in the clear. Plaintext is therefore only acceptable on
     a trusted network — a private transport such as a peered VPC, PrivateLink,
     or a VPN/tailnet. Configuration:
-    [INSTALL.md](INSTALL.md#proxy--one-set-per-datasource). Where pinning does
-    and does not cover this hop:
-    [KNOWN_LIMITATIONS.md](KNOWN_LIMITATIONS.md#wire-cert-pinning-pmon--proxy).
+    [INSTALL.md](INSTALL.md#proxy--one-set-per-datasource). The remaining trust
+    limits are documented in
+    [KNOWN_LIMITATIONS.md](KNOWN_LIMITATIONS.md#wire-cert-distribution-direct-clients-and-pmon).
 - Broker: goproxy reaches the target DB with a per-datasource service account;
   the token only proves _who you are_, never _what you can see_ — enforcement
   and JIT elevation are independent of how it was obtained.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -173,14 +173,13 @@ configured per proxy under `PM_TARGET_*`.
   PrivateLink, or a VPN/tailnet) and plaintext wire (unset). Set them only for
   an untrusted client↔proxy path (or an encrypt-everywhere policy); then the
   _proxy_ terminates TLS — a generic NLB/ALB can't, because SQL negotiates TLS
-  in-band. With TLS on, the proxy computes its leaf cert's SHA-256 and
-  advertises it at registration (it refuses to boot if it cannot), and pmon pins
-  each connection to exactly that leaf — no CA and no hostname check — so a
-  self-signed cert works and nothing has to reach the client's trust store. Any
-  cert the proxy can present the private key for is therefore fine; ACM Private
-  CA (exportable, unlike public ACM certs) via Secrets Manager is one convenient
-  source. Rotating the cert re-advertises the new fingerprint on the next
-  register, so clients pick it up without redistribution.
+  in-band. With TLS on, the proxy advertises its certificate chain at
+  registration. pmon uses that chain as its trust pool and verifies the
+  advertised hostname; a self-signed leaf works as its own anchor, so nothing
+  has to enter the client's system trust store. ACM Private CA (exportable,
+  unlike public ACM certs) via Secrets Manager is one convenient source.
+  Rotating the cert re-advertises the new chain on the next register, so clients
+  pick it up without redistribution.
 - `PM_SECRET_TOKEN` — _required_. The shared gRPC secret; must equal the CP's.
 
 ### Web console

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -311,9 +311,9 @@ Fixes for gaps documented in
 - Proxy-side cancel brokering: issue synthetic `TargetDbKeyData` and broker
   cancels proxy-side, so `CancelRequest` can require TLS without breaking psql's
   Ctrl-C.
-- Wire-cert rotation refresh: a rotated proxy leaf cert only re-advertises its
-  pinning fingerprint on the next reconnect resync. Push the new fingerprint on
-  rotation instead, so a pinning client is never left on a stale one.
+- Wire-cert rotation refresh: a rotated proxy leaf cert is only re-advertised on
+  the next reconnect resync. Push the new chain on rotation so a verifying
+  client is never left with stale trust material.
 - PostgreSQL brokering in `pmon`: the daemon fronts MySQL only, so PostgreSQL
   datasources are discovered but skipped and their connection strings are
   rendered without a broker behind them.
@@ -333,8 +333,8 @@ Fixes for gaps documented in
 - Push-based datasource discovery for `pmon`. Rediscovery polls every 30
   seconds, so a revoked datasource keeps its broker open for up to that long. A
   per-principal stream would cut revocation latency to sub-second and carry a
-  rotated certificate fingerprint; the poll stays the authoritative backstop,
-  since a dropped stream must never read as "no change". Waits on the pmon API
+  rotated certificate chain; the poll stays the authoritative backstop, since a
+  dropped stream must never read as "no change". Waits on the pmon API
   authentication decision — the existing event stream is cookie-authenticated
   and `pmon` holds no cookie.
 - Menu-bar app signing and distribution. The tray app is built and ad-hoc


### PR DESCRIPTION
pmon has verified the advertised chain plus hostname since the initial commit (`upstreamTLSConfig`), and the daemon renews the wire token (`maybeRenew`); ARCHITECTURE/DESIGN/INSTALL/backlog still described leaf-fingerprint pinning and login-only renewal. Docs only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vu7Y8iae4qVJAU6J34pULA