### PR TITLE
feat(editor): run an editor submit's statements as one task, one result tab each

### DIFF
--- a/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
+++ b/control-plane/src/main/kotlin/com/ridi/oss/proxymonster/controlplane/Query.kt
@@ -43,6 +43,7 @@ import com.ridi.oss.proxymonster.probe.Dialect
 import com.ridi.oss.proxymonster.probe.Masking
 import com.ridi.oss.proxymonster.probe.analyzerFor
 import com.ridi.oss.proxymonster.probe.bindMasks
+import com.ridi.oss.proxymonster.probe.splitStatements
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
@@ -1032,11 +1033,23 @@ data class EditorSessionOpened(val sessionId: String)
 /** Async editor SUBMIT ack: the born-APPROVED EDITOR task and its single result child (task:child 1:1). No
  *  rows inline — completion is observed by polling the task/result endpoints. */
 @Serializable
-data class EditorSubmitResponse(val taskId: Long, val childId: Long)
+data class EditorSubmitResponse(
+    val taskId: Long,
+    val childId: Long,
+    /** The statements the submit was split into, in run order — one result child each. */
+    val statements: List<String> = emptyList(),
+)
 
 /** Editor task poll: the parent task status plus its child result metadata (rows stay behind /result). */
 @Serializable
-data class EditorTaskStatus(val taskId: Long, val status: String, val result: QueryResultMeta? = null)
+data class EditorTaskStatus(
+    val taskId: Long,
+    val status: String,
+    /** The batch's active statement. */
+    val result: QueryResultMeta? = null,
+    /** Every statement of the batch, in run order, each with its own status. */
+    val statements: List<QueryResultMeta> = emptyList(),
+)
 
 /**
  * Persistent editor SESSION + async task routes (connection-model.md; editor-as-task). Open
@@ -1114,7 +1127,12 @@ fun Route.editorSessionRoutes(
             return@post call.respond(HttpStatusCode.Forbidden, ApiError("common.forbidden"))
         }
 
-        val task = accessStore.createEditorTask(principal, ds.id, listOf(sql), ownRoles.toList(), approver = principal)
+        // Split server-side, like the workflow: one task, one child per statement.
+        val splitConfig = ds.splitEngineConfig()
+            ?: return@post call.respond(HttpStatusCode.BadRequest, ApiError("approval.unsplittable_sql"))
+        val statements = splitStatements(sql, splitConfig)
+            ?: return@post call.respond(HttpStatusCode.BadRequest, ApiError("approval.unsplittable_sql"))
+        val task = accessStore.createEditorTask(principal, ds.id, statements, ownRoles.toList(), approver = principal)
         val childId = accessStore.editorChildId(task.id) ?: -1L
         // Same single-execution claim as /execute, atomic so a cancel can't slip into an EXECUTING-but-no-
         // RUNNING-child gap: APPROVED → EXECUTING and the child NULL → RUNNING commit in one transaction.
@@ -1132,35 +1150,49 @@ fun Route.editorSessionRoutes(
             // The target-DB error behind a failure (both forms), stored so the FAILED view releases one per viewer.
             var diagnostic: RunError? = null
             val failureCode = try {
-                // runOnSession decides on the EDITOR channel under empty assumeRoles (the caller's own roles)
-                // and saves the enforced result instead of returning it inline.
-                val response = runExecService.runOnSession(
-                    sessionId, principal, sql, maxRows,
+                var batchFailure: String? = null
+                // One mutex hold for the batch, so a concurrent submit cannot land inside its transaction.
+                // Decides on the EDITOR channel under the caller's own roles and saves each result.
+                runExecService.runBatchOnSession(
+                    sessionId, principal, statementCount = statements.size, maxRows = maxRows,
                     requesterIp = requesterIp,
                     taskId = task.id,
                     preflight = { store.meta(task.id)?.status == "RUNNING" },
                     exchangeTimeoutMs = config.queryExchangeTimeoutMs,
-                )
-                if (response.decision == EnfAction.DENY) {
-                    denyReason = response.denyReason
-                    denyDecisionId = response.decisionId
-                    // Reuse the already-translated approval.* result codes (en/ko errors.json) — the messages
-                    // ("denied at execution time" / "execution failed") are channel-agnostic, so the web
-                    // localizes the polled code with no editor-specific catalog entries.
-                    "approval.execute_denied"
-                } else {
+                    // Statement 0 is RUNNING from the claim; a cancel between statements leaves none
+                    // pending, so the batch stops here.
+                    statementAt = { ordinal ->
+                        if (ordinal == 0) statements[0] else store.startNextRun(task.id, principal)?.sql
+                    },
+                    onStatement = { ordinal, response ->
+                    if (response.decision == EnfAction.DENY) {
+                        denyReason = response.denyReason
+                        denyDecisionId = response.decisionId
+                        // Reuse the already-translated approval.* result codes (en/ko errors.json) — the messages
+                        // ("denied at execution time" / "execution failed") are channel-agnostic, so the web
+                        // localizes the polled code with no editor-specific catalog entries.
+                        batchFailure = "approval.execute_denied"
+                        false
+                    } else {
                     val result = DecryptedResult(response.columns, response.rows, response.rowsAffected, response.resultFingerprint)
-                    // Child DONE + parent EXECUTED commit in ONE transaction (see /execute): a crash can never
-                    // leave a readable DONE child under a non-EXECUTED task. The run's per-statement Decide
-                    // round-trip already wrote the real audit decision (ALLOW/MASK/DENY + decisionId), so no
-                    // task-level audit row is added here — it would only duplicate that as a false ALLOW.
+                    // The parent flips to EXECUTED only on the LAST statement. The per-statement Decide
+                    // already wrote the real audit decision, so no task-level row is added here.
+                    val last = ordinal == statements.lastIndex
                     val completed = store.completeRun(task.id, result, QueryResultStore.RESULT_RETENTION_SEC) { conn, _ ->
-                        if (!accessStore.markExecuted(task.id, conn)) {
+                        if (last && !accessStore.markExecuted(task.id, conn)) {
                             throw IllegalStateException("editor task ${task.id} left EXECUTING before completion")
                         }
                     }
-                    if (completed != null) null else "approval.query_failed"
-                }
+                    if (completed == null) {
+                        batchFailure = "approval.query_failed"
+                        false
+                    } else {
+                        true
+                    }
+                    }
+                    },
+                )
+                batchFailure
             } catch (_: RunCanceledBeforeStartException) {
                 null
             } catch (_: NoProxyAttachedException) {
@@ -1170,6 +1202,9 @@ fun Route.editorSessionRoutes(
             } catch (_: ProxyRunTimeoutException) {
                 "query.proxy_timeout"
             } catch (e: TargetDbRunException) {
+                // The target DB's own error for the statement that failed, in the form the run's decision
+                // chose. Stored encrypted on the failed child and re-gated per viewer, so it must survive
+                // the batch walk rather than collapsing into a bare failure code.
                 diagnostic = e.toDiagnostic()
                 "approval.query_failed"
             } catch (_: ProxyRunException) {
@@ -1191,7 +1226,10 @@ fun Route.editorSessionRoutes(
             // SSE stream so the tab updates at once; best-effort, the tab also polls (see TaskCompletionHub).
             accessStore.getRequest(task.id)?.status?.let { taskCompletionHub?.publish(principal, TaskEvent(task.id, it)) }
         }
-        call.respond(HttpStatusCode.Accepted, EditorSubmitResponse(taskId = task.id, childId = childId))
+        call.respond(
+            HttpStatusCode.Accepted,
+            EditorSubmitResponse(taskId = task.id, childId = childId, statements = statements),
+        )
     }
 
     // Poll: task status + child metadata. Owner-scoped to the caller's own EDITOR tasks (task.read/own);
@@ -1216,7 +1254,12 @@ fun Route.editorSessionRoutes(
         if (mayRead is AuthzDecision.Deny) {
             return@get call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "editor task")))
         }
-        call.respond(EditorTaskStatus(task.id, task.status, queryResultStore?.meta(taskId)))
+        call.respond(
+            EditorTaskStatus(
+                task.id, task.status, queryResultStore?.meta(taskId),
+                statements = queryResultStore?.statements(taskId).orEmpty(),
+            ),
+        )
     }
 
     post("/api/editor/tasks/{taskId}/cancel") {
@@ -1237,7 +1280,12 @@ fun Route.editorSessionRoutes(
             return@post call.respond(HttpStatusCode.Forbidden, ApiError("approval.cancel_forbidden"))
         }
         if (task.status != "EXECUTING") {
-            return@post call.respond(EditorTaskStatus(task.id, task.status, queryResultStore?.meta(taskId)))
+            return@post call.respond(
+                EditorTaskStatus(
+                    task.id, task.status, queryResultStore?.meta(taskId),
+                    statements = queryResultStore?.statements(taskId).orEmpty(),
+                ),
+            )
         }
         val store = queryResultStore
             ?: return@post call.respond(HttpStatusCode.ServiceUnavailable, ApiError("approval.result_storage_not_configured"))
@@ -1254,7 +1302,12 @@ fun Route.editorSessionRoutes(
         }
         val updated = accessStore.getRequest(taskId)
             ?: return@post call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "editor task")))
-        call.respond(EditorTaskStatus(updated.id, updated.status, store.meta(taskId)))
+        call.respond(
+            EditorTaskStatus(
+                updated.id, updated.status, store.meta(taskId),
+                statements = store.statements(taskId),
+            ),
+        )
     }
 
     // Rows: task.assume gates the viewer (no authDebug bypass — data confidentiality), then the stored result
@@ -1277,7 +1330,13 @@ fun Route.editorSessionRoutes(
         }
         // One read captures ciphertext + meta; decrypt is lazy (only after authz passes → an unauthorized
         // viewer never triggers a decrypt, and a concurrent re-run can't swap the row between check + decrypt).
-        val access = queryResultStore?.accessFor(taskId)
+        // ?statement=<ordinal> selects one statement of a batch; absent takes the active one.
+        val ordinalParam = call.request.queryParameters["statement"]
+        val ordinal = if (ordinalParam == null) null else {
+            ordinalParam.toIntOrNull()?.takeIf { it >= 0 }
+                ?: return@get call.respond(HttpStatusCode.BadRequest, ApiError("common.bad_id"))
+        }
+        val access = queryResultStore?.accessFor(taskId, ordinal)
             ?: return@get call.respond(HttpStatusCode.NotFound, ApiError("common.not_found", mapOf("resource" to "editor task")))
         val mayAssume = authz.authorizeWithContext(
             principal, AuthzAction.TASK_ASSUME,

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/EditorSubmitRouteDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/EditorSubmitRouteDbTest.kt
@@ -1,6 +1,5 @@
 package com.ridi.oss.proxymonster.controlplane
 
-
 import com.ridi.oss.proxymonster.controlplane.authz.CedarPolicyInput
 import com.ridi.oss.proxymonster.controlplane.grpc.CONTROL_PROTOCOL_VERSION
 import com.ridi.oss.proxymonster.controlplane.grpc.ControlPlaneGrpcService
@@ -256,6 +255,92 @@ class EditorSubmitRouteDbTest {
             assertEquals(HttpStatusCode.NoContent, client.delete("/api/editor/tasks/${ack.taskId}").status)
             assertNull(core.accessStore.getRequest(ack.taskId))
             assertEquals(HttpStatusCode.NoContent, client.delete("/api/editor/tasks/${ack.taskId}").status)
+
+            client.delete("/api/editor/sessions/${session.sessionId}")
+            session.await()
+        }
+    }
+
+    @Test
+    fun `a multi-statement submit runs each statement in order on the one held session`() = testApplication {
+        val client = wire()
+        supervisorScope {
+            // Each statement gets its own single-column result, so the saved rows identify which ran.
+            val seen = java.util.concurrent.CopyOnWriteArrayList<String>()
+            val session = openFakeSession(client) { req, control ->
+                seen += control.query.sql
+                req.send(proxyRunMsg { decision = runDecision { decision = WireEnfAction.ALLOW } })
+                req.send(rowsChunk(listOf("v"), listOf(listOf(control.query.sql))))
+                req.send(proxyRunMsg { done = runDone { rowsAffected = -1 } })
+            }
+
+            val submit = client.post("/api/editor/sessions/${session.sessionId}/query") {
+                contentType(ContentType.Application.Json)
+                setBody(QueryRequest("select 1; select 'a;b' from t; select 3", 100))
+            }
+            assertEquals(HttpStatusCode.Accepted, submit.status)
+            val ack = submit.body<EditorSubmitResponse>()
+            // Split server-side at the ENGINE's boundaries: the `;` inside the literal is not one.
+            assertEquals(listOf("select 1", "select 'a;b' from t", "select 3"), ack.statements)
+
+            awaitUntil("every statement DONE") {
+                core.accessStore.getRequest(ack.taskId)?.status == "EXECUTED" &&
+                    resultStore.statements(ack.taskId).all { it.status == "DONE" }
+            }
+            // One task, one child per statement, run in the order written — on the SAME session (a single
+            // held connection), which is what lets a batch's earlier statement affect a later one.
+            assertEquals(ack.statements, seen.toList())
+            val children = resultStore.statements(ack.taskId)
+            assertEquals(listOf(0, 1, 2), children.map { it.ordinal })
+            assertEquals(ack.statements, children.map { it.sql })
+            // Each statement's OWN rows are stored under its own ordinal.
+            for ((ordinal, statement) in ack.statements.withIndex()) {
+                assertEquals(
+                    listOf(listOf(statement)),
+                    resultStore.accessFor(ack.taskId, ordinal)!!.decrypted!!.rows,
+                    "statement $ordinal must hold its own result",
+                )
+            }
+            // The poll reports every statement, so a tab per statement can read its own verdict.
+            val status = client.get("/api/editor/tasks/${ack.taskId}").body<EditorTaskStatus>()
+            assertEquals(listOf("DONE", "DONE", "DONE"), status.statements.map { it.status })
+
+            client.delete("/api/editor/sessions/${session.sessionId}")
+            session.await()
+        }
+    }
+
+    @Test
+    fun `a DENY mid-batch stops the run and skips the statements after it`() = testApplication {
+        val client = wire()
+        supervisorScope {
+            val seen = java.util.concurrent.CopyOnWriteArrayList<String>()
+            val session = openFakeSession(client) { req, control ->
+                seen += control.query.sql
+                // The SECOND statement is denied at execute; the third must never be sent.
+                if (control.query.sql.contains("ssn")) {
+                    req.send(proxyRunMsg { decision = runDecision { decision = WireEnfAction.DENY; denyReason = "no" } })
+                } else {
+                    req.send(proxyRunMsg { decision = runDecision { decision = WireEnfAction.ALLOW } })
+                    req.send(rowsChunk(listOf("v"), listOf(listOf("1"))))
+                    req.send(proxyRunMsg { done = runDone { rowsAffected = -1 } })
+                }
+            }
+
+            val submit = client.post("/api/editor/sessions/${session.sessionId}/query") {
+                contentType(ContentType.Application.Json)
+                setBody(QueryRequest("select id from t; select ssn from t; select 3", 100))
+            }
+            val ack = submit.body<EditorSubmitResponse>()
+            awaitUntil("task FAILED") { core.accessStore.getRequest(ack.taskId)?.status == "FAILED" }
+
+            // The statement after the denial was never sent to the proxy.
+            assertEquals(listOf("select id from t", "select ssn from t"), seen.toList())
+            val children = resultStore.statements(ack.taskId)
+            assertEquals(listOf("DONE", "FAILED", "SKIPPED"), children.map { it.status })
+            // The statement that ran BEFORE the denial keeps its result.
+            assertEquals(listOf(listOf("1")), resultStore.accessFor(ack.taskId, 0)!!.decrypted!!.rows)
+            assertEquals("approval.execute_denied", children[1].errorCode)
 
             client.delete("/api/editor/sessions/${session.sessionId}")
             session.await()

--- a/web/src/components/query/use-result-tabs.ts
+++ b/web/src/components/query/use-result-tabs.ts
@@ -48,7 +48,10 @@ interface BaseTab {
   res: ResultState
   // The async editor task backing this tab's current run: the tab polls it to completion and
   // deletes it on re-run/close. Null before the first submit (or for a table tab yet to load).
+  // Tabs of one batch share a taskId; it is reaped when the last of them closes.
   taskId: number | null
+  // Which statement of [taskId] this tab shows.
+  ordinal: number
 }
 export interface QueryTab extends BaseTab {
   kind: 'query'
@@ -166,8 +169,15 @@ export function useResultTabs(datasourceId: number | null, maxRows: number): Res
     setTabs((ts) => ts.map((t) => (t.id === id ? { ...t, res: { ...t.res, ...res } } : t)))
   }, [])
 
-  const setTabTaskId = useCallback((id: string, taskId: number | null) => {
-    setTabs((ts) => ts.map((t) => (t.id === id ? { ...t, taskId } : t)))
+  const setTabTaskId = useCallback((id: string, taskId: number | null, ordinal = 0) => {
+    setTabs((ts) => ts.map((t) => (t.id === id ? { ...t, taskId, ordinal } : t)))
+  }, [])
+
+  /** Drop a task's saved results, but only once no tab still shows one of its statements. */
+  const releaseTask = useCallback((taskId: number | null, keepTabIds: string[] = []) => {
+    if (taskId == null) return
+    const stillUsed = tabsRef.current.some((t) => t.taskId === taskId && !keepTabIds.includes(t.id))
+    if (!stillUsed) void deleteEditorTask(taskId).catch(() => {})
   }, [])
 
   const appendLog = useCallback((entry: QueryLogEntry, execution: number) => {
@@ -186,8 +196,44 @@ export function useResultTabs(datasourceId: number | null, maxRows: number): Res
     executionOrderRef.current.clear()
   }, [])
 
