### PR TITLE
build(analyzer): adopt sqlglot-go v0.33.0

### DIFF
--- a/analyzer/go.mod
+++ b/analyzer/go.mod
@@ -8,6 +8,6 @@ module github.com/ridi-oss/proxy-monster/analyzer
 
 go 1.26.0
 
-require github.com/ridi-oss/sqlglot-go v0.29.0
+require github.com/ridi-oss/sqlglot-go v0.33.0
 
 require google.golang.org/protobuf v1.36.12

--- a/analyzer/go.sum
+++ b/analyzer/go.sum
@@ -1,6 +1,6 @@
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/ridi-oss/sqlglot-go v0.29.0 h1:57pno9UcLVeyNpsyxJMoWdGWkc97N/QEB6NqBU3o7rA=
-github.com/ridi-oss/sqlglot-go v0.29.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
+github.com/ridi-oss/sqlglot-go v0.33.0 h1:+Jr6I6EhjXnUMso3DUMwQIgDDSW3CbgrE9MhAVMcppA=
+github.com/ridi-oss/sqlglot-go v0.33.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
 google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
 google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/analyzer/probe/explain_table_test.go
+++ b/analyzer/probe/explain_table_test.go
@@ -1,0 +1,75 @@
+package probe
+
+import (
+	"sort"
+	"testing"
+
+	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
+)
+
+func columnGrantSet(f *pb.StatementFacts) []string {
+	cols := []string{}
+	for _, g := range f.GetResultReads() {
+		if c := g.GetColumn(); c != nil {
+			cols = append(cols, c.GetIdentity().GetTable()+"."+c.GetIdentity().GetColumn())
+		}
+	}
+	sort.Strings(cols)
+	return cols
+}
+
+// A TABLE-shorthand EXPLAIN reads the scanned table like the `SELECT * FROM t` it abbreviates: the
+// grants are EVERY catalog column of the table (the synthetic star expands against the catalog), equal
+// to the spelled-out form's, with no output columns (the output is the plan).
+func TestExplainTableEmitsEveryTableColumn(t *testing.T) {
+	all := []string{"users.email", "users.id", "users.ssn"}
+	for _, tc := range []struct {
+		name  string
+		facts func(*testing.T, string) *pb.StatementFacts
+		sqls  []string
+	}{
+		{"mysql", mysqlFacts, []string{"EXPLAIN TABLE users", "EXPLAIN ANALYZE TABLE users", "EXPLAIN FORMAT=JSON TABLE users"}},
+		{"postgres", postgresFacts, []string{"EXPLAIN TABLE users", "EXPLAIN ANALYZE TABLE users", "EXPLAIN (FORMAT JSON) TABLE users"}},
+	} {
+		spelled := columnGrantSet(tc.facts(t, "EXPLAIN SELECT * FROM users"))
+		for _, sql := range tc.sqls {
+			f := tc.facts(t, sql)
+			if !f.GetResolved() || len(f.GetOutputColumns()) != 0 {
+				t.Errorf("%s %q: resolved=%v outCols=%d", tc.name, sql, f.GetResolved(), len(f.GetOutputColumns()))
+				continue
+			}
+			got := columnGrantSet(f)
+			if len(got) != len(all) || got[0] != all[0] || got[1] != all[1] || got[2] != all[2] {
+				t.Errorf("%s %q: column grants = %v, want every users column %v", tc.name, sql, got, all)
+			}
+			if len(got) != len(spelled) {
+				t.Errorf("%s %q: grants differ from EXPLAIN SELECT * FROM users: %v vs %v", tc.name, sql, got, spelled)
+			}
+		}
+	}
+}
+
+// The TABLE-shorthand forms the parser deliberately degrades to Command must stay unanalyzable.
+func TestExplainTableDegradedFormsFailClosed(t *testing.T) {
+	for _, c := range []struct {
+		sql   string
+		mysql bool
+	}{
+		{"EXPLAIN ANALYZE TABLE users PARTITION (p0)", true},
+		{"EXPLAIN ANALYZE TABLE users AS JSON", true},
+		{"EXPLAIN TABLE users garbage trailing", true},
+		{"EXPLAIN TABLE ONLY users", false},
+		{"EXPLAIN TABLE users *", false},
+		{"EXPLAIN TABLE users garbage trailing", false},
+	} {
+		var f *pb.StatementFacts
+		if c.mysql {
+			f = mysqlFacts(t, c.sql)
+		} else {
+			f = postgresFacts(t, c.sql)
+		}
+		if f.GetResolved() {
+			t.Errorf("%q: must stay unresolved, got kind=%v reads=%+v", c.sql, factsKind(f), f.GetResultReads())
+		}
+	}
+}

