### PR TITLE
fix(pmon): use moby/moby HostConfig in client interop test

### DIFF
--- a/pmon/go.mod
+++ b/pmon/go.mod
@@ -6,7 +6,6 @@ require github.com/ridi-oss/proxy-monster/mysqlwire v0.1.4
 
 require (
 	github.com/alecthomas/kong v1.16.1
-	github.com/docker/docker v28.5.2+incompatible
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/moby/moby/api v1.55.0
 	github.com/testcontainers/testcontainers-go v0.44.0

--- a/pmon/go.sum
+++ b/pmon/go.sum
@@ -34,8 +34,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
-github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.8.1 h1:JibmG5hULs5qXSr/cp/w3Pw5fZuStt4MOHMUExb29/M=
 github.com/docker/go-connections v0.8.1/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=

--- a/pmon/internal/daemon/clientinterop_test.go
+++ b/pmon/internal/daemon/clientinterop_test.go
@@ -35,9 +35,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/moby/moby/api/types/network"
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 


### PR DESCRIPTION
testcontainers-go's `HostConfigModifier` takes `moby/moby` container types; the `docker/docker` alias no longer compiles under the `e2e_clients` build tag (invisible to `verify`, which skips that tag). `go mod tidy` drops the now-unused `docker/docker` dependency.

Verified: `go vet -tags e2e_clients ./...` in pmon, and `mise run verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvrD1afHaM1nk5fWvRFWTK