### PR TITLE
fix(goproxy): reopen the events stream promptly after a max-age rotation

### DIFF
--- a/goproxy/cp/client.go
+++ b/goproxy/cp/client.go
@@ -69,6 +69,11 @@ const (
 	// stream, and that is what makes this reopen dial a FRESH connection rather than reuse this one —
 	// re-homing to a live instance where a load balancer fronts several, or reconnecting once it is back.
 	eventsDrainReconnect = 500 * time.Millisecond
+	// eventsRotationReconnect paces the reopen after the max-age expiry below. The proxy reads as UNATTACHED
+	// until the stream is back, and every run dispatched in that window fails "no proxy is attached", so the
+	// error backoff would spend 5s of every rotation refusing queries. Non-zero for the same reason as the
+	// drain pace: the reopen launches a resync, so a stream that expires instantly must not spin the loop.
+	eventsRotationReconnect = 100 * time.Millisecond
 	// eventsStreamMaxAge bounds how long one Events stream is used before it is replaced. HTTP/2 keepalive
 	// proves the CONNECTION is alive, not that the stream on it still reaches a live control plane: a
 	// load balancer that keeps a connection open toward a replaced target DB leaves the proxy holding a
@@ -85,14 +90,16 @@ const (
 )
 
 type eventLoopTimings struct {
-	reconnect    time.Duration
-	streamMaxAge time.Duration
+	reconnect         time.Duration
+	rotationReconnect time.Duration
+	streamMaxAge      time.Duration
 }
 
 func defaultEventLoopTimings() eventLoopTimings {
 	return eventLoopTimings{
-		reconnect:    eventsReconnectDefault,
-		streamMaxAge: eventsStreamMaxAgeDefault,
+		reconnect:         eventsReconnectDefault,
+		rotationReconnect: eventsRotationReconnect,
+		streamMaxAge:      eventsStreamMaxAgeDefault,
 	}
 }
 
@@ -455,6 +462,11 @@ func (c *Client) StreamEvents(
 // what points that reconnect at a fresh connection.
 var errDraining = errors.New("cp: control plane draining")
 
+// errRotated is returned by streamEvents when THIS proxy's own max-age deadline ended the stream. The
+// distinction matters for pacing: a DeadlineExceeded off the wire (a server-side deadline, an LB timeout)
+// is a fault deserving the error backoff, while the local rotation is routine and reopens promptly.
+var errRotated = errors.New("cp: events stream reached its max age")
+
 func (c *Client) streamEvents(
 	parent context.Context,
 	maxAge time.Duration,
@@ -474,6 +486,13 @@ func (c *Client) streamEvents(
 	for {
 		ev, err := stream.Recv()
 		if err != nil {
+			// Attribute by whose deadline fired, not by the status code: a wire DeadlineExceeded from a
+			// server-side deadline stays an error. Compared against the deadline itself rather than
+			// ctx.Err(), which Recv can beat back — the stream error surfaces before the cancellation is
+			// visible on the context, and a rotation read as a fault waits out the error backoff.
+			if deadline, hasDeadline := ctx.Deadline(); hasDeadline && !time.Now().Before(deadline) {
+				return errRotated
+			}
 			return err
 		}
 		switch {
@@ -554,7 +573,10 @@ func (c *Client) runEventsLoop(
 		case errors.Is(err, errDraining):
 			slog.Info("control plane draining; reconnecting to re-home", "reconnect_in", eventsDrainReconnect)
 			reconnectIn = eventsDrainReconnect
-		case errors.Is(err, context.DeadlineExceeded) || status.Code(err) == codes.DeadlineExceeded:
+		case errors.Is(err, errRotated):
+			// This proxy's own timer firing, not a fault, so it reopens promptly rather than waiting out a
+			// backoff meant for a control plane that is actually unwell.
+			reconnectIn = timings.rotationReconnect
 			slog.Info("events stream reached its max age; reopening", "max_age", timings.streamMaxAge)
 		default:
 			slog.Info("events stream ended; reconnecting", "error", err, "reconnect_in", timings.reconnect)

--- a/goproxy/cp/client_test.go
+++ b/goproxy/cp/client_test.go
@@ -669,8 +669,9 @@ func TestEventsLoopReconnectsFastOnDrain(t *testing.T) {
 	go func() {
 		defer close(loopDone)
 		c.runEventsLoop(ctx, eventLoopTimings{
-			streamMaxAge: time.Minute, // long enough that only the drain path paces this test
-			reconnect:    backoff,
+			streamMaxAge:      time.Minute, // long enough that only the drain path paces this test
+			reconnect:         backoff,
+			rotationReconnect: eventsRotationReconnect,
 		}, func() {}, func() {}, func(spi.RunOpen) {}, func(string, string, string) {})
 	}()
 	t.Cleanup(func() {
@@ -718,6 +719,11 @@ func (f *holdOpenControlPlane) openCount() int {
 }
 
 func startHoldOpenControlPlane(t *testing.T, fake *holdOpenControlPlane) *Client {
+	t.Helper()
+	return startControlPlane(t, fake)
+}
+
+func startControlPlane(t *testing.T, fake pb.ControlPlaneServer) *Client {
 	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -784,8 +790,9 @@ func TestRunEventsLoopExitsOnEventsVersionRejection(t *testing.T) {
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- c.runEventsLoop(context.Background(), eventLoopTimings{
-			streamMaxAge: time.Minute,
-			reconnect:    10 * time.Millisecond,
+			streamMaxAge:      time.Minute,
+			reconnect:         10 * time.Millisecond,
+			rotationReconnect: eventsRotationReconnect,
 		}, func() {}, func() {}, func(spi.RunOpen) {}, func(string, string, string) {})
 	}()
 	select {
@@ -817,8 +824,10 @@ func TestStreamEventsEndsAtItsMaxAge(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected the stream to end at its max age")
 	}
-	if status.Code(err) != codes.DeadlineExceeded {
-		t.Fatalf("err = %v, want DeadlineExceeded", err)
+	// errRotated, not a bare DeadlineExceeded: the loop pins the fast reopen to THIS proxy's timer, so a
+	// deadline off the wire keeps the error backoff.
+	if !errors.Is(err, errRotated) {
+		t.Fatalf("err = %v, want errRotated", err)
 	}
 	if elapsed > 3*time.Second {
 		t.Fatalf("took %v — the deadline did not bound the stream", elapsed)
@@ -836,8 +845,9 @@ func TestEventsLoopReopensAfterMaxAge(t *testing.T) {
 	go func() {
 		defer close(loopDone)
 		c.runEventsLoop(ctx, eventLoopTimings{
-			streamMaxAge: 150 * time.Millisecond,
-			reconnect:    10 * time.Millisecond,
+			streamMaxAge:      150 * time.Millisecond,
+			reconnect:         10 * time.Millisecond,
+			rotationReconnect: 10 * time.Millisecond,
 		}, func() {}, func() {}, func(spi.RunOpen) {}, func(string, string, string) {})
 	}()
 	t.Cleanup(func() {
@@ -858,6 +868,115 @@ func TestEventsLoopReopensAfterMaxAge(t *testing.T) {
 	}
 }
 
+// The bug and the fix, in one run. The error backoff is set absurdly high relative to the budget so the
+// two pacings differ by orders of magnitude, not by a margin a stalled CI runner could erase: under the
+// backoff the SECOND open alone needs 30s, under the rotation pace all four land in well under a second.
+func TestEventsLoopRotationGapStaysBoundedAcrossPeriods(t *testing.T) {
+	const backoff = 30 * time.Second
+	const rotationPace = 10 * time.Millisecond
+	const wantOpens = 4 // three reopens
+	const budget = 3 * time.Second
+
+	opensWithin := func(t *testing.T, timings eventLoopTimings) int {
+		t.Helper()
+		fake := &holdOpenControlPlane{done: make(chan struct{})}
+		c := startHoldOpenControlPlane(t, fake)
+		ctx, cancel := context.WithCancel(context.Background())
+		loopDone := make(chan struct{})
+		go func() {
+			defer close(loopDone)
+			c.runEventsLoop(ctx, timings, func() {}, func() {}, func(spi.RunOpen) {}, func(string, string, string) {})
+		}()
+		defer func() {
+			cancel()
+			<-loopDone
+		}()
+		deadline := time.After(budget)
+		for fake.openCount() < wantOpens {
+			select {
+			case <-deadline:
+				return fake.openCount()
+			case <-time.After(2 * time.Millisecond):
+			}
+		}
+		return fake.openCount()
+	}
+
+	// 1. Reproduce: pacing the rotation with the error backoff is the pre-fix behavior. One open fits in the
+	//    budget; the second reopen alone would need 30s.
+	unpaced := opensWithin(t, eventLoopTimings{
+		streamMaxAge:      30 * time.Millisecond,
+		reconnect:         backoff,
+		rotationReconnect: backoff,
+	})
+	if unpaced < 1 || unpaced >= wantOpens {
+		t.Fatalf("backoff-paced rotation opened %d streams in %s, want 1..%d — the bug did not reproduce, "+
+			"so the fixed leg below proves nothing", unpaced, budget, wantOpens-1)
+	}
+	t.Logf("reproduced: backoff-paced rotation opened %d/%d streams in %s", unpaced, wantOpens, budget)
+
+	// 2. Fix: the rotation pace reaches every open inside the same budget, at each period.
+	for _, period := range []time.Duration{30 * time.Millisecond, 75 * time.Millisecond, 200 * time.Millisecond} {
+		t.Run(period.String(), func(t *testing.T) {
+			started := time.Now()
+			got := opensWithin(t, eventLoopTimings{
+				streamMaxAge:      period,
+				reconnect:         backoff,
+				rotationReconnect: rotationPace,
+			})
+			if got < wantOpens {
+				t.Fatalf("maxAge=%s: only %d opens in %s (want %d) — reopen is not paced for a rotation",
+					period, got, budget, wantOpens)
+			}
+			t.Logf("fixed: maxAge=%s opened %d streams in %s", period, got, time.Since(started).Round(time.Millisecond))
+		})
+	}
+}
+
+// A DeadlineExceeded off the WIRE — a server-side stream deadline, an LB timeout — is a fault, not this
+// proxy's rotation. Pacing it at the rotation speed would reconnect at 10Hz against an unwell control
+// plane, launching a resync each time, so it must wait out the error backoff instead.
+// The production defaults, not just injected timings: a rotationReconnect left at zero (spinning) or set
+// back to the error backoff (the outage) would pass every test that supplies its own timings.
+func TestDefaultRotationReconnectIsPacedAndFast(t *testing.T) {
+	got := defaultEventLoopTimings()
+	if got.rotationReconnect <= 0 {
+		t.Fatalf("rotationReconnect = %s; a zero pace spins the loop, since each reopen launches a resync",
+			got.rotationReconnect)
+	}
+	if got.rotationReconnect >= got.reconnect {
+		t.Fatalf("rotationReconnect = %s is not faster than the %s error backoff — every rotation would leave "+
+			"the datasource unattached for that long", got.rotationReconnect, got.reconnect)
+	}
+}
+
+func TestEventsLoopBacksOffOnServerDeadlineExceeded(t *testing.T) {
+	const backoff = 1500 * time.Millisecond
+	fake := &deadlineControlPlane{}
+	c := startControlPlane(t, fake)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	loopDone := make(chan struct{})
+	go func() {
+		defer close(loopDone)
+		c.runEventsLoop(ctx, eventLoopTimings{
+			streamMaxAge:      time.Minute, // long, so only the server's status ends the stream
+			reconnect:         backoff,
+			rotationReconnect: 10 * time.Millisecond,
+		}, func() {}, func() {}, func(spi.RunOpen) {}, func(string, string, string) {})
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-loopDone
+	})
+
+	// Under the rotation pace this would open ~100 streams in a second; under the backoff, at most two.
+	time.Sleep(backoff - 300*time.Millisecond)
+	if opens := fake.openCount(); opens > 1 {
+		t.Fatalf("opened %d streams before one backoff elapsed — a wire DeadlineExceeded took the rotation pace", opens)
+	}
+}
+
 func TestEventsLoopReopensWithoutWaitingForResync(t *testing.T) {
 	// resync introspects the whole catalog and retries with its own backoff. Run in line it delays the
 	// reopen, and the datasource reads as unattached for that whole time — so a resync that never returns
@@ -874,8 +993,9 @@ func TestEventsLoopReopensWithoutWaitingForResync(t *testing.T) {
 	go func() {
 		defer close(loopDone)
 		c.runEventsLoop(ctx, eventLoopTimings{
-			streamMaxAge: 150 * time.Millisecond,
-			reconnect:    10 * time.Millisecond,
+			streamMaxAge:      150 * time.Millisecond,
+			reconnect:         10 * time.Millisecond,
+			rotationReconnect: 10 * time.Millisecond,
 		}, resync, func() {}, func(spi.RunOpen) {}, func(string, string, string) {})
 	}()
 	t.Cleanup(func() {
@@ -946,8 +1066,9 @@ func TestEventsLoopWaitsTheBackoffBetweenReopens(t *testing.T) {
 	go func() {
 		defer close(loopDone)
 		c.runEventsLoop(ctx, eventLoopTimings{
-			streamMaxAge: time.Minute, // long enough that only the backoff paces this test
-			reconnect:    backoff,
+			streamMaxAge:      time.Minute, // long enough that only the backoff paces this test
+			reconnect:         backoff,
+			rotationReconnect: eventsRotationReconnect,
 		}, func() {}, func() {}, func(spi.RunOpen) {}, func(string, string, string) {})
 	}()
 	t.Cleanup(func() {
@@ -972,4 +1093,25 @@ func TestEventsLoopWaitsTheBackoffBetweenReopens(t *testing.T) {
 			t.Fatalf("reopen %d came %v after the previous one, faster than the %v backoff", i, gap, backoff)
 		}
 	}
+}
+
+// deadlineControlPlane fails every Events call with DeadlineExceeded, standing in for a server-side
+// deadline or an intermediary timeout — a fault that happens to carry the same code as a local rotation.
+type deadlineControlPlane struct {
+	pb.UnimplementedControlPlaneServer
+	mu    sync.Mutex
+	opens int
+}
+
+func (f *deadlineControlPlane) Events(_ *pb.EventsRequest, _ grpc.ServerStreamingServer[pb.ControlEvent]) error {
+	f.mu.Lock()
+	f.opens++
+	f.mu.Unlock()
+	return status.Error(codes.DeadlineExceeded, "server-side deadline")
+}
+
+func (f *deadlineControlPlane) openCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.opens
 }


### PR DESCRIPTION
The Events stream is replaced every 4 minutes on purpose, so a stream left pointing at a replaced
control plane self-heals. The reopen after that expiry waited out `eventsReconnectDefault` (5s) — the
backoff meant for a control plane that is actually unwell.

The proxy reads as UNATTACHED until the stream is back, so every run dispatched in that window fails
with `No proxy is attached to this datasource`. That is a ~5s outage every 4 minutes, on every
datasource, and it was hit while testing the console.

A drain already reconnects fast for exactly this reason. This gives the rotation the same treatment
with its own 100ms pace — non-zero, since each reopen launches a resync and a stream that expired
instantly would otherwise spin the loop.

The rotation is identified by whose deadline fired, not by the status code: `streamEvents` returns an
`errRotated` sentinel when its own `context.WithTimeout` expired. A `DeadlineExceeded` off the wire — a
server-side deadline, an LB timeout — stays a fault and keeps the 5s backoff. Keying on the code alone
would have turned such a fault into a 10Hz reconnect loop, each iteration launching a resync; a test
pins that (it opens 101 streams in 1.2s against the code-based attribution, at most 1 against this one).

The test reproduces the bug before asserting the fix, in one run: pacing the rotation with the error
backoff opens 1 of 4 expected streams, and the test FAILS if that stops reproducing, so the budget can
never silently degrade into proving nothing. It then shows the fixed pace holding across three
rotation periods (30ms / 75ms / 200ms), driven through the real gRPC client against a real server.

Verified beyond the unit test: 45 consecutive batch submits over 4.5 minutes on a live stack, spanning
a real rotation (confirmed in the proxy log), zero failures. Stability: 20 runs under `-race` and 10
more at `GOMAXPROCS=1` — the closest local stand-in for a loaded CI runner — all green.
