### PR TITLE
feat(web): review a workflow request statement by statement

### DIFF
--- a/web/messages/en/workflows.json
+++ b/web/messages/en/workflows.json
@@ -126,11 +126,13 @@
     "discoverFailed": "Couldn't check roles.",
     "retry": "Retry",
     "selectRole": "Select a role",
-    "noRolesFound": "No role can run this query.",
+    "noRolesFound": "No role can run every statement.",
     "outcome": {
       "ALLOW": "cleartext",
       "MASK": "masked"
-    }
+    },
+    "sqlHint": "Several statements are allowed — separate them with ;. They run in order, and stop at the first one that is denied.",
+    "statementCount": "{count, plural, one {# statement} other {# statements}}"
   },
   "roleComposer": {
     "submittedToast": "Access request submitted — awaiting approver review",
@@ -174,7 +176,12 @@
     "awaitingApprover": "Awaiting an approver to run this query.",
     "rejectTitle": "Reject query approval",
     "rejectDescription": "Reject this query approval request from {principal}.",
-    "rejectPlaceholder": "Explain why this query should not be approved."
+    "rejectPlaceholder": "Explain why this query should not be approved.",
+    "statementsHeading": "Statements",
+    "statementLabel": "Statement {n} of {total}",
+    "statementTab": "Statement {n}",
+    "statementRows": "{rows, plural, one {# row} other {# rows}}",
+    "batchSummary": "{count, plural, one {# statement} other {# statements}}"
   },
   "approveDialog": {
     "approveFailed": "approve failed",

--- a/web/messages/ko/workflows.json
+++ b/web/messages/ko/workflows.json
@@ -126,11 +126,13 @@
     "discoverFailed": "역할을 확인하지 못했습니다.",
     "retry": "다시 시도",
     "selectRole": "역할 선택",
-    "noRolesFound": "이 쿼리를 실행할 수 있는 역할이 없습니다.",
+    "noRolesFound": "모든 문장을 실행할 수 있는 역할이 없습니다.",
     "outcome": {
       "ALLOW": "평문",
       "MASK": "마스킹"
-    }
+    },
+    "sqlHint": "여러 문장을 입력할 수 있습니다 — ;로 구분하세요. 순서대로 실행되며, 거부되는 문장에서 멈춥니다.",
+    "statementCount": "문장 {count}개"
   },
   "roleComposer": {
     "submittedToast": "액세스 요청이 제출되었습니다 — 승인자 검토 대기 중",
@@ -174,7 +176,12 @@
     "awaitingApprover": "승인자가 이 쿼리를 실행하기를 기다리는 중입니다.",
     "rejectTitle": "쿼리 승인 반려",
     "rejectDescription": "{principal}의 이 쿼리 승인 요청을 반려합니다.",
-    "rejectPlaceholder": "이 쿼리를 승인하면 안 되는 이유를 설명하세요."
+    "rejectPlaceholder": "이 쿼리를 승인하면 안 되는 이유를 설명하세요.",
+    "statementsHeading": "문장",
+    "statementLabel": "{total}개 중 {n}번째 문장",
+    "statementTab": "{n}번 문장",
+    "statementRows": "{rows}행",
+    "batchSummary": "문장 {count}개"
   },
   "approveDialog": {
     "approveFailed": "승인에 실패했습니다",

--- a/web/src/components/approvals/approval-detail.tsx
+++ b/web/src/components/approvals/approval-detail.tsx
@@ -2,15 +2,15 @@
 
 import { useEffect, useState, type ReactNode } from 'react'
 import { useTranslations } from 'next-intl'
-import useSWR, { mutate as globalMutate } from 'swr'
+import { mutate as globalMutate } from 'swr'
 import { toast } from 'sonner'
-import { ApiError, cancelApproval, executeApproval, getApprovalResult, rejectApproval } from '@/lib/api/client'
+import { cancelApproval, executeApproval, rejectApproval } from '@/lib/api/client'
 import { onTaskEvent, subscribeTaskEvents } from '@/lib/api/task-events'
-import { translateApiError } from '@/lib/i18n/errors'
 import { swrKeys, useApproval } from '@/lib/hooks'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable'
 import {
   Dialog,
   DialogContent,
@@ -22,6 +22,7 @@ import {
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { ErrorState, LoadingState } from '@/components/page-scaffold'
+import { ApprovalResultTabs } from './approval-result-tabs'
 import { ApproveQueryDialog } from './approve-query-dialog'
 
 const STATUS_STYLE: Record<string, string> = {
@@ -34,6 +35,7 @@ const STATUS_STYLE: Record<string, string> = {
   FAILED: 'border-red-500/30 bg-red-500/10 text-red-500',
   CANCELLED: 'border-border text-muted-foreground',
   DELETED: 'border-border text-muted-foreground',
+  SKIPPED: 'border-border text-muted-foreground',
 }
 
 const DECISION_STYLE: Record<string, string> = {
@@ -57,42 +59,11 @@ function Field({ label, children }: { label: string; children: ReactNode }) {
   )
 }
 
-function ResultGrid({ columns, rows }: { columns: string[]; rows: (string | null)[][] }) {
-  const t = useTranslations('Workflows')
-  return (
-    <div className="border-border overflow-x-auto rounded-lg border">
-      <table className="w-full text-left text-xs">
-        <thead className="bg-muted/50 text-muted-foreground">
-          <tr>
-            {columns.map((c) => (
-              <th key={c} className="px-3 py-2 font-mono font-medium whitespace-nowrap">{c}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {rows.length === 0 ? (
-            <tr>
-              <td colSpan={Math.max(columns.length, 1)} className="text-muted-foreground px-3 py-3">
-                {t('approvalDetail.noRows')}
-              </td>
-            </tr>
-          ) : (
-            rows.map((row, i) => (
-              <tr key={i} className="border-border/60 border-t">
-                {row.map((v, j) => (
-                  <td key={j} className="text-foreground/90 px-3 py-1.5 font-mono whitespace-pre">
-                    {v ?? <span className="text-muted-foreground">NULL</span>}
-                  </td>
-                ))}
-              </tr>
-            ))
-          )}
-        </tbody>
-      </table>
-    </div>
-  )
-}
-
+/**
+ * One statement of the request, with its own status and — once it has rows and the viewer may see them —
+ * its own result grid. Each statement is authorized and stored separately, so it is labelled by what
+ * happened to IT, never by the task's overall status.
+ */
 function Pill({ value, styles }: { value?: string | null; styles: Record<string, string> }) {
   if (!value) return <span className="text-muted-foreground">—</span>
   return (
@@ -122,17 +93,10 @@ export function ApprovalDetail({ id }: { id: number }) {
   // (RUNNING → DONE | FAILED). Gating on `runStarted` — not on `result` — keeps the Run button visible
   // while APPROVED-not-yet-run, and keeps progress/rows/error visible once the parent leaves APPROVED.
   const runStarted = result != null && result.status != null
-  const canViewRows = result?.status === 'DONE'
-
-  // Only an expected absence (404 can't-assume, 409 not-ready) becomes null; a 5xx re-throws so SWR retries.
-  const { data: resultView } = useSWR(
-    canViewRows || result?.status === 'FAILED' ? (['approval-result', id] as const) : null,
-    () =>
-      getApprovalResult(id).catch((e) => {
-        if (e instanceof ApiError && (e.status === 404 || e.status === 409)) return null
-        throw e
-      }),
-  )
+  // Every statement of the batch, in run order. A single-statement request has one entry, so the same
+  // rendering covers both without a special case. Each statement fetches its own rows and error detail
+  // (StatementResult), so there is no task-level result fetch here.
+  const statements = data?.statements ?? []
 
   // Task-event push: revalidate the moment this task terminalizes (execute done, cancel) instead of waiting
   // for the 15s poll. Best-effort accelerator — the refreshInterval above remains the fallback on stream absence.
@@ -210,8 +174,16 @@ export function ApprovalDetail({ id }: { id: number }) {
 
   const approvedCopy = t('approvalDetail.approvedExecuteUnderR')
 
+  const ranStatements = statements.filter((s) => s.status === 'DONE' || s.status === 'FAILED')
+
   return (
-    <>
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+      {/* Details scroll above, results dock below on a drag handle — the editor's editor-over-results
+          split, so a long script never pushes the rows off-screen. */}
+      <ResizablePanelGroup orientation="vertical" className="min-h-0 flex-1">
+        <ResizablePanel defaultSize={ranStatements.length > 0 ? 55 : 100} minSize={20}>
+          <div className="h-full min-h-0 overflow-y-auto">
+            <div className="mx-auto w-full max-w-5xl p-6">
       <Card>
         <CardHeader>
           <div className="flex flex-wrap items-start justify-between gap-3">
@@ -270,11 +242,22 @@ export function ApprovalDetail({ id }: { id: number }) {
             </Field>
           </div>
 
-          <Field label={t('fields.sql')}>
-            <pre className="border-border bg-muted/40 text-foreground/90 mt-1 overflow-x-auto rounded-lg border p-3 font-mono text-xs leading-relaxed whitespace-pre-wrap break-words">
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-muted-foreground text-[10px] font-semibold tracking-widest uppercase">
+                {t('approvalDetail.statementsHeading')}
+              </p>
+              {statements.length > 1 && (
+                <span className="text-muted-foreground text-xs">
+                  {t('approvalDetail.batchSummary', { count: statements.length })}
+                </span>
+              )}
+            </div>
+            {/* The submitted script verbatim, terminators and all — what the requester actually wrote. */}
+            <pre className="border-border bg-muted/40 text-foreground/90 overflow-x-auto rounded-lg border p-3 font-mono text-xs leading-relaxed whitespace-pre-wrap break-words">
               {request.sql ?? '—'}
             </pre>
-          </Field>
+          </div>
 
           <div className="grid gap-4 sm:grid-cols-2">
             <Field label={t('fields.denyReason')}>{request.denyReason ?? '—'}</Field>
@@ -338,18 +321,6 @@ export function ApprovalDetail({ id }: { id: number }) {
                     )}
                   </div>
 
-                  {result.status === 'FAILED' && result.errorCode && (
-                    <div className="space-y-1 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-500">
-                      <div>{t('approvalDetail.failedCode', { code: translateApiError(result.errorCode) })}</div>
-                      {resultView?.errorDetail && (
-                        <div className="font-mono text-xs break-words opacity-80">{resultView.errorDetail}</div>
-                      )}
-                    </div>
-                  )}
-
-                  {canViewRows && resultView && (
-                    <ResultGrid columns={resultView.columns} rows={resultView.rows} />
-                  )}
                 </div>
               )}
 
@@ -362,6 +333,23 @@ export function ApprovalDetail({ id }: { id: number }) {
           )}
         </CardContent>
       </Card>
+            </div>
+          </div>
+        </ResizablePanel>
+
+        {ranStatements.length > 0 && (
+          <>
+            <ResizableHandle />
+            <ResizablePanel defaultSize={45} minSize={15}>
+              <ApprovalResultTabs
+                taskId={id}
+                datasourceId={request.datasourceId ?? null}
+                statements={statements}
+              />
+            </ResizablePanel>
+          </>
+        )}
+      </ResizablePanelGroup>
 
       <ApproveQueryDialog
         key={approveOpen ? request.id : 'closed'}
@@ -407,6 +395,6 @@ export function ApprovalDetail({ id }: { id: number }) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </>
+    </div>
   )
 }

--- a/web/src/components/approvals/approval-result-tabs.tsx
+++ b/web/src/components/approvals/approval-result-tabs.tsx
@@ -1,0 +1,198 @@
+'use client'
+
+// The approval page's result workspace, matching the editor's: a permanent Logs tab first, then one tab
+// per statement that ran. The editor builds its tabs by RUNNING queries; a decided request already has its
+// results stored, so these tabs read them instead — the presentation (ResultsPanel, QueryLogs) is shared.
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useTranslations } from 'next-intl'
+import useSWR from 'swr'
+import { ScrollText } from 'lucide-react'
+import { ApiError, getApprovalResult } from '@/lib/api/client'
+import type { QueryResponse, QueryResultMeta, QueryResultView } from '@/lib/api/types'
+import { translateApiError } from '@/lib/i18n/errors'
+import { cn } from '@/lib/utils'
+import { QueryLogs } from '@/components/query/query-logs'
+import { ResultsPanel } from '@/components/query/results-panel'
+import type { QueryLogEntry } from '@/components/query/use-result-tabs'
+
+/** A stored result rendered through the editor's panel, which speaks QueryResponse. */
+function asQueryResponse(view: QueryResultView, meta: QueryResultMeta): QueryResponse {
+  return {
+    decision: view.decision ?? 'ALLOW',
+    decisionId: meta.decisionId ?? null,
+    denyReason: meta.denyReason ?? null,
+    maskedColumns: view.maskedColumns ?? [],
+    piiTouched: [],
+    effectiveRoles: [],
+    columns: view.columns ?? [],
+    rows: view.rows ?? [],
+    rowsAffected: meta.rowCount ?? null,
+    latencyMs: 0,
+  }
+}
+
+function StatementTab({
+  taskId,
+  statement,
+  datasourceId,
+  onLog,
+}: {
+  taskId: number
+  statement: QueryResultMeta
+  datasourceId: number | null
+  onLog: (entry: QueryLogEntry) => void
+}) {
+  const canViewRows = statement.status === 'DONE'
+  // FAILED is fetched too: the view carries this statement's target-DB errorDetail, released per viewer.
+  // Only an expected absence (404 can't-assume, 409 not-ready) becomes null; a 5xx re-throws so SWR retries.
+  const { data: view, error } = useSWR(
+    canViewRows || statement.status === 'FAILED'
+      ? (['approval-result', taskId, statement.ordinal] as const)
+      : null,
+    () =>
+      getApprovalResult(taskId, statement.ordinal).catch((e) => {
+        if (e instanceof ApiError && (e.status === 404 || e.status === 409)) return null
+        throw e
+      }),
+  )
+
+  const failure =
+    statement.status === 'FAILED'
+      ? [statement.errorCode ? translateApiError(statement.errorCode) : null, view?.errorDetail]
+          .filter(Boolean)
+          .join('\n')
+      : null
+
+  // Feed the Logs tab one line per statement, the way a run does in the editor.
+  const entry = useMemo<QueryLogEntry>(
+    () => ({
+      id: `${taskId}:${statement.ordinal}`,
+      datasourceId: datasourceId ?? 0,
+      statement: statement.sql ?? '',
+      // ERROR, not DENY: a FAILED statement was authorized and then failed on the target DB. A DENY here
+      // would read as "policy refused it", which is a different outcome entirely.
+      decision: statement.status === 'FAILED' ? 'ERROR' : (view?.decision ?? 'ALLOW'),
+      denyReason: failure,
+      rowsReturned: statement.rowCount ?? 0,
+      latencyMs: 0,
+      error: failure,
+      timestamp: statement.executedAt ?? '',
+    }),
+    [taskId, datasourceId, statement, view, failure],
+  )
+  useEffect(() => {
+    onLog(entry)
+  }, [entry, onLog])
+
+  return (
+    <ResultsPanel
+      result={view && canViewRows ? asQueryResponse(view, statement) : null}
+      running={false}
+      error={failure ?? (error ? String(error) : null)}
+      onRequestAccess={() => {}}
+    />
+  )
+}
+
+export function ApprovalResultTabs({
+  taskId,
+  datasourceId,
+  statements,
+}: {
+  taskId: number
+  datasourceId: number | null
+  statements: QueryResultMeta[]
+}) {
+  const t = useTranslations('Query')
+  const tq = useTranslations('Workflows')
+  // Only statements that RAN have a result to show; a skipped one is visible in the script above.
+  const ran = statements.filter((s) => s.status === 'DONE' || s.status === 'FAILED')
+  const [activeOrdinal, setActiveOrdinal] = useState<number | null>(ran[0]?.ordinal ?? null)
+  const [viewingLogs, setViewingLogs] = useState(false)
+  const [logs, setLogs] = useState<Record<string, QueryLogEntry>>({})
+
+  // Compared by VALUE and stable across renders: the effect below rebuilds its entry object every render,
+  // so an identity check would set state forever.
+  const addLog = useCallback((entry: QueryLogEntry) => {
+    setLogs((prev) => {
+      const seen = prev[entry.id]
+      if (seen && JSON.stringify(seen) === JSON.stringify(entry)) return prev
+      return { ...prev, [entry.id]: entry }
+    })
+  }, [])
+
+  if (ran.length === 0) return null
+  const active = ran.find((s) => s.ordinal === activeOrdinal) ?? ran[0]
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <div className="flex shrink-0 items-stretch overflow-x-auto border-b">
+        <div
+          role="tab"
+          aria-selected={viewingLogs}
+          onClick={() => setViewingLogs(true)}
+          className={cn(
+            'flex shrink-0 cursor-pointer items-center gap-1.5 border-r px-3 py-1.5 text-xs',
+            viewingLogs ? 'bg-background text-foreground' : 'text-muted-foreground hover:bg-muted/50',
+          )}
+        >
+          <ScrollText className="size-3.5 shrink-0" />
+          <span>{t('tabs.logs')}</span>
+        </div>
+        {ran.map((statement) => {
+          const selected = !viewingLogs && statement.ordinal === active.ordinal
+          return (
+            <div
+              key={statement.ordinal}
+              role="tab"
+              aria-selected={selected}
+              onClick={() => {
+                setViewingLogs(false)
+                setActiveOrdinal(statement.ordinal)
+              }}
+              className={cn(
+                'flex shrink-0 cursor-pointer items-center gap-1.5 border-r px-3 py-1.5 text-xs',
+                selected ? 'bg-background text-foreground' : 'text-muted-foreground hover:bg-muted/50',
+                statement.status === 'FAILED' && !selected && 'text-red-500/80',
+              )}
+              title={statement.sql ?? undefined}
+            >
+              <span className={cn(statement.status === 'FAILED' && 'text-red-500')}>
+                {tq('approvalDetail.statementTab', { n: statement.ordinal + 1 })}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        {viewingLogs ? (
+          <QueryLogs logs={ran.map((s) => logs[`${taskId}:${s.ordinal}`]).filter(Boolean)} clearLogs={() => setLogs({})} />
+        ) : (
+          <StatementTab
+            key={active.ordinal}
+            taskId={taskId}
+            statement={active}
+            datasourceId={datasourceId}
+            onLog={addLog}
+          />
+        )}
+        {/* Every statement mounts so the Logs tab is complete without visiting each one; only the
+            active one is visible. */}
+        <div className="hidden">
+          {ran
+            .filter((s) => s.ordinal !== active.ordinal)
+            .map((s) => (
+              <StatementTab
+                key={s.ordinal}
+                taskId={taskId}
+                statement={s}
+                datasourceId={datasourceId}
+                onLog={addLog}
+              />
+            ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/workflows/query-request-composer.tsx
+++ b/web/src/components/workflows/query-request-composer.tsx
@@ -270,11 +270,12 @@ export function QueryRequestComposer({
                     id="approval-sql"
                     value={sql}
                     onChange={(e) => setSql(e.target.value)}
-                    placeholder="SELECT id, ssn FROM users WHERE id = 1"
+                    placeholder={'SELECT id, ssn FROM users WHERE id = 1;\nUPDATE users SET status = 1 WHERE id = 1;'}
                     rows={8}
                     required
                     className="font-mono text-xs"
                   />
+                  <p className="text-muted-foreground text-xs">{t('queryComposer.sqlHint')}</p>
                 </div>
               </CardContent>
             </Card>

--- a/web/src/components/workflows/workflow-request-list.tsx
+++ b/web/src/components/workflows/workflow-request-list.tsx
@@ -50,9 +50,12 @@ function requestContext(entry: WorkflowRequestEntry, t: Translator): string {
 
 function requestPreview(entry: WorkflowRequestEntry, t: Translator): string {
   const { request } = entry
-  if (request.kind === 'QUERY') return oneLine(request.sql, t)
-
-  return request.reason ?? ''
+  if (request.kind !== 'QUERY') return request.reason ?? ''
+  const preview = oneLine(request.sql, t)
+  // A batch collapses to one line, so say how many statements it holds — otherwise the preview reads as a
+  // single statement that happens to be long.
+  const count = request.statementCount ?? 1
+  return count > 1 ? `${preview} (${t('queryComposer.statementCount', { count })})` : preview
 }
 
 export function WorkflowRequestList({

--- a/web/src/components/workflows/workflows-master-detail.tsx
+++ b/web/src/components/workflows/workflows-master-detail.tsx
@@ -39,6 +39,15 @@ export type WorkflowComposeDraft =
       sourceDecisionError?: string | null
     }
 
+/** The scroll + centered padding every detail view but the query one (which owns its full height) uses. */
+function DetailScroll({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto w-full max-w-5xl p-6">{children}</div>
+    </div>
+  )
+}
+
 function DetailPanel({
   selectedId,
   compose,
@@ -65,24 +74,26 @@ function DetailPanel({
   const composeError = compose?.kind === 'QUERY' ? compose.sourceDecisionError : null
 
   if (invalidSelectedId) {
-    return <ErrorState error={t('masterDetail.invalidRequestId')} />
+    return <DetailScroll><ErrorState error={t('masterDetail.invalidRequestId')} /></DetailScroll>
   }
   if (composeError) {
-    return <ErrorState error={composeError} />
+    return <DetailScroll><ErrorState error={composeError} /></DetailScroll>
   }
   if (auxiliary === 'ACTIVE_GRANTS') {
-    return <ActiveRoleGrants />
+    return <DetailScroll><ActiveRoleGrants /></DetailScroll>
   }
   if (compose?.kind === 'ROLE') {
-    return <RoleRequestComposer onCreated={onCreated} onCancel={onCancel} />
+    return <DetailScroll><RoleRequestComposer onCreated={onCreated} onCancel={onCancel} /></DetailScroll>
   }
   if (compose?.kind === 'QUERY') {
     return (
-      <QueryRequestComposer
-        sourceDecisionId={compose.sourceDecisionId}
-        onCreated={onCreated}
-        onCancel={onCancel}
-      />
+      <DetailScroll>
+        <QueryRequestComposer
+          sourceDecisionId={compose.sourceDecisionId}
+          onCreated={onCreated}
+          onCancel={onCancel}
+        />
+      </DetailScroll>
     )
   }
 
@@ -92,20 +103,22 @@ function DetailPanel({
       ?? (selectedEntry?.request.kind === 'ROLE' ? selectedEntry.request : null)
 
     if (selectedRoleRequest) {
-      return <RoleRequestDetail request={selectedRoleRequest} />
+      return <DetailScroll><RoleRequestDetail request={selectedRoleRequest} /></DetailScroll>
     }
     if (selectedEntry?.request.kind === 'QUERY') {
+      // Full height, no wrapper scroll: this one docks its results panel at the bottom and scrolls its
+      // own details pane, the way the editor does.
       return (
-        <div data-workflow-detail-kind="QUERY">
+        <div data-workflow-detail-kind="QUERY" className="flex min-h-0 flex-1 flex-col">
           <ApprovalDetail id={selectedId} />
         </div>
       )
     }
     if (roleLookupLoading) {
-      return <LoadingState label={t('masterDetail.lookingUpType')} />
+      return <DetailScroll><LoadingState label={t('masterDetail.lookingUpType')} /></DetailScroll>
     }
     if (roleLookupError) {
-      return <ErrorState error={roleLookupError} />
+      return <DetailScroll><ErrorState error={roleLookupError} /></DetailScroll>
     }
 
     return (
@@ -116,11 +129,13 @@ function DetailPanel({
   }
 
   return (
-    <EmptyState
-      icon={<Inbox className="size-9" />}
-      title={t('masterDetail.selectRequestTitle')}
-      hint={t('masterDetail.selectRequestHint')}
-    />
+    <DetailScroll>
+      <EmptyState
+        icon={<Inbox className="size-9" />}
+        title={t('masterDetail.selectRequestTitle')}
+        hint={t('masterDetail.selectRequestHint')}
+      />
+    </DetailScroll>
   )
 }
 
@@ -242,20 +257,18 @@ export function WorkflowsMasterDetail({
           </div>
         </div>
 
-        <div data-testid="workflow-detail-panel" className="min-h-0 flex-1 overflow-y-auto">
-          <div className="mx-auto w-full max-w-5xl p-6">
-            <DetailPanel
-              selectedId={selectedId}
-              compose={compose}
-              auxiliary={auxiliary}
-              lists={lists}
-              roleRequestsById={roleRequestsById}
-              roleLookupLoading={roleLookupLoading}
-              roleLookupError={roleLookupError}
-              onCreated={handleCreated}
-              onCancel={() => router.push('/workflows')}
-            />
-          </div>
+        <div data-testid="workflow-detail-panel" className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <DetailPanel
+            selectedId={selectedId}
+            compose={compose}
+            auxiliary={auxiliary}
+            lists={lists}
+            roleRequestsById={roleRequestsById}
+            roleLookupLoading={roleLookupLoading}
+            roleLookupError={roleLookupError}
+            onCreated={handleCreated}
+            onCancel={() => router.push('/workflows')}
+          />
         </div>
       </div>
     </div>

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -593,8 +593,10 @@ export function cancelApproval(id: number): Promise<AccessRequest> {
 }
 
 /** Fetch decrypted rows after the latest child reaches DONE. */
-export function getApprovalResult(id: number): Promise<QueryResultView> {
-  return request<QueryResultView>(`/api/approvals/${id}/result`)
+/** [ordinal] selects one statement of a batch; omit it for the active statement. */
+export function getApprovalResult(id: number, ordinal?: number): Promise<QueryResultView> {
+  const qs = ordinal == null ? '' : `?statement=${ordinal}`
+  return request<QueryResultView>(`/api/approvals/${id}/result${qs}`)
 }
 
 // ---- Wire tokens (expiring-only) -------------------------------------------

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -341,8 +341,11 @@ export interface AccessRequest {
   rejectionReason?: string | null
   createdAt: string
   kind: 'ROLE' | 'QUERY'
+  /** The task's statements joined in run order — the request's readable form, never what is authorized. */
   sql?: string | null
   sqlHash?: string | null
+  /** How many statements the task holds. 1 for an ordinary single-statement request. */
+  statementCount?: number
   denyReason?: string | null
   sourceDecisionId?: number | null
   title?: string | null
@@ -403,11 +406,16 @@ export interface DiscoverRolesResponse {
 /** Latest task-child metadata — never the rows themselves. */
 export interface QueryResultMeta {
   taskId: number
+  /** The statement's 0-based position in its task's batch. A single-statement task has only ordinal 0. */
+  ordinal: number
+  /** The statement itself. */
+  sql?: string | null
   executedBy?: string | null
   executedAt?: string | null
   rowCount?: number | null
   expiresAt?: string | null
-  status?: 'RUNNING' | 'DONE' | 'FAILED' | 'CANCELLED' | null
+  /** SKIPPED: a statement the batch never reached, because an earlier one denied or failed. */
+  status?: 'RUNNING' | 'DONE' | 'FAILED' | 'CANCELLED' | 'SKIPPED' | null
   errorCode?: string | null
   /**
    * Present only when the failure was a POLICY DENIAL: the reason the decision recorded, and the audit
@@ -423,6 +431,8 @@ export interface ApprovalDetail {
   request: AccessRequest
   canDecide: boolean
   result?: QueryResultMeta | null
+  /** Every statement of the batch, in run order. One entry for a single-statement request. */
+  statements?: QueryResultMeta[]
   canExecute?: boolean
   canCancel?: boolean
 }


### PR DESCRIPTION
The detail rendered one SQL blob with one result grid, which cannot say which statement produced which
rows or which one stopped the run.

The submitted script now stays whole at the top — semicolons and all, as written — and the results
dock at the bottom of the pane in the editor's own panel: a Logs tab with the whole execution as a
console trace, then one tab per statement that ran, each with its rows or its target-DB error.

Reusing the editor's `ResultsPanel` and `QueryLogs` is what keeps a large result bounded: the panel is
a fixed pane that scrolls internally, so a batch returning thousands of rows per statement no longer
grows the page without limit.

Only statements that RAN get a tab; a skipped one has nothing to show beyond its place in the script
above. A FAILED statement logs as ERROR, not DENY — it was authorized and then failed on the target
DB, which is a different outcome from a policy refusal.

Docking required the workflows detail pane to stop being a scroll-and-pad container, since the panel
needs the full height. That container is shared, so the other detail views (role request, composers,
active grants, empty state) keep their previous scroll and padding through a `DetailScroll` wrapper —
verified unchanged in the browser.

The list preview shows the statement count so a collapsed line isn't read as one long statement.

Verified: `mise run verify` green on this commit alone — 1220 control-plane, 65 engine tests, plus the
web build; and exercised in the console against a real batch (2 statements with rows, 1 failed, 1
skipped).
