### PR TITLE
fix(mysqlproxy): allow MariaDB's default NO_AUTO_CREATE_USER sql_mode flag

### DIFF
--- a/goproxy/mysqlproxy/session.go
+++ b/goproxy/mysqlproxy/session.go
@@ -113,7 +113,7 @@ func isSafeMySQLCharset(value string) bool {
 	}
 }
 
-// mysqlParseSafeSqlModes are the MySQL 8.0 sql_mode flags known NOT to affect how a statement is TOKENIZED
+// mysqlParseSafeSqlModes are the MySQL 8.0 and MariaDB sql_mode flags known NOT to affect how a statement is TOKENIZED
 // or PARSED — they change runtime/execution semantics only (strictness, zero-date handling, GROUP BY
 // validation, type mapping, CHAR padding, …), so the analyzer parses the same text the same way whether or
 // not they are set. Everything the analyzer's lexer/grammar is sensitive to is handled explicitly by
@@ -127,6 +127,7 @@ func isSafeMySQLCharset(value string) bool {
 var mysqlParseSafeSqlModes = map[string]bool{
 	"ALLOW_INVALID_DATES":        true,
 	"ERROR_FOR_DIVISION_BY_ZERO": true,
+	"NO_AUTO_CREATE_USER":        true,
 	"NO_AUTO_VALUE_ON_ZERO":      true,
 	"NO_DIR_IN_CREATE":           true,
 	"NO_ENGINE_SUBSTITUTION":     true,

--- a/goproxy/mysqlproxy/sqlmode_test.go
+++ b/goproxy/mysqlproxy/sqlmode_test.go
@@ -15,7 +15,8 @@ import (
 func TestSqlModeClassifyUnit(t *testing.T) {
 	// Known parse-safe flags: ansiQuotes=false, no error.
 	safe := []string{"", "STRICT_TRANS_TABLES", "STRICT_TRANS_TABLES,NO_ZERO_DATE",
-		"ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"}
+		"ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION",
+		"STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"}
 	for _, m := range safe {
 		if aq, err := classifyMySQLSqlMode(m); err != nil || aq {
 			t.Errorf("classifyMySQLSqlMode(%q) = (%v, %v), want (false, nil)", m, aq, err)


### PR DESCRIPTION
Fixes #297

On a MariaDB target with the engine-default `sql_mode`, every run fails closed at the namespace probe: `NO_AUTO_CREATE_USER` was removed in MySQL 8.0 but is still a MariaDB default (10.2 through 11.4), and `mysqlParseSafeSqlModes` did not list it. The catalog sync never runs the probe, so the datasource looked healthy while no statement could run.

`NO_AUTO_CREATE_USER` only controls whether `GRANT` implicitly creates an account. It does not change tokenizing or parsing, so the analyzer parses the same text the same way either way, which is the bar for the allow list.

- `goproxy/mysqlproxy/session.go`: add `NO_AUTO_CREATE_USER` to `mysqlParseSafeSqlModes`
- `goproxy/mysqlproxy/sqlmode_test.go`: MariaDB's default `sql_mode` string joins the safe cases in `TestSqlModeClassifyUnit`

Verified with `go test -race ./goproxy/mysqlproxy/ -run TestSqlModeClassifyUnit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