--- a/analyzer/probe/facts.go
+++ b/analyzer/probe/facts.go
@@ -378,13 +378,18 @@ func factsFromProbe(report ProbeResult) *pb.StatementFacts {
 	return facts
 }
 
-// isTableShorthandDescribe reports a Describe carrying kind=TABLE over a Table target — MySQL's
-// `EXPLAIN TABLE t` (`TABLE t` is `SELECT * FROM t` shorthand), a plan of a scan. The one predicate is
+// isTableShorthandDescribe reports a Describe planning the `TABLE t` SELECT-shorthand — a plan of a
+// scan, never table metadata. MySQL parses it as kind=TABLE; PostgreSQL as kind=EXPLAIN over a Table
+// target (PG has no DESCRIBE, so that shape is always `EXPLAIN [opts] TABLE t`). The one predicate is
 // shared by classification (describeKind → EXPLAIN) and emission (emitDescribeFacts → lineage) so the
 // two can never disagree about which arm a statement takes.
 func isTableShorthandDescribe(root exp.Expression) bool {
 	this := root.This()
-	return strings.EqualFold(root.Text("kind"), "TABLE") && this != nil && this.Kind() == exp.KindTable
+	if this == nil || this.Kind() != exp.KindTable {
+		return false
+	}
+	kind := root.Text("kind")
+	return strings.EqualFold(kind, "TABLE") || strings.EqualFold(kind, "EXPLAIN")
 }
 
 func emitDescribeFacts(root exp.Expression, eng engine, qualifySchema schema.Schema, namespace NamespaceConfig) *pb.StatementFacts {

--- a/analyzer/probe/kinds.go
+++ b/analyzer/probe/kinds.go
@@ -145,9 +145,9 @@ func insertKind(root exp.Expression) pb.StatementKind {
 // returns the plan, not rows: a READ is the read-shaped STATEMENT_KIND_EXPLAIN (the body), a WRITE keeps
 // its own kind. `DESCRIBE <table>`, `DESC <table>`, and `EXPLAIN <table>` are all table introspection and
 // parse to an identical Describe{this:Table} node — indistinguishable, so all three are DESCRIBE.
-// `EXPLAIN TABLE t` is distinct: its Describe carries kind=TABLE (`TABLE t` is `SELECT * FROM t`
-// shorthand), so it plans a scan of t — the same plan-only read EXPLAIN of that SELECT is, and the same
-// signal emitDescribeFacts routes through lineage.
+// The `TABLE t` SELECT-shorthand target is distinct (MySQL kind=TABLE, PostgreSQL kind=EXPLAIN over a
+// Table — see isTableShorthandDescribe): it plans a scan of t, the same plan-only read EXPLAIN of that
+// SELECT is, and the same predicate emitDescribeFacts routes through lineage.
 func describeKind(root exp.Expression, eng engine) pb.StatementKind {
 	if isTableShorthandDescribe(root) {
 		return pb.StatementKind_STATEMENT_KIND_EXPLAIN

--- a/analyzer/probe/mysql_statement_coverage_test.go
+++ b/analyzer/probe/mysql_statement_coverage_test.go
@@ -374,7 +374,7 @@ var mysqlStatements = []mysqlStatement{
 	{"DESC", "DESC users", "stmt.kind.describe", pb.StatementKind_STATEMENT_KIND_DESCRIBE},
 	{"EXPLAIN (query)", "EXPLAIN SELECT id FROM users", "result.read + stmt.kind.explain", pb.StatementKind_STATEMENT_KIND_EXPLAIN},
 	{"EXPLAIN ANALYZE", "EXPLAIN ANALYZE SELECT id FROM users", "result.read + stmt.kind.explain", pb.StatementKind_STATEMENT_KIND_EXPLAIN},
-	{"EXPLAIN (table)", "EXPLAIN users", "stmt.kind.describe", pb.StatementKind_STATEMENT_KIND_DESCRIBE}, // EXPLAIN <table> is AST-identical to DESCRIBE <table>
+	{"EXPLAIN (table)", "EXPLAIN users", "stmt.kind.describe", pb.StatementKind_STATEMENT_KIND_DESCRIBE},                 // EXPLAIN <table> is AST-identical to DESCRIBE <table>
 	{"EXPLAIN TABLE", "EXPLAIN TABLE users", "result.read + stmt.kind.explain", pb.StatementKind_STATEMENT_KIND_EXPLAIN}, // TABLE t is SELECT * FROM t shorthand — a plan of a scan, gated as a read
 	{"HELP", "HELP 'contents'", "stmt.kind.help + unanalyzable→exception.unanalyzable", pb.StatementKind_STATEMENT_KIND_HELP},
 	{"USE", "USE acme", "stmt.kind.use", pb.StatementKind_STATEMENT_KIND_USE},

--- a/analyzer/probe/statement_facts_test.go
+++ b/analyzer/probe/statement_facts_test.go
@@ -268,10 +268,12 @@ func TestStatementFactsExplainKind(t *testing.T) {
 		{"mysql describe table shorthand", mysqlFacts(t, "DESCRIBE TABLE users"), true, pb.StatementKind_STATEMENT_KIND_EXPLAIN},
 		{"mysql desc table shorthand", mysqlFacts(t, "DESC TABLE users"), true, pb.StatementKind_STATEMENT_KIND_EXPLAIN},
 		{"mysql describe table", mysqlFacts(t, "DESCRIBE users"), true, pb.StatementKind_STATEMENT_KIND_DESCRIBE},
-		// The pinned parser degrades EXPLAIN ANALYZE/FORMAT=JSON over TABLE shorthand to Command → the
-		// accepted over-deny (unanalyzable, fail-closed), not a silent metadata pass.
-		{"mysql explain analyze table fail-closed", mysqlFacts(t, "EXPLAIN ANALYZE TABLE users"), true, pb.StatementKind_STATEMENT_KIND_STMT_UNKNOWN},
-		{"mysql explain format table fail-closed", mysqlFacts(t, "EXPLAIN FORMAT=JSON TABLE users"), true, pb.StatementKind_STATEMENT_KIND_STMT_UNKNOWN},
+		{"mysql explain analyze table", mysqlFacts(t, "EXPLAIN ANALYZE TABLE users"), true, pb.StatementKind_STATEMENT_KIND_EXPLAIN},
+		{"mysql explain format table", mysqlFacts(t, "EXPLAIN FORMAT=JSON TABLE users"), true, pb.StatementKind_STATEMENT_KIND_EXPLAIN},
+		// PostgreSQL parses TABLE-shorthand under EXPLAIN as kind=EXPLAIN over a Table target — the same
+		// plan-of-a-scan, so it must route through lineage, never the bare-table metadata passthrough.
+		{"pg explain table", postgresFacts(t, "EXPLAIN TABLE users"), true, pb.StatementKind_STATEMENT_KIND_EXPLAIN},
+		{"pg explain analyze table", postgresFacts(t, "EXPLAIN ANALYZE TABLE users"), true, pb.StatementKind_STATEMENT_KIND_EXPLAIN},
 		// A write keeps its own kind, plan-only or ANALYZE, so it gates + denies as the write. The
 		// MATERIALIZING forms are the security boundary — an EXPLAIN ANALYZE that copies masked PII into a
 		// new/other table must NOT classify as the read-shaped EXPLAIN kind (which would run unmasked). Each

--- a/goproxy/go.mod
+++ b/goproxy/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/ridi-oss/sqlglot-go v0.29.0 // indirect
+	github.com/ridi-oss/sqlglot-go v0.33.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.6 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect

--- a/goproxy/go.sum
+++ b/goproxy/go.sum
@@ -105,8 +105,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/ridi-oss/sqlglot-go v0.29.0 h1:57pno9UcLVeyNpsyxJMoWdGWkc97N/QEB6NqBU3o7rA=
-github.com/ridi-oss/sqlglot-go v0.29.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
+github.com/ridi-oss/sqlglot-go v0.33.0 h1:+Jr6I6EhjXnUMso3DUMwQIgDDSW3CbgrE9MhAVMcppA=
+github.com/ridi-oss/sqlglot-go v0.33.0/go.mod h1:uj8jRoyYvCZFR94rVzQs6s5xCKkOqZXlf6Ye9dCXNFE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/shirou/gopsutil/v4 v4.26.6 h1:Mzr/npDtQC/xpeEuQKHZt8Zo9CmPvhTj8nkR8w5TLDs=


### PR DESCRIPTION
v0.33.0 parses every EXPLAIN form as Describe with a real target, so the modifier TABLE-shorthand forms (`EXPLAIN ANALYZE TABLE t`, `EXPLAIN FORMAT=JSON TABLE t`) analyze and gate as plan-only EXPLAINs instead of failing closed. PostgreSQL parses the shorthand as `kind=EXPLAIN` over a Table target: `isTableShorthandDescribe` accepts that shape too, routing it through lineage — required with this bump, or PG's `EXPLAIN TABLE t` would resolve as bare-table metadata passthrough and relay a scan plan as metadata. Parser-degraded forms (trailing garbage, PG `TABLE ONLY t`/`TABLE t *`, MySQL `PARTITION`/`AS JSON` after modifier+TABLE) stay fail-closed, now pinned by analyzer tests.

goproxy's transitive pin rides along (`check-image-gomod`).

Verified: analyzer suite uncached, DB-backed EXPLAIN view/gate tests, `mise run verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvrD1afHaM1nk5fWvRFWTK