+  // fetchInto and openSiblingTabs are mutually recursive, so siblings reach it through a ref.
+  const fetchIntoRef = useRef<
+    (id: string, sql: string, rows: number, attach?: { taskId: number; ordinal: number }) => void
+  >(() => {})
+
+  /** Open a tab per remaining statement (1..N-1), each on the same task at its own ordinal. */
+  const openSiblingTabs = useCallback(
+    (afterTabId: string, taskId: number, statements: string[], rows: number) => {
+      const siblings = statements.map((sql, index) => ({
+        tab: {
+          id: newId(),
+          kind: 'query' as const,
+          key: `${norm(sql)}#${taskId}:${index + 1}`,
+          title: label(sql),
+          sql,
+          pinned: false,
+          taskId,
+          ordinal: index + 1,
+          res: { ...EMPTY, loading: true },
+        },
+        ordinal: index + 1,
+      }))
+      setTabs((ts) => {
+        const at = ts.findIndex((t) => t.id === afterTabId)
+        const next = [...ts]
+        next.splice(at < 0 ? next.length : at + 1, 0, ...siblings.map((s) => s.tab))
+        return next
+      })
+      for (const { tab, ordinal } of siblings) {
+        fetchIntoRef.current(tab.id, tab.sql, rows, { taskId, ordinal })
+      }
+    },
+    [],
+  )
+
   const fetchInto = useCallback(
-    (id: string, sql: string, rows: number) => {
+    // [attach] binds this tab to a statement of an already-submitted batch instead of submitting.
+    (id: string, sql: string, rows: number, attach?: { taskId: number; ordinal: number }) => {
       if (datasourceId == null) return
       const token = (tokenRef.current[id] = (tokenRef.current[id] ?? 0) + 1)
       const statement = norm(sql)
@@ -201,32 +247,51 @@ export function useResultTabs(datasourceId: number | null, maxRows: number): Res
 
       // Submit the run; supersede the tab's previous task first (best-effort) so a re-run REPLACES it.
       const submitOnce = async (sid: string) => {
-        const prev = tabsRef.current.find((t) => t.id === id)?.taskId
-        if (prev != null) void deleteEditorTask(prev).catch(() => {})
+        releaseTask(tabsRef.current.find((t) => t.id === id)?.taskId ?? null, [id])
         return submitEditorQuery(sid, { sql: statement, maxRows: rows })
       }
 
       const run = async (): Promise<QueryResponse | null> => {
-        let submit
-        try {
-          submit = await submitOnce(await ensureSession())
-        } catch (e) {
-          // The held session may have been reaped (idle) or expired — reopen once and retry.
-          if (e instanceof Error && /session/i.test(e.message)) {
-            sessionIdRef.current = null
-            submit = await submitOnce(await ensureSession())
-          } else {
-            throw e
+        let submit: { taskId: number; ordinal: number }
+        if (attach) {
+          submit = attach
+        } else {
+          let posted
+          try {
+            posted = await submitOnce(await ensureSession())
+          } catch (e) {
+            // The held session may have been reaped (idle) or expired — reopen once and retry.
+            if (e instanceof Error && /session/i.test(e.message)) {
+              sessionIdRef.current = null
+              posted = await submitOnce(await ensureSession())
+            } else {
+              throw e
+            }
+          }
+          if (!current()) {
+            // The tab was superseded (re-run) or closed while this POST was in flight — the server task now
+            // exists but no tab owns its id, so delete-on-close/re-run can never reach it. Reap it here
+            // (best-effort) before unwinding, so a slow submit can't leak a persisted result.
+            void deleteEditorTask(posted.taskId).catch(() => {})
+            throw SUPERSEDED
+          }
+          submit = { taskId: posted.taskId, ordinal: 0 }
+          const split = posted.statements ?? []
+          const rest = split.slice(1)
+          if (rest.length > 0) {
+            // Relabel: left as the whole selection it would title the batch while holding only its rows.
+            const own = split[0]!
+            setTabs((ts) =>
+              ts.map((t) =>
+                t.id === id && t.kind === 'query'
+                  ? { ...t, sql: own, title: label(own), key: `${norm(own)}#${posted.taskId}:0` }
+                  : t,
+              ),
+            )
+            openSiblingTabs(id, posted.taskId, rest, rows)
           }
         }
-        if (!current()) {
-          // The tab was superseded (re-run) or closed while this POST was in flight — the server task now
-          // exists but no tab owns its id, so delete-on-close/re-run can never reach it. Reap it here
-          // (best-effort) before unwinding, so a slow submit can't leak a persisted result.
-          void deleteEditorTask(submit.taskId).catch(() => {})
-          throw SUPERSEDED
-        }
-        setTabTaskId(id, submit.taskId)
+        setTabTaskId(id, submit.taskId, submit.ordinal)
 
         // Poll the task to a terminal state, then fetch the saved rows on DONE (the editor never blocks —
         // each tab polls independently). A FAILED task (incl. a DENY at execute) surfaces its error code.
@@ -234,7 +299,40 @@ export function useResultTabs(datasourceId: number | null, maxRows: number): Res
           if (!current()) throw SUPERSEDED
           const status = await getEditorTask(submit.taskId)
           if (!current()) throw SUPERSEDED
-          const child = status.result
+          // THIS tab's statement: the active child would show another statement's verdict here.
+          const child =
+            status.statements?.find((sc) => sc.ordinal === submit.ordinal) ??
+            (submit.ordinal === 0 ? status.result : null)
+          if (child?.status === 'SKIPPED') {
+            if (current()) {
+              patch(id, {
+                loading: false,
+                canceling: false,
+                canceled: false,
+                result: null,
+                error: translateApiError('approval.statement_skipped'),
+              })
+            }
+            return null
+          }
+          if (child?.status === 'DONE') {
+            const view = await getEditorResult(submit.taskId, submit.ordinal)
+            return {
+              // From the server's re-decision, never assumed: these rows are released under the viewer's
+              // live context, which can mask columns the execution itself returned in the clear. Only a
+              // FAILED view omits the verdict, and this branch is DONE.
+              decision: view.decision!,
+              decisionId: null,
+              denyReason: null,
+              maskedColumns: view.maskedColumns,
+              piiTouched: [],
+              effectiveRoles: [],
+              columns: view.columns,
+              rows: view.rows,
+              rowsAffected: null,
+              latencyMs: Math.max(0, Math.round(performance.now() - startedAt)),
+            }
+          }
           if (status.status === 'FAILED' || child?.status === 'FAILED') {
             // A policy DENY is a decision, not an error: returning it as a DENY result is what gives the
             // panel the reason and the decisionId it needs to offer "request approval". Throwing here
@@ -256,7 +354,7 @@ export function useResultTabs(datasourceId: number | null, maxRows: number): Res
             // Any other failure really is one. Localize the catalog code, and append the /result errorDetail
             // when present; the code is the real signal, so any detail-fetch failure falls back to it alone.
             const code = translateApiError(child?.errorCode ?? 'approval.query_failed')
-            const detail = await getEditorResult(submit.taskId)
+            const detail = await getEditorResult(submit.taskId, submit.ordinal)
               .then((view) => view.errorDetail)
               .catch(() => null)
             throw new Error(detail ? `${code}: ${detail}` : code)
@@ -288,22 +386,6 @@ export function useResultTabs(datasourceId: number | null, maxRows: number): Res
               })
             }
             return null
-          }
-          if (child?.status === 'DONE') {
-            const view = await getEditorResult(submit.taskId)
-            return {
-              // From the server's re-decision, never assumed. Only a FAILED view omits the verdict.
-              decision: view.decision!,
-              decisionId: null,
-              denyReason: null,
-              maskedColumns: view.maskedColumns,
-              piiTouched: [],
-              effectiveRoles: [],
-              columns: view.columns,
-              rows: view.rows,
-              rowsAffected: null,
-              latencyMs: Math.max(0, Math.round(performance.now() - startedAt)),
-            }
           }
           // Wait for this task's push (instant on completion) or the fallback tick, whichever comes first.
           await waitForTaskEvent(submit.taskId, POLL_INTERVAL_MS)
@@ -367,8 +449,9 @@ export function useResultTabs(datasourceId: number | null, maxRows: number): Res
           }
         })
     },
