### PR TITLE
fix(analyzer): support NATURAL JOIN lineage

### DIFF
--- a/analyzer/probe/engine.go
+++ b/analyzer/probe/engine.go
@@ -13,6 +13,18 @@ import (
 	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
 )
 
+// starOrder is a merging join's star-expansion column order: the merged common columns, then the
+// remaining columns of each side.
+type starOrder int
+
+const (
+	// starOrderCommonLeftRight: common columns, the left table's rest, the right's (PostgreSQL).
+	starOrderCommonLeftRight starOrder = iota
+	// starOrderCommonRightLeft: common columns, the RIGHT table's rest, the left's — MySQL expands
+	// `a RIGHT JOIN b` as `b LEFT JOIN a`.
+	starOrderCommonRightLeft
+)
+
 // engine owns every engine-specific analysis decision, built once per Probe call from the caller's
 // EngineConfig — everything an engine needs (server version, MySQL's lower_case_table_names, the
 // sqlglot-go Dialect built from them) is captured at construction, so nothing downstream re-derives
@@ -57,6 +69,9 @@ type engine interface {
 	// or CTE body whose output labels collide (MySQL ER_DUP_FIELDNAME; PostgreSQL allows duplicate
 	// OUTPUT labels and rejects only a reference to one).
 	RejectsDuplicateDerivedOutputLabels() bool
+	// RightJoinStarOrder is how this engine's target DB orders a NATURAL/USING RIGHT JOIN's star
+	// expansion. A plain ON right join is written order on both engines.
+	RightJoinStarOrder() starOrder
 	// NativeOutputLabel computes the output label THIS engine's target DB natively assigns to an
 	// unaliased projection: PostgreSQL derives it from the resolved expression (parse_target.c
 	// FigureColname, written function names from the parse-time SpanText); MySQL uses the
@@ -256,6 +271,8 @@ func (e *mysqlEngine) CommandPassthrough(string) bool { return false }
 // MySQL rejects a derived-table/CTE body with duplicated output labels: ER_DUP_FIELDNAME.
 func (e *mysqlEngine) RejectsDuplicateDerivedOutputLabels() bool { return true }
 
+func (e *mysqlEngine) RightJoinStarOrder() starOrder { return starOrderCommonRightLeft }
+
 type postgresEngine struct {
 	dialect *dialects.Dialect
 }
@@ -327,6 +344,8 @@ func (e *postgresEngine) CommandPassthrough(command string) bool {
 
 // PostgreSQL allows duplicate OUTPUT labels; only a reference to one is ambiguous.
 func (e *postgresEngine) RejectsDuplicateDerivedOutputLabels() bool { return false }
+
+func (e *postgresEngine) RightJoinStarOrder() starOrder { return starOrderCommonLeftRight }
 
 // PostgreSQL names an unaliased projection per parse_target.c FigureColname; a call is labeled by
 // its WRITTEN function name, read from the projection's parse-time SpanText.

--- a/analyzer/probe/parity_test.go
+++ b/analyzer/probe/parity_test.go
@@ -82,7 +82,8 @@ func probeParityCases() []probeParityCase {
 		{name: "create view", sql: "CREATE VIEW sink AS SELECT id, ssn FROM users", category: "create"},
 		{name: "select into", sql: "SELECT id, ssn INTO sink FROM users", category: "select into"},
 		{name: "pivot", sql: "SELECT * FROM users PIVOT (SUM(id) FOR region IN ('x')) AS p", category: "fail closed"},
-		{name: "natural join", sql: "SELECT * FROM users NATURAL JOIN orders", category: "fail closed"},
+		{name: "natural join", dialect: "mysql", sql: "SELECT * FROM users NATURAL JOIN orders", category: "join", deferredReason: "Go expands NATURAL JOIN through catalog-backed USING semantics; the pinned Python oracle intentionally denies it"},
+		{name: "natural join", dialect: "postgres", sql: "SELECT * FROM users NATURAL JOIN orders", category: "join", deferredReason: "Go expands NATURAL JOIN through catalog-backed USING semantics; the pinned Python oracle intentionally denies it"},
 		{name: "unknown table", sql: "SELECT id FROM nope", category: "fail closed"},
 		{name: "unknown column", sql: "SELECT nope FROM users", category: "fail closed"},
 		{name: "multiple statements", sql: "SELECT 1; SELECT 2", category: "fail closed"},
@@ -211,7 +212,7 @@ func TestProbeParity(t *testing.T) {
 		t.Logf("regenerated %s (%d entries)", goldenPath, len(golden))
 	}
 
-	const minParity = 91 // Ratchet: set to the achieved count and never lower to mask a regression.
+	const minParity = 90 // Ratchet: set to the achieved count and never lower to mask a regression.
 	if exactMatches < minParity {
 		t.Fatalf("probe parity regressed: got %d/%d exact matches, min %d", exactMatches, len(expanded), minParity)
 	}

--- a/analyzer/probe/probe.go
+++ b/analyzer/probe/probe.go
@@ -125,6 +125,9 @@ type prober struct {
 	physicalTables    map[exp.Expression]tableID
 	nonPhysicalTables map[exp.Expression]bool
 	newTargets        map[exp.Expression]bool
+
+	naturalStarOrders  map[exp.Expression][]naturalStarColumn
+	naturalStarPending map[exp.Expression]bool
 }
 
 type resolveKey struct {
@@ -137,6 +140,11 @@ type identKey struct {
 	scope *optimizer.Scope
 	alias string
 	name  string
+}
+
+type naturalStarColumn struct {
+	name   string
+	tables []string
 }
 
 func Probe(sql string, engineConfig *pb.EngineConfig, sch *schema.Mapping, namespace NamespaceConfig) ProbeResult {
@@ -190,6 +198,9 @@ func probeParsed(root exp.Expression, eng engine, qualifySchema schema.Schema, n
 		physicalTables:    map[exp.Expression]tableID{},
 		nonPhysicalTables: map[exp.Expression]bool{},
 		newTargets:        map[exp.Expression]bool{},
+
+		naturalStarOrders:  map[exp.Expression][]naturalStarColumn{},
+		naturalStarPending: map[exp.Expression]bool{},
 	}
 	// Emit the called-function facts even when analysis FAILS after parsing — an unsupported/
 	// unresolved statement (`SELECT * FROM dblink(...)`, a data-modifying CTE, PIVOT, …) that resolves=false.
@@ -220,11 +231,6 @@ func probeParsed(root exp.Expression, eng engine, qualifySchema schema.Schema, n
 	if len(p.root.FindAll(exp.KindPivot)) > 0 {
 		return failResult("VALIDATE", "PIVOT/UNPIVOT not supported")
 	}
-	for _, join := range p.root.FindAll(exp.KindJoin) {
-		if strings.ToUpper(fmt.Sprint(firstNonNil(join.Arg("method"), ""))) == "NATURAL" || fmt.Sprint(join.Arg("kind")) == "NATURAL" {
-			return failResult("VALIDATE", "NATURAL JOIN not supported (shared-column lineage is ambiguous)")
-		}
-	}
 	for _, oc := range p.root.FindAll(exp.KindOnConflict) {
 		if truthy(oc.Arg("constraint")) {
 			return failResult("VALIDATE", "ON CONFLICT ON CONSTRAINT — cannot map a named constraint to columns")
@@ -232,6 +238,7 @@ func probeParsed(root exp.Expression, eng engine, qualifySchema schema.Schema, n
 	}
 	if fail := runStage("VALIDATE", func() {
 		p.qroot = p.root.Copy()
+		p.expandNaturalJoins(p.qroot)
 		p.markNewTargets(p.qroot)
 		// MySQL's DELETE target-alias list names sources already present under FROM. Keeping the
 		// selector nodes during qualification makes the native DML scope reject the duplicate alias;
@@ -292,6 +299,243 @@ func probeParsed(root exp.Expression, eng engine, qualifySchema schema.Schema, n
 		return *fail
 	}
 	return result
+}
+
+func (p *prober) expandNaturalJoins(root exp.Expression) {
+	for _, scope := range optimizer.TraverseScope(root) {
+		if scope == nil || scope.Expression == nil {
+			continue
+		}
+		joins := expressionsFor(scope.Expression, "joins")
+		needsExpansion := false
+		for _, join := range joins {
+			// Any NATURAL or USING join merges its common columns first in the star order, which
+			// differs from sqlglot's per-table expansion — every such scope needs the merge pass.
+			if isNaturalJoin(join) || len(expressionsFor(join, "using")) > 0 {
+				needsExpansion = true
+				break
+			}
+		}
+		if !needsExpansion {
+			continue
+		}
+		if scope.Expression.Kind() != exp.KindSelect {
+			panic(fmt.Errorf("NATURAL JOIN is unsupported in %s", exp.ClassName(scope.Expression.Kind())))
+		}
+
+		sourceOrder := p.fromSourceOrder(scope.Expression)
+		if len(sourceOrder) != len(joins)+1 {
+			panic(fmt.Errorf("NATURAL JOIN source order is incomplete"))
+		}
+		resolver := optimizer.NewResolver(scope, p.qualifySchema, false)
+		sourceColumns := func(alias string) []naturalStarColumn {
+			names := resolver.GetSourceColumns(alias, true)
+			if len(names) == 0 {
+				panic(fmt.Errorf("NATURAL JOIN source %q has no known columns", alias))
+			}
+			columns := make([]naturalStarColumn, 0, len(names))
+			for _, name := range names {
+				if name == "*" {
+					panic(fmt.Errorf("NATURAL JOIN source %q has an unknown column set", alias))
+				}
+				columns = append(columns, naturalStarColumn{name: name, tables: []string{alias}})
+			}
+			return columns
+		}
+
+		prefix := []naturalStarColumn{}
+		group := sourceColumns(sourceOrder[0])
+		outerMerged := false
+		for i, join := range joins {
+			right := sourceColumns(sourceOrder[i+1])
+			if isCommaJoin(join) {
+				prefix = append(prefix, group...)
+				group = right
+				continue
+			}
+			kind := strings.ToUpper(fmt.Sprint(join.Arg("kind")))
+			side := strings.ToUpper(fmt.Sprint(join.Arg("side")))
+			if kind == "SEMI" || kind == "ANTI" || side == "SEMI" || side == "ANTI" {
+				panic(fmt.Errorf("NATURAL JOIN with %s%s join is unsupported", side, kind))
+			}
+
+			mergeLeft, mergeRight := group, right
+			if side == "RIGHT" && p.engine.RightJoinStarOrder() == starOrderCommonRightLeft {
+				mergeLeft, mergeRight = right, group
+			}
+			using := p.joinUsingColumns(join)
+			if isNaturalJoin(join) {
+				// Both targets reject NATURAL combined with ON/USING as a syntax error; expanding it
+				// would hand back data for a statement the target would refuse.
+				if join.Arg("on") != nil || len(using) > 0 {
+					panic(fmt.Errorf("NATURAL JOIN with an ON/USING clause is invalid on the target"))
+				}
+				var err error
+				using, err = naturalCommonColumns(mergeLeft, mergeRight, p.engine.FoldColumn)
+				if err != nil {
+					panic(err)
+				}
+				join.Set("method", nil)
+				if strings.EqualFold(fmt.Sprint(join.Arg("kind")), "NATURAL") {
+					join.Set("kind", nil)
+				}
+				if len(using) == 0 {
+					if side == "" {
+						join.Set("kind", "CROSS")
+						join.Set("side", nil)
+					} else {
+						join.Set("on", exp.Boolean(exp.Args{"this": true}))
+					}
+				} else {
+					identifiers := make([]exp.Expression, 0, len(using))
+					for _, name := range using {
+						identifiers = append(identifiers, exp.ToIdentifier(name, true))
+					}
+					join.Set("using", identifiers)
+				}
+			}
+
+			if len(using) > 0 {
+				// Qualify expands USING against the first scope source carrying the name, so a key
+				// whose value lives elsewhere would bind the join to the wrong table: a same-named
+				// column in an earlier comma group, or a merged value produced by a preceding
+				// RIGHT/FULL join (its carrier is not the leftmost table). Fail closed on both.
+				if outerMerged {
+					panic(fmt.Errorf("NATURAL/USING join after an outer merging join — the merged key needs COALESCE semantics"))
+				}
+				for _, name := range using {
+					folded := p.engine.FoldColumn(name)
+					for _, column := range prefix {
+						if p.engine.FoldColumn(column.name) == folded {
+							panic(fmt.Errorf("NATURAL/USING key %q also names a column outside the joined tables", name))
+						}
+					}
+				}
+				if side == "RIGHT" || side == "FULL" {
+					outerMerged = true
+				}
+			}
+
+			if len(using) == 0 {
+				group = append(append([]naturalStarColumn{}, mergeLeft...), mergeRight...)
+				continue
+			}
+			merged, err := mergeUsingColumns(mergeLeft, mergeRight, using, p.engine.FoldColumn)
+			if err != nil {
+				panic(err)
+			}
+			group = merged
+		}
+		p.naturalStarOrders[scope.Expression] = append(prefix, group...)
+		for _, proj := range scope.Expression.Selects() {
+			if proj.Kind() == exp.KindStar {
+				p.naturalStarPending[scope.Expression] = true
+			}
+		}
+	}
+
+	for _, join := range root.FindAll(exp.KindJoin) {
+		if isNaturalJoin(join) {
+			panic(fmt.Errorf("NATURAL JOIN source shape is unsupported"))
+		}
+	}
+}
+
+func isNaturalJoin(join exp.Expression) bool {
+	return join != nil && (strings.EqualFold(fmt.Sprint(join.Arg("method")), "NATURAL") ||
+		strings.EqualFold(fmt.Sprint(join.Arg("kind")), "NATURAL"))
+}
+
+func isCommaJoin(join exp.Expression) bool {
+	return join != nil && join.Arg("method") == nil && join.Arg("kind") == nil &&
+		join.Arg("side") == nil && join.Arg("on") == nil && len(expressionsFor(join, "using")) == 0
+}
+
+func (p *prober) joinUsingColumns(join exp.Expression) []string {
+	using := expressionsFor(join, "using")
+	out := make([]string, 0, len(using))
+	for _, identifier := range using {
+		identifier = identifier.Copy()
+		p.dialect.NormalizeIdentifier(identifier)
+		out = append(out, identifier.Name())
+	}
+	return out
+}
+
+func naturalCommonColumns(left, right []naturalStarColumn, fold func(string) string) ([]string, error) {
+	leftCounts := map[string]int{}
+	rightCounts := map[string]int{}
+	for _, column := range left {
+		leftCounts[fold(column.name)]++
+	}
+	for _, column := range right {
+		rightCounts[fold(column.name)]++
+	}
+	common := []string{}
+	seen := map[string]bool{}
+	for _, column := range left {
+		key := fold(column.name)
+		if seen[key] || rightCounts[key] == 0 {
+			continue
+		}
+		seen[key] = true
+		if leftCounts[key] != 1 || rightCounts[key] != 1 {
+			return nil, fmt.Errorf("NATURAL JOIN common column %q is ambiguous", column.name)
+		}
+		common = append(common, column.name)
+	}
+	return common, nil
+}
+
+func mergeUsingColumns(left, right []naturalStarColumn, using []string, fold func(string) string) ([]naturalStarColumn, error) {
+	leftByName := map[string][]naturalStarColumn{}
+	rightByName := map[string][]naturalStarColumn{}
+	for _, column := range left {
+		leftByName[fold(column.name)] = append(leftByName[fold(column.name)], column)
+	}
+	for _, column := range right {
+		rightByName[fold(column.name)] = append(rightByName[fold(column.name)], column)
+	}
+
+	merged := make([]naturalStarColumn, 0, len(left)+len(right))
+	usingSet := map[string]bool{}
+	for _, rawName := range using {
+		name := fold(rawName)
+		if usingSet[name] {
+			return nil, fmt.Errorf("JOIN USING column %q appears more than once", rawName)
+		}
+		usingSet[name] = true
+		leftMatches := leftByName[name]
+		rightMatches := rightByName[name]
+		if len(leftMatches) != 1 || len(rightMatches) != 1 {
+			return nil, fmt.Errorf("JOIN USING column %q is missing or ambiguous", rawName)
+		}
+		tables := append([]string(nil), leftMatches[0].tables...)
+		for _, table := range rightMatches[0].tables {
+			found := false
+			for _, existing := range tables {
+				if existing == table {
+					found = true
+					break
+				}
+			}
+			if !found {
+				tables = append(tables, table)
+			}
+		}
+		merged = append(merged, naturalStarColumn{name: leftMatches[0].name, tables: tables})
+	}
+	for _, column := range left {
+		if !usingSet[fold(column.name)] {
+			merged = append(merged, column)
+		}
+	}
+	for _, column := range right {
+		if !usingSet[fold(column.name)] {
+			merged = append(merged, column)
+		}
+	}
+	return merged, nil
 }
 
 func tableNodes(node exp.Expression) []exp.Expression {
@@ -1173,6 +1417,12 @@ func (p *prober) lineage() ProbeResult {
 			}
 			starExpanded = true
 		}
+		// A merged star inside a derived table/CTE never reaches resortBareStarInplace (only the
+		// outer branches are resorted), so its expansion order — and the outer scope's ordinals
+		// with it — would silently disagree with the target.
+		if len(p.naturalStarPending) > 0 {
+			return failResult("VALIDATE", "NATURAL/USING `*` inside a derived scope — column order can't bind to mask ordinals")
+		}
 		if starExpanded {
 			relayRoot := p.qroot
 			// Repair the outermost display labels on a relay-only copy — lineage and mask ordinals
@@ -1586,11 +1836,9 @@ func (p *prober) predicateLiteralRefs() []PredicateLiteralRef {
 // IO/exec/admin function (pg_read_file, dblink, lo_*, load_file, rds_*, keyring_*, get_raw_page, …) parses
 // Anonymous, whereas standard-SQL builtins with dedicated node kinds (Count, Cast, Substring, …) are safe,
 // out of the shipped dangerous set, and carry unreliable Name()s (`count(*)` → "*"). Names are lowercased
-// so the resolver's fold-insensitive match is stable. This fact is the SOLE enforcement path for a FROM'd
-// dangerous builtin: the call resolves + emits here + is forbidden by the control-plane function gate
-// (via the per-version manifest or the version-independent BaselineDangerousFunctions floor). A no-FROM
-// dangerous call is gated separately by noFromFunctionGrants (facts.go), which emits a Function grant the
-// control-plane denies.
+// so the resolver's fold-insensitive match is stable. The control plane classifies these names against the
+// per-version manifest and the version-independent BaselineDangerousFunctions floor; functionCallGrants
+// separately preserves qualifiers and provides the fail-closed Function grant.
 func (p *prober) calledFunctions() []string {
 	seen := map[string]bool{}
 	out := []string{}
@@ -2263,9 +2511,6 @@ func (p *prober) expandableSources(sel exp.Expression) (bool, string) {
 		srcs = append(srcs, frm.This())
 	}
 	for _, j := range expressionsFor(sel, "joins") {
-		if strings.ToUpper(fmt.Sprint(firstNonNil(j.Arg("method"), ""))) == "NATURAL" || j.Arg("kind") == "NATURAL" {
-			return false, "a NATURAL join"
-		}
 		srcs = append(srcs, j.This())
 	}
 	for _, s := range srcs {
@@ -2287,6 +2532,31 @@ func (p *prober) expandableSources(sel exp.Expression) (bool, string) {
 	return true, ""
 }
 
+// Table aliases recorded before Qualify compare folded (MySQL lower_case_table_names folds them
+// during qualification; the projection carries the folded spelling).
+func (p *prober) naturalStarProjectionMatches(projection exp.Expression, expected naturalStarColumn) bool {
+	if projection == nil || projection.AliasOrName() != expected.name {
+		return false
+	}
+	foldTable := func(name string) string { return p.dialect.FoldIdentifierName(name, true) }
+	actualTables := map[string]bool{}
+	for _, column := range projection.FindAll(exp.KindColumn) {
+		if column.Name() != expected.name || column.TableName() == "" {
+			return false
+		}
+		actualTables[foldTable(column.TableName())] = true
+	}
+	if len(actualTables) != len(expected.tables) {
+		return false
+	}
+	for _, table := range expected.tables {
+		if !actualTables[foldTable(table)] {
+			return false
+		}
+	}
+	return true
+}
+
 func (p *prober) resortBareStarInplace(osel, qsel exp.Expression) {
 	starIdx := -1
 	for i, proj := range osel.Selects() {
@@ -2306,6 +2576,45 @@ func (p *prober) resortBareStarInplace(osel, qsel exp.Expression) {
 		pos[alias] = i
 	}
 	block := append([]exp.Expression(nil), qs[nb:len(qs)-na]...)
+	if order, ok := p.naturalStarOrders[qsel]; ok {
+		delete(p.naturalStarPending, qsel)
+		if len(order) != len(block) {
+			panic(fmt.Errorf("NATURAL JOIN star expansion produced %d columns, want %d", len(block), len(order)))
+		}
+		ordered := make([]exp.Expression, 0, len(block))
+		used := make([]bool, len(block))
+		for _, column := range order {
+			matched := -1
+			for i, projection := range block {
+				if !used[i] && p.naturalStarProjectionMatches(projection, column) {
+					matched = i
+					break
+				}
+			}
+			if matched < 0 {
+				panic(fmt.Errorf("NATURAL JOIN star output %q could not be ordered faithfully", column.name))
+			}
+			used[matched] = true
+			ordered = append(ordered, block[matched])
+		}
+		identity := true
+		for i := range ordered {
+			if ordered[i] != block[i] {
+				identity = false
+				break
+			}
+		}
+		// Qualify already rebound positional ORDER BY/GROUP BY ordinals against the pre-merge
+		// expansion; reordering the select list would leave them pointing at the wrong column.
+		if !identity && selectUsesPositionalOrdinals(osel) {
+			panic(fmt.Errorf("positional ORDER BY/GROUP BY over a NATURAL/USING star — ordinals cannot bind faithfully"))
+		}
+		newSelects := append([]exp.Expression(nil), qs[:nb]...)
+		newSelects = append(newSelects, ordered...)
+		newSelects = append(newSelects, qs[len(qs)-na:]...)
+		qsel.Set("expressions", newSelects)
+		return
+	}
 	position := func(proj exp.Expression) int {
 		if col := proj.Find(exp.KindColumn); col != nil {
 			if value, ok := pos[col.TableName()]; ok {
@@ -2321,6 +2630,22 @@ func (p *prober) resortBareStarInplace(osel, qsel exp.Expression) {
 	qsel.Set("expressions", newSelects)
 }
 
+func selectUsesPositionalOrdinals(sel exp.Expression) bool {
+	for _, arg := range []string{"order", "group"} {
+		clause := asExpression(sel.Arg(arg))
+		if clause == nil {
+			continue
+		}
+		for _, lit := range clause.FindAll(exp.KindLiteral) {
+			if !truthy(lit.Arg("is_string")) {
+				if _, err := strconv.Atoi(lit.Name()); err == nil {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
 func (p *prober) cteReferenced(cte exp.Expression, root exp.Expression) bool {
 	if cte == nil || root == nil || cte.This() == nil {
 		return false

--- a/analyzer/probe/probe_test.go
+++ b/analyzer/probe/probe_test.go
@@ -2,6 +2,7 @@ package probe
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	pb "github.com/ridi-oss/proxy-monster/analyzer/probe/pb"
@@ -97,6 +98,163 @@ func TestFromSourceOrder(t *testing.T) {
 	}
 }
 
+func TestPostgresNaturalJoinExpandsWithPhysicalLineage(t *testing.T) {
+	result := analyzeProbe(t, &pb.AnalyzeRequest{
+		Sql:          "SELECT * FROM public.left_table l NATURAL JOIN public.right_table r",
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+		Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+		Catalog: []*pb.ColumnSpec{
+			columnSpec("acme", "public", "left_table", "left_value", "TEXT"),
+			columnSpec("acme", "public", "left_table", "id", "BIGINT"),
+			columnSpec("acme", "public", "right_table", "id", "BIGINT"),
+			columnSpec("acme", "public", "right_table", "right_value", "TEXT"),
+		},
+	})
+	if !result.Resolved {
+		t.Fatalf("NATURAL JOIN must resolve: stage=%v detail=%q", result.FailedStage, result.Detail)
+	}
+	wantNames := []string{"id", "left_value", "right_value"}
+	if result.OutputColumns != len(wantNames) {
+		t.Fatalf("output columns = %d, want %d: %+v", result.OutputColumns, len(wantNames), result.Origins)
+	}
+	for i, want := range wantNames {
+		if result.Origins[i].Column != want {
+			t.Fatalf("output %d = %q, want %q: %+v", i, result.Origins[i].Column, want, result.Origins)
+		}
+	}
+	wantIDOrigins := []string{"acme.public.left_table.id", "acme.public.right_table.id"}
+	if !reflect.DeepEqual(result.Origins[0].Origins, wantIDOrigins) {
+		t.Fatalf("id origins = %v, want %v", result.Origins[0].Origins, wantIDOrigins)
+	}
+	for _, column := range wantIDOrigins {
+		found := false
+		for _, reference := range result.References[JOIN] {
+			if reference == column {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("JOIN references = %v, missing %s", result.References[JOIN], column)
+		}
+	}
+	if result.RewrittenSQL == nil {
+		t.Fatal("NATURAL JOIN star must carry an executable rewrite")
+	}
+	rewritten, err := sqlglot.ParseOne(*result.RewrittenSQL, "postgres")
+	if err != nil {
+		t.Fatalf("parse rewritten SQL: %v", err)
+	}
+	for i, want := range wantNames {
+		if got := rewritten.Selects()[i].AliasOrName(); got != want {
+			t.Fatalf("rewritten output %d = %q, want %q: %q", i, got, want, *result.RewrittenSQL)
+		}
+	}
+}
+
+func TestPostgresNaturalJoinChainsAfterUsing(t *testing.T) {
+	result := analyzeProbe(t, &pb.AnalyzeRequest{
+		Sql:          "SELECT * FROM public.a JOIN public.b USING (id) NATURAL JOIN public.c",
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+		Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+		Catalog: []*pb.ColumnSpec{
+			columnSpec("acme", "public", "a", "id", "BIGINT"),
+			columnSpec("acme", "public", "a", "a_value", "TEXT"),
+			columnSpec("acme", "public", "b", "id", "BIGINT"),
+			columnSpec("acme", "public", "b", "shared", "TEXT"),
+			columnSpec("acme", "public", "b", "b_value", "TEXT"),
+			columnSpec("acme", "public", "c", "shared", "TEXT"),
+			columnSpec("acme", "public", "c", "c_value", "TEXT"),
+		},
+	})
+	if !result.Resolved {
+		t.Fatalf("chained NATURAL JOIN must resolve: stage=%v detail=%q", result.FailedStage, result.Detail)
+	}
+	want := []string{"shared", "id", "a_value", "b_value", "c_value"}
+	if len(result.Origins) != len(want) {
+		t.Fatalf("origins = %+v, want %d outputs", result.Origins, len(want))
+	}
+	for i, name := range want {
+		if result.Origins[i].Column != name {
+			t.Fatalf("output %d = %q, want %q: %+v", i, result.Origins[i].Column, name, result.Origins)
+		}
+	}
+}
+
+func TestPostgresNaturalJoinRespectsCommaPrecedence(t *testing.T) {
+	result := analyzeProbe(t, &pb.AnalyzeRequest{
+		Sql:          "SELECT * FROM public.a, public.b NATURAL JOIN public.c",
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+		Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+		Catalog: []*pb.ColumnSpec{
+			columnSpec("acme", "public", "a", "id", "BIGINT"),
+			columnSpec("acme", "public", "a", "a_value", "TEXT"),
+			columnSpec("acme", "public", "b", "shared", "TEXT"),
+			columnSpec("acme", "public", "b", "b_value", "TEXT"),
+			columnSpec("acme", "public", "c", "id", "BIGINT"),
+			columnSpec("acme", "public", "c", "shared", "TEXT"),
+			columnSpec("acme", "public", "c", "c_value", "TEXT"),
+		},
+	})
+	if !result.Resolved {
+		t.Fatalf("comma-bound NATURAL JOIN must resolve: stage=%v detail=%q", result.FailedStage, result.Detail)
+	}
+	want := []string{"id", "a_value", "shared", "b_value", "id", "c_value"}
+	if len(result.Origins) != len(want) {
+		t.Fatalf("origins = %+v, want %d outputs", result.Origins, len(want))
+	}
+	for i, name := range want {
+		if result.Origins[i].Column != name {
+			t.Fatalf("output %d = %q, want %q: %+v", i, result.Origins[i].Column, name, result.Origins)
+		}
+	}
+}
+
+func TestPostgresNaturalJoinWithoutCommonColumns(t *testing.T) {
+	catalog := []*pb.ColumnSpec{
+		columnSpec("acme", "public", "a", "a_id", "BIGINT"),
+		columnSpec("acme", "public", "b", "b_id", "BIGINT"),
+	}
+	for _, tc := range []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{name: "inner", sql: "SELECT * FROM public.a NATURAL JOIN public.b", want: "TRUE"},
+		{name: "left", sql: "SELECT * FROM public.a NATURAL LEFT JOIN public.b", want: "TRUE"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := analyzeProbe(t, &pb.AnalyzeRequest{
+				Sql:          tc.sql,
+				EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+				Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+				Catalog:      catalog,
+			})
+			if !result.Resolved || result.RewrittenSQL == nil {
+				t.Fatalf("empty-intersection NATURAL JOIN must resolve with a rewrite: %+v", result)
+			}
+			if !strings.Contains(strings.ToUpper(*result.RewrittenSQL), tc.want) {
+				t.Fatalf("rewrite %q does not contain %q", *result.RewrittenSQL, tc.want)
+			}
+		})
+	}
+}
+
+func TestPostgresNaturalJoinRejectsAmbiguousCommonColumn(t *testing.T) {
+	result := analyzeProbe(t, &pb.AnalyzeRequest{
+		Sql:          "SELECT * FROM (SELECT id, id AS id FROM public.a) l NATURAL JOIN public.b",
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_POSTGRES},
+		Namespace:    &pb.Namespace{Catalog: "acme", SearchPath: []string{"public"}},
+		Catalog: []*pb.ColumnSpec{
+			columnSpec("acme", "public", "a", "id", "BIGINT"),
+			columnSpec("acme", "public", "b", "id", "BIGINT"),
+		},
+	})
+	if result.Resolved || result.FailedStage == nil || *result.FailedStage != "VALIDATE" || !strings.Contains(result.Detail, "ambiguous") {
+		t.Fatalf("ambiguous NATURAL JOIN must fail closed in validation: %+v", result)
+	}
+}
+
 func TestMySQLPlaceholderResolvesAndTracesColumns(t *testing.T) {
 	cols := []*pb.ColumnSpec{
 		columnSpec("def", "app", "users", "id", "BIGINT"),
@@ -123,5 +281,210 @@ func TestCTEColNames(t *testing.T) {
 	want := []string{"x"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("cteColNames = %v, want %v", got, want)
+	}
+}
+
+// MySQL star order: merged columns first in left-table order, then each table's remaining columns.
+func TestMysqlNaturalJoinExpandsWithPhysicalLineage(t *testing.T) {
+	result := analyzeProbe(t, &pb.AnalyzeRequest{
+		Sql:          "SELECT * FROM a NATURAL JOIN b",
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_MYSQL, EngineVersion: "8.0.46", MysqlLowerCaseTableNames: proto.Int32(1)},
+		Namespace:    &pb.Namespace{Catalog: "def", SearchPath: []string{"app"}},
+		Catalog: []*pb.ColumnSpec{
+			columnSpec("def", "app", "a", "id", "BIGINT"),
+			columnSpec("def", "app", "a", "name", "VARCHAR"),
+			columnSpec("def", "app", "a", "a_only", "BIGINT"),
+			columnSpec("def", "app", "b", "b_only", "BIGINT"),
+			columnSpec("def", "app", "b", "id", "BIGINT"),
+			columnSpec("def", "app", "b", "name", "VARCHAR"),
+		},
+	})
+	if !result.Resolved {
+		t.Fatalf("NATURAL JOIN must resolve: stage=%v detail=%q", result.FailedStage, result.Detail)
+	}
+	wantNames := []string{"id", "name", "a_only", "b_only"}
+	if result.OutputColumns != len(wantNames) {
+		t.Fatalf("output columns = %d, want %d: %+v", result.OutputColumns, len(wantNames), result.Origins)
+	}
+	for i, want := range wantNames {
+		if result.Origins[i].Column != want {
+			t.Fatalf("output %d = %q, want %q: %+v", i, result.Origins[i].Column, want, result.Origins)
+		}
+	}
+	wantIDOrigins := []string{"def.app.a.id", "def.app.b.id"}
+	if !reflect.DeepEqual(result.Origins[0].Origins, wantIDOrigins) {
+		t.Fatalf("id origins = %v, want %v", result.Origins[0].Origins, wantIDOrigins)
+	}
+}
+
+// A MySQL NATURAL/USING RIGHT JOIN's star puts the right table's columns first — merged columns,
+// then b's remaining columns, then a's. PostgreSQL keeps the written table order instead.
+func TestMysqlNaturalRightJoinStarOrderCommonRightLeft(t *testing.T) {
+	catalog := []*pb.ColumnSpec{
+		columnSpec("def", "app", "a", "id", "BIGINT"),
+		columnSpec("def", "app", "a", "name", "VARCHAR"),
+		columnSpec("def", "app", "a", "a_only", "BIGINT"),
+		columnSpec("def", "app", "b", "b_only", "BIGINT"),
+		columnSpec("def", "app", "b", "id", "BIGINT"),
+		columnSpec("def", "app", "b", "name", "VARCHAR"),
+	}
+	for _, tc := range []struct {
+		sql  string
+		want []string
+	}{
+		{"SELECT * FROM a NATURAL RIGHT JOIN b", []string{"id", "name", "b_only", "a_only"}},
+		{"SELECT * FROM a RIGHT JOIN b USING (id)", []string{"id", "b_only", "name", "name", "a_only"}},
+		{"SELECT * FROM a NATURAL LEFT JOIN b", []string{"id", "name", "a_only", "b_only"}},
+	} {
+		result := analyzeProbe(t, &pb.AnalyzeRequest{
+			Sql:          tc.sql,
+			EngineConfig: &pb.EngineConfig{Engine: pb.Engine_MYSQL, EngineVersion: "8.0.46", MysqlLowerCaseTableNames: proto.Int32(1)},
+			Namespace:    &pb.Namespace{Catalog: "def", SearchPath: []string{"app"}},
+			Catalog:      catalog,
+		})
+		if !result.Resolved {
+			t.Fatalf("%q must resolve: stage=%v detail=%q", tc.sql, result.FailedStage, result.Detail)
+		}
+		got := make([]string, 0, len(result.Origins))
+		for _, origin := range result.Origins {
+			got = append(got, origin.Column)
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("%q star order = %v, want %v", tc.sql, got, tc.want)
+		}
+	}
+}
+
+// MySQL matches shared NATURAL columns case-insensitively (u1.ID joins u2.id). PostgreSQL treats
+// them as distinct columns.
+func TestMysqlNaturalJoinFoldsColumnCase(t *testing.T) {
+	result := analyzeProbe(t, &pb.AnalyzeRequest{
+		Sql:          "SELECT * FROM u1 NATURAL JOIN u2",
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_MYSQL, EngineVersion: "8.0.46", MysqlLowerCaseTableNames: proto.Int32(1)},
+		Namespace:    &pb.Namespace{Catalog: "def", SearchPath: []string{"app"}},
+		Catalog: []*pb.ColumnSpec{
+			columnSpec("def", "app", "u1", "ID", "BIGINT"),
+			columnSpec("def", "app", "u1", "x", "BIGINT"),
+			columnSpec("def", "app", "u2", "id", "BIGINT"),
+			columnSpec("def", "app", "u2", "y", "BIGINT"),
+		},
+	})
+	if !result.Resolved {
+		t.Fatalf("case-folded NATURAL JOIN must resolve: stage=%v detail=%q", result.FailedStage, result.Detail)
+	}
+	// The probe folds MySQL catalog identifiers on build (NormalizeCatalogOnBuild), so the merged
+	// label reads folded; mask ordinals — position 0 spanning both tables — are what enforcement uses.
+	want := []string{"id", "x", "y"}
+	got := make([]string, 0, len(result.Origins))
+	for _, origin := range result.Origins {
+		got = append(got, origin.Column)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("star order = %v, want %v", got, want)
+	}
+	wantMerged := []string{"def.app.u1.id", "def.app.u2.id"}
+	if !reflect.DeepEqual(result.Origins[0].Origins, wantMerged) {
+		t.Fatalf("merged origins = %v, want %v", result.Origins[0].Origins, wantMerged)
+	}
+}
+
+// NATURAL JOIN with no shared columns degrades to a cross join on both engines.
+func TestMysqlNaturalJoinWithoutCommonColumns(t *testing.T) {
+	result := analyzeProbe(t, &pb.AnalyzeRequest{
+		Sql:          "SELECT * FROM n1 NATURAL JOIN n2",
+		EngineConfig: &pb.EngineConfig{Engine: pb.Engine_MYSQL, EngineVersion: "8.0.46", MysqlLowerCaseTableNames: proto.Int32(1)},
+		Namespace:    &pb.Namespace{Catalog: "def", SearchPath: []string{"app"}},
+		Catalog: []*pb.ColumnSpec{
+			columnSpec("def", "app", "n1", "p", "BIGINT"),
+			columnSpec("def", "app", "n2", "q", "BIGINT"),
+		},
+	})
+	if !result.Resolved {
+		t.Fatalf("no-common-column NATURAL JOIN must resolve as cross: stage=%v detail=%q", result.FailedStage, result.Detail)
+	}
+	want := []string{"p", "q"}
+	got := make([]string, 0, len(result.Origins))
+	for _, origin := range result.Origins {
+		got = append(got, origin.Column)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("star order = %v, want %v", got, want)
+	}
+}
+
+// Plain (non-NATURAL) USING joins also merge the key column first in the star order on both
+// engines; the empty-common NATURAL RIGHT degrades to a cross with the right table's columns
+// first on MySQL; folded table aliases still match after qualification.
+func TestMysqlUsingAndNaturalStarOrderEdgeCases(t *testing.T) {
+	catalog := []*pb.ColumnSpec{
+		columnSpec("def", "app", "a", "a_only", "BIGINT"),
+		columnSpec("def", "app", "a", "id", "BIGINT"),
+		columnSpec("def", "app", "b", "id", "BIGINT"),
+		columnSpec("def", "app", "b", "b_only", "BIGINT"),
+		columnSpec("def", "app", "n1", "p", "BIGINT"),
+		columnSpec("def", "app", "n2", "q", "BIGINT"),
+	}
+	for _, tc := range []struct {
+		sql  string
+		want []string
+	}{
+		{"SELECT * FROM a JOIN b USING (id)", []string{"id", "a_only", "b_only"}},
+		{"SELECT * FROM a LEFT JOIN b USING (id)", []string{"id", "a_only", "b_only"}},
+		{"SELECT * FROM n1 NATURAL RIGHT JOIN n2", []string{"q", "p"}},
+		{"SELECT * FROM a AS A NATURAL JOIN b AS B", []string{"id", "a_only", "b_only"}},
+		{"SELECT * FROM a NATURAL RIGHT JOIN b ORDER BY b_only", []string{"id", "b_only", "a_only"}},
+	} {
+		result := analyzeProbe(t, &pb.AnalyzeRequest{
+			Sql:          tc.sql,
+			EngineConfig: &pb.EngineConfig{Engine: pb.Engine_MYSQL, EngineVersion: "8.0.46", MysqlLowerCaseTableNames: proto.Int32(1)},
+			Namespace:    &pb.Namespace{Catalog: "def", SearchPath: []string{"app"}},
+			Catalog:      catalog,
+		})
+		if !result.Resolved {
+			t.Fatalf("%q must resolve: stage=%v detail=%q", tc.sql, result.FailedStage, result.Detail)
+		}
+		got := make([]string, 0, len(result.Origins))
+		for _, origin := range result.Origins {
+			got = append(got, origin.Column)
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("%q star order = %v, want %v", tc.sql, got, tc.want)
+		}
+	}
+}
+
+// Shapes whose expansion cannot bind mask ordinals faithfully — or that the target itself
+// rejects — must fail closed rather than resolve with a divergent order.
+func TestNaturalJoinFailClosedShapes(t *testing.T) {
+	catalog := []*pb.ColumnSpec{
+		columnSpec("def", "app", "a", "a_only", "BIGINT"),
+		columnSpec("def", "app", "a", "id", "BIGINT"),
+		columnSpec("def", "app", "b", "id", "BIGINT"),
+		columnSpec("def", "app", "b", "b_only", "BIGINT"),
+		columnSpec("def", "app", "c", "id", "BIGINT"),
+		columnSpec("def", "app", "c", "c_only", "BIGINT"),
+		columnSpec("def", "app", "sa", "shared", "BIGINT"),
+		columnSpec("def", "app", "sa", "a1", "BIGINT"),
+		columnSpec("def", "app", "sb", "shared", "BIGINT"),
+		columnSpec("def", "app", "sb", "b1", "BIGINT"),
+		columnSpec("def", "app", "sc", "shared", "BIGINT"),
+		columnSpec("def", "app", "sc", "c1", "BIGINT"),
+	}
+	for _, tc := range []struct{ name, sql string }{
+		{"merged star inside a derived scope", "SELECT * FROM (SELECT * FROM a NATURAL JOIN b) ab"},
+		{"join key repeated outside the joined tables", "SELECT sa.a1, sb.b1 FROM sa, sb NATURAL JOIN sc"},
+		{"NATURAL after an outer merging join", "SELECT * FROM a NATURAL RIGHT JOIN b NATURAL JOIN c"},
+		{"positional ordinal over a merged star", "SELECT * FROM a NATURAL RIGHT JOIN b ORDER BY 2"},
+		{"NATURAL with an ON clause", "SELECT * FROM a NATURAL JOIN b ON a.id = b.id"},
+	} {
+		result := analyzeProbe(t, &pb.AnalyzeRequest{
+			Sql:          tc.sql,
+			EngineConfig: &pb.EngineConfig{Engine: pb.Engine_MYSQL, EngineVersion: "8.0.46", MysqlLowerCaseTableNames: proto.Int32(1)},
+			Namespace:    &pb.Namespace{Catalog: "def", SearchPath: []string{"app"}},
+			Catalog:      catalog,
+		})
+		if result.Resolved {
+			t.Fatalf("%s must fail closed: %q", tc.name, tc.sql)
+		}
 	}
 }

--- a/analyzer/probe/testdata/golden.json
+++ b/analyzer/probe/testdata/golden.json
@@ -471,17 +471,6 @@
     "isWrite": false,
     "rewrittenSql": null
   },
-  "mysql|natural join": {
-    "resolved": false,
-    "failedStage": "VALIDATE",
-    "detail": "NATURAL JOIN not supported (shared-column lineage is ambiguous)",
-    "outputColumns": 0,
-    "tracedColumns": 0,
-    "origins": [],
-    "references": {},
-    "isWrite": false,
-    "rewrittenSql": null
-  },
   "mysql|nested derived": {
     "resolved": true,
     "failedStage": null,
@@ -1470,17 +1459,6 @@
     "resolved": false,
     "failedStage": "PARSE",
     "detail": "expected 1 statement, got 2",
-    "outputColumns": 0,
-    "tracedColumns": 0,
-    "origins": [],
-    "references": {},
-    "isWrite": false,
-    "rewrittenSql": null
-  },
-  "postgres|natural join": {
-    "resolved": false,
-    "failedStage": "VALIDATE",
-    "detail": "NATURAL JOIN not supported (shared-column lineage is ambiguous)",
     "outputColumns": 0,
     "tracedColumns": 0,
     "origins": [],

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/BaselineDangerousFunctionEnforcementDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/BaselineDangerousFunctionEnforcementDbTest.kt
@@ -171,10 +171,8 @@ class BaselineDangerousFunctionEnforcementDbTest {
         // the call resolves + emits a function fact + is forbidden by the function gate. A `system:critical`
         // function (lo_export) is forbidden UNCONDITIONALLY (V25 -130), even under system:development.
         configure(pg, pg17, listOf("system:development"))
-        // Control: the exception.unanalyzable relay path IS live on this dev datasource — an actually-unanalyzable
-        // statement (NATURAL JOIN) is relayed verbatim (ALLOW, passthrough). This is the path the dangerous
-        // call would take without the function gate.
-        val relay = decide(pg, "select count(*) from orders natural join users")
+        // The exception.unanalyzable relay remains active for an unresolved catalog column.
+        val relay = decide(pg, "select missing_column from orders")
         assertEquals(EnfAction.ALLOW, relay.action, "dev datasource relays an unanalyzable statement via exception.unanalyzable")
         assertTrue(relay.passthrough, "the unanalyzable relay is a verbatim passthrough")
         // Improvement (RESOLVED forms only): a projected/scalar dangerous call RESOLVES + emits a function
@@ -195,13 +193,13 @@ class BaselineDangerousFunctionEnforcementDbTest {
         // - but a system:critical function (dblink_exec) hiding in a resolved=false statement DENIES even on a
         //   system:development datasource — the function gate runs ahead of the exception.unanalyzable relay, so a
         //   critical builtin is NEVER relayed verbatim (V25 -130 is unconditional). This is the residue CLOSED.
-        val critical = decide(pg, "select dblink_exec('c','s') from users natural join users")
+        val critical = decide(pg, "select dblink_exec('c','s'), missing_column from users")
         assertEquals(EnfAction.DENY, critical.action, "a resolved=false critical function is denied even on a system:development datasource (not relayed via exception.unanalyzable)")
         assertTrue(critical.detail?.contains("dangerous system function") == true, "the DENY is the function gate, not the relay: ${critical.detail}")
         // Both resolved=false forms DENY on the production floor (no exception.unanalyzable permit).
         configure(pg, pg17, listOf("system:production"))
         assertEquals(EnfAction.DENY, decide(pg, "select * from dblink('h','SELECT 1') as t(c text)").action, "resolved=false data-leak denies on the floor")
-        assertEquals(EnfAction.DENY, decide(pg, "select dblink_exec('c','s') from users natural join users").action, "resolved=false critical denies on the floor")
+        assertEquals(EnfAction.DENY, decide(pg, "select dblink_exec('c','s'), missing_column from users").action, "resolved=false critical denies on the floor")
         // BOUNDARY (explicit, not a gap this closes): the backfill only fires on a POST-PARSE failure — a
         // statement that sqlglot cannot PARSE (p.root == nil) emits no function facts, so a critical builtin in
         // a parse-failing statement the target DB still accepts takes the exception.unanalyzable verbatim relay on a

--- a/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/UnanalyzableGateDbTest.kt
+++ b/control-plane/src/test/kotlin/com/ridi/oss/proxymonster/controlplane/UnanalyzableGateDbTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertTrue
 
 /**
  * Unanalyzable-statement gate (docs/facts-emission.md) end-to-end on real PostgreSQL + real Cedar. The
- * analyzer cannot prove lineage for a NATURAL JOIN (shared-column lineage is ambiguous) → `resolved=false`.
+ * analyzer cannot resolve an unknown output column → `resolved=false`.
  * decideQuery asks the datasource for the `exception.unanalyzable` exception:
  *  - production floor (no exception policy) → DENY; and
  *  - a datasource that shipped a `exception.unanalyzable` permit → ALLOW, relaying the ORIGINAL statement verbatim
@@ -25,9 +25,8 @@ class UnanalyzableGateDbTest {
     private lateinit var fx: EnforcementFixture
     private val principal = "analyst@example.com"
 
-    // Admitted (single SELECT statement, passes the sql.select kind gate) but unanalyzable: the probe rejects
-    // NATURAL JOIN early, before catalog resolution, so this is `resolved=false` regardless of the schema.
-    private val unanalyzable = "select count(*) from orders natural join users"
+    // Admitted as SELECT but unresolved against the catalog.
+    private val unanalyzable = "select missing_column from orders"
 
     @BeforeAll
     fun setup() {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -366,6 +366,51 @@ Fixes for gaps documented in
 
 ## Analyzer & masking
 
+- Carry MySQL column visibility (`INVISIBLE`) through the catalog contract.
+  Introspection lists invisible columns like any other, so the analyzer includes
+  them in `SELECT *` expansion and NATURAL-join matching while the target
+  excludes them from both — the predicted star order and join key diverge from
+  what actually runs. Needs a visibility flag on `ColumnSpec` (introspected from
+  `information_schema.columns.EXTRA`), star expansion and NATURAL matching
+  skipping invisible columns, and explicit references still resolving.
+- Reorder merged NATURAL/USING stars inside derived tables and CTEs. The
+  faithful reorder runs only on the outer query's branches, so a merged star in
+  a derived scope fails closed today; supporting it needs the resort pass to
+  walk nested scopes and the outer scope to consume the derived output's merged
+  order.
+- Support a NATURAL/USING join after an outer merging join (RIGHT/FULL). The
+  merged key's value is `COALESCE(l.k, r.k)`, which a rewrite to plain USING
+  cannot express against a single carrier table; fails closed today.
+- Couple function-catalog freshness to the held connection. Function resolution
+  reads a datasource-level snapshot the proxy pushes on whole-catalog
+  introspection, so a same-named user function created ahead of `pg_catalog` on
+  the search path keeps resolving as the builtin (and relays) until the catalog
+  refreshes — the shadowing window in
+  [`KNOWN_LIMITATIONS.md`](../KNOWN_LIMITATIONS.md). The column catalog already
+  decides per connection against a generation stamp; the function catalog should
+  ride the same seam (deny function calls on a stale/absent generation) instead
+  of a process-global map, which also closes the transactional-DDL commit
+  ordering and concurrent-re-push reorder edges.
+- Fail closed on ambiguous unqualified columns in write payloads. The
+  write-payload resolver treats a column that is ambiguous among the payload's
+  local sources (`SELECT … FROM orders o, orders p WHERE ctid = …` — same for a
+  real column) as a correlated reference to the outer write target, where a bare
+  SELECT of the same shape fails closed. Grants still cover the read and
+  PostgreSQL rejects the ambiguous statement before execution, so this is
+  mis-attribution, not a leak — but the resolver should deny like the read path
+  does.
+- Synthesize implicit system columns per relation KIND. Synthesis adds all six
+  PostgreSQL system columns to every cataloged relation, but a view has none and
+  a foreign table has only `tableoid` — `SELECT xmin FROM a_view` resolves (with
+  a Column grant) and the target rejects it. Gated then engine-rejected, never a
+  leak; fixing it means the proxy pushing relation kinds with the catalog.
+- Tag the state-mutation / DoS builtins in the system-classification manifests.
+  `get_lock`/`sleep`/`benchmark` (MySQL) and `pg_advisory_lock`/`pg_sleep`/
+  `setval`/`nextval`/`lo_put`/`lowrite` (PostgreSQL) resolve as safe builtins
+  and relay ungated, so a read-authorized client can hold application locks or
+  mutate sequence / large-object state. Decide the tag (reuse `system:critical`
+  vs. a new state-mutation category) and audit the full surface before landing —
+  a manifest change per shipped engine version, curated like the native lists.
 - Reconsider redacting, rather than denying, a masked column used only in
   `GROUP BY` / `DISTINCT`; `DISTINCT` is the more defensible loosening.
 - Validate that a bare column's inferred source actually exposes it before


### PR DESCRIPTION
Expand catalog-backed NATURAL and USING joins before qualification on both engines, combining shared-column lineage from every physical source. The star order follows each target DB: merged common columns first, then each table's rest — except MySQL expands a RIGHT JOIN as the swapped LEFT JOIN (right table's columns first) and matches shared names case-insensitively.

Shapes whose expansion cannot bind mask ordinals faithfully fail closed: a merged star inside a derived scope, a NATURAL/USING join after an outer merging join (needs COALESCE semantics), a positional ORDER BY/GROUP BY over a reordered star, a USING key that also names a column outside the joined tables, and NATURAL with an ON clause (target syntax error).

Trap: plain `JOIN ... USING` (no NATURAL) also merges its key column first in `SELECT *` — the expansion pass now runs for every USING join, not just NATURAL.

Verified: star orders pinned against live MySQL 8.0/8.4 and PostgreSQL 16; probe suite + `mise run verify` green; triple-reviewed, all findings fixed or fail-closed with regression tests, remaining design gaps (MySQL INVISIBLE columns, derived-scope reorder, post-RIGHT NATURAL chains) in docs/backlog.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3S55XrwTAptjTZi7GD2j9