### PR TITLE
refactor(control-plane): address a task's result children by ordinal

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Access.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Access.kt
@@ -38,7 +38,13 @@ data class AccessRequest(
     val requestedDurationSec: Long, val status: String, val decidedBy: String? = null,
     val executedBy: String? = null,
     val decidedAt: String? = null, val rejectionReason: String? = null, val createdAt: String,
-    val kind: String = "ROLE", val sql: String? = null, val sqlHash: String? = null,
+    val kind: String = "ROLE",
+    /** The task's statements joined in run order — the request's readable form. Each statement is
+     *  authorized, executed, and stored on its own child; this text is never the unit of authorization. */
+    val sql: String? = null,
+    val sqlHash: String? = null,
+    /** How many statements the task holds. 1 for an ordinary single-statement request. */
+    val statementCount: Int = 1,
     val denyReason: String? = null, val sourceDecisionId: Long? = null,
     val title: String? = null, val evaluatedDecision: String? = null,
     val approvedAt: String? = null,
@@ -155,7 +161,9 @@ class AccessStore(private val dataSource: DataSource) {
     fun createQueryRequest(
         principal: String,
         datasourceId: Long,
-        sql: String,
+        // The batch's statements, in the order they run — one query_result child each, split server-side by
+        // the analyzer. A single-statement request is the one-element case.
+        statements: List<String>,
         denyReason: String?,
         sourceDecisionId: Long?,
         reason: String?,
@@ -178,9 +186,7 @@ class AccessStore(private val dataSource: DataSource) {
         actor: AuditActor? = null,
         recorder: ManagementAuditRecorder? = null,
     ): AccessRequest {
-        val sqlHash = MessageDigest.getInstance("SHA-256")
-            .digest(sql.toByteArray(Charsets.UTF_8))
-            .joinToString("") { "%02x".format(it) }
+        require(statements.isNotEmpty()) { "a query request needs at least one statement" }
         val id = dataSource.inTx { c ->
             val executeAs = roleId?.let { id ->
                 c.prepareStatement("SELECT name FROM app_role WHERE id = ? AND deleted_at IS NULL").use { ps ->
@@ -213,14 +219,7 @@ class AccessStore(private val dataSource: DataSource) {
                     if (rs.next()) rs.getLong(1) else throw DuplicatePendingQueryRequestException()
                 }
             }
-            c.prepareStatement(
-                "INSERT INTO query_result (task_id, sql, sql_hash) VALUES (?, ?, ?)",
-            ).use { ps ->
-                ps.setLong(1, taskId)
-                ps.setString(2, sql)
-                ps.setString(3, sqlHash)
-                ps.executeUpdate()
-            }
+            insertStatements(c, taskId, statements)
             if (actor != null && recorder != null) {
                 recorder.record(
                     c, actor, AuthzAction.TASK_REQUEST, auditEntity("AccessRequest", taskId.toString()),
@@ -246,13 +245,11 @@ class AccessStore(private val dataSource: DataSource) {
     fun createEditorTask(
         principal: String,
         datasourceId: Long,
-        sql: String,
+        statements: List<String>,
         executeAs: List<String>,
         approver: String,
     ): AccessRequest {
-        val sqlHash = MessageDigest.getInstance("SHA-256")
-            .digest(sql.toByteArray(Charsets.UTF_8))
-            .joinToString("") { "%02x".format(it) }
+        require(statements.isNotEmpty()) { "an editor task needs at least one statement" }
         val id = dataSource.inTx { c ->
             val now = Timestamp.from(Instant.now())
             val taskId = c.prepareStatement(
@@ -271,17 +268,34 @@ class AccessStore(private val dataSource: DataSource) {
                 ps.setString(7, json.encodeToString(stringList, executeAs))
                 ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) }
             }
-            c.prepareStatement(
-                "INSERT INTO query_result (task_id, sql, sql_hash) VALUES (?, ?, ?)",
-            ).use { ps ->
-                ps.setLong(1, taskId)
-                ps.setString(2, sql)
-                ps.setString(3, sqlHash)
-                ps.executeUpdate()
-            }
+            insertStatements(c, taskId, statements)
             taskId
         }
         return getRequest(id)!!
+    }
+
+    /**
+     * Insert a task's statements as its ordered result children — one row per statement, `ordinal` its
+     * 0-based position in the batch. Each child carries its OWN sql and sql_hash: the batch is authorized,
+     * executed, and stored per statement, so a hash over the joined text would identify nothing that runs.
+     */
+    private fun sha256Hex(value: String): String = MessageDigest.getInstance("SHA-256")
+        .digest(value.toByteArray(Charsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
+
+    private fun insertStatements(c: Connection, taskId: Long, statements: List<String>) {
+        c.prepareStatement(
+            "INSERT INTO query_result (task_id, ordinal, sql, sql_hash) VALUES (?, ?, ?, ?)",
+        ).use { ps ->
+            statements.forEachIndexed { ordinal, statement ->
+                ps.setLong(1, taskId)
+                ps.setInt(2, ordinal)
+                ps.setString(3, statement)
+                ps.setString(4, sha256Hex(statement))
+                ps.addBatch()
+            }
+            ps.executeBatch()
+        }
     }
 
     /**
@@ -331,9 +345,9 @@ class AccessStore(private val dataSource: DataSource) {
         ps.executeQuery().use { rs -> if (rs.next()) rs.getLong(1) else null }
     }
 
-    /** The id of an EDITOR task's single result child (task:child 1:1) — carried in the submit ack. */
+    /** The id of an EDITOR task's FIRST result child — carried in the submit ack. */
     fun editorChildId(taskId: Long): Long? = dataSource.connection.use { c ->
-        c.prepareStatement("SELECT id FROM query_result WHERE task_id = ? ORDER BY id DESC LIMIT 1").use { ps ->
+        c.prepareStatement("SELECT id FROM query_result WHERE task_id = ? ORDER BY ordinal LIMIT 1").use { ps ->
             ps.setLong(1, taskId)
             ps.executeQuery().use { rs -> if (rs.next()) rs.getLong(1) else null }
         }
@@ -521,10 +535,41 @@ class AccessStore(private val dataSource: DataSource) {
             }
             // Set expires_at too, so purgeExpired eventually GCs this orphaned metadata — otherwise a
             // NULL-expiry FAILED row accumulates on every restart-with-orphan (no ciphertext, but unbounded).
+            val expiry = Timestamp.from(Instant.now().plusSeconds(QueryResultStore.RESULT_RETENTION_SEC))
             c.prepareStatement(
                 "UPDATE query_result SET status = 'FAILED', error_code = 'task.orphaned_on_restart', expires_at = ? WHERE status = 'RUNNING'",
             ).use { ps ->
-                ps.setTimestamp(1, Timestamp.from(Instant.now().plusSeconds(QueryResultStore.RESULT_RETENTION_SEC)))
+                ps.setTimestamp(1, expiry)
+                ps.executeUpdate()
+            }
+            // A crash BETWEEN a batch's statements leaves no RUNNING child to carry the orphan reason — the
+            // previous statement is DONE and the next never started. Fail the lowest pending child of each
+            // orphaned task so the failure is attributed to the statement that would have run next, rather
+            // than leaving a FAILED task whose children are all DONE/SKIPPED and explain nothing.
+            c.prepareStatement(
+                """UPDATE query_result SET status = 'FAILED', error_code = 'task.orphaned_on_restart', expires_at = ?
+                   WHERE id IN (
+                       SELECT DISTINCT ON (qr.task_id) qr.id
+                         FROM query_result qr
+                         JOIN access_request ar ON ar.id = qr.task_id
+                        WHERE qr.status IS NULL AND ar.kind = 'QUERY' AND ar.status = 'FAILED'
+                          AND NOT EXISTS (
+                              SELECT 1 FROM query_result done
+                               WHERE done.task_id = qr.task_id AND done.status = 'FAILED'
+                          )
+                        ORDER BY qr.task_id, qr.ordinal
+                   )""",
+            ).use { ps ->
+                ps.setTimestamp(1, expiry)
+                ps.executeUpdate()
+            }
+            // The statements after the orphaned one will never run either — the task is FAILED. Terminalize
+            // them as SKIPPED so no child of a finished task still reads as "not started yet".
+            c.prepareStatement(
+                """UPDATE query_result SET status = 'SKIPPED', expires_at = ?
+                   WHERE status IS NULL AND task_id IN (SELECT id FROM access_request WHERE kind = 'QUERY' AND status = 'FAILED')""",
+            ).use { ps ->
+                ps.setTimestamp(1, expiry)
                 ps.executeUpdate()
             }
         }
@@ -715,6 +760,7 @@ class AccessStore(private val dataSource: DataSource) {
         decidedAt = getTimestamp("decided_at")?.toInstant()?.toString(),
         rejectionReason = getString("rejection_reason"), createdAt = getTimestamp("created_at").toInstant().toString(),
         kind = getString("kind"), sql = getString("task_sql"), sqlHash = getString("task_sql_hash"),
+        statementCount = getInt("statement_count"),
         denyReason = getString("deny_reason"), sourceDecisionId = longOrNull("source_decision_id"),
         title = getString("title"), evaluatedDecision = getString("evaluated_decision"),
         approvedAt = getTimestamp("approved_at")?.toInstant()?.toString(),
@@ -736,9 +782,13 @@ class AccessStore(private val dataSource: DataSource) {
             """SELECT ar.id, ar.principal, ar.role_id, r.name AS role_name, ar.datasource_id, d.name AS datasource_name,
                       ar.reason, ar.requested_duration_sec, ar.status, ar.decided_by, ar.decided_at, ar.rejection_reason, ar.created_at,
                       ar.kind,
-                      (SELECT qr.sql FROM query_result qr WHERE qr.task_id = ar.id ORDER BY qr.id LIMIT 1) AS task_sql,
-                      (SELECT qr.sql_hash FROM query_result qr WHERE qr.task_id = ar.id ORDER BY qr.id LIMIT 1) AS task_sql_hash,
-                      (SELECT qr.executed_by FROM query_result qr WHERE qr.task_id = ar.id ORDER BY qr.id LIMIT 1) AS executed_by,
+                      -- The whole batch as one text, statements in run order. Each child keeps its own sql and
+                      -- sql_hash; this is the request's readable form (list preview, notifications), never the
+                      -- unit of authorization.
+                      (SELECT string_agg(qr.sql, E';\n' ORDER BY qr.ordinal) FROM query_result qr WHERE qr.task_id = ar.id) AS task_sql,
+                      (SELECT count(*) FROM query_result qr WHERE qr.task_id = ar.id) AS statement_count,
+                      (SELECT qr.sql_hash FROM query_result qr WHERE qr.task_id = ar.id ORDER BY qr.ordinal LIMIT 1) AS task_sql_hash,
+                      (SELECT qr.executed_by FROM query_result qr WHERE qr.task_id = ar.id ORDER BY qr.ordinal LIMIT 1) AS executed_by,
                       ar.deny_reason, ar.source_decision_id, ar.title, ar.evaluated_decision,
                       ar.approved_at, ar.executing_at, ar.executed_at, ar.execute_as, ar.creator_kind,
                       ar.statement_carries_protected_literal

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Approvals.kt
@@ -477,7 +477,7 @@ fun Route.approvalRoutes(
                 accessStore.createQueryRequest(
                     principal = principal,
                     datasourceId = datasourceId,
-                    sql = source.statement,
+                    statements = listOf(source.statement),
                     denyReason = source.detail,
                     sourceDecisionId = sourceDecisionId,
                     reason = input.reason.trim(),
@@ -537,7 +537,7 @@ fun Route.approvalRoutes(
         val request = accessStore.createQueryRequest(
             principal = principal,
             datasourceId = ds.id,
-            sql = sql,
+            statements = listOf(sql),
             denyReason = if (decision.action == EnfAction.DENY) (decision.denyReason ?: decision.detail) else null,
             sourceDecisionId = null,
             reason = input.reason.trim(),

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -1111,7 +1111,7 @@ fun Route.editorSessionRoutes(
             return@post call.respond(HttpStatusCode.Forbidden, ApiError("common.forbidden"))
         }
 
-        val task = accessStore.createEditorTask(principal, ds.id, sql, ownRoles.toList(), approver = principal)
+        val task = accessStore.createEditorTask(principal, ds.id, listOf(sql), ownRoles.toList(), approver = principal)
         val childId = accessStore.editorChildId(task.id) ?: -1L
         // Same single-execution claim as /execute, atomic so a cancel can't slip into an EXECUTING-but-no-
         // RUNNING-child gap: APPROVED → EXECUTING and the child NULL → RUNNING commit in one transaction.

--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/QueryResultStore.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/QueryResultStore.kt
@@ -22,6 +22,9 @@ import org.postgresql.util.PGobject
 @Serializable
 data class QueryResultMeta(
     val taskId: Long,
+    // The statement's 0-based position in its task's batch. A single-statement task has only ordinal 0.
+    val ordinal: Int = 0,
+    val sql: String? = null,
     val executedBy: String? = null,
     val executedAt: String? = null,
     val rowCount: Int? = null,
@@ -121,6 +124,8 @@ class QueryResultStore(private val dataSource: DataSource, private val crypto: R
 
     private fun ResultSet.toMeta() = QueryResultMeta(
         taskId = getLong("task_id"),
+        ordinal = getInt("ordinal"),
+        sql = getString("sql"),
         executedBy = getString("executed_by"),
         executedAt = getTimestamp("executed_at")?.toInstant()?.toString(),
         rowCount = getInt("row_count").let { if (wasNull()) null else it },
@@ -132,28 +137,17 @@ class QueryResultStore(private val dataSource: DataSource, private val crypto: R
         columns = json.decodeFromString(stringList, getString("columns") ?: "[]"),
     )
 
-    fun startRun(taskId: Long, executedBy: String): QueryResultMeta? = dataSource.connection.use { c ->
-        val childId = latestChildId(c, taskId, "status IS NULL") ?: return@use null
-        val started = c.prepareStatement(
-            "UPDATE query_result SET status = 'RUNNING', executed_by = ?, error_code = NULL WHERE id = ? AND status IS NULL",
-        ).use { ps ->
-            ps.setString(1, executedBy)
-            ps.setLong(2, childId)
-            ps.executeUpdate() > 0
-        }
-        if (started) meta(taskId, c) else null
-    }
-
     /**
-     * Atomically claim a task for execution AND start its run: the parent's `APPROVED → EXECUTING` flip
-     * (via [claimParent]) and the child's `NULL → RUNNING` flip commit in ONE transaction. This closes the
-     * window a separate claim-then-start left open — where a cancel arriving between the two saw an
-     * `EXECUTING` parent with no `RUNNING` child yet, so [cancelRun] no-oped and the query ran anyway. After
-     * this, an `EXECUTING` task always has a `RUNNING` child for a cancel to catch.
+     * Atomically claim a task for execution AND start its FIRST statement: the parent's
+     * `APPROVED → EXECUTING` flip (via [claimParent]) and that child's `NULL → RUNNING` flip commit in ONE
+     * transaction. This closes the window a separate claim-then-start left open — where a cancel arriving
+     * between the two saw an `EXECUTING` parent with no `RUNNING` child yet, so [cancelRun] no-oped and the
+     * query ran anyway. After this, an `EXECUTING` task always has a `RUNNING` child for a cancel to catch.
      *
-     * Returns the `RUNNING` child meta on success; `null` when [claimParent] finds the task not `APPROVED`
-     * (already claimed/terminal → the caller treats it as already-executed). A claimed parent with no
-     * pending child is an invariant violation that rolls the whole claim back (leaving the task `APPROVED`).
+     * Returns the `RUNNING` child meta on success (its [QueryResultMeta.ordinal] is where the batch starts);
+     * `null` when [claimParent] finds the task not `APPROVED` (already claimed/terminal → the caller treats
+     * it as already-executed). A claimed parent with no pending child is an invariant violation that rolls
+     * the whole claim back (leaving the task `APPROVED`).
      */
     fun claimAndStartRun(
         taskId: Long,
@@ -161,17 +155,32 @@ class QueryResultStore(private val dataSource: DataSource, private val crypto: R
         claimParent: (Connection) -> Boolean,
     ): QueryResultMeta? = dataSource.inTx { c ->
         if (!claimParent(c)) return@inTx null
-        val childId = latestChildId(c, taskId, "status IS NULL")
+        val child = pendingChild(c, taskId)
             ?: error("task $taskId claimed for execution but has no pending child")
-        val started = c.prepareStatement(
-            "UPDATE query_result SET status = 'RUNNING', executed_by = ?, error_code = NULL WHERE id = ? AND status IS NULL",
-        ).use { ps ->
-            ps.setString(1, executedBy)
-            ps.setLong(2, childId)
-            ps.executeUpdate() > 0
-        }
-        if (!started) error("task $taskId child $childId not startable")
-        meta(taskId, c)
+        if (!startChild(c, child.id, executedBy)) error("task $taskId child ${child.id} not startable")
+        meta(taskId, child.ordinal, c)
+    }
+
+    /**
+     * Start the lowest pending statement, in one transaction so a concurrent caller cannot read the same
+     * child before it flips. Null once none remains, or when the flip lost a race with a cancel.
+     */
+    fun startNextRun(taskId: Long, executedBy: String): QueryResultMeta? = dataSource.inTx { c ->
+        val child = pendingChild(c, taskId) ?: return@inTx null
+        if (!startChild(c, child.id, executedBy)) return@inTx null
+        meta(taskId, child.ordinal, c)
+    }
+
+    /**
+     * Mark the statements the batch never reached SKIPPED, so they stop reading as "not started yet".
+     * Runs in the caller's transaction, so the stop and the skip commit together.
+     */
+    fun skipPendingChildren(taskId: Long, c: Connection): Int = c.prepareStatement(
+        "UPDATE query_result SET status = 'SKIPPED', expires_at = ? WHERE task_id = ? AND status IS NULL",
+    ).use { ps ->
+        ps.setTimestamp(1, Timestamp.from(Instant.now().plusSeconds(RESULT_RETENTION_SEC)))
+        ps.setLong(2, taskId)
+        ps.executeUpdate()
     }
 
     fun completeRun(
@@ -183,8 +192,8 @@ class QueryResultStore(private val dataSource: DataSource, private val crypto: R
         val blob = crypto.encrypt(ResultPayloadCodec.encode(result))
         val now = Instant.now()
         return dataSource.inTx { c ->
-            val childId = latestChildId(c, taskId, "status = 'RUNNING'")
-            val updated = childId != null && c.prepareStatement(
+            val child = runningChild(c, taskId)
+            val updated = child != null && c.prepareStatement(
                 """UPDATE query_result
                    SET status = 'DONE', ciphertext = ?, row_count = ?, columns = ?,
                        executed_at = ?, expires_at = ?, error_code = NULL
@@ -200,10 +209,10 @@ class QueryResultStore(private val dataSource: DataSource, private val crypto: R
                 }
                 ps.setTimestamp(4, Timestamp.from(now))
                 ps.setTimestamp(5, Timestamp.from(now.plusSeconds(retentionSec)))
-                ps.setLong(6, childId)
+                ps.setLong(6, child.id)
                 ps.executeUpdate() > 0
             }
-            val meta = if (updated) meta(taskId, c) else null
+            val meta = if (updated) meta(taskId, child.ordinal, c) else null
             if (meta != null) audit(c, meta)
             meta
         }
@@ -224,8 +233,8 @@ class QueryResultStore(private val dataSource: DataSource, private val crypto: R
         onFailed: (Connection, QueryResultMeta) -> Unit = { _, _ -> },
     ): QueryResultMeta? = dataSource.inTx { c ->
         val now = Instant.now()
-        val childId = latestChildId(c, taskId, "status = 'RUNNING'")
-        val updated = childId != null && c.prepareStatement(
+        val child = runningChild(c, taskId)
+        val updated = child != null && c.prepareStatement(
             "UPDATE query_result SET status = 'FAILED', error_code = ?, deny_reason = ?, decision_id = ?, " +
                 "error_detail = ?, expires_at = ? WHERE id = ? AND status = 'RUNNING'",
         ).use { ps ->
@@ -235,58 +244,142 @@ class QueryResultStore(private val dataSource: DataSource, private val crypto: R
             if (diagnostic == null) ps.setNull(4, java.sql.Types.BINARY)
             else ps.setBytes(4, crypto.encrypt(diagnostic.toByteArray()))
             ps.setTimestamp(5, Timestamp.from(now.plusSeconds(RESULT_RETENTION_SEC)))
-            ps.setLong(6, childId)
+            ps.setLong(6, child.id)
             ps.executeUpdate() > 0
         }
-        val meta = if (updated) meta(taskId, c) else null
-        if (meta != null) onFailed(c, meta)
+        val meta = if (updated) meta(taskId, child.ordinal, c) else null
+        if (meta != null) {
+            skipPendingChildren(taskId, c)
+            onFailed(c, meta)
+        }
         meta
     }
 
+    /**
+     * Cancel the statement in flight, or — between a batch's statements, where none is running — the one
+     * queued next. Without that second case the cancel no-ops and the batch runs on.
+     */
     fun cancelRun(
         taskId: Long,
         onCancelled: (Connection, QueryResultMeta) -> Unit = { _, _ -> },
     ): QueryResultMeta? = dataSource.inTx { c ->
         val now = Instant.now()
-        val childId = latestChildId(c, taskId, "status = 'RUNNING'")
-        val updated = childId != null && c.prepareStatement(
+        val expiry = Timestamp.from(now.plusSeconds(RESULT_RETENTION_SEC))
+        // Locked: without it a statement finishing between this read and the UPDATE below leaves the cancel
+        // updating zero rows, and the batch runs on past a cancel the user was told had landed.
+        val child = runningChild(c, taskId, lockRows = true) ?: pendingChild(c, taskId, lockRows = true)
+        val updated = child != null && c.prepareStatement(
             "UPDATE query_result SET status = 'CANCELLED', error_code = 'approval.canceled', expires_at = ? " +
-                "WHERE id = ? AND status = 'RUNNING'",
+                "WHERE id = ? AND (status = 'RUNNING' OR status IS NULL)",
         ).use { ps ->
-            ps.setTimestamp(1, Timestamp.from(now.plusSeconds(RESULT_RETENTION_SEC)))
-            ps.setLong(2, childId)
+            ps.setTimestamp(1, expiry)
+            ps.setLong(2, child.id)
             ps.executeUpdate() > 0
         }
-        val meta = if (updated) meta(taskId, c) else null
-        if (meta != null) onCancelled(c, meta)
+        val meta = if (updated) meta(taskId, child.ordinal, c) else null
+        if (meta != null) {
+            skipPendingChildren(taskId, c)
+            onCancelled(c, meta)
+        }
         meta
     }
 
+    /** The batch's active statement: the one running, else the furthest one to have reached a terminal
+     *  state — what a poller watching a single-child task has always been shown. */
     fun meta(taskId: Long): QueryResultMeta? = dataSource.connection.use { c -> meta(taskId, c) }
 
-    // The active child is selected by a SEPARATE read, then updated by its own id. The per-status guard
-    // stays on the UPDATE, so the transition is still a race-safe compare-and-set.
-    private fun latestChildId(c: Connection, taskId: Long, statusClause: String): Long? = c.prepareStatement(
-        "SELECT id FROM query_result WHERE task_id = ? AND $statusClause ORDER BY id DESC LIMIT 1",
-    ).use { ps ->
-        ps.setLong(1, taskId)
-        ps.executeQuery().use { rs -> if (rs.next()) rs.getLong(1) else null }
+    /** One statement of a task's batch, addressed by its [ordinal]. */
+    fun meta(taskId: Long, ordinal: Int): QueryResultMeta? =
+        dataSource.connection.use { c -> meta(taskId, ordinal, c) }
+
+    /** Every statement of a task, in batch order. */
+    fun statements(taskId: Long): List<QueryResultMeta> = dataSource.connection.use { c ->
+        c.prepareStatement("SELECT $META_COLS FROM query_result WHERE task_id = ? ORDER BY ordinal").use { ps ->
+            ps.setLong(1, taskId)
+            ps.executeQuery().use { rs ->
+                val out = ArrayList<QueryResultMeta>()
+                while (rs.next()) out += rs.toMeta()
+                out
+            }
+        }
     }
 
-    private fun meta(taskId: Long, c: Connection): QueryResultMeta? = c.prepareStatement(
-        "SELECT $META_COLS FROM query_result WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+    private class ChildRef(val id: Long, val ordinal: Int)
+
+    // The child is selected by a SEPARATE read, then updated by its own id. The per-status guard stays on
+    // the UPDATE, so every transition is still a race-safe compare-and-set. lockRows additionally holds the
+    // row for the caller's transaction, for a caller that must not lose it to a concurrent status flip.
+    private fun childBy(
+        c: Connection,
+        taskId: Long,
+        statusClause: String,
+        order: String,
+        lockRows: Boolean = false,
+    ): ChildRef? =
+        c.prepareStatement(
+            "SELECT id, ordinal FROM query_result WHERE task_id = ? AND $statusClause ORDER BY ordinal $order LIMIT 1" +
+                if (lockRows) " FOR UPDATE" else "",
+        ).use { ps ->
+            ps.setLong(1, taskId)
+            ps.executeQuery().use { rs -> if (rs.next()) ChildRef(rs.getLong(1), rs.getInt(2)) else null }
+        }
+
+    /** The next statement to run: the LOWEST pending ordinal, so a batch executes in the order written. */
+    private fun pendingChild(c: Connection, taskId: Long, lockRows: Boolean = false): ChildRef? =
+        childBy(c, taskId, "status IS NULL", "ASC", lockRows)
+
+    /** The statement currently in flight. At most one per task — the batch runs them one at a time. */
+    private fun runningChild(c: Connection, taskId: Long, lockRows: Boolean = false): ChildRef? =
+        childBy(c, taskId, "status = 'RUNNING'", "ASC", lockRows)
+
+    private fun startChild(c: Connection, childId: Long, executedBy: String): Boolean = c.prepareStatement(
+        "UPDATE query_result SET status = 'RUNNING', executed_by = ?, error_code = NULL WHERE id = ? AND status IS NULL",
+    ).use { ps ->
+        ps.setString(1, executedBy)
+        ps.setLong(2, childId)
+        ps.executeUpdate() > 0
+    }
+
+    private fun meta(taskId: Long, ordinal: Int, c: Connection): QueryResultMeta? = c.prepareStatement(
+        "SELECT $META_COLS FROM query_result WHERE task_id = ? AND ordinal = ?",
     ).use { ps ->
         ps.setLong(1, taskId)
+        ps.setInt(2, ordinal)
         ps.executeQuery().use { rs -> if (rs.next()) rs.toMeta() else null }
     }
 
-    fun accessFor(taskId: Long): ResultAccess? {
+    /**
+     * The furthest statement to have RUN, else the first — what a caller naming no ordinal gets. SKIPPED
+     * is excluded: it holds the highest ordinals, so `[DONE, FAILED, SKIPPED]` would report the skip
+     * instead of the failure. Correlated on task_id, so it takes a second bind.
+     */
+    private fun activeOrdinalClause() =
+        "ordinal = COALESCE((SELECT MAX(ordinal) FROM query_result " +
+            "WHERE task_id = ? AND status IS NOT NULL AND status <> 'SKIPPED'), 0)"
+
+    private fun meta(taskId: Long, c: Connection): QueryResultMeta? = c.prepareStatement(
+        "SELECT $META_COLS FROM query_result WHERE task_id = ? AND ${activeOrdinalClause()}",
+    ).use { ps ->
+        ps.setLong(1, taskId)
+        ps.setLong(2, taskId)
+        ps.executeQuery().use { rs -> if (rs.next()) rs.toMeta() else null }
+    }
+
+    /**
+     * A one-read snapshot of one statement's stored result. [ordinal] selects the statement within its
+     * task's batch; null takes the batch's active statement (the only one a single-statement task has).
+     * Reading the bytes and the meta together is what keeps a concurrent re-execute from swapping the row
+     * between the caller's authz check and its decrypt.
+     */
+    fun accessFor(taskId: Long, ordinal: Int? = null): ResultAccess? {
         val row = dataSource.connection.use { c ->
+            val selector = if (ordinal == null) activeOrdinalClause() else "ordinal = ?"
             c.prepareStatement(
                 "SELECT $META_COLS, qr.sql, ciphertext, error_detail FROM query_result qr " +
-                    "WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+                    "WHERE task_id = ? AND $selector",
             ).use { ps ->
                 ps.setLong(1, taskId)
+                if (ordinal == null) ps.setLong(2, taskId) else ps.setInt(2, ordinal)
                 ps.executeQuery().use { rs ->
                     if (!rs.next()) return null
                     RawResultRow(rs.toMeta(), rs.getString("sql"), rs.getBytes("ciphertext"), rs.getBytes("error_detail"))
@@ -375,7 +468,7 @@ class QueryResultStore(private val dataSource: DataSource, private val crypto: R
         // Every column [toMeta] reads. The mapper reads by NAME, so a column added there and missed here
         // fails the read at runtime rather than at compile time — keep the two in step.
         private const val META_COLS =
-            "task_id, executed_by, executed_at, row_count, expires_at, status, error_code, " +
+            "task_id, ordinal, sql, executed_by, executed_at, row_count, expires_at, status, error_code, " +
                 "deny_reason, decision_id, columns"
     }
 }

--- a/control-plane/src/main/resources/db/migration/V25__query_result_batch.sql
+++ b/control-plane/src/main/resources/db/migration/V25__query_result_batch.sql
@@ -1,0 +1,29 @@
+-- One query_result child per statement of a batch, addressed by position rather than by
+-- `ORDER BY id DESC LIMIT 1` (correct only while a task holds one child).
+ALTER TABLE query_result ADD COLUMN ordinal INT NOT NULL DEFAULT 0;
+
+-- Numbered by insert order, not a constant 0: query_result is 1:N in schema, so a task that does hold
+-- two rows would collide on the index below and abort the migration.
+UPDATE query_result qr
+   SET ordinal = ranked.position
+  FROM (
+        SELECT id, row_number() OVER (PARTITION BY task_id ORDER BY id) - 1 AS position
+          FROM query_result
+       ) AS ranked
+ WHERE qr.id = ranked.id;
+
+-- A duplicate would make "the statement at position k" ambiguous — run one twice, or skip one.
+CREATE UNIQUE INDEX uq_query_result_task_ordinal ON query_result (task_id, ordinal);
+
+-- The batch runs one statement at a time. Two RUNNING children would let completeRun store a result
+-- against the wrong statement's SQL, so the database refuses the second rather than trusting callers.
+CREATE UNIQUE INDEX uq_query_result_one_running ON query_result (task_id) WHERE status = 'RUNNING';
+
+-- SKIPPED: never reached, because an earlier statement stopped the batch. Distinct from the NULL status
+-- that means "not started yet".
+ALTER TABLE query_result DROP CONSTRAINT query_result_status_check;
+ALTER TABLE query_result ADD CONSTRAINT query_result_status_check
+    CHECK (status IN ('RUNNING', 'DONE', 'FAILED', 'CANCELLED', 'SKIPPED'));
+
+COMMENT ON COLUMN query_result.ordinal IS
+    'The statement''s 0-based position in its task''s batch. Dense, fixed at creation, unique per task.';

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalExecuteRouteDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalExecuteRouteDbTest.kt
@@ -198,7 +198,7 @@ class ApprovalExecuteRouteDbTest {
     private fun seedApprovedRoleRequest(roleName: String, decidedBy: String = executor): Long {
         val roleId = core.policyStore.createRole(RoleInput(roleName)).id
         val id = core.accessStore.createQueryRequest(
-            principal = requester, datasourceId = datasource.id, sql = "select ssn from users",
+            principal = requester, datasourceId = datasource.id, statements = listOf("select ssn from users"),
             denyReason = null, sourceDecisionId = null, reason = "need it", title = null,
             evaluatedDecision = "DENY", roleId = roleId,
         ).id
@@ -711,7 +711,7 @@ class ApprovalExecuteRouteDbTest {
                 ps.setLong(1, id); ps.executeUpdate()
             }
         }
-        assertNotNull(resultStore.startRun(id, approver))
+        assertNotNull(resultStore.startNextRun(id, approver))
 
         assertEquals(HttpStatusCode.NoContent, client.post("/test/session/$unrelated").status)
         val denied = client.post("/api/approvals/$id/cancel")

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultDeactivationDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultDeactivationDbTest.kt
@@ -95,7 +95,7 @@ class ApprovalResultDeactivationDbTest {
             }
         }
         fx.dataSource.connection.use { c -> c.prepareStatement("INSERT INTO query_result (task_id, sql, sql_hash) VALUES (?, 'select 1', 'fixture')").use { ps -> ps.setLong(1, reqId); ps.executeUpdate() } }
-        resultStore.startRun(reqId, viewer)!!
+        resultStore.startNextRun(reqId, viewer)!!
         resultStore.completeRun(reqId, DecryptedResult(listOf("id"), listOf(listOf("1"))), 3600)!!
         return reqId
     }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultViewContextDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultViewContextDbTest.kt
@@ -249,7 +249,7 @@ class ApprovalResultViewContextDbTest {
             }
         }
         fx.dataSource.connection.use { c -> c.prepareStatement("INSERT INTO query_result (task_id, sql, sql_hash) VALUES (?, ?, 'fixture')").use { ps -> ps.setLong(1, reqId); ps.setString(2, sql); ps.executeUpdate() } }
-        assertNotNull(resultStore.startRun(reqId, executor))
+        assertNotNull(resultStore.startNextRun(reqId, executor))
         assertNotNull(resultStore.completeRun(reqId, DecryptedResult(columns, rows, resultFingerprint = resultFingerprint?.let { fingerprintOf(it) }), 3600))
         return reqId
     }
@@ -276,7 +276,7 @@ class ApprovalResultViewContextDbTest {
                 ps.executeUpdate()
             }
         }
-        assertNotNull(resultStore.startRun(reqId, executor))
+        assertNotNull(resultStore.startNextRun(reqId, executor))
         assertNotNull(resultStore.failRun(reqId, "approval.query_failed", diagnostic = runError { message = redactedForm; rawMessage = rawText; targetDbError = true }))
         return reqId
     }

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalSurfaceCreatorKindDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalSurfaceCreatorKindDbTest.kt
@@ -112,7 +112,7 @@ class ApprovalSurfaceCreatorKindDbTest {
     }
 
     private fun seedWorkflowRequest(): Long = core.accessStore.createQueryRequest(
-        principal = principal, datasourceId = datasource.id, sql = "select id from users",
+        principal = principal, datasourceId = datasource.id, statements = listOf("select id from users"),
         denyReason = "policy denies", sourceDecisionId = null, reason = "need it", title = "t",
         evaluatedDecision = "DENY",
     ).id
@@ -127,7 +127,7 @@ class ApprovalSurfaceCreatorKindDbTest {
     }
 
     private fun seedEditorTask(): Long = core.accessStore.createEditorTask(
-        principal, datasource.id, "select id from users", listOf("analyst"), principal,
+        principal, datasource.id, listOf("select id from users"), listOf("analyst"), principal,
     ).id
 
     @Test

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/EditorSubmitRouteDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/EditorSubmitRouteDbTest.kt
@@ -482,7 +482,7 @@ class EditorSubmitRouteDbTest {
         // freshly-inserted forbid takes effect live and its deletion restores the baseline.
         val client = wire()
         val task = core.accessStore.createEditorTask(
-            caller, datasource.id, "select id from t", listOf("editor-analyst"), caller,
+            caller, datasource.id, listOf("select id from t"), listOf("editor-analyst"), caller,
         )
         // Baseline: the owner's self-read permit (V33/V38 task.read on own Request) lets the poll through.
         assertEquals(HttpStatusCode.OK, client.get("/api/editor/tasks/${task.id}").status)
@@ -514,7 +514,7 @@ class EditorSubmitRouteDbTest {
         // A task owned by someone OTHER than the signed-in caller: poll is owner-scoped and result is
         // task.assume-scoped, so both 404.
         val other = core.accessStore.createEditorTask(
-            "someone-else@example.com", datasource.id, "select id from t", listOf("editor-analyst"), "someone-else@example.com",
+            "someone-else@example.com", datasource.id, listOf("select id from t"), listOf("editor-analyst"), "someone-else@example.com",
         )
         assertEquals(HttpStatusCode.NotFound, client.get("/api/editor/tasks/${other.id}").status)
         assertEquals(HttpStatusCode.NotFound, client.get("/api/editor/tasks/${other.id}/result").status)

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/EditorTaskStoreDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/EditorTaskStoreDbTest.kt
@@ -60,7 +60,7 @@ class EditorTaskStoreDbTest {
     @Test
     fun `createEditorTask is born APPROVED as EDITOR with own roles and one child`() {
         val task = accessStore.createEditorTask(
-            principal = "alice@example.com", datasourceId = datasourceId, sql = "select id from t",
+            principal = "alice@example.com", datasourceId = datasourceId, statements = listOf("select id from t"),
             executeAs = listOf("analyst"), approver = "alice@example.com",
         )
         assertEquals("APPROVED", task.status)
@@ -117,13 +117,13 @@ class EditorTaskStoreDbTest {
     @Test
     fun `the born-APPROVED editor task runs the same single-execution status machine`() {
         val task = accessStore.createEditorTask(
-            "bob@example.com", datasourceId, "select id from t", listOf("analyst"), "bob@example.com",
+            "bob@example.com", datasourceId, listOf("select id from t"), listOf("analyst"), "bob@example.com",
         )
         assertTrue(accessStore.claimExecution(task.id), "APPROVED → EXECUTING")
         assertEquals("EXECUTING", accessStore.getRequest(task.id)?.status)
         assertFalse(accessStore.claimExecution(task.id), "a second claim on a non-APPROVED task loses")
 
-        assertEquals("RUNNING", resultStore.startRun(task.id, "bob@example.com")?.status)
+        assertEquals("RUNNING", resultStore.startNextRun(task.id, "bob@example.com")?.status)
         val done = resultStore.completeRun(task.id, result(), 3600) { conn, _ ->
             assertTrue(accessStore.markExecuted(task.id, conn))
         }
@@ -135,9 +135,9 @@ class EditorTaskStoreDbTest {
     @Test
     fun `deleteResultsForTask drops the child but leaves the task, idempotently`() {
         val task = accessStore.createEditorTask(
-            "carol@example.com", datasourceId, "select id from t", listOf("analyst"), "carol@example.com",
+            "carol@example.com", datasourceId, listOf("select id from t"), listOf("analyst"), "carol@example.com",
         )
-        resultStore.startRun(task.id, "carol@example.com")
+        resultStore.startNextRun(task.id, "carol@example.com")
         resultStore.completeRun(task.id, result(), 3600)
         assertEquals(1, resultStore.deleteResultsForTask(task.id))
         assertEquals(0, childCount(task.id))
@@ -148,14 +148,14 @@ class EditorTaskStoreDbTest {
     @Test
     fun `deleteEditorResultsForPrincipal drops only that principal's editor children`() {
         val mine = accessStore.createEditorTask(
-            "dave@example.com", datasourceId, "select id from t", listOf("analyst"), "dave@example.com",
+            "dave@example.com", datasourceId, listOf("select id from t"), listOf("analyst"), "dave@example.com",
         )
         val other = accessStore.createEditorTask(
-            "erin@example.com", datasourceId, "select id from t", listOf("analyst"), "erin@example.com",
+            "erin@example.com", datasourceId, listOf("select id from t"), listOf("analyst"), "erin@example.com",
         )
         // A WORKFLOW task (creator_kind != EDITOR) owned by dave must be untouched by the editor-scoped delete.
         val workflow = accessStore.createQueryRequest(
-            principal = "dave@example.com", datasourceId = datasourceId, sql = "select id from t",
+            principal = "dave@example.com", datasourceId = datasourceId, statements = listOf("select id from t"),
             denyReason = null, sourceDecisionId = null, reason = "r", title = "t", evaluatedDecision = "MASK",
         )
 
@@ -168,10 +168,10 @@ class EditorTaskStoreDbTest {
     @Test
     fun `purgeExpiredEditorChildren deletes only expired editor children`() {
         val expired = accessStore.createEditorTask(
-            "frank@example.com", datasourceId, "select id from t", listOf("analyst"), "frank@example.com",
+            "frank@example.com", datasourceId, listOf("select id from t"), listOf("analyst"), "frank@example.com",
         )
         val live = accessStore.createEditorTask(
-            "grace@example.com", datasourceId, "select id from t", listOf("analyst"), "grace@example.com",
+            "grace@example.com", datasourceId, listOf("select id from t"), listOf("analyst"), "grace@example.com",
         )
         expireChild(expired.id)
         assertEquals(1, resultStore.purgeExpiredEditorChildren())
@@ -182,7 +182,7 @@ class EditorTaskStoreDbTest {
     @Test
     fun `deleteEditorTask cascades the child and is owner + EDITOR scoped`() {
         val task = accessStore.createEditorTask(
-            "heidi@example.com", datasourceId, "select id from t", listOf("analyst"), "heidi@example.com",
+            "heidi@example.com", datasourceId, listOf("select id from t"), listOf("analyst"), "heidi@example.com",
         )
         assertFalse(accessStore.deleteEditorTask(task.id, "mallory@example.com"), "a non-owner cannot delete it")
         assertTrue(childCount(task.id) == 1 && accessStore.getRequest(task.id) != null)

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ElevationContextRouteAuthzDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ElevationContextRouteAuthzDbTest.kt
@@ -174,7 +174,7 @@ class ElevationContextRouteAuthzDbTest {
 
     /** A PENDING QUERY approval request elevating [requester] to `target-role` on the tag-gated datasource. */
     private fun seedQueryRequest(): Long = core.accessStore.createQueryRequest(
-        principal = requester, datasourceId = datasource.id, sql = "select 1", denyReason = "denied",
+        principal = requester, datasourceId = datasource.id, statements = listOf("select 1"), denyReason = "denied",
         sourceDecisionId = null, reason = "need it", title = null,
         evaluatedDecision = "DENY", roleId = targetRoleId,
     ).id

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/JitApprovalAuditDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/JitApprovalAuditDbTest.kt
@@ -54,7 +54,7 @@ class JitApprovalAuditDbTest {
     )
 
     private fun seedQueryRequest() = core.accessStore.createQueryRequest(
-        principal = requester, datasourceId = datasource.id, sql = "select 1", denyReason = "denied",
+        principal = requester, datasourceId = datasource.id, statements = listOf("select 1"), denyReason = "denied",
         sourceDecisionId = null, reason = "need it", title = null, evaluatedDecision = "DENY", roleId = role.id,
     )
 
@@ -101,7 +101,7 @@ class JitApprovalAuditDbTest {
         val actor = actor()
 
         val request = core.accessStore.createQueryRequest(
-            principal = requester, datasourceId = datasource.id, sql = "select 1", denyReason = "denied",
+            principal = requester, datasourceId = datasource.id, statements = listOf("select 1"), denyReason = "denied",
             sourceDecisionId = null, reason = "need it", title = null, evaluatedDecision = "DENY", roleId = role.id,
             actor = actor, recorder = recorder,
         )

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PrincipalSessionStoreDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/PrincipalSessionStoreDbTest.kt
@@ -215,8 +215,8 @@ class PrincipalSessionStoreDbTest {
         )
         val principal = "teardown@example.com"
         composed.mintWeb(principal, null, 7200, 900, "device-t")
-        val task = accessStore.createEditorTask(principal, dsId, "select 1", listOf("analyst"), principal)
-        resultStore.startRun(task.id, principal)
+        val task = accessStore.createEditorTask(principal, dsId, listOf("select 1"), listOf("analyst"), principal)
+        resultStore.startNextRun(task.id, principal)
         resultStore.completeRun(task.id, DecryptedResult(listOf("c"), listOf(listOf("1"))), 3600)
         assertEquals(1, editorChildCount(principal), "seeded one editor result child")
 

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/QueryResultBatchDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/QueryResultBatchDbTest.kt
@@ -1,0 +1,272 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import org.flywaydb.core.Flyway
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import javax.sql.DataSource
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * A task holding SEVERAL statements: one query_result child per statement, addressed by ordinal.
+ *
+ * The batch runs in order and stops at the first statement that does not complete — the statements before
+ * it keep their stored results, the one that stopped it is FAILED, and the rest are SKIPPED rather than
+ * left reading as "not started yet".
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class QueryResultBatchDbTest {
+    private lateinit var dataSource: DataSource
+    private lateinit var store: QueryResultStore
+    private lateinit var accessStore: AccessStore
+    private var datasourceId = 0L
+
+    private val batch = listOf(
+        "select id from users",
+        "update users set name = 'x' where id = 1",
+        "select ssn from users",
+    )
+
+    @BeforeAll
+    fun setup() {
+        requireDockerOrSkip()
+        dataSource = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_qr_batch"))
+        Flyway.configure().dataSource(dataSource).load().migrate()
+        accessStore = AccessStore(dataSource)
+        datasourceId = DatasourceStore(dataSource).create(
+            DatasourceInput(name = "ds", engine = "postgres", host = "h", port = 5432, dbName = "d"),
+        ).id
+        store = QueryResultStore(dataSource, ResultCrypto(ByteArray(32) { it.toByte() }))
+    }
+
+    /** An APPROVED batch task — the state execution starts from (claimExecution flips APPROVED → EXECUTING). */
+    private fun newTask(statements: List<String> = batch): Long {
+        val id = accessStore.createQueryRequest(
+            principal = "alice@example.com",
+            datasourceId = datasourceId,
+            statements = statements,
+            denyReason = null,
+            sourceDecisionId = null,
+            reason = "r",
+            title = "t",
+            evaluatedDecision = "ALLOW",
+        ).id
+        accessStore.decideQueryRequest(id, approved = true, rejectionReason = null, decidedBy = "bob@example.com")
+        return id
+    }
+
+    private fun result(vararg values: String) = DecryptedResult(listOf("c"), values.map { listOf(it) })
+
+    @Test
+    fun `each statement becomes its own child, in batch order`() {
+        val id = newTask()
+        val statements = store.statements(id)
+        assertEquals(batch, statements.map { it.sql })
+        assertEquals(listOf(0, 1, 2), statements.map { it.ordinal })
+        // Each child hashes its OWN statement — the batch is authorized per statement, so a hash over the
+        // joined text would identify nothing that actually runs.
+        val hashes = dataSource.connection.use { c ->
+            c.prepareStatement("SELECT sql_hash FROM query_result WHERE task_id = ? ORDER BY ordinal").use { ps ->
+                ps.setLong(1, id)
+                ps.executeQuery().use { rs ->
+                    val out = ArrayList<String>()
+                    while (rs.next()) out += rs.getString(1)
+                    out
+                }
+            }
+        }
+        assertEquals(3, hashes.toSet().size, "each statement must hash distinctly: $hashes")
+    }
+
+    @Test
+    fun `the request's sql is the whole batch, and it counts its statements`() {
+        val request = assertNotNull(accessStore.getRequest(newTask()))
+        assertEquals(3, request.statementCount)
+        for (statement in batch) {
+            assertTrue(request.sql!!.contains(statement), "batch text is missing $statement: ${request.sql}")
+        }
+    }
+
+    @Test
+    fun `statements run in order, one at a time`() {
+        val id = newTask()
+        val first = assertNotNull(store.claimAndStartRun(id, "bob@example.com") { accessStore.claimExecution(id, it) })
+        assertEquals(0, first.ordinal)
+        assertEquals(batch[0], first.sql)
+        // Only the first statement is running; the rest are still pending.
+        assertEquals(listOf("RUNNING", null, null), store.statements(id).map { it.status })
+
+        store.completeRun(id, result("a"), 3600)
+        val second = assertNotNull(store.startNextRun(id, "bob@example.com"))
+        assertEquals(1, second.ordinal)
+        assertEquals(batch[1], second.sql)
+        store.completeRun(id, result("b"), 3600)
+
+        val third = assertNotNull(store.startNextRun(id, "bob@example.com"))
+        assertEquals(2, third.ordinal)
+        store.completeRun(id, result("c"), 3600)
+
+        assertEquals(listOf("DONE", "DONE", "DONE"), store.statements(id).map { it.status })
+        assertNull(store.startNextRun(id, "bob@example.com"), "a finished batch has nothing left to start")
+    }
+
+    @Test
+    fun `each statement's rows are stored and read back by ordinal`() {
+        val id = newTask()
+        store.claimAndStartRun(id, "bob@example.com") { accessStore.claimExecution(id, it) }
+        store.completeRun(id, result("first"), 3600)
+        store.startNextRun(id, "bob@example.com")
+        store.completeRun(id, result("second"), 3600)
+
+        assertEquals(result("first"), store.accessFor(id, 0)?.decrypted)
+        assertEquals(result("second"), store.accessFor(id, 1)?.decrypted)
+        // The re-decision binds to the child whose bytes were read, so each access carries its own SQL.
+        assertEquals(batch[0], store.accessFor(id, 0)?.sql)
+        assertEquals(batch[1], store.accessFor(id, 1)?.sql)
+    }
+
+    @Test
+    fun `a failure stops the batch and skips the statements after it`() {
+        val id = newTask()
+        store.claimAndStartRun(id, "bob@example.com") { accessStore.claimExecution(id, it) }
+        store.completeRun(id, result("a"), 3600)
+        store.startNextRun(id, "bob@example.com")
+
+        val failed = assertNotNull(store.failRun(id, "approval.execute_denied", denyReason = "no"))
+        assertEquals(1, failed.ordinal)
+        // Statement 0 keeps its result; 1 carries the failure; 2 never ran.
+        assertEquals(listOf("DONE", "FAILED", "SKIPPED"), store.statements(id).map { it.status })
+        assertEquals(result("a"), store.accessFor(id, 0)?.decrypted, "an earlier statement's result survives")
+        assertNull(store.startNextRun(id, "bob@example.com"), "a stopped batch never resumes")
+    }
+
+    @Test
+    fun `a cancel ends the whole batch`() {
+        val id = newTask()
+        store.claimAndStartRun(id, "bob@example.com") { accessStore.claimExecution(id, it) }
+        val cancelled = assertNotNull(store.cancelRun(id))
+        assertEquals(0, cancelled.ordinal)
+        assertEquals(listOf("CANCELLED", "SKIPPED", "SKIPPED"), store.statements(id).map { it.status })
+    }
+
+    // A cancel arriving BETWEEN statements finds no RUNNING child — the previous one is DONE and the next
+    // has not started. It must still stop the batch: without this the cancel no-ops while the run
+    // continues, the same EXECUTING-with-no-RUNNING-child hole claimAndStartRun closed at the start.
+    @Test
+    fun `a cancel between statements stops the batch`() {
+        val id = newTask()
+        store.claimAndStartRun(id, "bob@example.com") { accessStore.claimExecution(id, it) }
+        store.completeRun(id, result("a"), 3600)
+        // Statement 0 is DONE and statement 1 has not started — the gap.
+        assertEquals(listOf("DONE", null, null), store.statements(id).map { it.status })
+
+        val cancelled = assertNotNull(store.cancelRun(id), "a cancel in the gap must not no-op")
+        assertEquals(1, cancelled.ordinal, "the cancel lands on the statement that was about to run")
+        assertEquals(listOf("DONE", "CANCELLED", "SKIPPED"), store.statements(id).map { it.status })
+        // The run loop asks for the next statement and gets nothing, so the batch cannot resume.
+        assertNull(store.startNextRun(id, "bob@example.com"), "a cancelled batch never resumes")
+        assertEquals(result("a"), store.accessFor(id, 0)?.decrypted, "the finished statement keeps its rows")
+    }
+
+    // The ordinal-less readers must report the statement that actually ran, not the trailing SKIPPED one —
+    // SKIPPED rows carry the HIGHEST ordinals, so counting them as active would hide the real outcome.
+    @Test
+    fun `the ordinal-less readers ignore trailing SKIPPED statements`() {
+        val id = newTask()
+        store.claimAndStartRun(id, "bob@example.com") { accessStore.claimExecution(id, it) }
+        store.completeRun(id, result("a"), 3600)
+        store.startNextRun(id, "bob@example.com")
+        store.failRun(id, "approval.execute_denied", denyReason = "no")
+        assertEquals(listOf("DONE", "FAILED", "SKIPPED"), store.statements(id).map { it.status })
+
+        val active = assertNotNull(store.meta(id))
+        assertEquals(1, active.ordinal, "meta must report the FAILED statement, not the trailing SKIPPED one")
+        assertEquals("FAILED", active.status)
+        assertEquals("no", active.denyReason, "the denial's reason must reach an ordinal-less poller")
+        assertEquals(1, store.accessFor(id)?.meta?.ordinal, "accessFor agrees with meta")
+    }
+
+    // A crash BETWEEN statements leaves no RUNNING child for the restart reconcile to attribute the failure
+    // to — the previous statement is DONE and the next never started. The reconcile must still leave the
+    // task explaining itself, rather than a FAILED task whose children are all DONE/SKIPPED.
+    @Test
+    fun `boot reconcile fails the statement a crash stopped before, not just the tail`() {
+        val id = newTask()
+        store.claimAndStartRun(id, "bob@example.com") { accessStore.claimExecution(id, it) }
+        store.completeRun(id, result("a"), 3600)
+        // The process dies here: statement 0 DONE, statement 1 never started, parent still EXECUTING.
+        assertEquals("EXECUTING", accessStore.getRequest(id)?.status)
+        assertEquals(listOf("DONE", null, null), store.statements(id).map { it.status })
+
+        accessStore.reconcileOrphanedExecutions()
+
+        assertEquals("FAILED", accessStore.getRequest(id)?.status)
+        val statements = store.statements(id)
+        assertEquals(listOf("DONE", "FAILED", "SKIPPED"), statements.map { it.status })
+        assertEquals(
+            "task.orphaned_on_restart",
+            statements[1].errorCode,
+            "the statement that would have run next carries the orphan reason",
+        )
+        // And the ordinal-less readers land on it, so a poller sees why the task failed.
+        assertEquals(1, store.meta(id)?.ordinal)
+        assertEquals("task.orphaned_on_restart", store.meta(id)?.errorCode)
+    }
+
+    @Test
+    fun `a single-statement task behaves exactly as before`() {
+        val id = newTask(listOf("select 1"))
+        assertEquals(1, assertNotNull(accessStore.getRequest(id)).statementCount)
+        val running = assertNotNull(store.claimAndStartRun(id, "bob@example.com") { accessStore.claimExecution(id, it) })
+        assertEquals(0, running.ordinal)
+        store.completeRun(id, result("only"), 3600)
+        // The ordinal-less readers still land on the one child.
+        assertEquals("DONE", store.meta(id)?.status)
+        assertEquals(result("only"), store.accessFor(id)?.decrypted)
+        assertEquals("select 1", store.accessFor(id)?.sql)
+    }
+
+    @Test
+    fun `the ordinal-less readers follow the batch's active statement`() {
+        val id = newTask()
+        store.claimAndStartRun(id, "bob@example.com") { accessStore.claimExecution(id, it) }
+        assertEquals(0, store.meta(id)?.ordinal)
+        store.completeRun(id, result("a"), 3600)
+        store.startNextRun(id, "bob@example.com")
+        // Once statement 1 starts, the un-ordinal'd read follows it rather than staying on statement 0.
+        assertEquals(1, store.meta(id)?.ordinal)
+        assertEquals("RUNNING", store.meta(id)?.status)
+    }
+
+    // completeRun binds the result to the LOWEST running child, so a second RUNNING statement would let
+    // statement 1's rows land on statement 0 and be re-authorized against statement 0's SQL.
+    @Test
+    fun `a task can never have two running statements`() {
+        val id = newTask()
+        assertNotNull(store.claimAndStartRun(id, "bob@example.com") { accessStore.claimExecution(id, it) })
+        assertFailsWith<Exception>("starting a second statement while one runs must be refused") {
+            store.startNextRun(id, "bob@example.com")
+        }
+        assertEquals(listOf("RUNNING", null, null), store.statements(id).map { it.status })
+    }
+
+    // A cancel that reads the running child, then loses it to a completion before its UPDATE, used to
+    // return null — the route then skipped cancelActiveRun and the next statement ran anyway.
+    @Test
+    fun `a cancel racing a completion still stops the batch`() {
+        val id = newTask()
+        assertNotNull(store.claimAndStartRun(id, "bob@example.com") { accessStore.claimExecution(id, it) })
+        store.completeRun(id, result("a"), 3600)
+        // Nothing is RUNNING now — exactly the window the race lands in.
+        val cancelled = assertNotNull(store.cancelRun(id), "a cancel between statements must still land")
+        assertEquals(1, cancelled.ordinal)
+        assertEquals(listOf("DONE", "CANCELLED", "SKIPPED"), store.statements(id).map { it.status })
+        assertNull(store.startNextRun(id, "bob@example.com"), "a cancelled batch never resumes")
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/QueryResultOrdinalMigrationDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/QueryResultOrdinalMigrationDbTest.kt
@@ -1,0 +1,75 @@
+package com.ridi.oss.proxymonster.controlplane
+
+import com.ridi.oss.proxymonster.controlplane.support.SharedPostgres
+import com.ridi.oss.proxymonster.controlplane.support.requireDockerOrSkip
+import org.flywaydb.core.Flyway
+import org.flywaydb.core.api.MigrationVersion
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.test.assertEquals
+
+/**
+ * V25 adds `query_result.ordinal` plus a unique `(task_id, ordinal)` index. `query_result` has always been
+ * 1:N in schema, so a task holding two rows is schema-valid pre-V25 even though every pre-batch writer
+ * inserted exactly one. Backfilling a constant 0 would collide on that index and ABORT the migration —
+ * an upgrade that fails on data the old schema allowed. The backfill numbers by insert order instead.
+ * Real PostgreSQL.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class QueryResultOrdinalMigrationDbTest {
+    @BeforeAll
+    fun requireDatabase() {
+        requireDockerOrSkip()
+    }
+
+    @Test
+    fun `V25 numbers pre-existing children by insert order instead of colliding on ordinal 0`() {
+        val ds = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_v25"))
+        // Stop just before V25, then plant data the OLD schema permits: one task with a single child (the
+        // shape every pre-batch writer produced) and one with two (schema-valid, and what a constant-0
+        // backfill would choke on).
+        Flyway.configure().dataSource(ds).target(MigrationVersion.fromVersion("24")).load().migrate()
+        val datasourceId = DatasourceStore(ds).create(
+            DatasourceInput(name = "ds", engine = "postgres", host = "h", port = 5432, dbName = "d"),
+        ).id
+        val (single, plural) = ds.connection.use { c ->
+            fun task(): Long = c.prepareStatement(
+                """INSERT INTO access_request (principal, kind, datasource_id, requested_duration_sec, creator_kind)
+                   VALUES ('alice@example.com', 'QUERY', ?, 3600, 'WORKFLOW') RETURNING id""",
+            ).use { ps ->
+                ps.setLong(1, datasourceId)
+                ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) }
+            }
+            fun child(taskId: Long, sql: String) = c.prepareStatement(
+                "INSERT INTO query_result (task_id, sql, sql_hash) VALUES (?, ?, ?)",
+            ).use { ps ->
+                ps.setLong(1, taskId); ps.setString(2, sql); ps.setString(3, "h-$sql")
+                ps.executeUpdate()
+            }
+            val one = task().also { child(it, "select 1") }
+            val two = task().also { child(it, "select 2"); child(it, "select 3") }
+            one to two
+        }
+
+        // The migration under test must APPLY, not abort on the two-child task.
+        Flyway.configure().dataSource(ds).load().migrate()
+
+        fun ordinalsFor(taskId: Long): List<Pair<Int, String>> = ds.connection.use { c ->
+            c.prepareStatement("SELECT ordinal, sql FROM query_result WHERE task_id = ? ORDER BY ordinal").use { ps ->
+                ps.setLong(1, taskId)
+                ps.executeQuery().use { rs ->
+                    val out = ArrayList<Pair<Int, String>>()
+                    while (rs.next()) out += rs.getInt("ordinal") to rs.getString("sql")
+                    out
+                }
+            }
+        }
+        assertEquals(listOf(0 to "select 1"), ordinalsFor(single), "a single-child task keeps ordinal 0")
+        assertEquals(
+            listOf(0 to "select 2", 1 to "select 3"),
+            ordinalsFor(plural),
+            "plural children are numbered densely by insert order, not all collapsed onto 0",
+        )
+    }
+}

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/QueryResultStoreDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/QueryResultStoreDbTest.kt
@@ -37,7 +37,7 @@ class QueryResultStoreDbTest {
     private fun newTask(requester: String = "alice@example.com"): Long = accessStore.createQueryRequest(
         principal = requester,
         datasourceId = datasourceId,
-        sql = "select id, ssn from users",
+        statements = listOf("select id, ssn from users"),
         denyReason = null,
         sourceDecisionId = null,
         reason = "r",
@@ -53,7 +53,7 @@ class QueryResultStoreDbTest {
     @Test
     fun `child transitions from pending to running to done with encrypted rows`() {
         val id = newTask()
-        val running = store.startRun(id, "bob@example.com")
+        val running = store.startNextRun(id, "bob@example.com")
         assertEquals("RUNNING", running?.status)
         assertEquals("bob@example.com", running?.executedBy)
         assertEquals("bob@example.com", accessStore.getRequest(id)?.executedBy)
@@ -77,7 +77,7 @@ class QueryResultStoreDbTest {
     @Test
     fun `DML result stores rowsAffected as row_count, not the empty result-set size`() {
         val id = newTask()
-        assertNotNull(store.startRun(id, "bob@example.com"))
+        assertNotNull(store.startNextRun(id, "bob@example.com"))
         val done = store.completeRun(id, DecryptedResult(emptyList(), emptyList(), rowsAffected = 1), 3600)
         assertEquals("DONE", done?.status)
         assertEquals(1, done?.rowCount)
@@ -86,7 +86,7 @@ class QueryResultStoreDbTest {
     @Test
     fun `failed child stores a stable error code without ciphertext`() {
         val id = newTask()
-        assertNotNull(store.startRun(id, "bob@example.com"))
+        assertNotNull(store.startNextRun(id, "bob@example.com"))
         val failed = store.failRun(id, "approval.execute_denied")
         assertEquals("FAILED", failed?.status)
         assertEquals("approval.execute_denied", failed?.errorCode)
@@ -97,7 +97,7 @@ class QueryResultStoreDbTest {
     @Test
     fun `a target-DB failure stores the backend error text encrypted, released only via accessFor`() {
         val id = newTask()
-        assertNotNull(store.startRun(id, "bob@example.com"))
+        assertNotNull(store.startNextRun(id, "bob@example.com"))
         val diagnostic = runError { message = "ER_TABLE_EXISTS_ERROR"; rawMessage = "Table 'bom.test' already exists"; targetDbError = true }
         val failed = store.failRun(id, "approval.query_failed", diagnostic = diagnostic)
         assertEquals("FAILED", failed?.status)
@@ -125,7 +125,7 @@ class QueryResultStoreDbTest {
     @Test
     fun `error detail is off the metadata path and reachable only through accessFor`() {
         val id = newTask()
-        assertNotNull(store.startRun(id, "bob@example.com"))
+        assertNotNull(store.startNextRun(id, "bob@example.com"))
         val detail = "constraint users_email_key violated"
         store.failRun(id, "approval.query_failed", diagnostic = runError { message = "ER_DUP_ENTRY"; rawMessage = detail; targetDbError = true })
         // The metadata poll (task.read) carries the stable code but has no channel for the raw detail — the
@@ -139,7 +139,7 @@ class QueryResultStoreDbTest {
     @Test
     fun `expiry purges the encrypted error detail`() {
         val id = newTask()
-        assertNotNull(store.startRun(id, "bob@example.com"))
+        assertNotNull(store.startNextRun(id, "bob@example.com"))
         store.failRun(id, "approval.query_failed", diagnostic = runError { message = "ER_NO_SUCH_TABLE"; rawMessage = "relation missing does not exist"; targetDbError = true })
         // failRun stamps expires_at RESULT_RETENTION_SEC ahead; force the row past expiry so the sweep hits it.
         dataSource.connection.use { c ->
@@ -164,7 +164,7 @@ class QueryResultStoreDbTest {
     @Test
     fun `accessFor withholds the error detail once past expiry, before any purge sweep`() {
         val id = newTask()
-        assertNotNull(store.startRun(id, "bob@example.com"))
+        assertNotNull(store.startNextRun(id, "bob@example.com"))
         store.failRun(id, "approval.query_failed", diagnostic = runError { message = "ER_NO_SUCH_TABLE"; rawMessage = "relation missing does not exist"; targetDbError = true })
         // Push the row past expiry WITHOUT purging: the ciphertext is still in the row when accessFor reads it.
         dataSource.connection.use { c ->
@@ -187,8 +187,6 @@ class QueryResultStoreDbTest {
     @Test
     fun `claimAndStartRun atomically claims the parent and starts the child, closing the cancel window`() {
         val id = newTask().also { approve(it) }
-        // While APPROVED there is no RUNNING child yet — a cancel would find nothing to cancel.
-        assertNull(store.cancelRun(id), "no RUNNING child before the run starts")
         // One transaction: parent APPROVED→EXECUTING AND child NULL→RUNNING commit together, so a cancel can
         // never observe an EXECUTING parent without a RUNNING child (the window that let a canceled query run).
         val started = store.claimAndStartRun(id, "bob@example.com") { c -> accessStore.claimExecution(id, c) }
@@ -199,6 +197,17 @@ class QueryResultStoreDbTest {
         val cancelled = store.cancelRun(id) { c, _ -> assertTrue(accessStore.markCancelled(id, c)) }
         assertEquals("CANCELLED", cancelled?.status)
         assertEquals("CANCELLED", accessStore.getRequest(id)?.status)
+    }
+
+    // A cancel that arrives before the run starts — or between a batch's statements — finds no RUNNING
+    // child, but must still stop the task rather than no-op while the run proceeds. It cancels the
+    // statement that was about to run, so claimAndStartRun then finds nothing pending.
+    @Test
+    fun `cancelRun catches a not-yet-started statement`() {
+        val id = newTask().also { approve(it) }
+        val cancelled = assertNotNull(store.cancelRun(id), "a pre-run cancel must not no-op")
+        assertEquals("CANCELLED", cancelled.status)
+        assertEquals(0, cancelled.ordinal)
     }
 
     @Test
@@ -218,7 +227,7 @@ class QueryResultStoreDbTest {
                 ps.setLong(1, id); ps.executeUpdate()
             }
         }
-        assertNotNull(store.startRun(id, "bob@example.com"))
+        assertNotNull(store.startNextRun(id, "bob@example.com"))
         val cancelled = store.cancelRun(id) { c, _ -> assertTrue(accessStore.markCancelled(id, c)) }
         assertEquals("CANCELLED", cancelled?.status)
         assertEquals("approval.canceled", cancelled?.errorCode)
@@ -229,10 +238,10 @@ class QueryResultStoreDbTest {
     }
 
     @Test
-    fun `one task supports multiple children and latest metadata wins`() {
+    fun `one task supports multiple children and metadata follows the active one`() {
         val id = newTask()
         dataSource.connection.use { c ->
-            c.prepareStatement("INSERT INTO query_result (task_id, sql, sql_hash) VALUES (?, 'select 2', 'second')").use { ps ->
+            c.prepareStatement("INSERT INTO query_result (task_id, ordinal, sql, sql_hash) VALUES (?, 1, 'select 2', 'second')").use { ps ->
                 ps.setLong(1, id)
                 ps.executeUpdate()
             }
@@ -244,39 +253,44 @@ class QueryResultStoreDbTest {
             }
         })
         assertNull(store.meta(id)?.status)
-        assertNotNull(store.startRun(id, "bob@example.com"))
+        assertNotNull(store.startNextRun(id, "bob@example.com"))
         assertEquals("FAILED", store.failRun(id, "approval.query_failed")?.status)
     }
 
     @Test
     fun `accessFor binds the released child's own sql to its ciphertext, not the first child's`() {
-        // Regression: a task with plural children whose SQL differs. accessFor returns the LATEST child's
-        // ciphertext, so it must also return that SAME child's sql — the view re-decides the released bytes
-        // against their own statement, never the first child's (which would let a later child's PII be
-        // released under an earlier child's non-PII verdict when the output labels happen to match).
-        val id = newTask() // first child carries "select id, ssn from users"
+        // Regression: a batch whose statements differ. accessFor returns ONE child's ciphertext, so it must
+        // return that SAME child's sql — the view re-decides the released bytes against their own statement,
+        // never another child's (which would let one statement's PII be released under a different
+        // statement's non-PII verdict when the output labels happen to match).
+        val id = newTask() // statement 0 carries "select id, ssn from users"
         dataSource.connection.use { c ->
             c.prepareStatement(
-                "INSERT INTO query_result (task_id, sql, sql_hash) VALUES (?, 'select ssn as v from users', 'second')",
+                "INSERT INTO query_result (task_id, ordinal, sql, sql_hash) VALUES (?, 1, 'select ssn as v from users', 'second')",
             ).use { ps ->
                 ps.setLong(1, id)
                 ps.executeUpdate()
             }
         }
-        assertNotNull(store.startRun(id, "bob@example.com")) // claims the latest NULL child (the second)
+        assertNotNull(store.startNextRun(id, "bob@example.com")) // claims statement 0
+        assertNotNull(store.completeRun(id, result(), 3600))
+        assertNotNull(store.startNextRun(id, "bob@example.com")) // statement 1
         val done = store.completeRun(id, DecryptedResult(listOf("v"), listOf(listOf("PM_SECRET_900101"))), 3600)
         assertEquals("DONE", done?.status)
 
-        val access = store.accessFor(id)
+        val access = store.accessFor(id, 1)
         assertNotNull(access)
-        assertEquals("select ssn as v from users", access?.sql, "accessFor.sql is the latest (released) child's own sql")
+        assertEquals("select ssn as v from users", access?.sql, "accessFor.sql is the released child's own sql")
         assertEquals(listOf(listOf("PM_SECRET_900101")), access?.decrypted?.rows, "and its ciphertext is that same child's")
+        // The other statement's bytes stay bound to ITS own sql — one task, two independently-gated results.
+        assertEquals("select id, ssn from users", store.accessFor(id, 0)?.sql)
+        assertEquals(result().rows, store.accessFor(id, 0)?.decrypted?.rows)
     }
 
     @Test
     fun `expiry purges the payload but keeps the child row and its sql for audit`() {
         val id = newTask()
-        store.startRun(id, "bob@example.com")
+        store.startNextRun(id, "bob@example.com")
         store.completeRun(id, result(), -1) // already expired
         assertTrue(store.purgeExpired() >= 1)
 

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TaskEventsRouteDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TaskEventsRouteDbTest.kt
@@ -48,7 +48,7 @@ class TaskEventsRouteDbTest {
     }
 
     private fun newTask(): Long =
-        core.accessStore.createEditorTask(caller, datasource.id, "select 1", listOf("editor-analyst"), caller).id
+        core.accessStore.createEditorTask(caller, datasource.id, listOf("select 1"), listOf("editor-analyst"), caller).id
 
     private fun readable(taskId: Long) =
         taskReadableForPush(caller, taskId, AuthzContext(), core.accessStore, core.authz, core.datasourceStore)

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TaskReconcileStartupDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TaskReconcileStartupDbTest.kt
@@ -39,7 +39,7 @@ class TaskReconcileStartupDbTest {
         // An orphan: claimed for execution and its child moved to RUNNING, then the process "died" before
         // either reached a terminal state.
         val orphan = core.accessStore.createQueryRequest(
-            principal = "requester@example.com", datasourceId = datasource.id, sql = "select 1",
+            principal = "requester@example.com", datasourceId = datasource.id, statements = listOf("select 1"),
             denyReason = null, sourceDecisionId = null, reason = "need it", title = null, evaluatedDecision = "DENY",
         ).id
         execute("UPDATE access_request SET status='APPROVED' WHERE id=$orphan")
@@ -51,7 +51,7 @@ class TaskReconcileStartupDbTest {
         // A task that never started: APPROVED with its statement child still NULL (not-started). Reconcile
         // must not touch it.
         val notStarted = core.accessStore.createQueryRequest(
-            principal = "requester@example.com", datasourceId = datasource.id, sql = "select 2",
+            principal = "requester@example.com", datasourceId = datasource.id, statements = listOf("select 2"),
             denyReason = null, sourceDecisionId = null, reason = "need it", title = null, evaluatedDecision = "DENY",
         ).id
         execute("UPDATE access_request SET status='APPROVED' WHERE id=$notStarted")
@@ -60,7 +60,7 @@ class TaskReconcileStartupDbTest {
         // the only shape a finished run can take). Reconcile sweeps only EXECUTING/RUNNING, so a completed task
         // must survive restart untouched — a DONE child must never be dragged to FAILED under its EXECUTED task.
         val completed = core.accessStore.createQueryRequest(
-            principal = "requester@example.com", datasourceId = datasource.id, sql = "select 3",
+            principal = "requester@example.com", datasourceId = datasource.id, statements = listOf("select 3"),
             denyReason = null, sourceDecisionId = null, reason = "need it", title = null, evaluatedDecision = "DENY",
         ).id
         execute("UPDATE access_request SET status='EXECUTED', executing_at=now(), executed_at=now() WHERE id=$completed")

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TaskStoreDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/TaskStoreDbTest.kt
@@ -82,11 +82,15 @@ class TaskStoreDbTest {
         }
     }
 
-    /** A statement child for [taskId] in [status] (null = not started). Leaves the `sql` column unset. */
-    private fun seedChild(taskId: Long, status: String? = null): Long = dataSource.connection.use { c ->
-        c.prepareStatement("INSERT INTO query_result (task_id, status) VALUES (?, ?)", Statement.RETURN_GENERATED_KEYS).use { ps ->
+    /** A statement child for [taskId] at [ordinal], in [status] (null = not started). Leaves `sql` unset. */
+    private fun seedChild(taskId: Long, status: String? = null, ordinal: Int = 0): Long = dataSource.connection.use { c ->
+        c.prepareStatement(
+            "INSERT INTO query_result (task_id, ordinal, status) VALUES (?, ?, ?)",
+            Statement.RETURN_GENERATED_KEYS,
+        ).use { ps ->
             ps.setLong(1, taskId)
-            if (status == null) ps.setNull(2, Types.VARCHAR) else ps.setString(2, status)
+            ps.setInt(2, ordinal)
+            if (status == null) ps.setNull(3, Types.VARCHAR) else ps.setString(3, status)
             ps.executeUpdate()
             ps.generatedKeys.use { rs -> rs.next(); rs.getLong(1) }
         }
@@ -288,12 +292,13 @@ class TaskStoreDbTest {
     }
 
     @Test
-    fun `a task carries one-to-many statement children, latest wins in meta`() {
+    fun `a task carries one child per statement, and meta follows the active one`() {
         val id = seedTask("APPROVED")
-        seedChild(id, status = "FAILED")
-        seedChild(id, status = "RUNNING")
-        assertEquals(2, childCount(id), "a task may accrue multiple children")
-        assertEquals("RUNNING", resultStore.meta(id)?.status, "meta returns the newest child")
+        seedChild(id, status = "FAILED", ordinal = 0)
+        seedChild(id, status = "RUNNING", ordinal = 1)
+        assertEquals(2, childCount(id), "a batch task holds one child per statement")
+        assertEquals("RUNNING", resultStore.meta(id)?.status, "meta follows the batch's active statement")
+        assertEquals(1, resultStore.meta(id)?.ordinal)
     }
 
     @Test
@@ -316,7 +321,7 @@ class TaskStoreDbTest {
     fun `createQueryRequest persists execute_as, creator_kind, and a not-started statement child`() {
         val roleId = fx.policyStore.createRole(RoleInput("task-store-round-trip")).id
         val req = store.createQueryRequest(
-            principal = "alice@example.com", datasourceId = fx.datasource.id, sql = "select 1",
+            principal = "alice@example.com", datasourceId = fx.datasource.id, statements = listOf("select 1"),
             denyReason = null, sourceDecisionId = null, reason = "need it", title = null,
             evaluatedDecision = "DENY", roleId = roleId,
         )

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationServiceDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationServiceDbTest.kt
@@ -65,7 +65,7 @@ class NotificationServiceDbTest {
 
     private fun newTask(principal: String = "req@example.com"): AccessRequest =
         fx.accessStore.createQueryRequest(
-            principal = principal, datasourceId = fx.datasource.id, sql = "SELECT 1",
+            principal = principal, datasourceId = fx.datasource.id, statements = listOf("SELECT 1"),
             denyReason = null, sourceDecisionId = null, reason = "r", title = "t", evaluatedDecision = "ALLOW",
         )
 
@@ -327,7 +327,7 @@ class NotificationServiceDbTest {
         // AccessRequest.executedBy is derived from it, so owner@x becomes both requester and executor.
         val req = newTask(principal = "owner@x")
         val resultStore = QueryResultStore(fx.dataSource, ResultCrypto(ByteArray(32) { it.toByte() }))
-        resultStore.startRun(req.id, "owner@x")
+        resultStore.startNextRun(req.id, "owner@x")
         resultStore.completeRun(req.id, DecryptedResult(listOf("id"), listOf(listOf("1"), listOf("2"), listOf("3"))), retentionSec = 3600)
 
         val svcWithResults = NotificationService(

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStoreTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/NotificationStoreTest.kt
@@ -45,7 +45,7 @@ class NotificationStoreTest {
     /** A fresh access_request the outbox rows can FK to. */
     private fun newTask(principal: String = "req@example.com"): Long =
         fx.accessStore.createQueryRequest(
-            principal = principal, datasourceId = fx.datasource.id, sql = "SELECT 1",
+            principal = principal, datasourceId = fx.datasource.id, statements = listOf("SELECT 1"),
             denyReason = null, sourceDecisionId = null, reason = "r", title = "t", evaluatedDecision = "ALLOW",
         ).id
 

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackDecisionHandlerDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackDecisionHandlerDbTest.kt
@@ -67,7 +67,7 @@ class SlackDecisionHandlerDbTest {
     }
 
     private fun pendingRequest(): Long = fx.accessStore.createQueryRequest(
-        principal = requester, datasourceId = fx.datasource.id, sql = "SELECT id FROM users",
+        principal = requester, datasourceId = fx.datasource.id, statements = listOf("SELECT id FROM users"),
         denyReason = null, sourceDecisionId = null, reason = "need it", title = "read users",
         evaluatedDecision = "ALLOW", roleId = roleId,
     ).id

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackNotificationE2eDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/notify/SlackNotificationE2eDbTest.kt
@@ -427,7 +427,7 @@ class SlackNotificationE2eDbTest {
         val task = core.accessStore.createQueryRequest(
             principal = approver,
             datasourceId = fx.datasource.id,
-            sql = "SELECT id FROM users",
+            statements = listOf("SELECT id FROM users"),
             denyReason = null,
             sourceDecisionId = null,
             reason = "audit",


### PR DESCRIPTION
A task's `query_result` children are addressed by ordinal instead of "the latest row by id", so a
task can own several statements and run them in order. No behavior change for the single-statement
tasks that exist today — one child at ordinal 0 — but the store stops assuming there is only ever one.

`V25` adds the `ordinal` column, backfills it with
`row_number() OVER (PARTITION BY task_id ORDER BY id) - 1`, and puts a unique index on
`(task_id, ordinal)`. The backfill is not a constant 0: a task can already hold more than one child
(a re-run adds a row), and defaulting those to 0 would abort the migration on the unique index.

`SKIPPED` joins the status CHECK. A batch that stops at a non-ALLOW verdict marks the statements it
never reached, so they read as terminal rather than "not started yet" and never resume.

The current child is `MAX(ordinal) WHERE status IS NOT NULL AND status <> 'SKIPPED'` — the furthest
statement that actually ran, so a stopped batch still reports the one that stopped it rather than a
skipped tail.

`cancelRun` now takes the running child, falling back to the pending one, which closes the window
where a cancel arriving between two statements found nothing `RUNNING` and no-oped while the batch
carried on.

`startRun` is deleted: it duplicated `startNextRun` with weaker transaction semantics (a separate
select and update instead of one transaction) and had no production callers. Its tests move to
`startNextRun`, so they exercise the path production actually uses.

Verified: `mise run verify` green on this commit alone — 1208 control-plane, 65 engine, 7 analyzer
tests, plus the web build.