-    [appendLog, datasourceId, patch, ensureSession, setTabTaskId, t],
+    [appendLog, datasourceId, patch, ensureSession, setTabTaskId, openSiblingTabs, releaseTask, t],
   )
+  fetchIntoRef.current = fetchInto
 
   const run = useCallback(
     (sql: string) => {
@@ -384,7 +467,7 @@ export function useResultTabs(datasourceId: number | null, maxRows: number): Res
         return
       }
       const id = newId()
-      const tab: QueryTab = { id, kind: 'query', key, title: label(sql), sql, pinned: false, taskId: null, res: { ...EMPTY, loading: true } }
+      const tab: QueryTab = { id, kind: 'query', key, title: label(sql), sql, pinned: false, taskId: null, ordinal: 0, res: { ...EMPTY, loading: true } }
       setTabs((ts) => [...ts, tab])
       setActiveId(id)
       fetchInto(id, sql, maxRows)
@@ -411,6 +494,7 @@ export function useResultTabs(datasourceId: number | null, maxRows: number): Res
         table,
         pinned: false,
         taskId: null,
+        ordinal: 0,
         res: { ...EMPTY, loading: true },
       }
       setTabs((ts) => [...ts, tab])
@@ -439,9 +523,10 @@ export function useResultTabs(datasourceId: number | null, maxRows: number): Res
 
   const close = useCallback(
     (id: string) => {
-      // Delete-on-close: drop the tab's saved result server-side (best-effort, idempotent).
+      // Delete-on-close: drop the tab's saved result server-side (best-effort, idempotent). The statements
+      // of one batch share a task, so it is released only once no other tab still shows one of them.
       const closing = tabsRef.current.find((t) => t.id === id)
-      if (closing?.taskId != null) void deleteEditorTask(closing.taskId).catch(() => {})
+      releaseTask(closing?.taskId ?? null, [id])
       setTabs((ts) => {
         const idx = ts.findIndex((t) => t.id === id)
         const next = ts.filter((t) => t.id !== id)
@@ -453,7 +538,7 @@ export function useResultTabs(datasourceId: number | null, maxRows: number): Res
         return next
       })
     },
-    [],
+    [releaseTask],
   )
 
   const active = tabs.find((t) => t.id === activeId) ?? null

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -291,8 +291,9 @@ export function getEditorTask(taskId: number): Promise<EditorTaskStatus> {
 }
 
 /** GET /api/editor/tasks/{taskId}/result — the saved, re-decided rows once the task is DONE. */
