### PR TITLE
fix(control-plane): fail orphaned RUNNING children before V25 builds its index

### DIFF
--- a/control-plane/src/main/resources/db/migration/V25__query_result_batch.sql
+++ b/control-plane/src/main/resources/db/migration/V25__query_result_batch.sql
@@ -15,6 +15,12 @@ UPDATE query_result qr
 -- A duplicate would make "the statement at position k" ambiguous — run one twice, or skip one.
 CREATE UNIQUE INDEX uq_query_result_task_ordinal ON query_result (task_id, ordinal);
 
+-- A RUNNING row at migration time belongs to no live execution — the process that owned it is gone —
+-- and reconcileOrphanedExecutions fails every one of them on the next boot regardless. Doing it here
+-- too keeps a task that somehow holds two from aborting the index below, and so the upgrade.
+UPDATE query_result SET status = 'FAILED', error_code = 'task.orphaned_on_restart'
+ WHERE status = 'RUNNING';
+
 -- The batch runs one statement at a time. Two RUNNING children would let completeRun store a result
 -- against the wrong statement's SQL, so the database refuses the second rather than trusting callers.
 CREATE UNIQUE INDEX uq_query_result_one_running ON query_result (task_id) WHERE status = 'RUNNING';

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/QueryResultOrdinalMigrationDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/QueryResultOrdinalMigrationDbTest.kt
@@ -72,4 +72,57 @@ class QueryResultOrdinalMigrationDbTest {
             "plural children are numbered densely by insert order, not all collapsed onto 0",
         )
     }
+
+    // The one-RUNNING index is built over live data, and a RUNNING row survives a crash. Two of them under
+    // one task would abort V25 and leave the schema half-migrated, so the migration fails them first —
+    // the same thing reconcileOrphanedExecutions does to every RUNNING row on the next boot.
+    @Test
+    fun `V25 applies to a task left holding two running children`() {
+        val ds = SharedPostgres.hikari(SharedPostgres.freshDatabase("pm_v25_running"))
+        Flyway.configure().dataSource(ds).target(MigrationVersion.fromVersion("24")).load().migrate()
+        val datasourceId = DatasourceStore(ds).create(
+            DatasourceInput(name = "ds", engine = "postgres", host = "h", port = 5432, dbName = "d"),
+        ).id
+        val taskId = ds.connection.use { c ->
+            val id = c.prepareStatement(
+                """INSERT INTO access_request (principal, kind, datasource_id, requested_duration_sec, creator_kind)
+                   VALUES ('alice@example.com', 'QUERY', ?, 3600, 'WORKFLOW') RETURNING id""",
+            ).use { ps ->
+                ps.setLong(1, datasourceId)
+                ps.executeQuery().use { rs -> rs.next(); rs.getLong(1) }
+            }
+            for (sql in listOf("select 1", "select 2")) {
+                c.prepareStatement(
+                    "INSERT INTO query_result (task_id, sql, sql_hash, status) VALUES (?, ?, ?, 'RUNNING')",
+                ).use { ps ->
+                    ps.setLong(1, id); ps.setString(2, sql); ps.setString(3, "h-$sql")
+                    ps.executeUpdate()
+                }
+            }
+            id
+        }
+
+        Flyway.configure().dataSource(ds).load().migrate()
+
+        val rows = ds.connection.use { c ->
+            c.prepareStatement(
+                "SELECT ordinal, status, error_code FROM query_result WHERE task_id = ? ORDER BY ordinal",
+            ).use { ps ->
+                ps.setLong(1, taskId)
+                ps.executeQuery().use { rs ->
+                    val out = ArrayList<Triple<Int, String, String>>()
+                    while (rs.next()) out += Triple(rs.getInt(1), rs.getString(2), rs.getString(3))
+                    out
+                }
+            }
+        }
+        assertEquals(
+            listOf(
+                Triple(0, "FAILED", "task.orphaned_on_restart"),
+                Triple(1, "FAILED", "task.orphaned_on_restart"),
+            ),
+            rows,
+            "both orphaned RUNNING children are failed, so the one-running index can be built",
+        )
+    }
 }


### PR DESCRIPTION
V25's one-RUNNING index is built over live data, and a RUNNING row survives the crash that stranded
it. A task holding two aborts the migration:

    ERROR:  could not create unique index "uq_query_result_one_running"
    DETAIL:  Key (task_id)=(4) is duplicated.

That halts the upgrade with the schema half-migrated and the control-plane unable to boot.

Not currently reachable: every RUNNING flip is guarded `WHERE status IS NULL`, and the pre-batch
creators insert exactly one child per task. It is latent — an operator repair, a restore, or any
direct write is enough to produce the shape, and the cost is an install that will not start.

The fix fails those rows before building the index, which is exactly what
`reconcileOrphanedExecutions` already does to every RUNNING row on the next boot, so nothing is lost
that a restart would have kept.

V25 has shipped in no release (`server-v0.1.23` tops out at V23), so no install has it applied and
editing it re-checksums nothing. The commit carries the `migration-reorg: sanctioned` marker the
append-only check requires; the marker is self-limiting and closes at the first `v*` release tag.

Verified by applying the migration to a seeded pre-V25 table on postgres:16 — it aborted before the
fix and completes after, leaving both children FAILED with `task.orphaned_on_restart` and ordinals
0/1 intact. The new test covers that shape; removing the normalize step fails it and leaves the
other migration test passing.

`mise run verify` green — 1211 control-plane, 65 engine, 7 analyzer tests.
