### PR TITLE
fix(analyzer): classify EXPLAIN TABLE as a plan-only EXPLAIN

### DIFF
--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -378,10 +378,18 @@ func factsFromProbe(report ProbeResult) *pb.StatementFacts {
 	return facts
 }
 
+// isTableShorthandDescribe reports a Describe carrying kind=TABLE over a Table target — MySQL's
+// `EXPLAIN TABLE t` (`TABLE t` is `SELECT * FROM t` shorthand), a plan of a scan. The one predicate is
+// shared by classification (describeKind → EXPLAIN) and emission (emitDescribeFacts → lineage) so the
+// two can never disagree about which arm a statement takes.
+func isTableShorthandDescribe(root exp.Expression) bool {
+	this := root.This()
+	return strings.EqualFold(root.Text("kind"), "TABLE") && this != nil && this.Kind() == exp.KindTable
+}
+
 func emitDescribeFacts(root exp.Expression, eng engine, qualifySchema schema.Schema, namespace NamespaceConfig) *pb.StatementFacts {
 	this := root.This()
-	kind := strings.ToUpper(fmt.Sprint(root.Arg("kind")))
-	if kind == "TABLE" && this != nil && this.Kind() == exp.KindTable {
+	if isTableShorthandDescribe(root) {
 		selectRoot := exp.Select(exp.Args{"expressions": []exp.Expression{exp.Star(nil)}, "from_": exp.From(exp.Args{"this": this.Copy()})})
 		return emitLineageFacts(selectRoot, eng, qualifySchema, namespace, true)
 	}

--- a/analyzer/probe/kinds.go
+++ b/analyzer/probe/kinds.go
@@ -144,9 +144,14 @@ func insertKind(root exp.Expression) pb.StatementKind {
 // describeKind classifies DESCRIBE / EXPLAIN. `EXPLAIN <query>` (its `this` is an analyzable statement)
 // returns the plan, not rows: a READ is the read-shaped STATEMENT_KIND_EXPLAIN (the body), a WRITE keeps
 // its own kind. `DESCRIBE <table>`, `DESC <table>`, and `EXPLAIN <table>` are all table introspection and
-// parse to an identical Describe{this:Table} node — indistinguishable, so all three are DESCRIBE
-// (STATEMENT_KIND_EXPLAIN_TABLE has no AST signal to key on).
+// parse to an identical Describe{this:Table} node — indistinguishable, so all three are DESCRIBE.
+// `EXPLAIN TABLE t` is distinct: its Describe carries kind=TABLE (`TABLE t` is `SELECT * FROM t`
+// shorthand), so it plans a scan of t — the same plan-only read EXPLAIN of that SELECT is, and the same
+// signal emitDescribeFacts routes through lineage.
 func describeKind(root exp.Expression, eng engine) pb.StatementKind {
+	if isTableShorthandDescribe(root) {
+		return pb.StatementKind_STATEMENT_KIND_EXPLAIN
+	}
 	// `EXPLAIN (SELECT …)` wraps the query in a Subquery (parentheses are real syntax); peel it so a
 	// parenthesized target classifies like a bare one — matching emitDescribeFacts.
 	inner := unwrapSubquery(root.This())

--- a/analyzer/probe/mysql_statement_coverage_test.go
+++ b/analyzer/probe/mysql_statement_coverage_test.go
@@ -375,6 +375,7 @@ var mysqlStatements = []mysqlStatement{
 	{"EXPLAIN (query)", "EXPLAIN SELECT id FROM users", "result.read + stmt.kind.explain", pb.StatementKind_STATEMENT_KIND_EXPLAIN},
 	{"EXPLAIN ANALYZE", "EXPLAIN ANALYZE SELECT id FROM users", "result.read + stmt.kind.explain", pb.StatementKind_STATEMENT_KIND_EXPLAIN},
 	{"EXPLAIN (table)", "EXPLAIN users", "stmt.kind.describe", pb.StatementKind_STATEMENT_KIND_DESCRIBE}, // EXPLAIN <table> is AST-identical to DESCRIBE <table>
+	{"EXPLAIN TABLE", "EXPLAIN TABLE users", "result.read + stmt.kind.explain", pb.StatementKind_STATEMENT_KIND_EXPLAIN}, // TABLE t is SELECT * FROM t shorthand — a plan of a scan, gated as a read
 	{"HELP", "HELP 'contents'", "stmt.kind.help + unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_HELP},
 	{"USE", "USE acme", "stmt.kind.use", pb.StatementKind_STATEMENT_KIND_USE},
 

--- a/analyzer/probe/statement_facts_test.go
+++ b/analyzer/probe/statement_facts_test.go
@@ -263,7 +263,15 @@ func TestStatementFactsExplainKind(t *testing.T) {
 		// A parenthesized target wraps the query in a Subquery; it must still classify, not fall unresolved.
 		{"mysql read parenthesized", mysqlFacts(t, "EXPLAIN (SELECT ssn FROM users)"), true, pb.StatementKind_STATEMENT_KIND_EXPLAIN},
 		{"mysql read analyze parenthesized", mysqlFacts(t, "EXPLAIN ANALYZE (SELECT ssn FROM users)"), true, pb.StatementKind_STATEMENT_KIND_EXPLAIN},
-		{"mysql explain table", mysqlFacts(t, "EXPLAIN TABLE users"), true, pb.StatementKind_STATEMENT_KIND_DESCRIBE},
+		{"mysql explain table", mysqlFacts(t, "EXPLAIN TABLE users"), true, pb.StatementKind_STATEMENT_KIND_EXPLAIN},
+		// DESCRIBE/DESC TABLE t parse to the same kind=TABLE shape as EXPLAIN TABLE t and plan the same scan.
+		{"mysql describe table shorthand", mysqlFacts(t, "DESCRIBE TABLE users"), true, pb.StatementKind_STATEMENT_KIND_EXPLAIN},
+		{"mysql desc table shorthand", mysqlFacts(t, "DESC TABLE users"), true, pb.StatementKind_STATEMENT_KIND_EXPLAIN},
+		{"mysql describe table", mysqlFacts(t, "DESCRIBE users"), true, pb.StatementKind_STATEMENT_KIND_DESCRIBE},
+		// The pinned parser degrades EXPLAIN ANALYZE/FORMAT=JSON over TABLE shorthand to Command → the
+		// accepted over-deny (unanalyzable, fail-closed), not a silent metadata pass.
+		{"mysql explain analyze table fail-closed", mysqlFacts(t, "EXPLAIN ANALYZE TABLE users"), true, pb.StatementKind_STATEMENT_KIND_STMT_UNKNOWN},
+		{"mysql explain format table fail-closed", mysqlFacts(t, "EXPLAIN FORMAT=JSON TABLE users"), true, pb.StatementKind_STATEMENT_KIND_STMT_UNKNOWN},
 		// A write keeps its own kind, plan-only or ANALYZE, so it gates + denies as the write. The
 		// MATERIALIZING forms are the security boundary — an EXPLAIN ANALYZE that copies masked PII into a
 		// new/other table must NOT classify as the read-shaped EXPLAIN kind (which would run unmasked). Each

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultAssumeMysqlDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/ApprovalResultAssumeMysqlDbTest.kt
@@ -348,6 +348,18 @@ class ApprovalResultAssumeMysqlDbTest {
     }
 
     @Test
+    fun `an explain table result releases like a plan-only explain`() {
+        // MySQL's `EXPLAIN TABLE t` plans the `SELECT * FROM t` shorthand, so it classifies as the
+        // plan-only EXPLAIN kind and its stored plan releases under the same clean-ALLOW gate.
+        val sql = "EXPLAIN TABLE users"
+        val stored = storedExplain(sql)
+        assertPlanOnlyExplain(viewerCtx(sql, "100.100.1.10", req = request(sql), channel = Channel.EDITOR))
+        val allowed = assertIs<ResultViewDecision.Allowed>(viewExplain(sql, stored))
+        assertEquals(stored.columns, allowed.columns)
+        assertEquals(stored.rows, allowed.rows)
+    }
+
+    @Test
     fun `a non-explain allow with empty outputs never takes the plan release`() {
         // The statementKind conjunct is load-bearing: an ALLOW with empty masks and outputColumns whose
         // kind is not EXPLAIN (a synthetic non-EXPLAIN context) must fall through to the projection-width

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/GateSqlglotRegressionTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/GateSqlglotRegressionTest.kt
@@ -122,6 +122,11 @@ class GateSqlglotRegressionTest {
         // EXPLAIN TABLE analyzes SELECT * over the ungranted orders table, so its columns resolve DENIED;
         // RESET MASTER is administrative. (A plan-only EXPLAIN of a GRANTED read is exercised separately.)
         denied(mysql, "EXPLAIN TABLE orders")
+        // EXPLAIN TABLE gates as a read (stmt.kind.explain), not metadata: the explainer role holds
+        // cat.read and NO cat.metadata, so this ALLOW pins the category move.
+        val planned = mysql.decide("EXPLAIN TABLE users", principal = "explainer@example.com")
+        assertEquals(EnfAction.ALLOW, planned.action, "a read grant clears EXPLAIN TABLE: ${'$'}{planned.denyReason}")
+        assertTrue(planned.masks.isEmpty(), "a released plan binds no masks")
         denied(mysql, "RESET MASTER")
         denied(postgres, """SELECT U&"set_confi\0067"('search_path','restricted',false)""")
     }

--- a/docs/statement-facts-contract.md
+++ b/docs/statement-facts-contract.md
@@ -201,8 +201,9 @@ describes the table and `DESCRIBE SELECT …` explains a query. Both parse to a
    MySQL's `TABLE t` is shorthand for `SELECT * FROM t`, so `EXPLAIN TABLE t`
    scans `t`. Checking `this.Kind()==Table` alone would misclassify this as
    harmless metadata and let the scan bypass lineage — a leak. So
-   `kind=="TABLE"` is decided first and routed as a query-explain over the
-   scanned table.
+   `kind=="TABLE"` is decided first, routed as a query-explain over the scanned
+   table, and classified `stmt.kind.explain` like any other plan-only read
+   EXPLAIN.
 2. else `Describe.this.Kind() == Table` → describe of a table (metadata; allow),
    including the column/wildcard forms `DESCRIBE tbl col` /
    `DESCRIBE tbl 'wild%'`. The column slot is a single identifier only:

--- a/docs/statement-typing.md
+++ b/docs/statement-typing.md
@@ -63,13 +63,13 @@ authority and enforces exhaustiveness.
 <!-- prettier-ignore -->
 | Category | Kinds |
 | --- | --- |
-| `read` | `select`, `table`, `values`, `with_select`, `set_op` (union/intersect/except) |
+| `read` | `select`, `table`, `values`, `with_select`, `set_op` (union/intersect/except), `explain` (a plan-only EXPLAIN of a read, `EXPLAIN TABLE t` included) |
 | `write.insert` | `insert`, `insert_select` |
 | `write.update` | `update`, `insert_on_dup` (an upsert can modify an existing row, so it needs the higher-privilege leaf) |
 | `write.delete` | `delete`, `replace` (delete+insert) |
 | `ddl` | `create_table`, `create_view`, `create_index`, `alter_table`, `drop_table`, `truncate_table`, `rename_table`, `select_into` (a `SELECT … INTO @var`/`<table>` — a write to an unmaskable target), … (every CREATE/ALTER/DROP/TRUNCATE of a schema object) |
 | `session` | `start_transaction`, `commit`, `rollback`, `savepoint`, `set_transaction`, `set_var`, `set_names`, `set_charset`, `use`, `empty` (a statement with no statements — blank/comment-only, answered natively by the target) — connection-local, exposes no rows/credentials, changes no privilege |
-| `metadata` | `show_tables`, `show_columns`, `show_create_table`, `describe`, `explain_table`, … — schema introspection that exposes no rows, credentials, or topology |
+| `metadata` | `show_tables`, `show_columns`, `show_create_table`, `describe`, … — schema introspection that exposes no rows, credentials, or topology |
 | `admin.account` | `create_user`, `alter_user`, `drop_user`, `rename_user`, `create_role`, `drop_role`, `grant_priv`, `grant_role`, `revoke_priv`, `revoke_role`, `set_password`, `set_role`, `set_default_role`, `show_grants`, `show_create_user` |
 | `admin.replication` | `change_replication_source`, `start_replica`, `stop_replica`, `reset_replica`, `start_group_replication`, `purge_binary_logs`, `reset_master`, `set_sql_log_bin`, `binlog`, `show_master_status`, `show_binary_logs`, `show_binlog_events`, `show_replica_status`, `show_replicas` |
 | `admin.process` | `kill`, `show_processlist`, `show_engine_status` — the MySQL PROCESS privilege: inspect and terminate other sessions |


### PR DESCRIPTION
MySQL's `EXPLAIN TABLE t` plans the `SELECT * FROM t` shorthand — its facts were already lineage-traced with plan-shaped output, but the kind stayed DESCRIBE, so the saved-result view (which releases plan output only for the EXPLAIN kind) refused every stored `EXPLAIN TABLE` result. `describeKind` now keys off the same `Describe.kind==TABLE` signal `emitDescribeFacts` routes through lineage (one shared predicate, `isTableShorthandDescribe`).

Behavior change: `EXPLAIN TABLE` (and the equivalent `DESCRIBE TABLE`/`DESC TABLE`) gates as `stmt.cat.read` (`stmt.kind.explain`), not `stmt.cat.metadata` — a metadata-only role loses it, a read role gains it; its facts always carried the per-column read grants. `EXPLAIN ANALYZE TABLE t` / `EXPLAIN FORMAT=JSON TABLE t` parse unresolved and stay fail-closed denies until the next sqlglot-go release parses them.

Closes #284. Verified: analyzer kind/coverage tests, DB-backed read-role ALLOW + stored-view release tests, `mise run verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvrD1afHaM1nk5fWvRFWTK