### PR TITLE
feat(analyzer): split a multi-statement batch at statement boundaries

### DIFF
--- a/analyzer/cmd/libsqlglot/main.go
+++ b/analyzer/cmd/libsqlglot/main.go
@@ -37,6 +37,21 @@ func AnalyzeStatement(reqBytes *C.char, reqLen C.size_t, outLen *C.size_t) unsaf
 	return C.CBytes(out) // malloc'd; caller frees via FreeCString.
 }
 
+// SplitStatements cuts a multi-statement batch into its statements. Same byte-buffer convention and
+// FreeCString ownership as AnalyzeStatement. A panic becomes ok=false, but a Go stack overflow is a
+// fatal error no recover() catches: ~40k nested parens still aborts the process.
+//
+//export SplitStatements
+func SplitStatements(reqBytes *C.char, reqLen C.size_t, outLen *C.size_t) unsafe.Pointer {
+	req := analyzeRequestBytesFromC(reqBytes, reqLen)
+	out := probe.SplitStatementsSafe(req)
+	*outLen = C.size_t(len(out))
+	if len(out) == 0 {
+		return nil
+	}
+	return C.CBytes(out) // malloc'd; caller frees via FreeCString.
+}
+
 func analyzeRequestBytesFromC(p *C.char, n C.size_t) []byte {
 	// C.GoBytes takes a C.int length. Reject anything that cannot be represented exactly rather than
 	// narrowing it and reading a different byte sequence.

--- a/analyzer/jvm/src/main/kotlin/com/ridi/oss/sqlglotgo/Sqlglot.kt
+++ b/analyzer/jvm/src/main/kotlin/com/ridi/oss/sqlglotgo/Sqlglot.kt
@@ -27,6 +27,7 @@ import java.nio.file.StandardCopyOption
 object Sqlglot {
     private val linker = Linker.nativeLinker()
     private val analyzeStatementHandle: MethodHandle
+    private val splitStatementsHandle: MethodHandle
     private val sqlNormalizeHandle: MethodHandle
     private val freeHandle: MethodHandle
 
@@ -43,6 +44,17 @@ object Sqlglot {
                 // The native library supports 64-bit Darwin/Linux targets, where C size_t matches JAVA_LONG.
                 ValueLayout.JAVA_LONG, // reqLen
                 ValueLayout.ADDRESS,   // outLen (an out-parameter pointer this call writes the result length into)
+            ),
+        )
+        splitStatementsHandle = linker.downcallHandle(
+            lookup.find("SplitStatements").orElseThrow {
+                IllegalStateException("SplitStatements not exported by native lib")
+            },
+            FunctionDescriptor.of(
+                ValueLayout.ADDRESS,
+                ValueLayout.ADDRESS,
+                ValueLayout.JAVA_LONG,
+                ValueLayout.ADDRESS,
             ),
         )
         sqlNormalizeHandle = linker.downcallHandle(
@@ -71,6 +83,12 @@ object Sqlglot {
      * StatementFacts, so a malformed request yields a `resolved=false` message rather than an error.
      */
     fun analyzeStatement(requestBytes: ByteArray): ByteArray = callByteBufferHandle(analyzeStatementHandle, requestBytes)
+
+    /**
+     * Cut a multi-statement batch into its statements: a marshaled `analyzerv1.SplitRequest` in, a
+     * marshaled `analyzerv1.SplitResponse` out. Same raw-bytes convention as [analyzeStatement].
+     */
+    fun splitStatements(requestBytes: ByteArray): ByteArray = callByteBufferHandle(splitStatementsHandle, requestBytes)
 
     /**
      * The byte-buffer FFM calling convention [analyzeStatement] follows: one byte buffer in (a
@@ -125,7 +143,8 @@ object Sqlglot {
         }
     }
 
-    private fun hasWellFormedUtf16(s: String): Boolean {
+    /** Whether every surrogate in [s] is paired — an unpaired one encodes to `?`, changing the SQL. */
+    fun hasWellFormedUtf16(s: String): Boolean {
         var i = 0
         while (i < s.length) {
             val ch = s[i]

--- a/analyzer/probe/pb/analyzer.pb.go
+++ b/analyzer/probe/pb/analyzer.pb.go
@@ -990,6 +990,125 @@ func (x *AnalyzeRequest) GetEngineConfig() *EngineConfig {
 	return nil
 }
 
+// Cut a multi-statement batch into its individual statements at the dialect's own semicolon tokens,
+// so a `;` inside a literal, a quoted identifier, a comment, or a dollar-quoted body is not a
+// boundary. The batch surfaces (the approval workflow, the editor) split here rather than in the
+// client, so the statement boundary the control-plane stores, hashes, and authorizes is the
+// engine's, not a caller's guess.
+type SplitRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Sql string `protobuf:"bytes,1,opt,name=sql,proto3" json:"sql,omitempty"`
+	// The dialect decides where a statement ends, so this is the same config analysis uses: MySQL's
+	// version gates executable comments (`/*!80000 OR 1=1 */` is SQL the server runs) and ansi_quotes
+	// decides whether `"a;b"` is one literal or a boundary. An engine-invalid config fails closed.
+	EngineConfig *EngineConfig `protobuf:"bytes,2,opt,name=engine_config,json=engineConfig,proto3" json:"engine_config,omitempty"`
+}
+
+func (x *SplitRequest) Reset() {
+	*x = SplitRequest{}
+	mi := &file_analyzer_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SplitRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SplitRequest) ProtoMessage() {}
+
+func (x *SplitRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_analyzer_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SplitRequest.ProtoReflect.Descriptor instead.
+func (*SplitRequest) Descriptor() ([]byte, []int) {
+	return file_analyzer_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *SplitRequest) GetSql() string {
+	if x != nil {
+		return x.Sql
+	}
+	return ""
+}
+
+func (x *SplitRequest) GetEngineConfig() *EngineConfig {
+	if x != nil {
+		return x.EngineConfig
+	}
+	return nil
+}
+
+// Each statement is a verbatim slice of the request's sql (trimmed, terminator dropped) — never
+// regenerated text, so what is stored and authorized is exactly what the caller wrote. [ok] false
+// leaves [statements] empty and means the batch could not be split safely (bad dialect, invalid
+// UTF-8, an embedded NUL, a tokenizer failure, or no statement at all); the caller denies rather
+// than falling back to its own split.
+type SplitResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Ok         bool     `protobuf:"varint,1,opt,name=ok,proto3" json:"ok,omitempty"`
+	Statements []string `protobuf:"bytes,2,rep,name=statements,proto3" json:"statements,omitempty"`
+}
+
+func (x *SplitResponse) Reset() {
+	*x = SplitResponse{}
+	mi := &file_analyzer_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SplitResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SplitResponse) ProtoMessage() {}
+
+func (x *SplitResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_analyzer_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SplitResponse.ProtoReflect.Descriptor instead.
+func (*SplitResponse) Descriptor() ([]byte, []int) {
+	return file_analyzer_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *SplitResponse) GetOk() bool {
+	if x != nil {
+		return x.Ok
+	}
+	return false
+}
+
+func (x *SplitResponse) GetStatements() []string {
+	if x != nil {
+		return x.Statements
+	}
+	return nil
+}
+
 // One physical target-DB relation the statement scans (docs/facts-emission.md). catalog/schema/table
 // is the resolved identity; covered is true once at least one traced column fact names this table
 // (see probe.go's SourceInfo doc comment for the full per-table coverage rationale).
@@ -1006,7 +1125,7 @@ type SourceInfo struct {
 
 func (x *SourceInfo) Reset() {
 	*x = SourceInfo{}
-	mi := &file_analyzer_proto_msgTypes[5]
+	mi := &file_analyzer_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1018,7 +1137,7 @@ func (x *SourceInfo) String() string {
 func (*SourceInfo) ProtoMessage() {}
 
 func (x *SourceInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_analyzer_proto_msgTypes[5]
+	mi := &file_analyzer_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1031,7 +1150,7 @@ func (x *SourceInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SourceInfo.ProtoReflect.Descriptor instead.
 func (*SourceInfo) Descriptor() ([]byte, []int) {
-	return file_analyzer_proto_rawDescGZIP(), []int{5}
+	return file_analyzer_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *SourceInfo) GetCatalog() string {
@@ -1075,7 +1194,7 @@ type RequireStatementExecGrant struct {
 
 func (x *RequireStatementExecGrant) Reset() {
 	*x = RequireStatementExecGrant{}
-	mi := &file_analyzer_proto_msgTypes[6]
+	mi := &file_analyzer_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1087,7 +1206,7 @@ func (x *RequireStatementExecGrant) String() string {
 func (*RequireStatementExecGrant) ProtoMessage() {}
 
 func (x *RequireStatementExecGrant) ProtoReflect() protoreflect.Message {
-	mi := &file_analyzer_proto_msgTypes[6]
+	mi := &file_analyzer_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1100,7 +1219,7 @@ func (x *RequireStatementExecGrant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequireStatementExecGrant.ProtoReflect.Descriptor instead.
 func (*RequireStatementExecGrant) Descriptor() ([]byte, []int) {
-	return file_analyzer_proto_rawDescGZIP(), []int{6}
+	return file_analyzer_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *RequireStatementExecGrant) GetStatementKind() StatementKind {
@@ -1121,7 +1240,7 @@ type ColumnResource struct {
 
 func (x *ColumnResource) Reset() {
 	*x = ColumnResource{}
-	mi := &file_analyzer_proto_msgTypes[7]
+	mi := &file_analyzer_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1133,7 +1252,7 @@ func (x *ColumnResource) String() string {
 func (*ColumnResource) ProtoMessage() {}
 
 func (x *ColumnResource) ProtoReflect() protoreflect.Message {
-	mi := &file_analyzer_proto_msgTypes[7]
+	mi := &file_analyzer_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1146,7 +1265,7 @@ func (x *ColumnResource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ColumnResource.ProtoReflect.Descriptor instead.
 func (*ColumnResource) Descriptor() ([]byte, []int) {
-	return file_analyzer_proto_rawDescGZIP(), []int{7}
+	return file_analyzer_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ColumnResource) GetCatalog() string {
@@ -1187,7 +1306,7 @@ type PredicateLiteral struct {
 
 func (x *PredicateLiteral) Reset() {
 	*x = PredicateLiteral{}
-	mi := &file_analyzer_proto_msgTypes[8]
+	mi := &file_analyzer_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1199,7 +1318,7 @@ func (x *PredicateLiteral) String() string {
 func (*PredicateLiteral) ProtoMessage() {}
 
 func (x *PredicateLiteral) ProtoReflect() protoreflect.Message {
-	mi := &file_analyzer_proto_msgTypes[8]
+	mi := &file_analyzer_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1212,7 +1331,7 @@ func (x *PredicateLiteral) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PredicateLiteral.ProtoReflect.Descriptor instead.
 func (*PredicateLiteral) Descriptor() ([]byte, []int) {
-	return file_analyzer_proto_rawDescGZIP(), []int{8}
+	return file_analyzer_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *PredicateLiteral) GetColumn() *ColumnResource {
@@ -1241,7 +1360,7 @@ type TableResource struct {
 
 func (x *TableResource) Reset() {
 	*x = TableResource{}
-	mi := &file_analyzer_proto_msgTypes[9]
+	mi := &file_analyzer_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1253,7 +1372,7 @@ func (x *TableResource) String() string {
 func (*TableResource) ProtoMessage() {}
 
 func (x *TableResource) ProtoReflect() protoreflect.Message {
-	mi := &file_analyzer_proto_msgTypes[9]
+	mi := &file_analyzer_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1266,7 +1385,7 @@ func (x *TableResource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TableResource.ProtoReflect.Descriptor instead.
 func (*TableResource) Descriptor() ([]byte, []int) {
-	return file_analyzer_proto_rawDescGZIP(), []int{9}
+	return file_analyzer_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *TableResource) GetCatalog() string {
@@ -1300,7 +1419,7 @@ type FunctionResource struct {
 
 func (x *FunctionResource) Reset() {
 	*x = FunctionResource{}
-	mi := &file_analyzer_proto_msgTypes[10]
+	mi := &file_analyzer_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1312,7 +1431,7 @@ func (x *FunctionResource) String() string {
 func (*FunctionResource) ProtoMessage() {}
 
 func (x *FunctionResource) ProtoReflect() protoreflect.Message {
-	mi := &file_analyzer_proto_msgTypes[10]
+	mi := &file_analyzer_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1325,7 +1444,7 @@ func (x *FunctionResource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FunctionResource.ProtoReflect.Descriptor instead.
 func (*FunctionResource) Descriptor() ([]byte, []int) {
-	return file_analyzer_proto_rawDescGZIP(), []int{10}
+	return file_analyzer_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *FunctionResource) GetName() string {
@@ -1346,7 +1465,7 @@ type UtilityResource struct {
 
 func (x *UtilityResource) Reset() {
 	*x = UtilityResource{}
-	mi := &file_analyzer_proto_msgTypes[11]
+	mi := &file_analyzer_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1358,7 +1477,7 @@ func (x *UtilityResource) String() string {
 func (*UtilityResource) ProtoMessage() {}
 
 func (x *UtilityResource) ProtoReflect() protoreflect.Message {
-	mi := &file_analyzer_proto_msgTypes[11]
+	mi := &file_analyzer_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1371,7 +1490,7 @@ func (x *UtilityResource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UtilityResource.ProtoReflect.Descriptor instead.
 func (*UtilityResource) Descriptor() ([]byte, []int) {
-	return file_analyzer_proto_rawDescGZIP(), []int{11}
+	return file_analyzer_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *UtilityResource) GetCommand() string {
@@ -1405,7 +1524,7 @@ type RequireResultReadGrant struct {
 
 func (x *RequireResultReadGrant) Reset() {
 	*x = RequireResultReadGrant{}
-	mi := &file_analyzer_proto_msgTypes[12]
+	mi := &file_analyzer_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1417,7 +1536,7 @@ func (x *RequireResultReadGrant) String() string {
 func (*RequireResultReadGrant) ProtoMessage() {}
 
 func (x *RequireResultReadGrant) ProtoReflect() protoreflect.Message {
-	mi := &file_analyzer_proto_msgTypes[12]
+	mi := &file_analyzer_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1430,7 +1549,7 @@ func (x *RequireResultReadGrant) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequireResultReadGrant.ProtoReflect.Descriptor instead.
 func (*RequireResultReadGrant) Descriptor() ([]byte, []int) {
-	return file_analyzer_proto_rawDescGZIP(), []int{12}
+	return file_analyzer_proto_rawDescGZIP(), []int{14}
 }
 
 func (m *RequireResultReadGrant) GetResource() isRequireResultReadGrant_Resource {
@@ -1525,7 +1644,7 @@ type ResultFingerprint struct {
 
 func (x *ResultFingerprint) Reset() {
 	*x = ResultFingerprint{}
-	mi := &file_analyzer_proto_msgTypes[13]
+	mi := &file_analyzer_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1537,7 +1656,7 @@ func (x *ResultFingerprint) String() string {
 func (*ResultFingerprint) ProtoMessage() {}
 
 func (x *ResultFingerprint) ProtoReflect() protoreflect.Message {
-	mi := &file_analyzer_proto_msgTypes[13]
+	mi := &file_analyzer_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1550,7 +1669,7 @@ func (x *ResultFingerprint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResultFingerprint.ProtoReflect.Descriptor instead.
 func (*ResultFingerprint) Descriptor() ([]byte, []int) {
-	return file_analyzer_proto_rawDescGZIP(), []int{13}
+	return file_analyzer_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ResultFingerprint) GetGrants() []*RequireResultReadGrant {
@@ -1606,7 +1725,7 @@ type StatementFacts struct {
 
 func (x *StatementFacts) Reset() {
 	*x = StatementFacts{}
-	mi := &file_analyzer_proto_msgTypes[14]
+	mi := &file_analyzer_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1618,7 +1737,7 @@ func (x *StatementFacts) String() string {
 func (*StatementFacts) ProtoMessage() {}
 
 func (x *StatementFacts) ProtoReflect() protoreflect.Message {
-	mi := &file_analyzer_proto_msgTypes[14]
+	mi := &file_analyzer_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1631,7 +1750,7 @@ func (x *StatementFacts) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatementFacts.ProtoReflect.Descriptor instead.
 func (*StatementFacts) Descriptor() ([]byte, []int) {
-	return file_analyzer_proto_rawDescGZIP(), []int{14}
+	return file_analyzer_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *StatementFacts) GetResolved() bool {
@@ -1797,7 +1916,18 @@ var file_analyzer_proto_rawDesc = []byte{
 	0x6e, 0x66, 0x69, 0x67, 0x52, 0x0c, 0x65, 0x6e, 0x67, 0x69, 0x6e, 0x65, 0x43, 0x6f, 0x6e, 0x66,
 	0x69, 0x67, 0x4a, 0x04, 0x08, 0x02, 0x10, 0x03, 0x4a, 0x04, 0x08, 0x05, 0x10, 0x06, 0x52, 0x07,
 	0x64, 0x69, 0x61, 0x6c, 0x65, 0x63, 0x74, 0x52, 0x0e, 0x65, 0x6e, 0x67, 0x69, 0x6e, 0x65, 0x5f,
-	0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x22, 0x6e, 0x0a, 0x0a, 0x53, 0x6f, 0x75, 0x72, 0x63,
+	0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x22, 0x6d, 0x0a, 0x0c, 0x53, 0x70, 0x6c, 0x69, 0x74,
+	0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x10, 0x0a, 0x03, 0x73, 0x71, 0x6c, 0x18, 0x01,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x73, 0x71, 0x6c, 0x12, 0x4b, 0x0a, 0x0d, 0x65, 0x6e, 0x67,
+	0x69, 0x6e, 0x65, 0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x26, 0x2e, 0x70, 0x72, 0x6f, 0x78, 0x79, 0x6d, 0x6f, 0x6e, 0x73, 0x74, 0x65, 0x72, 0x2e,
+	0x61, 0x6e, 0x61, 0x6c, 0x79, 0x7a, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x45, 0x6e, 0x67, 0x69,
+	0x6e, 0x65, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x52, 0x0c, 0x65, 0x6e, 0x67, 0x69, 0x6e, 0x65,
+	0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x22, 0x3f, 0x0a, 0x0d, 0x53, 0x70, 0x6c, 0x69, 0x74, 0x52,
+	0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x0e, 0x0a, 0x02, 0x6f, 0x6b, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x08, 0x52, 0x02, 0x6f, 0x6b, 0x12, 0x1e, 0x0a, 0x0a, 0x73, 0x74, 0x61, 0x74, 0x65,
+	0x6d, 0x65, 0x6e, 0x74, 0x73, 0x18, 0x02, 0x20, 0x03, 0x28, 0x09, 0x52, 0x0a, 0x73, 0x74, 0x61,
+	0x74, 0x65, 0x6d, 0x65, 0x6e, 0x74, 0x73, 0x22, 0x6e, 0x0a, 0x0a, 0x53, 0x6f, 0x75, 0x72, 0x63,
 	0x65, 0x49, 0x6e, 0x66, 0x6f, 0x12, 0x18, 0x0a, 0x07, 0x63, 0x61, 0x74, 0x61, 0x6c, 0x6f, 0x67,
 	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x63, 0x61, 0x74, 0x61, 0x6c, 0x6f, 0x67, 0x12,
 	0x16, 0x0a, 0x06, 0x73, 0x63, 0x68, 0x65, 0x6d, 0x61, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52,
@@ -2276,7 +2406,7 @@ func file_analyzer_proto_rawDescGZIP() []byte {
 }
 
 var file_analyzer_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_analyzer_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_analyzer_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_analyzer_proto_goTypes = []any{
 	(MaskedDisposition)(0),            // 0: proxymonster.analyzer.v1.MaskedDisposition
 	(StatementKind)(0),                // 1: proxymonster.analyzer.v1.StatementKind
@@ -2286,44 +2416,47 @@ var file_analyzer_proto_goTypes = []any{
 	(*Namespace)(nil),                 // 5: proxymonster.analyzer.v1.Namespace
 	(*EngineConfig)(nil),              // 6: proxymonster.analyzer.v1.EngineConfig
 	(*AnalyzeRequest)(nil),            // 7: proxymonster.analyzer.v1.AnalyzeRequest
-	(*SourceInfo)(nil),                // 8: proxymonster.analyzer.v1.SourceInfo
-	(*RequireStatementExecGrant)(nil), // 9: proxymonster.analyzer.v1.RequireStatementExecGrant
-	(*ColumnResource)(nil),            // 10: proxymonster.analyzer.v1.ColumnResource
-	(*PredicateLiteral)(nil),          // 11: proxymonster.analyzer.v1.PredicateLiteral
-	(*TableResource)(nil),             // 12: proxymonster.analyzer.v1.TableResource
-	(*FunctionResource)(nil),          // 13: proxymonster.analyzer.v1.FunctionResource
-	(*UtilityResource)(nil),           // 14: proxymonster.analyzer.v1.UtilityResource
-	(*RequireResultReadGrant)(nil),    // 15: proxymonster.analyzer.v1.RequireResultReadGrant
-	(*ResultFingerprint)(nil),         // 16: proxymonster.analyzer.v1.ResultFingerprint
-	(*StatementFacts)(nil),            // 17: proxymonster.analyzer.v1.StatementFacts
-	(Engine)(0),                       // 18: proxymonster.v1.Engine
+	(*SplitRequest)(nil),              // 8: proxymonster.analyzer.v1.SplitRequest
+	(*SplitResponse)(nil),             // 9: proxymonster.analyzer.v1.SplitResponse
+	(*SourceInfo)(nil),                // 10: proxymonster.analyzer.v1.SourceInfo
+	(*RequireStatementExecGrant)(nil), // 11: proxymonster.analyzer.v1.RequireStatementExecGrant
+	(*ColumnResource)(nil),            // 12: proxymonster.analyzer.v1.ColumnResource
+	(*PredicateLiteral)(nil),          // 13: proxymonster.analyzer.v1.PredicateLiteral
+	(*TableResource)(nil),             // 14: proxymonster.analyzer.v1.TableResource
+	(*FunctionResource)(nil),          // 15: proxymonster.analyzer.v1.FunctionResource
+	(*UtilityResource)(nil),           // 16: proxymonster.analyzer.v1.UtilityResource
+	(*RequireResultReadGrant)(nil),    // 17: proxymonster.analyzer.v1.RequireResultReadGrant
+	(*ResultFingerprint)(nil),         // 18: proxymonster.analyzer.v1.ResultFingerprint
+	(*StatementFacts)(nil),            // 19: proxymonster.analyzer.v1.StatementFacts
+	(Engine)(0),                       // 20: proxymonster.v1.Engine
 }
 var file_analyzer_proto_depIdxs = []int32{
 	3,  // 0: proxymonster.analyzer.v1.ColumnSpec.identity:type_name -> proxymonster.analyzer.v1.RelationIdentity
-	18, // 1: proxymonster.analyzer.v1.EngineConfig.engine:type_name -> proxymonster.v1.Engine
+	20, // 1: proxymonster.analyzer.v1.EngineConfig.engine:type_name -> proxymonster.v1.Engine
 	5,  // 2: proxymonster.analyzer.v1.AnalyzeRequest.namespace:type_name -> proxymonster.analyzer.v1.Namespace
 	4,  // 3: proxymonster.analyzer.v1.AnalyzeRequest.catalog:type_name -> proxymonster.analyzer.v1.ColumnSpec
 	6,  // 4: proxymonster.analyzer.v1.AnalyzeRequest.engine_config:type_name -> proxymonster.analyzer.v1.EngineConfig
-	1,  // 5: proxymonster.analyzer.v1.RequireStatementExecGrant.statement_kind:type_name -> proxymonster.analyzer.v1.StatementKind
-	3,  // 6: proxymonster.analyzer.v1.ColumnResource.identity:type_name -> proxymonster.analyzer.v1.RelationIdentity
-	10, // 7: proxymonster.analyzer.v1.PredicateLiteral.column:type_name -> proxymonster.analyzer.v1.ColumnResource
-	10, // 8: proxymonster.analyzer.v1.RequireResultReadGrant.column:type_name -> proxymonster.analyzer.v1.ColumnResource
-	12, // 9: proxymonster.analyzer.v1.RequireResultReadGrant.table:type_name -> proxymonster.analyzer.v1.TableResource
-	13, // 10: proxymonster.analyzer.v1.RequireResultReadGrant.function:type_name -> proxymonster.analyzer.v1.FunctionResource
-	14, // 11: proxymonster.analyzer.v1.RequireResultReadGrant.utility:type_name -> proxymonster.analyzer.v1.UtilityResource
-	0,  // 12: proxymonster.analyzer.v1.RequireResultReadGrant.masked_disposition:type_name -> proxymonster.analyzer.v1.MaskedDisposition
-	15, // 13: proxymonster.analyzer.v1.ResultFingerprint.grants:type_name -> proxymonster.analyzer.v1.RequireResultReadGrant
-	2,  // 14: proxymonster.analyzer.v1.StatementFacts.failure_class:type_name -> proxymonster.analyzer.v1.FailureClass
-	8,  // 15: proxymonster.analyzer.v1.StatementFacts.sources:type_name -> proxymonster.analyzer.v1.SourceInfo
-	9,  // 16: proxymonster.analyzer.v1.StatementFacts.statement_exec:type_name -> proxymonster.analyzer.v1.RequireStatementExecGrant
-	15, // 17: proxymonster.analyzer.v1.StatementFacts.result_reads:type_name -> proxymonster.analyzer.v1.RequireResultReadGrant
-	11, // 18: proxymonster.analyzer.v1.StatementFacts.predicate_literals:type_name -> proxymonster.analyzer.v1.PredicateLiteral
-	10, // 19: proxymonster.analyzer.v1.StatementFacts.diagnostic_leak_columns:type_name -> proxymonster.analyzer.v1.ColumnResource
-	20, // [20:20] is the sub-list for method output_type
-	20, // [20:20] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	6,  // 5: proxymonster.analyzer.v1.SplitRequest.engine_config:type_name -> proxymonster.analyzer.v1.EngineConfig
+	1,  // 6: proxymonster.analyzer.v1.RequireStatementExecGrant.statement_kind:type_name -> proxymonster.analyzer.v1.StatementKind
+	3,  // 7: proxymonster.analyzer.v1.ColumnResource.identity:type_name -> proxymonster.analyzer.v1.RelationIdentity
+	12, // 8: proxymonster.analyzer.v1.PredicateLiteral.column:type_name -> proxymonster.analyzer.v1.ColumnResource
+	12, // 9: proxymonster.analyzer.v1.RequireResultReadGrant.column:type_name -> proxymonster.analyzer.v1.ColumnResource
+	14, // 10: proxymonster.analyzer.v1.RequireResultReadGrant.table:type_name -> proxymonster.analyzer.v1.TableResource
+	15, // 11: proxymonster.analyzer.v1.RequireResultReadGrant.function:type_name -> proxymonster.analyzer.v1.FunctionResource
+	16, // 12: proxymonster.analyzer.v1.RequireResultReadGrant.utility:type_name -> proxymonster.analyzer.v1.UtilityResource
+	0,  // 13: proxymonster.analyzer.v1.RequireResultReadGrant.masked_disposition:type_name -> proxymonster.analyzer.v1.MaskedDisposition
+	17, // 14: proxymonster.analyzer.v1.ResultFingerprint.grants:type_name -> proxymonster.analyzer.v1.RequireResultReadGrant
+	2,  // 15: proxymonster.analyzer.v1.StatementFacts.failure_class:type_name -> proxymonster.analyzer.v1.FailureClass
+	10, // 16: proxymonster.analyzer.v1.StatementFacts.sources:type_name -> proxymonster.analyzer.v1.SourceInfo
+	11, // 17: proxymonster.analyzer.v1.StatementFacts.statement_exec:type_name -> proxymonster.analyzer.v1.RequireStatementExecGrant
+	17, // 18: proxymonster.analyzer.v1.StatementFacts.result_reads:type_name -> proxymonster.analyzer.v1.RequireResultReadGrant
+	13, // 19: proxymonster.analyzer.v1.StatementFacts.predicate_literals:type_name -> proxymonster.analyzer.v1.PredicateLiteral
+	12, // 20: proxymonster.analyzer.v1.StatementFacts.diagnostic_leak_columns:type_name -> proxymonster.analyzer.v1.ColumnResource
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_analyzer_proto_init() }
@@ -2333,20 +2466,20 @@ func file_analyzer_proto_init() {
 	}
 	file_engine_proto_init()
 	file_analyzer_proto_msgTypes[3].OneofWrappers = []any{}
-	file_analyzer_proto_msgTypes[12].OneofWrappers = []any{
+	file_analyzer_proto_msgTypes[14].OneofWrappers = []any{
 		(*RequireResultReadGrant_Column)(nil),
 		(*RequireResultReadGrant_Table)(nil),
 		(*RequireResultReadGrant_Function)(nil),
 		(*RequireResultReadGrant_Utility)(nil),
 	}
-	file_analyzer_proto_msgTypes[14].OneofWrappers = []any{}
+	file_analyzer_proto_msgTypes[16].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_analyzer_proto_rawDesc,
 			NumEnums:      3,
-			NumMessages:   15,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/analyzer/probe/split.go
+++ b/analyzer/probe/split.go
@@ -1,0 +1,63 @@
+package probe
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
+	"github.com/ridi-oss/sqlglot-go"
+	exp "github.com/ridi-oss/sqlglot-go/expressions"
+)
+
+// SplitStatements cuts a batch into its statements, each a VERBATIM slice of sql — the text is stored,
+// hashed, and authorized, so Generate() would rewrite what the caller wrote. ok=false denies the batch.
+//
+//	SELECT 'a;b' FROM t; SELECT 2                  ->  ["SELECT 'a;b' FROM t", "SELECT 2"]
+//	CREATE PROCEDURE p() BEGIN a; b; END; SELECT 2  ->  ["CREATE PROCEDURE p() BEGIN a; b; END", "SELECT 2"]
+func SplitStatements(sql string, config *pb.EngineConfig) (statements []string, ok bool) {
+	defer func() {
+		if recover() != nil {
+			statements = nil
+			ok = false
+		}
+	}()
+
+	if !utf8.ValidString(sql) || strings.IndexByte(sql, 0) >= 0 {
+		return nil, false
+	}
+
+	// The dialect decides where a statement ends: under ANSI_QUOTES `SELECT "a;b"` is two statements,
+	// and one otherwise — so split with exactly the config the target and the analyzer use.
+	eng, err := createEngine(config)
+	if err != nil {
+		return nil, false
+	}
+	d := eng.Dialect()
+	// Parsed, not scanned for `;` — a `;` inside `'a;b'` or a BEGIN…END body ends nothing.
+	parsed, err := sqlglot.Parse(sql, d)
+	if err != nil {
+		return nil, false
+	}
+
+	out := make([]string, 0, len(parsed))
+	for _, statement := range parsed {
+		// `;;` leaves a nil slot and a bare `;` a Semicolon node — nothing to run, nothing to authorize.
+		if statement == nil || statement.Kind() == exp.KindSemicolon {
+			continue
+		}
+		text, spanned := statement.SpanText()
+		// No span means no slice of sql carries this statement, so nothing verbatim to authorize.
+		if !spanned {
+			return nil, false
+		}
+		if trimmed := strings.TrimSpace(text); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	// TODO: PG runs a bare `;` and the wire path relays EmptyQueryResponse; here it denies, since a
+	// batch of nothing would mean a task with zero children.
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, true
+}

--- a/analyzer/probe/split_test.go
+++ b/analyzer/probe/split_test.go
@@ -1,0 +1,374 @@
+package probe
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
+	"google.golang.org/protobuf/proto"
+)
+
+// The engine configs the splitter is exercised with: the same shape the control-plane forwards from
+// what the proxy reported at introspection.
+func mysqlSplitConfig() *pb.EngineConfig {
+	return &pb.EngineConfig{
+		Engine:                   pb.Engine_MYSQL,
+		EngineVersion:            "8.0.46",
+		MysqlLowerCaseTableNames: proto.Int32(1),
+	}
+}
+
+func postgresSplitConfig() *pb.EngineConfig {
+	return &pb.EngineConfig{Engine: pb.Engine_POSTGRES, EngineVersion: "16.0"}
+}
+
+func TestSplitStatements(t *testing.T) {
+	cases := []struct {
+		name   string
+		sql    string
+		engine *pb.EngineConfig
+		want   []string
+	}{
+		{"single", "SELECT 1", mysqlSplitConfig(), []string{"SELECT 1"}},
+		{"pair", "SELECT 1; SELECT 2", mysqlSplitConfig(), []string{"SELECT 1", "SELECT 2"}},
+		{"trailing terminator", "SELECT 1;", mysqlSplitConfig(), []string{"SELECT 1"}},
+		{"blank segments dropped", "SELECT 1;; SELECT 2;", mysqlSplitConfig(), []string{"SELECT 1", "SELECT 2"}},
+		{"newline separated", "SELECT 1;\n\nSELECT 2\n", mysqlSplitConfig(), []string{"SELECT 1", "SELECT 2"}},
+		// A `;` the tokenizer sees inside a literal, an identifier, or a comment is not a boundary.
+		{"literal", "SELECT 'a;b' FROM users; SELECT 2", mysqlSplitConfig(), []string{"SELECT 'a;b' FROM users", "SELECT 2"}},
+		{"quoted identifier", "SELECT `a;b` FROM t; SELECT 2", mysqlSplitConfig(), []string{"SELECT `a;b` FROM t", "SELECT 2"}},
+		{"line comment", "SELECT 1 -- a;b\n; SELECT 2", mysqlSplitConfig(), []string{"SELECT 1", "SELECT 2"}},
+		{"block comment", "SELECT /* a;b */ 1; SELECT 2", mysqlSplitConfig(), []string{"SELECT /* a;b */ 1", "SELECT 2"}},
+		{"dollar quoted body", "CREATE FUNCTION f() RETURNS int AS $$ BEGIN; RETURN 1; END; $$ LANGUAGE plpgsql; SELECT 2", postgresSplitConfig(),
+			[]string{"CREATE FUNCTION f() RETURNS int AS $$ BEGIN; RETURN 1; END; $$ LANGUAGE plpgsql", "SELECT 2"}},
+		{"postgres literal", "SELECT 'a;b'; SELECT 2", postgresSplitConfig(), []string{"SELECT 'a;b'", "SELECT 2"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := SplitStatements(c.sql, c.engine)
+			if !ok {
+				t.Fatalf("SplitStatements(%q) failed closed, want %q", c.sql, c.want)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("SplitStatements(%q) = %q, want %q", c.sql, got, c.want)
+			}
+		})
+	}
+}
+
+// Every statement must be a verbatim slice of the input: the batch is stored, hashed, and authorized
+// per statement, so a regenerated (or re-quoted) form would authorize text the caller never wrote.
+func TestSplitStatementsSlicesVerbatim(t *testing.T) {
+	sql := "SELECT `a;b`,  'x'  FROM t WHERE id = 1;\n  UPDATE t SET c = 'p;q' WHERE id = 2"
+	got, ok := SplitStatements(sql, mysqlSplitConfig())
+	if !ok {
+		t.Fatalf("SplitStatements failed closed")
+	}
+	for _, statement := range got {
+		if !strings.Contains(sql, statement) {
+			t.Fatalf("statement %q is not a verbatim slice of the input", statement)
+		}
+	}
+}
+
+func TestSplitStatementsFailsClosed(t *testing.T) {
+	cases := []struct {
+		name   string
+		sql    string
+		engine *pb.EngineConfig
+	}{
+		{"unset engine", "SELECT 1", &pb.EngineConfig{}},
+		{"nil config", "SELECT 1", nil},
+		// createEngine requires both for MySQL; splitting under a partial config would use a dialect the
+		// target does not, so it fails closed exactly as analysis does.
+		{"mysql without version", "SELECT 1", &pb.EngineConfig{Engine: pb.Engine_MYSQL, MysqlLowerCaseTableNames: proto.Int32(1)}},
+		{"mysql without lower_case_table_names", "SELECT 1", &pb.EngineConfig{Engine: pb.Engine_MYSQL, EngineVersion: "8.0.46"}},
+		{"embedded NUL", "SELECT 1\x00; SELECT 2", mysqlSplitConfig()},
+		{"invalid utf8", "SELECT '\xff\xfe'", mysqlSplitConfig()},
+		{"empty", "", mysqlSplitConfig()},
+		{"blank", "   \n  ", mysqlSplitConfig()},
+		{"terminators only", ";;;", mysqlSplitConfig()},
+		{"unterminated literal", "SELECT 'abc", mysqlSplitConfig()},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got, ok := SplitStatements(c.sql, c.engine); ok {
+				t.Fatalf("SplitStatements(%q, %q) = %q, want fail-closed", c.sql, c.engine, got)
+			}
+		})
+	}
+}
+
+// A split statement must analyze on its own: the batch path feeds each slice back through EmitFacts,
+// which admits exactly one statement.
+func TestSplitStatementsProduceSingleStatements(t *testing.T) {
+	got, ok := SplitStatements("SELECT 'a;b' FROM users; UPDATE users SET name = 'x;y' WHERE id = 1", mysqlSplitConfig())
+	if !ok {
+		t.Fatalf("SplitStatements failed closed")
+	}
+	for _, statement := range got {
+		if inner, ok := SplitStatements(statement, mysqlSplitConfig()); !ok || len(inner) != 1 {
+			t.Fatalf("split statement %q does not re-split to exactly one statement: %q (ok=%v)", statement, inner, ok)
+		}
+	}
+}
+
+// A routine body's semicolons separate the body's OWN statements, so the whole definition is ONE
+// statement — and a statement after its END is its own, separately authorized.
+func TestSplitStatementsKeepsRoutineBodiesWhole(t *testing.T) {
+	cases := []struct {
+		sql  string
+		want []string
+	}{
+		{"CREATE PROCEDURE p() BEGIN SELECT 1; SELECT 2; END",
+			[]string{"CREATE PROCEDURE p() BEGIN SELECT 1; SELECT 2; END"}},
+		{"SELECT 1; CREATE PROCEDURE p() BEGIN SELECT 2; END",
+			[]string{"SELECT 1", "CREATE PROCEDURE p() BEGIN SELECT 2; END"}},
+		// The trailing statement is NOT absorbed into the routine: it is authorized on its own.
+		{"CREATE PROCEDURE p() BEGIN SELECT 1; END; SELECT 2",
+			[]string{"CREATE PROCEDURE p() BEGIN SELECT 1; END", "SELECT 2"}},
+		{"CREATE PROCEDURE p() BEGIN END; SELECT 2",
+			[]string{"CREATE PROCEDURE p() BEGIN END", "SELECT 2"}},
+	}
+	for _, c := range cases {
+		got, ok := SplitStatements(c.sql, mysqlSplitConfig())
+		if !ok {
+			t.Fatalf("SplitStatements(%q) failed closed, want %q", c.sql, c.want)
+		}
+		if !reflect.DeepEqual(got, c.want) {
+			t.Fatalf("SplitStatements(%q) = %q, want %q", c.sql, got, c.want)
+		}
+	}
+}
+
+// Every routine form folds whole, and a statement after its END stays its own — so a trailing
+// statement is authorized separately rather than riding the routine's verdict.
+func TestSplitStatementsFoldsEveryRoutineForm(t *testing.T) {
+	cases := []struct {
+		engine *pb.EngineConfig
+		sql    string
+		want   []string
+	}{
+		{mysqlSplitConfig(), "CREATE TRIGGER t BEFORE INSERT ON x FOR EACH ROW BEGIN SET @a = 1; END; SELECT 2",
+			[]string{"CREATE TRIGGER t BEFORE INSERT ON x FOR EACH ROW BEGIN SET @a = 1; END", "SELECT 2"}},
+		{mysqlSplitConfig(), "CREATE FUNCTION f() RETURNS INT BEGIN RETURN 1; END; SELECT 2",
+			[]string{"CREATE FUNCTION f() RETURNS INT BEGIN RETURN 1; END", "SELECT 2"}},
+		{postgresSplitConfig(), "CREATE FUNCTION f() RETURNS int LANGUAGE SQL BEGIN ATOMIC SELECT 1; END; SELECT 2",
+			[]string{"CREATE FUNCTION f() RETURNS int LANGUAGE SQL BEGIN ATOMIC SELECT 1; END", "SELECT 2"}},
+		// Bodies with no BEGIN wrapper: the terminator is the block's own, not a semicolon.
+		{mysqlSplitConfig(), "CREATE PROCEDURE p() IF 1 THEN SELECT 1; END IF; SELECT 2",
+			[]string{"CREATE PROCEDURE p() IF 1 THEN SELECT 1; END IF", "SELECT 2"}},
+		{mysqlSplitConfig(), "CREATE PROCEDURE p() WHILE x DO SELECT 1; END WHILE; SELECT 2",
+			[]string{"CREATE PROCEDURE p() WHILE x DO SELECT 1; END WHILE", "SELECT 2"}},
+		{mysqlSplitConfig(), "CREATE PROCEDURE p() LOOP SELECT 1; END LOOP; SELECT 2",
+			[]string{"CREATE PROCEDURE p() LOOP SELECT 1; END LOOP", "SELECT 2"}},
+		{mysqlSplitConfig(), "CREATE PROCEDURE p() REPEAT SELECT 1; UNTIL x END REPEAT; SELECT 2",
+			[]string{"CREATE PROCEDURE p() REPEAT SELECT 1; UNTIL x END REPEAT", "SELECT 2"}},
+		{mysqlSplitConfig(), "CREATE PROCEDURE p() CASE x WHEN 1 THEN SELECT 1; END CASE; SELECT 2",
+			[]string{"CREATE PROCEDURE p() CASE x WHEN 1 THEN SELECT 1; END CASE", "SELECT 2"}},
+	}
+	for _, c := range cases {
+		got, ok := SplitStatements(c.sql, c.engine)
+		if !ok {
+			t.Fatalf("SplitStatements(%q) failed closed, want %q", c.sql, c.want)
+		}
+		if !reflect.DeepEqual(got, c.want) {
+			t.Fatalf("SplitStatements(%q) = %q, want %q", c.sql, got, c.want)
+		}
+	}
+}
+
+// PostgreSQL's `END` is COMMIT, so `BEGIN; …; END` is an ordinary transaction batch — denying it
+// would refuse valid SQL. MySQL has no such form: a top-level END there is a routine body's tail.
+func TestSplitStatementsPostgresTransactionEnd(t *testing.T) {
+	const sql = "BEGIN; UPDATE t SET a = 1; END"
+	got, ok := SplitStatements(sql, postgresSplitConfig())
+	if !ok {
+		t.Fatalf("SplitStatements(%q, POSTGRES) denied a valid transaction batch", sql)
+	}
+	want := []string{"BEGIN", "UPDATE t SET a = 1", "END"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SplitStatements(%q) = %q, want %q", sql, got, want)
+	}
+	// MySQL has no END statement — real MySQL 8.4 rejects a bare `END` with 1064, and the parser
+	// agrees, so the batch is denied without a guard of our own.
+	for _, mysqlEnd := range []string{"END", "SELECT 1; END", "END; SELECT 1"} {
+		if got, ok := SplitStatements(mysqlEnd, mysqlSplitConfig()); ok {
+			t.Fatalf("MySQL has no END statement; want denial for %q, got %q", mysqlEnd, got)
+		}
+	}
+}
+
+// A keyword-named identifier inside a routine body must never let the extent swallow what follows:
+// merging `DROP TABLE users` into the CREATE would run it under the routine's verdict.
+func TestSplitStatementsNeverMergesTrailingStatement(t *testing.T) {
+	// A statement after a routine must be authorized on its own — absorbed into the routine's span it
+	// would ride the CREATE's verdict, so a DROP would be permitted by a grant to create routines.
+	for _, sql := range []string{
+		"CREATE PROCEDURE p() BEGIN SELECT begin FROM t; END; DROP TABLE users",
+		"CREATE PROCEDURE p() WHILE x DO SELECT 1; END WHILE; DROP TABLE users",
+		"CREATE PROCEDURE p() IF 1 THEN SELECT 1; END IF; DROP TABLE users",
+		"CREATE PROCEDURE p() LOOP SELECT 1; END LOOP; DROP TABLE users",
+		"CREATE PROCEDURE p() REPEAT SELECT 1; UNTIL x END REPEAT; DROP TABLE users",
+		"CREATE PROCEDURE p() CASE x WHEN 1 THEN SELECT 1; END CASE; DROP TABLE users",
+		"CREATE TRIGGER t BEFORE INSERT ON x FOR EACH ROW BEGIN SET @a = 1; END; DROP TABLE users",
+	} {
+		got, ok := SplitStatements(sql, mysqlSplitConfig())
+		if !ok {
+			t.Fatalf("SplitStatements(%q) denied a valid batch", sql)
+		}
+		if len(got) != 2 || got[1] != "DROP TABLE users" {
+			t.Fatalf("SplitStatements(%q) = %q; the DROP must stand alone", sql, got)
+		}
+	}
+}
+
+// The mirror of a merge: a statement INSIDE a routine body must never surface as its own top-level
+// statement, or it would be authorized as that statement instead of as part of the definition.
+func TestSplitStatementsNeverEscapesBodyStatement(t *testing.T) {
+	for _, sql := range []string{
+		"CREATE PROCEDURE p() BEGIN DROP TABLE x; SELECT 1; END",
+		"CREATE PROCEDURE p() BEGIN SET @a = end; DROP TABLE x; END",
+	} {
+		got, ok := SplitStatements(sql, mysqlSplitConfig())
+		if !ok {
+			continue // denying the batch is fine; escaping is not
+		}
+		for _, statement := range got {
+			if statement == "DROP TABLE x" {
+				t.Fatalf("SplitStatements(%q) = %q; a body statement escaped to top level", sql, got)
+			}
+		}
+	}
+}
+
+// A chunk the parser cannot place denies the WHOLE batch. Without this, sqlglot-go <= v0.28.0
+// returned just [SELECT 1] here — silently dropping SELECT 2, which would then never be authorized.
+func TestSplitStatementsDeniesOnParseError(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT 1; ELSE; SELECT 2",
+		// A body statement missing its terminator: real MySQL rejects this with 1064.
+		"CREATE PROCEDURE p() BEGIN SELECT 1 END",
+		// A label that does not match the block it closes.
+		"CREATE PROCEDURE p() lbl: LOOP LEAVE lbl; END LOOP wrong; SELECT 2",
+	} {
+		if got, ok := SplitStatements(sql, mysqlSplitConfig()); ok {
+			t.Fatalf("a parse error must deny the batch, got %q for %q", got, sql)
+		}
+	}
+}
+
+// A transaction BEGIN and a CASE … END are ordinary statement content and must still split: they share
+// the BEGIN / END tokens with a routine body, so keying on those alone would refuse a legitimate batch.
+func TestSplitStatementsAllowsTransactionAndCase(t *testing.T) {
+	cases := []struct {
+		sql  string
+		want []string
+	}{
+		{"BEGIN; SELECT 1; COMMIT", []string{"BEGIN", "SELECT 1", "COMMIT"}},
+		{"START TRANSACTION; UPDATE t SET a = 1; COMMIT", []string{"START TRANSACTION", "UPDATE t SET a = 1", "COMMIT"}},
+		{"SELECT CASE WHEN a = 1 THEN 'x' ELSE 'y' END FROM t; SELECT 2",
+			[]string{"SELECT CASE WHEN a = 1 THEN 'x' ELSE 'y' END FROM t", "SELECT 2"}},
+	}
+	for _, c := range cases {
+		got, ok := SplitStatements(c.sql, mysqlSplitConfig())
+		if !ok {
+			t.Fatalf("SplitStatements(%q) failed closed, want %q", c.sql, c.want)
+		}
+		if !reflect.DeepEqual(got, c.want) {
+			t.Fatalf("SplitStatements(%q) = %q, want %q", c.sql, got, c.want)
+		}
+	}
+}
+
+// A comment carries no statement. The tokenizer attaches comments to the following token rather than
+// emitting them, so a comment-only segment is non-blank text with no tokens — emitting it would add a
+// statement the caller never wrote, and the batch would fail on it.
+func TestSplitStatementsDropsCommentOnlySegments(t *testing.T) {
+	cases := []struct {
+		sql  string
+		want []string
+	}{
+		{"SELECT 1; -- trailing note", []string{"SELECT 1"}},
+		{"SELECT 1; /* trailing */", []string{"SELECT 1"}},
+		{"SELECT 1;\n-- a\n-- b", []string{"SELECT 1"}},
+		{"-- leading\nSELECT 1; SELECT 2", []string{"SELECT 1", "SELECT 2"}},
+	}
+	for _, c := range cases {
+		got, ok := SplitStatements(c.sql, mysqlSplitConfig())
+		if !ok {
+			t.Fatalf("SplitStatements(%q) failed closed, want %q", c.sql, c.want)
+		}
+		if !reflect.DeepEqual(got, c.want) {
+			t.Fatalf("SplitStatements(%q) = %q, want %q", c.sql, got, c.want)
+		}
+	}
+	// Nothing but comments is not a batch at all.
+	for _, sql := range []string{"-- note", "/* note */", "-- a\n-- b"} {
+		if got, ok := SplitStatements(sql, mysqlSplitConfig()); ok {
+			t.Fatalf("comment-only input must fail closed, got %q for %q", got, sql)
+		}
+	}
+}
+
+// MySQL runs a version-gated comment's body as SQL, so it must be AUTHORIZED, not discarded: under a
+// versionless dialect `DELETE … WHERE id=1 /*!80000 OR 1=1 */` spans only the scoped delete while the
+// server deletes every row. The target's own dialect keeps the body inside the span it belongs to.
+func TestSplitStatementsKeepsMysqlExecutableComment(t *testing.T) {
+	for _, c := range []struct {
+		sql  string
+		want []string
+	}{
+		{"SELECT 1; /*!40101 DROP TABLE users */", []string{"SELECT 1", "/*!40101 DROP TABLE users */"}},
+		{"/*! DROP TABLE users */; SELECT 1", []string{"/*! DROP TABLE users */", "SELECT 1"}},
+		{"DELETE FROM users WHERE id=1 /*!80000 OR 1=1 */", []string{"DELETE FROM users WHERE id=1 /*!80000 OR 1=1 */"}},
+		{"INSERT INTO t /*!80000 SELECT * FROM users */", []string{"INSERT INTO t /*!80000 SELECT * FROM users */"}},
+	} {
+		got, ok := SplitStatements(c.sql, mysqlSplitConfig())
+		if !ok {
+			t.Errorf("SplitStatements(%q) denied", c.sql)
+			continue
+		}
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("SplitStatements(%q) = %q, want %q — the body must be authorized, not dropped", c.sql, got, c.want)
+		}
+	}
+	// A body the parser cannot place in a clean span fails closed rather than authorizing a subset.
+	for _, sql := range []string{
+		"SELECT 1 /*!80000 ; DROP TABLE users */",
+		"/*!40101 SELECT 2 */ SELECT 1",
+	} {
+		if got, ok := SplitStatements(sql, mysqlSplitConfig()); ok {
+			t.Errorf("SplitStatements(%q) = %q, want deny", sql, got)
+		}
+	}
+	// PostgreSQL has no executable comments — it is an ordinary comment there.
+	if _, ok := SplitStatements("SELECT 1; /*!40101 DROP TABLE users */", postgresSplitConfig()); !ok {
+		t.Error("PostgreSQL must not deny a plain comment")
+	}
+}
+
+// ANSI_QUOTES moves a boundary: `"…"` is a string by default (one statement) and a quoted identifier
+// under the mode, where the `\` is literal, the quote closes, and the `;` splits. Splitting under the
+// wrong one would fold DROP TABLE users into the SELECT's span and authorize it as that SELECT.
+func TestSplitStatementsHonorsAnsiQuotes(t *testing.T) {
+	const sql = `SELECT "a\" FROM t; DROP TABLE users; -- "`
+	ansi := &pb.EngineConfig{
+		Engine:                   pb.Engine_MYSQL,
+		EngineVersion:            "8.0.46",
+		MysqlLowerCaseTableNames: proto.Int32(1),
+		MysqlAnsiQuotes:          proto.Bool(true),
+	}
+	got, ok := SplitStatements(sql, ansi)
+	if !ok {
+		t.Fatalf("SplitStatements(%q) denied under ANSI_QUOTES", sql)
+	}
+	want := []string{`SELECT "a\" FROM t`, "DROP TABLE users"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SplitStatements(%q) = %q, want %q — the DROP must stand alone", sql, got, want)
+	}
+	if plain, _ := SplitStatements(sql, mysqlSplitConfig()); len(plain) != 1 {
+		t.Fatalf("default mode = %q, want one statement (the `\"…\"` is a literal there)", plain)
+	}
+}

--- a/analyzer/probe/wire.go
+++ b/analyzer/probe/wire.go
@@ -53,6 +53,32 @@ func AnalyzeStatementSafe(reqBytes []byte) (out []byte) {
 	return out
 }
 
+// SplitStatementsSafe is the panic-safe FFI entry point for the batch split: anything that goes wrong
+// becomes an encoded ok=false, never a panic crossing into the JVM.
+func SplitStatementsSafe(reqBytes []byte) (out []byte) {
+	defer func() {
+		if r := recover(); r != nil {
+			out = splitFailure
+		}
+	}()
+	var req pb.SplitRequest
+	if err := proto.Unmarshal(reqBytes, &req); err != nil {
+		return splitFailure
+	}
+	statements, ok := SplitStatements(req.GetSql(), req.GetEngineConfig())
+	if !ok {
+		return splitFailure
+	}
+	encoded, err := proto.Marshal(&pb.SplitResponse{Ok: true, Statements: statements})
+	if err != nil {
+		return splitFailure
+	}
+	return encoded
+}
+
+// The encoded fail-closed SplitResponse, computed once so the failure path never has to marshal.
+var splitFailure = must(proto.Marshal(&pb.SplitResponse{Ok: false}))
+
 // marshalErrorFallback is a statically-valid encoded fail-closed StatementFacts, computed once so
 // mustFailProto never has to marshal twice on the (essentially unreachable) path where encoding the
 // real failure result itself errors — proto.Marshal on a well-formed message practically never

--- a/engine/src/main/kotlin/com/ridi/oss/proxymonster/probe/SplitStatements.kt
+++ b/engine/src/main/kotlin/com/ridi/oss/proxymonster/probe/SplitStatements.kt
@@ -1,0 +1,26 @@
+package com.ridi.oss.proxymonster.probe
+
+import com.ridi.oss.proxymonster.analyzer.pb.EngineConfig as PbEngineConfig
+import com.ridi.oss.proxymonster.analyzer.pb.SplitResponse
+import com.ridi.oss.proxymonster.analyzer.pb.splitRequest
+import com.ridi.oss.sqlglotgo.Sqlglot
+
+/**
+ * Cut a batch into its statements at the target's own boundaries — null when it cannot be split safely,
+ * and the caller denies. [engineConfig] is the config analysis uses, since the dialect decides where a
+ * statement ends: `SELECT "a;b"` is two statements under ANSI_QUOTES and one otherwise.
+ *
+ *   SELECT 'a;b' FROM t; SELECT 2  ->  ["SELECT 'a;b' FROM t", "SELECT 2"]
+ */
+fun splitStatements(sql: String, engineConfig: PbEngineConfig): List<String>? = try {
+    // Protobuf encodes an unpaired surrogate as `?`, so Go would split SQL the caller never wrote.
+    if (!Sqlglot.hasWellFormedUtf16(sql)) return null
+    val request = splitRequest {
+        this.sql = sql
+        this.engineConfig = engineConfig
+    }
+    val response = SplitResponse.parseFrom(Sqlglot.splitStatements(request.toByteArray()))
+    if (response.ok) response.statementsList.toList() else null
+} catch (_: Throwable) {
+    null
+}

--- a/engine/src/test/kotlin/com/ridi/oss/proxymonster/probe/SplitStatementsTest.kt
+++ b/engine/src/test/kotlin/com/ridi/oss/proxymonster/probe/SplitStatementsTest.kt
@@ -1,0 +1,147 @@
+package com.ridi.oss.proxymonster.probe
+
+import com.ridi.oss.proxymonster.analyzer.pb.EngineConfig as PbEngineConfig
+import com.ridi.oss.proxymonster.analyzer.pb.engineConfig
+import com.ridi.oss.proxymonster.grpc.Engine
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The batch split must cut only at real statement boundaries and hand back verbatim slices: the
+ * control-plane stores, hashes, and authorizes each statement it returns, so a boundary the engine
+ * would not draw (a `;` inside a literal) or a regenerated statement would authorize text nobody
+ * wrote. Anything unsplittable is null — the caller denies.
+ */
+class SplitStatementsTest {
+    private val mysql = engineConfig {
+        engine = Engine.MYSQL
+        engineVersion = "8.0.46"
+        mysqlLowerCaseTableNames = 1
+    }
+    private val postgres = engineConfig {
+        engine = Engine.POSTGRES
+        engineVersion = "16.0"
+    }
+
+    @Test fun `splits at statement boundaries`() {
+        for (d in listOf(mysql, postgres)) {
+            assertEquals(listOf("SELECT 1"), splitStatements("SELECT 1", d), "[$d] single statement")
+            assertEquals(listOf("SELECT 1"), splitStatements("SELECT 1;", d), "[$d] trailing terminator")
+            assertEquals(listOf("SELECT 1", "SELECT 2"), splitStatements("SELECT 1; SELECT 2", d), "[$d] pair")
+            assertEquals(
+                listOf("SELECT 1", "SELECT 2"),
+                splitStatements("SELECT 1;;\n\n SELECT 2;\n", d),
+                "[$d] blank segments are dropped",
+            )
+        }
+    }
+
+    @Test fun `a semicolon inside a literal or comment is not a boundary`() {
+        for (d in listOf(mysql, postgres)) {
+            assertEquals(
+                listOf("SELECT 'a;b' FROM users", "SELECT 2"),
+                splitStatements("SELECT 'a;b' FROM users; SELECT 2", d),
+                "[$d] literal",
+            )
+            assertEquals(
+                listOf("SELECT /* a;b */ 1", "SELECT 2"),
+                splitStatements("SELECT /* a;b */ 1; SELECT 2", d),
+                "[$d] block comment",
+            )
+        }
+        assertEquals(
+            listOf("SELECT `a;b` FROM t", "SELECT 2"),
+            splitStatements("SELECT `a;b` FROM t; SELECT 2", mysql),
+            "quoted identifier",
+        )
+        assertEquals(
+            listOf("CREATE FUNCTION f() RETURNS int AS \$\$ BEGIN; RETURN 1; END; \$\$ LANGUAGE plpgsql", "SELECT 2"),
+            splitStatements(
+                "CREATE FUNCTION f() RETURNS int AS \$\$ BEGIN; RETURN 1; END; \$\$ LANGUAGE plpgsql; SELECT 2",
+                postgres,
+            ),
+            "dollar-quoted body",
+        )
+    }
+
+    @Test fun `every statement is a verbatim slice of the batch`() {
+        val batch = "SELECT `a;b`,  'x'  FROM t WHERE id = 1;\n  UPDATE t SET c = 'p;q' WHERE id = 2"
+        val statements = assertNotNull(splitStatements(batch, mysql), "expected a split for: $batch")
+        for (statement in statements) {
+            assertTrue(batch.contains(statement), "not a verbatim slice of the batch: $statement")
+        }
+    }
+
+    @Test fun `each split statement analyzes as a single statement`() {
+        val statements = assertNotNull(
+            splitStatements("SELECT 'a;b' FROM users; UPDATE users SET name = 'x' WHERE id = 1", mysql),
+        )
+        for (statement in statements) {
+            assertEquals(listOf(statement), splitStatements(statement, mysql), "re-split changed: $statement")
+        }
+    }
+
+    // An incomplete config must never fall back to a default tokenizer: base reads `a;b` as TWO
+    // statements where MySQL sees one quoted identifier, so it would draw a boundary the target does not.
+    @Test fun `an unusable engine config fails closed`() {
+        assertNull(splitStatements("SELECT 1", PbEngineConfig.getDefaultInstance()))
+        assertNull(splitStatements("SELECT `a;b` FROM t; SELECT 2", PbEngineConfig.getDefaultInstance()))
+        // MySQL analysis requires both; splitting under a partial config would use the wrong dialect.
+        assertNull(splitStatements("SELECT 1", engineConfig { engine = Engine.MYSQL; engineVersion = "8.0.46" }))
+        assertNull(
+            splitStatements("SELECT 1", engineConfig { engine = Engine.MYSQL; mysqlLowerCaseTableNames = 1 }),
+        )
+    }
+
+    // The dialect decides where a statement ends: under ANSI_QUOTES `"…"` is a quoted identifier, so the
+    // `\` is literal, the quote closes, and the `;` splits — folding the DROP in would authorize it as
+    // part of the SELECT.
+    @Test fun `ansi quotes moves the boundary`() {
+        val sql = """SELECT "a\" FROM t; DROP TABLE users; -- """"
+        val ansi = engineConfig {
+            engine = Engine.MYSQL
+            engineVersion = "8.0.46"
+            mysqlLowerCaseTableNames = 1
+            mysqlAnsiQuotes = true
+        }
+        assertEquals(listOf("""SELECT "a\" FROM t""", "DROP TABLE users"), splitStatements(sql, ansi))
+        assertEquals(1, assertNotNull(splitStatements(sql, mysql)).size)
+    }
+
+    @Test fun `unsplittable input fails closed`() {
+        for (d in listOf(mysql, postgres)) {
+            assertNull(splitStatements("", d), "[$d] empty")
+            assertNull(splitStatements("   \n ", d), "[$d] blank")
+            assertNull(splitStatements(";;;", d), "[$d] terminators only")
+            assertNull(splitStatements("SELECT 'abc", d), "[$d] unterminated literal")
+            assertNull(splitStatements("SELECT 1\u0000; SELECT 2", d), "[$d] embedded NUL")
+        }
+    }
+
+    @Test
+    fun `an unpaired surrogate denies rather than becoming a question mark`() {
+        // Protobuf encodes an unpaired surrogate as `?`, so Go sees valid UTF-8 and cannot detect the
+        // substitution: "SELECT '\uD800'" would come back as "SELECT '?'" — not a slice of the input.
+        assertNull(splitStatements("SELECT '\uD800'; DROP TABLE users", mysql))
+        assertNull(splitStatements("SELECT '\uDC00'", postgres))
+        assertNotNull(splitStatements("SELECT '\uD83D\uDE00'; SELECT 2", mysql))
+    }
+
+    // MySQL runs a version-gated comment's body as SQL, so it must be authorized rather than dropped:
+    // under a versionless dialect the body falls outside every span and never reaches a decision.
+    @Test
+    fun `a MySQL executable comment stays in its statement`() {
+        assertEquals(
+            listOf("SELECT 1", "/*!40101 DROP TABLE users */"),
+            splitStatements("SELECT 1; /*!40101 DROP TABLE users */", mysql),
+        )
+        assertEquals(
+            listOf("DELETE FROM users WHERE id=1 /*!80000 OR 1=1 */"),
+            splitStatements("DELETE FROM users WHERE id=1 /*!80000 OR 1=1 */", mysql),
+        )
+        assertNotNull(splitStatements("SELECT 1; /* plain */", mysql))
+    }
+}

--- a/proto/src/main/proto/analyzer.proto
+++ b/proto/src/main/proto/analyzer.proto
@@ -82,6 +82,29 @@ message AnalyzeRequest {
   EngineConfig engine_config = 6;
 }
 
+// Cut a multi-statement batch into its individual statements at the dialect's own semicolon tokens,
+// so a `;` inside a literal, a quoted identifier, a comment, or a dollar-quoted body is not a
+// boundary. The batch surfaces (the approval workflow, the editor) split here rather than in the
+// client, so the statement boundary the control-plane stores, hashes, and authorizes is the
+// engine's, not a caller's guess.
+message SplitRequest {
+  string sql = 1;
+  // The dialect decides where a statement ends, so this is the same config analysis uses: MySQL's
+  // version gates executable comments (`/*!80000 OR 1=1 */` is SQL the server runs) and ansi_quotes
+  // decides whether `"a;b"` is one literal or a boundary. An engine-invalid config fails closed.
+  EngineConfig engine_config = 2;
+}
+
+// Each statement is a verbatim slice of the request's sql (trimmed, terminator dropped) — never
+// regenerated text, so what is stored and authorized is exactly what the caller wrote. [ok] false
+// leaves [statements] empty and means the batch could not be split safely (bad dialect, invalid
+// UTF-8, an embedded NUL, a tokenizer failure, or no statement at all); the caller denies rather
+// than falling back to its own split.
+message SplitResponse {
+  bool ok = 1;
+  repeated string statements = 2;
+}
+
 // ---- response side ----
 
 // One physical target-DB relation the statement scans (docs/facts-emission.md). catalog/schema/table


### PR DESCRIPTION
Adds `SplitStatements` — the analyzer cuts a multi-statement batch into its statements so each one is
authorized on its own. Nothing calls it yet; the control-plane and web consumers follow in later PRs.

The parser draws the boundaries, not a semicolon scan: `sqlglot.Parse()` plus each statement's
`SpanText()`, so a `;` inside a string literal, a comment, a `$$…$$` body, or a routine's `BEGIN…END`
ends nothing. Each statement is a verbatim slice of the input — `Generate()` is never used, since the
text is stored, hashed, and authorized, and regenerating it would rewrite `select id,  ssn` into
`SELECT id, ssn`.

Two invariants carry the security weight, both covered by tests:

- A statement after a routine is never absorbed into it. `CREATE PROCEDURE p() … END; DROP TABLE
  users` splitting to one statement would authorize the DROP as `stmt.kind.create_procedure`, so a
  grant to create routines would carry a DROP.
- A statement inside a routine body never surfaces at top level, where it would be authorized as
  itself rather than as part of the definition.

`SplitRequest` carries the full `EngineConfig`, not a bare `Engine`, because the dialect decides where
a statement ends:

- MySQL's version gates executable comments. Versionless, `DELETE FROM users WHERE id=1
  /*!80000 OR 1=1 */` spans only the scoped delete while 8.0.46 deletes every row — the authorized
  text would be narrower than what runs. With the version the body sits inside the span.
- `ANSI_QUOTES` makes `"…"` a quoted identifier, so `SELECT "a\" FROM t; DROP TABLE users; -- "` is
  two statements there and one by default.

A config that fails `createEngine` (absent, unset engine, MySQL missing its version or
lower_case_table_names) denies the batch, as analysis fails closed.

Fail-closed elsewhere too: a parse error, an absent span, invalid UTF-8, or an embedded NUL returns
`ok=false` and the caller denies — a silently dropped statement (never authorized, still run) is the
outcome to avoid. The JVM binding rejects malformed UTF-16 before encoding, since protobuf turns an
unpaired surrogate into `?` and Go would then split SQL the caller never wrote.

Two traps worth knowing. `SplitStatementsSafe` recovers panics but NOT a Go stack overflow — that is a
fatal error, so ~40k nested parens aborts the process; pre-existing on `AnalyzeStatementSafe`, not
addressed here. And a batch that is only `;` or whitespace denies (marked TODO) while real PostgreSQL
runs it and the wire path relays `EmptyQueryResponse`; running it would mean a task with zero children.
Empty slots *inside* a batch (`SELECT 1;;SELECT 2`) drop out, which matches PostgreSQL — it returns two
result sets there, not three.

Verified: `mise run verify` green on this commit alone — 1195 control-plane, 65 engine, 7 analyzer
tests, 32 Go packages, web build.
