### PR TITLE
fix(auditmon): walk the tail in bounded batches

### DIFF
--- a/auditmon/config/config.go
+++ b/auditmon/config/config.go
@@ -204,7 +204,10 @@ type SinkConfig struct {
 
 // MonitorConfig is the poll/sign loop and its off-box store + signer.
 type MonitorConfig struct {
-	PollInterval       time.Duration `koanf:"poll_interval"`
+	PollInterval time.Duration `koanf:"poll_interval"`
+	// TailBatch bounds each tail read of the verify/export loop, so a backlog accumulated while the
+	// monitor was down is walked in batches instead of materialized in memory at once.
+	TailBatch          int           `koanf:"tail_batch"`
 	SignInterval       time.Duration `koanf:"sign_interval"`
 	FullVerifyInterval time.Duration `koanf:"full_verify_interval"`
 	Bucket             string        `koanf:"bucket"`
@@ -228,6 +231,7 @@ type SignerConfig struct {
 // that itself contains underscores (poll_interval, key_path) is never mis-split into extra nesting levels.
 var envKeyMap = map[string]string{
 	"AUDITMON_MONITOR_POLL_INTERVAL":        "monitor.poll_interval",
+	"AUDITMON_MONITOR_TAIL_BATCH":           "monitor.tail_batch",
 	"AUDITMON_MONITOR_SIGN_INTERVAL":        "monitor.sign_interval",
 	"AUDITMON_MONITOR_FULL_VERIFY_INTERVAL": "monitor.full_verify_interval",
 	"AUDITMON_MONITOR_BUCKET":               "monitor.bucket",
@@ -247,6 +251,7 @@ const (
 	// boots and monitors. A monitor that refuses to start is worth strictly less than one polling at a
 	// sensible cadence, and every value here is overridable.
 	defaultPollInterval = 90 * time.Second
+	defaultTailBatch    = 5000
 	defaultSignInterval = time.Hour
 	// filekey is the dev signer; a real deployment sets signer.type: kms and a key id. Choosing filekey as
 	// the default keeps the fallback the one that cannot silently sign with someone else's key.
@@ -288,6 +293,9 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Monitor.PollInterval == 0 {
 		cfg.Monitor.PollInterval = defaultPollInterval
+	}
+	if cfg.Monitor.TailBatch == 0 {
+		cfg.Monitor.TailBatch = defaultTailBatch
 	}
 	if cfg.Monitor.SignInterval == 0 {
 		cfg.Monitor.SignInterval = defaultSignInterval
@@ -378,6 +386,9 @@ func (c *Config) Validate() error {
 	m := c.Monitor
 	if m.PollInterval <= 0 {
 		return fmt.Errorf("config: monitor.poll_interval must be > 0")
+	}
+	if c.Monitor.TailBatch < 0 {
+		return fmt.Errorf("config: monitor.tail_batch must be >= 0 (0 means the default)")
 	}
 	if m.SignInterval <= 0 {
 		return fmt.Errorf("config: monitor.sign_interval must be > 0")

--- a/auditmon/detect/detect.go
+++ b/auditmon/detect/detect.go
@@ -82,6 +82,17 @@ func New(reader WindowReader, sink AlertSink, rules config.RulesConfig) (*Detect
 // needsWindow reports whether any rate rule is enabled (and so a window read is worthwhile this poll).
 func (d *Detector) needsWindow() bool { return d.maxWindow > 0 }
 
+// InspectCatchUp evaluates only the per-event rules on a mid-catch-up batch. The rate rules re-read the
+// whole durable window on every call, so running them once per backlog batch would multiply that read by
+// the batch count — and mid-walk the window can hold rows the chain walk has not verified yet. Catch-up
+// batches take this path; the walk's final batch runs the full Inspect, whose window then covers every row
+// the catch-up shipped.
+func (d *Detector) InspectCatchUp(fresh []store.StoredEvent) error {
+	d.evalOffHours(fresh)
+	d.evalOffHoursAdmin(fresh)
+	return nil
+}
+
 // Inspect evaluates every enabled rule for the poll. off_hours runs on the fresh batch alone; the rate rules
 // read one window of the durable trail (widest rule window) and each re-floors it to its own window. A window
 // read failure is returned for the monitor to log and retry; it never blocks the loop.

--- a/auditmon/detect/detect_test.go
+++ b/auditmon/detect/detect_test.go
@@ -54,7 +54,7 @@ func seedAndInspect(t *testing.T, rules config.RulesConfig, events []canon.Audit
 	}
 	t.Cleanup(reader.Close)
 
-	fresh, err := reader.TailEvents(ctx, 0)
+	fresh, err := reader.TailEvents(ctx, 0, 10000)
 	if err != nil {
 		t.Fatalf("read fresh: %v", err)
 	}

--- a/auditmon/internal/dbtest/dbtest.go
+++ b/auditmon/internal/dbtest/dbtest.go
@@ -20,10 +20,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/moby/moby/api/types/network"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // registers the "pgx" database/sql driver for wait.ForSQL
+	"github.com/moby/moby/api/types/network"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )

--- a/auditmon/monitor/monitor.go
+++ b/auditmon/monitor/monitor.go
@@ -29,6 +29,7 @@ import (
 // deliberately runs without rules.
 type Detector interface {
 	Inspect(events []store.StoredEvent) error
+	InspectCatchUp(fresh []store.StoredEvent) error
 }
 
 // NoopDetector does nothing.
@@ -36,6 +37,8 @@ type NoopDetector struct{}
 
 // Inspect is a no-op.
 func (NoopDetector) Inspect([]store.StoredEvent) error { return nil }
+
+func (NoopDetector) InspectCatchUp([]store.StoredEvent) error { return nil }
 
 // IntegrityReporter delivers an integrity finding. cmd/auditmon supplies the webhook reporter
 // (alert.NewReporter); LoggingReporter (slog) is the fallback that only records it.
@@ -191,11 +194,28 @@ func (m *Monitor) selectBaseline() (baseline store.ChainHead, present bool, find
 	return store.ChainHead{LastID: 0, HeadHash: m.genesis}, false, nil, nil
 }
 
-// verifyChain selects the trusted baseline anchor, reads the committed tail after it, and re-walks that
-// tail. A bad anchor signature or a chain break is reported and returns ok=false, so no caller exports or
-// signs past a detected break. It never blocks: a tamper finding is reported and swallowed, and only an
-// infrastructure failure (DB/store unreachable) is returned as an error for the Run loop to retry.
-func (m *Monitor) verifyChain(ctx context.Context) (verifiedTail, bool, error) {
+// tailBatch bounds each tail read; the config default applies when a caller (tests) left it zero.
+func (m *Monitor) tailBatch() int {
+	if m.cfg.TailBatch > 0 {
+		return m.cfg.TailBatch
+	}
+	return 5000
+}
+
+// ReasonTailTruncated: rows the walk pinned as its target before the first page were gone by the time it
+// got there — a deletion between page reads, which a short final read must not pass off as completion.
+const ReasonTailTruncated = "tail_truncated"
+
+// verifyChain selects the trusted baseline anchor, pins the walk's target (the highest committed id at the
+// start), then reads and re-walks the tail after the anchor in bounded batches, calling each on every
+// verified batch — so peak memory depends on the batch size, never on how far behind the monitor is (a long
+// outage used to OOM here and crash-loop unrecoverably). Rows appended after the pin are left for the next
+// poll, so a sustained writer cannot keep the walk from returning. A walk that ends short of its pinned
+// target means rows were deleted between page reads (each page is its own snapshot) — reported as a finding,
+// never returned as success. A verified batch is exported/anchored by each BEFORE the next page is read:
+// never a byte of an unverified segment, but a clean prefix does commit before a later batch's break is
+// found (that prefix is exactly what a restart resumes from).
+func (m *Monitor) verifyChain(ctx context.Context, each func(verifiedTail) error) (verifiedTail, bool, error) {
 	head, present, finding, err := m.selectBaseline()
 	if err != nil {
 		return verifiedTail{}, false, err
@@ -205,47 +225,84 @@ func (m *Monitor) verifyChain(ctx context.Context) (verifiedTail, bool, error) {
 		return verifiedTail{}, false, nil
 	}
 
-	events, err := m.reader.TailEvents(ctx, head.LastID)
+	target, err := m.reader.MaxEventID(ctx)
 	if err != nil {
-		return verifiedTail{}, false, fmt.Errorf("monitor: read tail: %w", err)
+		return verifiedTail{}, false, fmt.Errorf("monitor: pin tail target: %w", err)
 	}
 
-	f, err := verify.VerifyTail(head, events)
-	if err != nil {
-		return verifiedTail{}, false, fmt.Errorf("monitor: verify tail: %w", err)
-	}
-	if f != nil {
-		m.report.Report(*f)
-		return verifiedTail{}, false, nil
-	}
+	batch := m.tailBatch()
+	for {
+		events, err := m.reader.TailEvents(ctx, head.LastID, batch)
+		if err != nil {
+			return verifiedTail{}, false, fmt.Errorf("monitor: read tail: %w", err)
+		}
 
-	verified := head
-	if len(events) > 0 {
-		last := events[len(events)-1]
-		verified = store.ChainHead{LastID: last.ID, HeadHash: last.RowHash}
+		f, err := verify.VerifyTail(head, events)
+		if err != nil {
+			return verifiedTail{}, false, fmt.Errorf("monitor: verify tail: %w", err)
+		}
+		if f != nil {
+			m.report.Report(*f)
+			return verifiedTail{}, false, nil
+		}
+
+		if len(events) > 0 {
+			last := events[len(events)-1]
+			head = store.ChainHead{LastID: last.ID, HeadHash: last.RowHash}
+		}
+		vt := verifiedTail{anchorPresent: present, head: head, events: events}
+		if each != nil && len(events) > 0 {
+			if err := each(vt); err != nil {
+				return verifiedTail{}, false, err
+			}
+		}
+		if head.LastID >= target {
+			return vt, true, nil
+		}
+		if len(events) < batch {
+			m.report.Report(verify.Finding{DivergentID: head.LastID + 1, Reason: ReasonTailTruncated})
+			return verifiedTail{}, false, nil
+		}
 	}
-	return verifiedTail{anchorPresent: present, head: verified, events: events}, true, nil
 }
 
-// Poll re-verifies the committed tail against the last anchor, runs detection, and exports the rows not yet
-// exported. On the very first run (no anchor yet) it verifies from genesis and writes the initial anchor. A
-// verification break or a bad anchor signature is reported and the poll returns without exporting — the
-// break is the finding; it never blocks. A returned error is an infrastructure failure (DB/store
-// unreachable), which the Run loop logs and retries.
+// catchUpBatch is the per-batch work of a verified tail walk: detection + export of the batch's fresh rows,
+// and — while catching up through a full batch (a backlog) — a checkpoint anchor over the verified head, so
+// a crash mid-catch-up resumes from the last exported batch instead of re-walking (and re-exporting) the
+// whole backlog; the first-ever walk checkpoints the same way. The export always precedes the anchor, so no
+// row is ever stranded below an anchor. A checkpoint the store refuses (a conflicting object already at
+// that id) is logged and skipped, not fatal: the checkpoint only buys resume granularity, and wedging the
+// walk on it would trade the backlog's export for a nicer restart. Steady-state batches (shorter than the
+// batch size) leave anchor cadence to SignHead.
+func (m *Monitor) catchUpBatch(vt verifiedTail) error {
+	catchUp := len(vt.events) == m.tailBatch()
+	if err := m.processFreshMode(vt, catchUp); err != nil {
+		return err
+	}
+	if catchUp {
+		if err := m.signAnchor(vt.head); err != nil {
+			m.log.Warn("monitor: catch-up checkpoint not written; continuing", "up_to_id", vt.head.LastID, "err", err)
+		}
+	}
+	return nil
+}
+
+// Poll re-verifies the committed tail against the last anchor in bounded batches, running detection on and
+// exporting each verified batch as it goes. On the very first run (no anchor yet) it verifies from genesis,
+// checkpointing full batches the same way, and writes the final anchor at the head. A verification break or
+// a bad anchor signature is reported and the poll stops — nothing of the broken batch (or beyond) is
+// exported or signed; batches verified before it remain committed, which is what a retry resumes from. A
+// returned error is an infrastructure failure (DB/store unreachable), which the Run loop logs and retries.
 func (m *Monitor) Poll(ctx context.Context) error {
 	if m.halted.Load() {
 		return nil
 	}
-	vt, ok, err := m.verifyChain(ctx)
+	vt, ok, err := m.verifyChain(ctx, m.catchUpBatch)
 	if err != nil {
 		return err
 	}
 	if !ok {
 		return nil
-	}
-
-	if err := m.processFresh(vt); err != nil {
-		return err
 	}
 
 	// First run: establish the initial signed anchor over the verified head so later polls have a baseline
@@ -265,14 +322,23 @@ func (m *Monitor) Poll(ctx context.Context) error {
 // they would be silently dropped from the SIEM/detection feed. Running it before every signAnchor keeps the
 // anchor from ever getting ahead of the export (exportedThrough >= anchor.UpToID), which is the invariant
 // that makes the anchor safe to floor the tail read at.
-func (m *Monitor) processFresh(vt verifiedTail) error {
+func (m *Monitor) processFresh(vt verifiedTail) error { return m.processFreshMode(vt, false) }
+
+// processFreshMode: catchUp batches run only the per-event rules (InspectCatchUp) — the window rules would
+// re-read the whole durable window per batch and see rows the walk has not verified yet; the walk's final
+// batch runs the full Inspect over a window that then covers everything the catch-up shipped.
+func (m *Monitor) processFreshMode(vt verifiedTail, catchUp bool) error {
 	// Only the rows past the export watermark are new work; the rest were already shipped.
 	fresh := eventsAfter(vt.events, m.exportedThrough)
 	if len(fresh) == 0 {
 		return nil
 	}
 
-	if err := m.detect.Inspect(fresh); err != nil {
+	inspect := m.detect.Inspect
+	if catchUp {
+		inspect = m.detect.InspectCatchUp
+	}
+	if err := inspect(fresh); err != nil {
 		m.log.Warn("monitor: detector error", "err", err)
 	}
 
@@ -296,15 +362,12 @@ func (m *Monitor) SignHead(ctx context.Context) error {
 	if m.halted.Load() {
 		return nil
 	}
-	vt, ok, err := m.verifyChain(ctx)
+	vt, ok, err := m.verifyChain(ctx, m.catchUpBatch)
 	if err != nil {
 		return err
 	}
 	if !ok {
 		return nil
-	}
-	if err := m.processFresh(vt); err != nil {
-		return err
 	}
 	return m.signAnchor(vt.head)
 }
@@ -630,14 +693,12 @@ func sameFinding(a, b verify.Finding) bool {
 // A finding derived from an anchor (a witnessed row that no longer exists) has no such row, in which case the
 // resume head is the anchor's own witnessed head and the walk simply continues from where it was.
 func (m *Monitor) resumeHashAt(ctx context.Context, id int64) ([]byte, error) {
-	events, err := m.reader.ChainedEventsAfter(ctx, id-1)
+	events, err := m.reader.ChainedEventsAfter(ctx, id-1, 1)
 	if err != nil {
 		return nil, fmt.Errorf("monitor: accept: read row %d: %w", id, err)
 	}
-	for _, ev := range events {
-		if ev.ID == id {
-			return ev.RowHash, nil
-		}
+	if len(events) == 1 && events[0].ID == id {
+		return events[0].RowHash, nil
 	}
 	return nil, nil
 }
@@ -653,15 +714,12 @@ func (m *Monitor) ResumeCoverage(ctx context.Context) error {
 	if m.halted.Load() {
 		return fmt.Errorf("monitor: resume coverage: still halted by an unaccepted break")
 	}
-	vt, ok, err := m.verifyChain(ctx)
+	vt, ok, err := m.verifyChain(ctx, m.catchUpBatch)
 	if err != nil {
 		return err
 	}
 	if !ok {
 		return fmt.Errorf("monitor: resume coverage: the tail no longer verifies")
-	}
-	if err := m.processFresh(vt); err != nil {
-		return err
 	}
 	return m.signAnchor(vt.head)
 }

--- a/auditmon/monitor/monitor_test.go
+++ b/auditmon/monitor/monitor_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -39,6 +40,8 @@ type spyDetector struct {
 	called bool
 	count  int
 }
+
+func (d *spyDetector) InspectCatchUp(events []store.StoredEvent) error { return d.Inspect(events) }
 
 func (d *spyDetector) Inspect(events []store.StoredEvent) error {
 	d.called = true
@@ -1746,3 +1749,212 @@ func TestAnInvalidAnchorMakesEvidenceIncomplete(t *testing.T) {
 			"skipped instead of counting as missing evidence, so a rewrite above the older anchors would pass")
 	}
 }
+
+// TestPollCatchesUpLongBacklogInBatches proves the tail walk is bounded AND checkpointed: starting from a
+// prior signed anchor at id 2 with a 7-row backlog behind it and tail_batch=2, one Poll verifies, exports,
+// and re-anchors batch by batch — checkpoint anchors land at every full-batch boundary, every row reaches
+// the store exactly once, and a fresh Monitor (a simulated crash) resumes from the last checkpoint rather
+// than re-walking the backlog (issue #240's OOM crash loop).
+func TestPollCatchesUpLongBacklogInBatches(t *testing.T) {
+	ctx := context.Background()
+	pool, dsn := dbtest.OpenPostgres(t)
+	dbtest.ApplySchema(t, ctx, pool)
+	genesis := canon.GenesisHash()
+
+	reader, err := store.Open(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer reader.Close()
+	signer, err := sign.NewFileKey(filepath.Join(t.TempDir(), "key"))
+	if err != nil {
+		t.Fatalf("new file key: %v", err)
+	}
+	objStore := worm.NewMemory()
+	reporter := &spyReporter{}
+	cfg := config.MonitorConfig{PollInterval: time.Second, SignInterval: time.Hour, TailBatch: 2}
+
+	// A steady-state monitor anchors at id 2, then goes down while 7 more rows land.
+	baseID, baseHead := dbtest.SeedChain(t, ctx, pool, genesis, []canon.AuditEvent{
+		decisionEvent("alice", "select 0"), decisionEvent("alice", "select 00"),
+	})
+	m0 := monitor.New(reader, signer, objStore, genesis, cfg, monitor.NoopDetector{}, reporter)
+	if err := m0.Poll(ctx); err != nil {
+		t.Fatalf("baseline poll: %v", err)
+	}
+	backlog := make([]canon.AuditEvent, 7)
+	for i := range backlog {
+		backlog[i] = decisionEvent("alice", fmt.Sprintf("select %d", i+1))
+	}
+	lastID, head := dbtest.AppendChain(t, ctx, pool, baseID+1, baseHead, backlog)
+
+	// A fresh Monitor (the restart after the outage) catches up in one Poll.
+	m := monitor.New(reader, signer, objStore, genesis, cfg, monitor.NoopDetector{}, reporter)
+	if err := m.Poll(ctx); err != nil {
+		t.Fatalf("catch-up poll: %v", err)
+	}
+	if len(reporter.findings) != 0 {
+		t.Fatalf("expected no findings, got %+v", reporter.findings)
+	}
+	ids := exportedIDs(t, objStore)
+	if len(ids) != 2+len(backlog) {
+		t.Fatalf("exported %d events, want %d: %v", len(ids), 2+len(backlog), ids)
+	}
+	seen := map[int64]bool{}
+	for _, id := range ids {
+		if seen[id] {
+			t.Fatalf("event %d exported more than once: %v", id, ids)
+		}
+		seen[id] = true
+	}
+	// Checkpoint anchors exist at every full-batch boundary of the catch-up (4, 6, 8), plus the baseline 2.
+	anchors, err := worm.ReadAnchors(objStore)
+	if err != nil {
+		t.Fatalf("read anchors: %v", err)
+	}
+	got := map[int64]bool{}
+	for _, a := range anchors {
+		got[a.UpToID] = true
+	}
+	for _, want := range []int64{2, 4, 6, 8} {
+		if !got[want] {
+			t.Fatalf("missing checkpoint anchor at %d; anchors=%v", want, got)
+		}
+	}
+	if got[lastID] {
+		t.Fatalf("the short final batch must not checkpoint; anchors=%v", got)
+	}
+
+	// A crash after the walk resumes from the LAST checkpoint: a fresh Monitor's first tail read starts
+	// after id 8, so only the final short batch is re-shipped — to its existing object key (idempotent) —
+	// and nothing below the checkpoint is re-read or re-exported.
+	spy := &spyDetector{}
+	m2 := monitor.New(reader, signer, objStore, genesis, cfg, spy, reporter)
+	if err := m2.Poll(ctx); err != nil {
+		t.Fatalf("resume poll: %v", err)
+	}
+	if spy.count != 1 {
+		t.Fatalf("resume inspected %d rows, want only the post-checkpoint row", spy.count)
+	}
+	after := exportedIDs(t, objStore)
+	if len(after) != 2+len(backlog) {
+		t.Fatalf("resume changed the exported set: %v", after)
+	}
+	if err := m2.SignHead(ctx); err != nil {
+		t.Fatalf("sign head: %v", err)
+	}
+	anchor, ok, err := readLastAnchor(t, objStore)
+	if err != nil || !ok {
+		t.Fatalf("read last anchor: ok=%v err=%v", ok, err)
+	}
+	if anchor.UpToID != lastID || anchor.HeadHash != hex.EncodeToString(head) {
+		t.Fatalf("final anchor = %+v, want head %d", anchor, lastID)
+	}
+}
+
+// TestPollBreakInLaterBatchStopsThere pins the batched walk's break semantics: a chain break in a LATER
+// batch leaves the earlier verified batches exported (and checkpointed), refuses everything from the broken
+// batch on, and reports the finding.
+func TestPollBreakInLaterBatchStopsThere(t *testing.T) {
+	ctx := context.Background()
+	pool, dsn := dbtest.OpenPostgres(t)
+	dbtest.ApplySchema(t, ctx, pool)
+	genesis := canon.GenesisHash()
+
+	events := make([]canon.AuditEvent, 6)
+	for i := range events {
+		events[i] = decisionEvent("alice", fmt.Sprintf("select %d", i))
+	}
+	dbtest.SeedChain(t, ctx, pool, genesis, events)
+	// Tamper row 5 (third batch of two) so batches 1-2 verify and the third breaks.
+	if _, err := pool.Exec(ctx, "UPDATE audit_event SET principal = 'mallory' WHERE id = 5"); err != nil {
+		t.Fatalf("tamper: %v", err)
+	}
+
+	reader, err := store.Open(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer reader.Close()
+	signer, err := sign.NewFileKey(filepath.Join(t.TempDir(), "key"))
+	if err != nil {
+		t.Fatalf("new file key: %v", err)
+	}
+	objStore := worm.NewMemory()
+	reporter := &spyReporter{}
+	cfg := config.MonitorConfig{PollInterval: time.Second, SignInterval: time.Hour, TailBatch: 2}
+	m := monitor.New(reader, signer, objStore, genesis, cfg, monitor.NoopDetector{}, reporter)
+
+	if err := m.Poll(ctx); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if len(reporter.findings) != 1 || reporter.findings[0].DivergentID != 5 ||
+		reporter.findings[0].Reason != verify.ReasonRowHashMismatch {
+		t.Fatalf("findings = %+v, want row_hash_mismatch at 5", reporter.findings)
+	}
+	ids := exportedIDs(t, objStore)
+	if len(ids) != 4 || ids[len(ids)-1] != 4 {
+		t.Fatalf("exported %v, want exactly the verified prefix 1-4", ids)
+	}
+	anchor, ok, err := readLastAnchor(t, objStore)
+	if err != nil {
+		t.Fatalf("read last anchor: %v", err)
+	}
+	if ok && anchor.UpToID > 4 {
+		t.Fatalf("anchor advanced past the break: %+v", anchor)
+	}
+}
+
+// TestPollReportsMidWalkTruncation pins the pinned-target rule: rows deleted between page reads (each page
+// is its own snapshot) surface as a tail_truncated finding, never as a short clean walk.
+func TestPollReportsMidWalkTruncation(t *testing.T) {
+	ctx := context.Background()
+	pool, dsn := dbtest.OpenPostgres(t)
+	dbtest.ApplySchema(t, ctx, pool)
+	genesis := canon.GenesisHash()
+
+	events := make([]canon.AuditEvent, 5)
+	for i := range events {
+		events[i] = decisionEvent("alice", fmt.Sprintf("select %d", i))
+	}
+	dbtest.SeedChain(t, ctx, pool, genesis, events)
+
+	reader, err := store.Open(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer reader.Close()
+	signer, err := sign.NewFileKey(filepath.Join(t.TempDir(), "key"))
+	if err != nil {
+		t.Fatalf("new file key: %v", err)
+	}
+	objStore := worm.NewMemory()
+	reporter := &spyReporter{}
+	cfg := config.MonitorConfig{PollInterval: time.Second, SignInterval: time.Hour, TailBatch: 2}
+
+	// deleteTailDetector simulates the race: after the first batch is inspected, rows 4-5 vanish.
+	deleted := false
+	det := detectFunc(func([]store.StoredEvent) error {
+		if !deleted {
+			deleted = true
+			if _, err := pool.Exec(ctx, "DELETE FROM audit_event WHERE id >= 4"); err != nil {
+				t.Errorf("delete tail: %v", err)
+			}
+		}
+		return nil
+	})
+	m := monitor.New(reader, signer, objStore, genesis, cfg, det, reporter)
+
+	if err := m.Poll(ctx); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if len(reporter.findings) != 1 || reporter.findings[0].Reason != monitor.ReasonTailTruncated {
+		t.Fatalf("findings = %+v, want one tail_truncated", reporter.findings)
+	}
+}
+
+// detectFunc adapts a func to the Detector interface (both hooks call it).
+type detectFunc func([]store.StoredEvent) error
+
+func (f detectFunc) Inspect(events []store.StoredEvent) error        { return f(events) }
+func (f detectFunc) InspectCatchUp(events []store.StoredEvent) error { return f(events) }

--- a/auditmon/store/store.go
+++ b/auditmon/store/store.go
@@ -65,29 +65,30 @@ const eventColumns = `id, ts, principal, roles, datasource, client_addr, stateme
        action, resource, outcome, kind, rows_returned, bytes_returned, decision_id,
        chain_version, prev_hash, row_hash`
 
-const tailQuery = `SELECT ` + eventColumns + ` FROM audit_event WHERE id > $1 ORDER BY id`
+const tailQuery = `SELECT ` + eventColumns + ` FROM audit_event WHERE id > $1 ORDER BY id LIMIT $2`
 
 const chainedTailQuery = `SELECT ` + eventColumns + `
-       FROM audit_event WHERE id > $1 AND chain_version IS NOT NULL ORDER BY id`
+       FROM audit_event WHERE id > $1 AND chain_version IS NOT NULL ORDER BY id LIMIT $2`
 
 const windowQuery = `SELECT ` + eventColumns + ` FROM audit_event WHERE ts >= $1 ORDER BY id`
 
-// TailEvents returns every audit_event with id greater than afterID, in id order. Because id is gap-free
-// and commit-ordered, id > cursor cannot skip a late-committing row.
-func (r *Reader) TailEvents(ctx context.Context, afterID int64) ([]StoredEvent, error) {
-	rows, err := r.pool.Query(ctx, tailQuery, afterID)
+// TailEvents returns up to limit audit_events with id greater than afterID, in id order — bounded so a
+// long backlog is walked in batches instead of materialized at once. Because id is gap-free and
+// commit-ordered, id > cursor cannot skip a late-committing row.
+func (r *Reader) TailEvents(ctx context.Context, afterID int64, limit int) ([]StoredEvent, error) {
+	rows, err := r.pool.Query(ctx, tailQuery, afterID, limit)
 	if err != nil {
 		return nil, fmt.Errorf("store: query tail: %w", err)
 	}
 	return scanEvents(rows)
 }
 
-// ChainedEventsAfter returns every audit_event with id greater than afterID that carries a chain_version,
-// in id order. It is the from-genesis full-verify read: pre-chain historical rows (chain_version NULL) are
+// ChainedEventsAfter returns up to limit audit_events with id greater than afterID that carry a
+// chain_version, in id order. It is the from-genesis full-verify read: pre-chain historical rows (chain_version NULL) are
 // skipped so a non-greenfield database — where the earliest rows predate the hash chain — is not falsely
 // flagged, and the walk begins at the first chained row (whose prev_hash is the pinned genesis).
-func (r *Reader) ChainedEventsAfter(ctx context.Context, afterID int64) ([]StoredEvent, error) {
-	rows, err := r.pool.Query(ctx, chainedTailQuery, afterID)
+func (r *Reader) ChainedEventsAfter(ctx context.Context, afterID int64, limit int) ([]StoredEvent, error) {
+	rows, err := r.pool.Query(ctx, chainedTailQuery, afterID, limit)
 	if err != nil {
 		return nil, fmt.Errorf("store: query chained tail: %w", err)
 	}
@@ -174,6 +175,17 @@ func scanEvents(rows pgx.Rows) ([]StoredEvent, error) {
 		return nil, fmt.Errorf("store: iterate rows: %w", err)
 	}
 	return out, nil
+}
+
+// MaxEventID returns the highest audit_event id (0 when the table is empty). The tail walk pins it as its
+// target before the first page: a walk that cannot reach the target it pinned means rows vanished between
+// pages, which must surface as a finding rather than a short, clean-looking read.
+func (r *Reader) MaxEventID(ctx context.Context) (int64, error) {
+	var id int64
+	if err := r.pool.QueryRow(ctx, `SELECT COALESCE(MAX(id), 0) FROM audit_event`).Scan(&id); err != nil {
+		return 0, fmt.Errorf("store: max event id: %w", err)
+	}
+	return id, nil
 }
 
 // ReadChainHead returns the singleton audit_chain_head row.

--- a/auditmon/store/store_test.go
+++ b/auditmon/store/store_test.go
@@ -56,7 +56,7 @@ func TestTailEventsReadsRowsAndChainColumns(t *testing.T) {
 	}
 	defer reader.Close()
 
-	got, err := reader.TailEvents(ctx, 0)
+	got, err := reader.TailEvents(ctx, 0, 10000)
 	if err != nil {
 		t.Fatalf("tail events: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestTailEventsRespectsCursor(t *testing.T) {
 	}
 	defer reader.Close()
 
-	got, err := reader.TailEvents(ctx, 2)
+	got, err := reader.TailEvents(ctx, 2, 10000)
 	if err != nil {
 		t.Fatalf("tail after cursor: %v", err)
 	}

--- a/auditmon/verify/verify.go
+++ b/auditmon/verify/verify.go
@@ -62,10 +62,14 @@ func VerifyTail(head store.ChainHead, events []store.StoredEvent) (*Finding, err
 }
 
 // ChainedEventSource is the paging read side VerifyFromGenesis walks: chained rows only (chain_version IS
-// NOT NULL), in id order. Satisfied by *store.Reader.
+// NOT NULL), in id order, at most limit per call. Satisfied by *store.Reader.
 type ChainedEventSource interface {
-	ChainedEventsAfter(ctx context.Context, afterID int64) ([]store.StoredEvent, error)
+	ChainedEventsAfter(ctx context.Context, afterID int64, limit int) ([]store.StoredEvent, error)
 }
+
+// pageSize bounds each read of the from-genesis walk, so peak memory depends on the page, not on how long
+// the trail is.
+const pageSize = 5000
 
 // AnchorCheck is a signed off-box witness to cross-check the walk against: the head_hash a valid anchor
 // recorded at UpToID. A recomputed head that no longer matches, or an UpToID the chain no longer reaches,
@@ -140,7 +144,7 @@ func VerifyFromGenesisAccepting(ctx context.Context, src ChainedEventSource, gen
 	head := store.ChainHead{LastID: 0, HeadHash: genesis}
 	cursor := int64(0)
 	for {
-		events, err := src.ChainedEventsAfter(ctx, cursor)
+		events, err := src.ChainedEventsAfter(ctx, cursor, pageSize)
 		if err != nil {
 			return nil, nil, fmt.Errorf("verify: read chained tail after %d: %w", cursor, err)
 		}

--- a/auditmon/verify/verify_test.go
+++ b/auditmon/verify/verify_test.go
@@ -43,7 +43,7 @@ func TestVerifyTailIntact(t *testing.T) {
 	reader := openReader(t, ctx, dsn)
 
 	// Verifying the whole trail against the genesis-based head (tail from 0) must be clean.
-	events, err := reader.TailEvents(ctx, 0)
+	events, err := reader.TailEvents(ctx, 0, 10000)
 	if err != nil {
 		t.Fatalf("tail: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestVerifyDetectsMutatedStatement(t *testing.T) {
 	}
 	reader := openReader(t, ctx, dsn)
 
-	events, err := reader.TailEvents(ctx, 0)
+	events, err := reader.TailEvents(ctx, 0, 10000)
 	if err != nil {
 		t.Fatalf("tail: %v", err)
 	}
@@ -192,7 +192,7 @@ VALUES (2, 'b', 'warehouse', 'q2', 'ALLOW', $1, $2, NULL)`,
 	}
 	reader := openReader(t, ctx, dsn)
 
-	events, err := reader.TailEvents(ctx, 0)
+	events, err := reader.TailEvents(ctx, 0, 10000)
 	if err != nil {
 		t.Fatalf("tail: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestVerifyDetectsDeletedRow(t *testing.T) {
 	}
 	reader := openReader(t, ctx, dsn)
 
-	events, err := reader.TailEvents(ctx, 0)
+	events, err := reader.TailEvents(ctx, 0, 10000)
 	if err != nil {
 		t.Fatalf("tail: %v", err)
 	}


### PR DESCRIPTION
`verifyChain` read every event after the anchor into one slice, so a backlog from a long outage OOMed on startup and crash-looped unrecoverably (the anchor never advanced, every restart re-read the same growing tail). The walk now pins its target id, reads in `monitor.tail_batch` batches (default 5000, env `AUDITMON_MONITOR_TAIL_BATCH`), and exports + checkpoints per verified batch — first run included — so peak memory depends on the batch size and a crash mid catch-up resumes from the last checkpoint. The from-genesis walk pages the same way.

Where it could bite:
- A break in a later batch now leaves the earlier verified batches exported/checkpointed (the old behavior was all-or-nothing per poll); nothing unverified is ever exported or signed.
- Rows deleted between page reads surface as a `tail_truncated` finding instead of a short clean walk.
- Catch-up batches run only the per-event rules; the window rules run on the walk's final batch.

Fixes #240 (reported by SangGyu Lee).

Verified: DB-backed tests for batch-boundary checkpoints, crash-resume, later-batch break, mid-walk truncation; `mise run verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvrD1afHaM1nk5fWvRFWTK