-export function getEditorResult(taskId: number): Promise<QueryResultView> {
-  return request<QueryResultView>(`/api/editor/tasks/${taskId}/result`)
+export function getEditorResult(taskId: number, ordinal?: number): Promise<QueryResultView> {
+  const qs = ordinal == null ? '' : `?statement=${ordinal}`
+  return request<QueryResultView>(`/api/editor/tasks/${taskId}/result${qs}`)
 }
 
 /** POST /api/editor/tasks/{taskId}/cancel — cancel a running editor task. */

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -530,6 +530,8 @@ export interface QueryResponse {
 export interface EditorSubmitResponse {
   taskId: number
   childId: number
+  /** The statements the submit was split into, in run order — one result child each. */
+  statements?: string[]
 }
 
 /** GET /api/editor/tasks/{taskId}: the parent task status + its child result metadata (rows are behind
@@ -541,5 +543,7 @@ export interface EditorTaskStatus {
   // The child metadata the server actually sends here IS QueryResultMeta; a structural copy of it drifted
   // from the real shape and silently hid the fields a denial needs.
   result: QueryResultMeta | null
+  /** Every statement of the batch, in run order, each with its own status. */
+  statements?: QueryResultMeta[]
 }
 


### PR DESCRIPTION
The last two commits of the batch work, kept separate so each still reads on its own: the
control-plane side, then the editor's tabs.

**Editor submit as one task.** A selection spanning several statements was sent as one string and
denied as a multi-statement batch. It now splits into one task with a child per statement, run in
order on the session's held connection under a single mutex hold — so `BEGIN` or a temp table from
statement k still applies at k+1, while each statement round-trips its own `Decide`. The submit ack
and the poll carry the statements, so a client reads each one's own verdict instead of whichever
finished last.

**One result tab per statement.** One submit is one task with N children, so a single tab would show
the whole selection while holding only statement 0's rows. Each statement gets its own tab bound to
that task at its ordinal. Tabs of one batch share a task, so delete-on-close and re-run release it
only once no tab still shows one of its statements.

Verified: `mise run verify` green on this branch — 1222 control-plane, 65 engine, 7 analyzer tests,
32 Go packages, web build.
